### PR TITLE
feat(secrets): zero-knowledge secret store (server) (#1128)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -21,6 +21,7 @@ import models.llm_pricing  # noqa: F401  # Issue #471: cost-grade pricing master
 import models.memory  # noqa: F401
 import models.neural  # noqa: F401
 import models.resource  # noqa: F401
+import models.secrets  # noqa: F401  # Issue #1128: zero-knowledge secret store
 import models.sleep  # noqa: F401  # Issue #471: SleepReportLLMUsage child added
 from alembic import context
 from config.database import get_database_url

--- a/backend/alembic/versions/e50_1128_secret_store.py
+++ b/backend/alembic/versions/e50_1128_secret_store.py
@@ -203,10 +203,13 @@ def upgrade() -> None:
     op.create_index("ix_secret_access_log_ws_id", "secret_access_log", ["workspace_id", "id"])
     op.create_index("ix_secret_access_log_secret_id", "secret_access_log", ["secret_id"])
 
-    # DB-level append-only enforcement (#1128 gate1 finding 1). Row triggers do
-    # NOT fire on TRUNCATE, so test teardown can still TRUNCATE the table; a
-    # malicious in-band UPDATE/DELETE is blocked. The hash chain catches any
-    # out-of-band mutation that bypasses the trigger.
+    # DB-level append-only enforcement (#1128 gate1 finding 1). A row-level guard
+    # blocks in-band UPDATE/DELETE, and a statement-level guard blocks TRUNCATE —
+    # otherwise a TRUNCATE would silently reset the per-workspace hash chain back
+    # to genesis with no forensic residue. Both reuse one guard function (TG_OP
+    # names the blocked op). The chain catches any out-of-band mutation that
+    # bypasses the triggers; an offsite checkpoint of each workspace's head hash
+    # is the defense against a DDL-privileged DROP of the triggers themselves.
     op.execute(
         sa.text(
             """
@@ -230,9 +233,19 @@ def upgrade() -> None:
             """
         )
     )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER secret_access_log_no_truncate
+            BEFORE TRUNCATE ON secret_access_log
+            FOR EACH STATEMENT EXECUTE FUNCTION secret_access_log_no_mutate();
+            """
+        )
+    )
 
 
 def downgrade() -> None:
+    op.execute(sa.text("DROP TRIGGER IF EXISTS secret_access_log_no_truncate ON secret_access_log"))
     op.execute(sa.text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log"))
     op.execute(sa.text("DROP FUNCTION IF EXISTS secret_access_log_no_mutate()"))
     op.drop_index("ix_secret_access_log_secret_id", table_name="secret_access_log")

--- a/backend/alembic/versions/e50_1128_secret_store.py
+++ b/backend/alembic/versions/e50_1128_secret_store.py
@@ -1,0 +1,247 @@
+"""Zero-knowledge secret store: recipient_pubkeys, secrets, secret_versions,
+secret_grants, secret_access_log (#1128).
+
+A passive, ciphertext-only store for devops API keys. The server holds public
+``age`` recipient keys + opaque ciphertext only and never decrypts. Tables are
+workspace-scoped and isolated from the memory/recall surface (their own models,
+no ``embedding_status`` column).
+
+``secret_access_log`` is append-only AND tamper-evident:
+- A ``BEFORE UPDATE OR DELETE`` trigger blocks any row mutation at the DB level
+  (application discipline alone is not trusted — this is the gate1 finding).
+- A per-workspace HMAC hash chain (``prev_hash`` → ``entry_hash``) makes any
+  out-of-band tampering independently detectable; the ``(workspace_id, prev_hash)``
+  unique constraint keeps the chain strictly linear (no forks).
+
+Revision ID: e50_1128_secret_store
+Revises: e49_1096_drop_stripe_cols
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e50_1128_secret_store"
+down_revision = "e49_1096_drop_stripe_cols"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- recipient_pubkeys -----------------------------------------------------
+    op.create_table(
+        "recipient_pubkeys",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("identity_id", sa.String(length=255), nullable=False),
+        sa.Column("pubkey", sa.String(length=128), nullable=False),
+        sa.Column("fingerprint", sa.String(length=64), nullable=False),
+        sa.Column("label", sa.String(length=100), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="pending"),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.Column("attested_at", sa.DateTime(), nullable=True),
+        sa.Column("attested_by", sa.String(length=255), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspaces.id"],
+            ondelete="CASCADE",
+            name="fk_recipient_pubkeys_workspace_id",
+        ),
+        sa.UniqueConstraint("workspace_id", "pubkey", name="uq_recipient_pubkeys_ws_pubkey"),
+        sa.CheckConstraint(
+            "status IN ('pending', 'active', 'revoked')",
+            name="valid_recipient_pubkey_status",
+        ),
+    )
+    op.create_index(
+        "ix_recipient_pubkeys_ws_identity",
+        "recipient_pubkeys",
+        ["workspace_id", "identity_id"],
+    )
+    op.create_index("ix_recipient_pubkeys_fingerprint", "recipient_pubkeys", ["fingerprint"])
+
+    # --- secrets ---------------------------------------------------------------
+    op.create_table(
+        "secrets",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False, server_default="active"),
+        sa.Column(
+            "rotation_needed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["workspace_id"],
+            ["workspaces.id"],
+            ondelete="CASCADE",
+            name="fk_secrets_workspace_id",
+        ),
+        sa.UniqueConstraint("workspace_id", "name", name="uq_secrets_ws_name"),
+        sa.CheckConstraint(
+            "status IN ('active', 'disabled')",
+            name="valid_secret_status",
+        ),
+    )
+
+    # --- secret_versions -------------------------------------------------------
+    op.create_table(
+        "secret_versions",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("secret_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("version_number", sa.Integer(), nullable=False),
+        sa.Column("ciphertext", sa.Text(), nullable=True),
+        sa.Column("blob_ref", sa.String(length=512), nullable=True),
+        sa.Column("alg", sa.String(length=16), nullable=False, server_default="age"),
+        sa.Column(
+            "recipients_snapshot",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(
+            ["secret_id"],
+            ["secrets.id"],
+            ondelete="CASCADE",
+            name="fk_secret_versions_secret_id",
+        ),
+        sa.UniqueConstraint("secret_id", "version_number", name="uq_secret_versions_secret_ver"),
+        sa.CheckConstraint("alg IN ('age')", name="valid_secret_version_alg"),
+        sa.CheckConstraint(
+            "(ciphertext IS NOT NULL) <> (blob_ref IS NOT NULL)",
+            name="secret_version_one_storage",
+        ),
+    )
+
+    # --- secret_grants ---------------------------------------------------------
+    op.create_table(
+        "secret_grants",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("secret_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("recipient_pubkey_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("granted_by", sa.String(length=255), nullable=False),
+        sa.Column("granted_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["secret_id"],
+            ["secrets.id"],
+            ondelete="CASCADE",
+            name="fk_secret_grants_secret_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recipient_pubkey_id"],
+            ["recipient_pubkeys.id"],
+            ondelete="CASCADE",
+            name="fk_secret_grants_recipient_pubkey_id",
+        ),
+        sa.UniqueConstraint(
+            "secret_id", "recipient_pubkey_id", name="uq_secret_grants_secret_pubkey"
+        ),
+    )
+    op.create_index(
+        "ix_secret_grants_recipient_pubkey_id",
+        "secret_grants",
+        ["recipient_pubkey_id"],
+    )
+
+    # --- secret_access_log (append-only, hash-chained) -------------------------
+    op.create_table(
+        "secret_access_log",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("secret_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("version_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("recipient_identity", sa.String(length=255), nullable=True),
+        sa.Column("actor_user_id", sa.String(length=255), nullable=False),
+        sa.Column("action", sa.String(length=16), nullable=False),
+        sa.Column("result", sa.String(length=16), nullable=False),
+        sa.Column("req_meta", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("prev_hash", sa.String(length=64), nullable=False),
+        sa.Column("entry_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.text("now()")),
+        sa.UniqueConstraint("workspace_id", "prev_hash", name="uq_secret_access_log_ws_prev"),
+        sa.CheckConstraint(
+            "action IN ('register', 'approve', 'put', 'get', 'revoke')",
+            name="valid_secret_access_log_action",
+        ),
+        sa.CheckConstraint(
+            "result IN ('ok', 'denied', 'error')",
+            name="valid_secret_access_log_result",
+        ),
+    )
+    op.create_index("ix_secret_access_log_ws_id", "secret_access_log", ["workspace_id", "id"])
+    op.create_index("ix_secret_access_log_secret_id", "secret_access_log", ["secret_id"])
+
+    # DB-level append-only enforcement (#1128 gate1 finding 1). Row triggers do
+    # NOT fire on TRUNCATE, so test teardown can still TRUNCATE the table; a
+    # malicious in-band UPDATE/DELETE is blocked. The hash chain catches any
+    # out-of-band mutation that bypasses the trigger.
+    op.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION secret_access_log_no_mutate()
+            RETURNS trigger AS $$
+            BEGIN
+                RAISE EXCEPTION
+                    'secret_access_log is append-only; % is not permitted', TG_OP
+                    USING ERRCODE = 'restrict_violation';
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER secret_access_log_append_only
+            BEFORE UPDATE OR DELETE ON secret_access_log
+            FOR EACH ROW EXECUTE FUNCTION secret_access_log_no_mutate();
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(sa.text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log"))
+    op.execute(sa.text("DROP FUNCTION IF EXISTS secret_access_log_no_mutate()"))
+    op.drop_index("ix_secret_access_log_secret_id", table_name="secret_access_log")
+    op.drop_index("ix_secret_access_log_ws_id", table_name="secret_access_log")
+    op.drop_table("secret_access_log")
+    op.drop_index("ix_secret_grants_recipient_pubkey_id", table_name="secret_grants")
+    op.drop_table("secret_grants")
+    op.drop_table("secret_versions")
+    op.drop_table("secrets")
+    op.drop_index("ix_recipient_pubkeys_fingerprint", table_name="recipient_pubkeys")
+    op.drop_index("ix_recipient_pubkeys_ws_identity", table_name="recipient_pubkeys")
+    op.drop_table("recipient_pubkeys")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -524,6 +524,7 @@ from api.routes import (  # noqa: E402
     resource_schema,  # Issue #238: Schema Management API
     resource_tokens,  # Issue #242: Resource Token Management API
     resources,  # Issue #47: Workspace resource list
+    secrets,  # Issue #1128: zero-knowledge secret store
     share_keys,  # Issue #1027: context-scoped read-only TTL share key
     sleep_reports,  # Issue #179: Sleep Report admin UI
     system,
@@ -561,6 +562,9 @@ app.include_router(api_keys.router, prefix="/api/v1")
 #     surface (read-only recall confined to the bound context).
 app.include_router(share_keys.router, prefix="/api/v1")
 app.include_router(share_keys.recall_router, prefix="/api/v1")
+
+# Issue #1128: zero-knowledge secret store (owner/admin management + member fetch).
+app.include_router(secrets.router, prefix="/api/v1")
 
 # Admin routes (Issue #43 - User management and system-wide stats)
 app.include_router(admin.router, prefix="/api/v1")

--- a/backend/src/api/routes/secrets.py
+++ b/backend/src/api/routes/secrets.py
@@ -214,7 +214,7 @@ async def approve_pubkey(
             workspace_id=workspace_id, actor_user_id=user_id, pubkey_id=pubkey_id
         )
     except SecretNotFound as e:
-        raise NotFoundException(str(e)) from e
+        raise NotFoundException("Recipient pubkey") from e
     except ValueError as e:
         raise BadRequestError(str(e)) from e
     await db.commit()
@@ -235,7 +235,7 @@ async def revoke_pubkey(
             workspace_id=workspace_id, actor_user_id=user_id, pubkey_id=pubkey_id
         )
     except SecretNotFound as e:
-        raise NotFoundException(str(e)) from e
+        raise NotFoundException("Recipient pubkey") from e
     except ValueError as e:
         raise BadRequestError(str(e)) from e
     await db.commit()
@@ -301,12 +301,12 @@ async def revoke_grant(
             recipient_pubkey_id=data.recipient_pubkey_id,
         )
     except SecretNotFound as e:
-        raise NotFoundException(str(e)) from e
+        raise NotFoundException("Secret or active grant") from e
     await db.commit()
     rows = await svc.list_secrets(workspace_id=_ws_id(user))
     match = next((r for r in rows if r["name"] == data.name), None)
     if match is None:  # pragma: no cover - defensive (revoke just succeeded)
-        raise NotFoundException("Secret not found")
+        raise NotFoundException("Secret")
     return SecretMetaResponse(**match)
 
 
@@ -337,5 +337,5 @@ async def fetch_secret(
     except SecretAccessDenied as e:
         raise AuthorizationError(str(e)) from e
     except SecretNotFound as e:
-        raise NotFoundException(str(e)) from e
+        raise NotFoundException("Secret version") from e
     return SecretValueResponse(**payload)

--- a/backend/src/api/routes/secrets.py
+++ b/backend/src/api/routes/secrets.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Request, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -58,6 +58,15 @@ def _ws_id(user: dict) -> UUID:
     """Extract the verified current workspace id from an auth dict."""
     raw = user.get("current_workspace_id")
     return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+def _rest_meta(request: Request) -> dict:
+    """Non-secret request metadata for the audit log (never the secret value)."""
+    return {
+        "source": "rest",
+        "ip": request.client.host if request.client else None,
+        "ua": request.headers.get("user-agent"),
+    }
 
 
 # ============================================================================
@@ -250,6 +259,7 @@ async def revoke_pubkey(
 @router.post("", response_model=SecretPutResponse, status_code=status.HTTP_201_CREATED)
 async def put_secret(
     data: SecretPut,
+    request: Request,
     user: WorkspaceAdmin,
     svc: SecretStoreService = Depends(get_secret_service),
     db: AsyncSession = Depends(get_db),
@@ -263,6 +273,7 @@ async def put_secret(
             ciphertext=data.ciphertext,
             recipients_snapshot=data.recipients_snapshot,
             grant_pubkey_ids=data.grant_pubkey_ids,
+            req_meta=_rest_meta(request),
         )
     except ValueError as e:
         raise BadRequestError(str(e)) from e
@@ -283,6 +294,32 @@ async def list_secrets(
     """List secret names + metadata. Never returns ciphertext/values."""
     rows = await svc.list_secrets(workspace_id=_ws_id(user))
     return [SecretMetaResponse(**r) for r in rows]
+
+
+class AuditVerifyResponse(BaseModel):
+    """Result of recomputing the workspace's tamper-evident audit chain."""
+
+    valid: bool
+    entries: int | None = None
+    head: str | None = None
+    broken_at: int | None = None
+    reason: str | None = None
+
+
+@router.get("/audit/verify", response_model=AuditVerifyResponse)
+async def verify_audit_chain(
+    user: WorkspaceAdmin,
+    svc: SecretStoreService = Depends(get_secret_service),
+) -> AuditVerifyResponse:
+    """Recompute the workspace's secret-access audit chain and report integrity.
+
+    Owner/admin ops surface that makes the tamper-evidence usable in-product:
+    walks the append-only log id-ascending, recomputes each HMAC ``entry_hash``
+    and verifies the ``prev_hash`` linkage. Returns ``valid: true`` with the head
+    hash, or ``valid: false`` with the first ``broken_at`` id and ``reason``.
+    """
+    result = await svc.verify_audit_chain(workspace_id=_ws_id(user))
+    return AuditVerifyResponse(**result)
 
 
 @router.post("/revoke-grant", response_model=SecretMetaResponse)
@@ -318,6 +355,7 @@ async def revoke_grant(
 @router.post("/fetch", response_model=SecretValueResponse)
 async def fetch_secret(
     data: SecretFetch,
+    request: Request,
     user: WorkspaceMember,
     svc: SecretStoreService = Depends(get_secret_service),
 ) -> SecretValueResponse:
@@ -333,6 +371,7 @@ async def fetch_secret(
             actor_user_id=get_user_id(user),
             name=data.name,
             version_number=data.version_number,
+            req_meta=_rest_meta(request),
         )
     except SecretAccessDenied as e:
         raise AuthorizationError(str(e)) from e

--- a/backend/src/api/routes/secrets.py
+++ b/backend/src/api/routes/secrets.py
@@ -1,0 +1,341 @@
+"""Zero-knowledge secret store routes (#1128).
+
+Server side of a passive, ciphertext-only secret store. The server holds public
+``age`` recipient keys + opaque ciphertext only and never decrypts. Surfaces:
+
+- **Management** (owner/admin): register-approval of recipient pubkeys, put /
+  list / revoke-grant of secrets. Owner-only for the pubkey trust gate
+  (approve/revoke) — the TOFU attestation root.
+- **Consumption** (member + grant): ``/fetch`` returns ciphertext to a caller
+  who holds an active grant via an active pubkey. The service enforces
+  default-deny and writes a fail-closed audit entry before returning ciphertext.
+
+The UI surface is intentionally **revoke-only / value-free**: ``list`` returns
+metadata, never values; there is no endpoint that displays plaintext (the server
+has none). Decryption happens entirely client-side in the SDK.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import WorkspaceAdmin, WorkspaceMember, WorkspaceOwner
+from db.base import get_db
+from models.api_base import TZAwareBaseModel
+from models.secrets import PUBKEY_LABEL_MAX_LEN, PUBKEY_MAX_LEN, SECRET_NAME_MAX_LEN
+from services.secret_store_service import (
+    CIPHERTEXT_MAX_LEN,
+    SecretAccessDenied,
+    SecretNotFound,
+    SecretStoreService,
+)
+from utils.auth_helpers import get_user_id
+from utils.exceptions import AuthorizationError, BadRequestError, NotFoundException
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/config/secrets", tags=["secrets"])
+
+
+# ============================================================================
+# Dependency Injection
+# ============================================================================
+
+
+async def get_secret_service(db: AsyncSession = Depends(get_db)) -> SecretStoreService:
+    """Get a SecretStoreService bound to the request session."""
+    return SecretStoreService(db)
+
+
+def _ws_id(user: dict) -> UUID:
+    """Extract the verified current workspace id from an auth dict."""
+    raw = user.get("current_workspace_id")
+    return raw if isinstance(raw, UUID) else UUID(str(raw))
+
+
+# ============================================================================
+# Pydantic Models
+# ============================================================================
+
+
+class PubkeyRegister(BaseModel):
+    """Register the caller's own age recipient pubkey (becomes pending)."""
+
+    pubkey: str = Field(
+        ..., min_length=8, max_length=PUBKEY_MAX_LEN, description="age recipient public key (age1…)"
+    )
+    label: str | None = Field(None, max_length=PUBKEY_LABEL_MAX_LEN, description="Friendly label")
+
+
+class PubkeyResponse(TZAwareBaseModel):
+    """Recipient pubkey metadata (the pubkey is public; no private material)."""
+
+    id: UUID
+    identity_id: str
+    pubkey: str
+    fingerprint: str
+    label: str | None
+    status: Literal["pending", "active", "revoked"]
+    created_at: datetime
+    attested_at: datetime | None
+    revoked_at: datetime | None
+
+    model_config = {"from_attributes": True}
+
+
+class SecretPut(BaseModel):
+    """Store a new ciphertext version of a secret. Server never sees plaintext."""
+
+    name: str = Field(..., min_length=1, max_length=SECRET_NAME_MAX_LEN)
+    ciphertext: str = Field(
+        ..., min_length=1, max_length=CIPHERTEXT_MAX_LEN, description="Armored age ciphertext"
+    )
+    recipients_snapshot: list[str] = Field(
+        ..., min_length=1, description="Fingerprints the ciphertext was encrypted to"
+    )
+    grant_pubkey_ids: list[UUID] = Field(
+        ..., min_length=1, description="Recipient pubkey ids to grant (must be active)"
+    )
+
+
+class SecretFetch(BaseModel):
+    """Fetch a secret's ciphertext (name carried in body to allow '/' names)."""
+
+    name: str = Field(..., min_length=1, max_length=SECRET_NAME_MAX_LEN)
+    version_number: int | None = Field(None, ge=1, description="Pin a version; omit for latest")
+
+
+class RevokeGrant(BaseModel):
+    """Revoke one recipient's grant on a secret (flags rotation_needed)."""
+
+    name: str = Field(..., min_length=1, max_length=SECRET_NAME_MAX_LEN)
+    recipient_pubkey_id: UUID
+
+
+class SecretMetaResponse(TZAwareBaseModel):
+    """Secret metadata — never includes the value."""
+
+    name: str
+    status: str
+    rotation_needed: bool
+    current_version: int | None
+    grant_count: int
+    created_at: datetime
+    updated_at: datetime | None
+
+
+class SecretPutResponse(TZAwareBaseModel):
+    """Result of a put."""
+
+    name: str
+    version_number: int
+    status: str
+    rotation_needed: bool
+
+
+class SecretValueResponse(TZAwareBaseModel):
+    """Opaque ciphertext returned to a granted caller. The server cannot read it."""
+
+    name: str
+    version_number: int
+    alg: str
+    ciphertext: str | None
+    blob_ref: str | None
+    recipients_snapshot: list[str]
+    rotation_needed: bool
+    created_at: datetime
+
+
+# ============================================================================
+# Recipient pubkeys
+# ============================================================================
+
+
+@router.post("/pubkeys", response_model=PubkeyResponse, status_code=status.HTTP_201_CREATED)
+async def register_pubkey(
+    data: PubkeyRegister,
+    user: WorkspaceMember,
+    svc: SecretStoreService = Depends(get_secret_service),
+    db: AsyncSession = Depends(get_db),
+) -> PubkeyResponse:
+    """Register the caller's own age recipient pubkey (pending owner approval)."""
+    user_id = get_user_id(user)
+    try:
+        row = await svc.register_pubkey(
+            workspace_id=_ws_id(user),
+            actor_user_id=user_id,
+            pubkey=data.pubkey,
+            label=data.label,
+        )
+    except ValueError as e:
+        raise BadRequestError(str(e)) from e
+    await db.commit()
+    return PubkeyResponse.model_validate(row)
+
+
+@router.get("/pubkeys", response_model=list[PubkeyResponse])
+async def list_pubkeys(
+    user: WorkspaceAdmin,
+    svc: SecretStoreService = Depends(get_secret_service),
+) -> list[PubkeyResponse]:
+    """List all recipient pubkeys in the workspace (owner/admin approval console)."""
+    rows = await svc.list_pubkeys(workspace_id=_ws_id(user))
+    return [PubkeyResponse.model_validate(r) for r in rows]
+
+
+@router.get("/pubkeys/me", response_model=list[PubkeyResponse])
+async def list_my_pubkeys(
+    user: WorkspaceMember,
+    svc: SecretStoreService = Depends(get_secret_service),
+) -> list[PubkeyResponse]:
+    """List the caller's own recipient pubkeys (e.g. to check approval status)."""
+    rows = await svc.list_pubkeys(workspace_id=_ws_id(user), identity_id=get_user_id(user))
+    return [PubkeyResponse.model_validate(r) for r in rows]
+
+
+@router.post("/pubkeys/{pubkey_id}/approve", response_model=PubkeyResponse)
+async def approve_pubkey(
+    pubkey_id: UUID,
+    owner: WorkspaceOwner,
+    svc: SecretStoreService = Depends(get_secret_service),
+    db: AsyncSession = Depends(get_db),
+) -> PubkeyResponse:
+    """Owner-approve a pending pubkey → active (the TOFU trust gate)."""
+    user_id, workspace_id = owner
+    try:
+        row = await svc.approve_pubkey(
+            workspace_id=workspace_id, actor_user_id=user_id, pubkey_id=pubkey_id
+        )
+    except SecretNotFound as e:
+        raise NotFoundException(str(e)) from e
+    except ValueError as e:
+        raise BadRequestError(str(e)) from e
+    await db.commit()
+    return PubkeyResponse.model_validate(row)
+
+
+@router.post("/pubkeys/{pubkey_id}/revoke", response_model=PubkeyResponse)
+async def revoke_pubkey(
+    pubkey_id: UUID,
+    owner: WorkspaceOwner,
+    svc: SecretStoreService = Depends(get_secret_service),
+    db: AsyncSession = Depends(get_db),
+) -> PubkeyResponse:
+    """Owner-revoke a pubkey; revokes its grants and flags rotation on affected secrets."""
+    user_id, workspace_id = owner
+    try:
+        row = await svc.revoke_pubkey(
+            workspace_id=workspace_id, actor_user_id=user_id, pubkey_id=pubkey_id
+        )
+    except SecretNotFound as e:
+        raise NotFoundException(str(e)) from e
+    except ValueError as e:
+        raise BadRequestError(str(e)) from e
+    await db.commit()
+    return PubkeyResponse.model_validate(row)
+
+
+# ============================================================================
+# Secrets — management (owner/admin)
+# ============================================================================
+
+
+@router.post("", response_model=SecretPutResponse, status_code=status.HTTP_201_CREATED)
+async def put_secret(
+    data: SecretPut,
+    user: WorkspaceAdmin,
+    svc: SecretStoreService = Depends(get_secret_service),
+    db: AsyncSession = Depends(get_db),
+) -> SecretPutResponse:
+    """Store a new ciphertext version + reconcile grants. Server never sees plaintext."""
+    try:
+        secret, version = await svc.put_secret(
+            workspace_id=_ws_id(user),
+            actor_user_id=get_user_id(user),
+            name=data.name,
+            ciphertext=data.ciphertext,
+            recipients_snapshot=data.recipients_snapshot,
+            grant_pubkey_ids=data.grant_pubkey_ids,
+        )
+    except ValueError as e:
+        raise BadRequestError(str(e)) from e
+    await db.commit()
+    return SecretPutResponse(
+        name=secret.name,
+        version_number=version.version_number,
+        status=secret.status,
+        rotation_needed=secret.rotation_needed,
+    )
+
+
+@router.get("", response_model=list[SecretMetaResponse])
+async def list_secrets(
+    user: WorkspaceAdmin,
+    svc: SecretStoreService = Depends(get_secret_service),
+) -> list[SecretMetaResponse]:
+    """List secret names + metadata. Never returns ciphertext/values."""
+    rows = await svc.list_secrets(workspace_id=_ws_id(user))
+    return [SecretMetaResponse(**r) for r in rows]
+
+
+@router.post("/revoke-grant", response_model=SecretMetaResponse)
+async def revoke_grant(
+    data: RevokeGrant,
+    user: WorkspaceAdmin,
+    svc: SecretStoreService = Depends(get_secret_service),
+    db: AsyncSession = Depends(get_db),
+) -> SecretMetaResponse:
+    """Revoke one recipient's grant; sets rotation_needed (revoke ≠ un-share)."""
+    try:
+        await svc.revoke_grant(
+            workspace_id=_ws_id(user),
+            actor_user_id=get_user_id(user),
+            name=data.name,
+            recipient_pubkey_id=data.recipient_pubkey_id,
+        )
+    except SecretNotFound as e:
+        raise NotFoundException(str(e)) from e
+    await db.commit()
+    rows = await svc.list_secrets(workspace_id=_ws_id(user))
+    match = next((r for r in rows if r["name"] == data.name), None)
+    if match is None:  # pragma: no cover - defensive (revoke just succeeded)
+        raise NotFoundException("Secret not found")
+    return SecretMetaResponse(**match)
+
+
+# ============================================================================
+# Secrets — consumption (member + grant)
+# ============================================================================
+
+
+@router.post("/fetch", response_model=SecretValueResponse)
+async def fetch_secret(
+    data: SecretFetch,
+    user: WorkspaceMember,
+    svc: SecretStoreService = Depends(get_secret_service),
+) -> SecretValueResponse:
+    """Return ciphertext to a granted caller (default-deny, audit-first).
+
+    The service writes and commits a fail-closed audit entry before the
+    ciphertext is returned; a denied read raises 403 after logging. The returned
+    ciphertext is opaque — the server holds no key to decrypt it.
+    """
+    try:
+        payload = await svc.get_secret(
+            workspace_id=_ws_id(user),
+            actor_user_id=get_user_id(user),
+            name=data.name,
+            version_number=data.version_number,
+        )
+    except SecretAccessDenied as e:
+        raise AuthorizationError(str(e)) from e
+    except SecretNotFound as e:
+        raise NotFoundException(str(e)) from e
+    return SecretValueResponse(**payload)

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -85,6 +85,16 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "list_tags",  # Issue #614: read-only tag discovery
         "recall_upcoming",  # Issue #877: deterministic read-only Time Memory window query (no Hebbian write)
         "load_pinned",  # Issue #886: deterministic always-load read (must run every turn; no Hebbian write)
+        # Issue #1128: secret-store tools carry NO embedding/LLM cost (the memory
+        # quota's cost driver) and must stay callable on EVERY plan — an agent has
+        # to be able to fetch its deploy key even after heavy recall use. Available
+        # on all plans (free/basic/pro); workspace-role gating + the append-only
+        # audit log bound abuse, not the memory rate limit.
+        "secret_register_pubkey",
+        "secret_put",
+        "secret_get",
+        "secret_list",
+        "secret_revoke_grant",
     }
 )
 

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -53,6 +53,12 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "get_file_download_url",  # Issue #485: uses file_id
         "delete_file",  # Issue #485: uses file_id
         "list_files",  # Issue #485: workspace-scoped listing
+        # Issue #1128: secret store — workspace-scoped, not memory-context-scoped.
+        "secret_register_pubkey",
+        "secret_put",
+        "secret_get",
+        "secret_list",
+        "secret_revoke_grant",
     }
 )
 
@@ -133,6 +139,13 @@ def _build_registry() -> dict[str, Any]:
         handle_setup_resource,
     )
     from mcp_server.tools.search_config import handle_update_search_config
+    from mcp_server.tools.secrets import (
+        handle_secret_get,
+        handle_secret_list,
+        handle_secret_put,
+        handle_secret_register_pubkey,
+        handle_secret_revoke_grant,
+    )
     from mcp_server.tools.sleep import (
         handle_get_sleep_history,
         handle_get_sleep_report,
@@ -194,6 +207,12 @@ def _build_registry() -> dict[str, Any]:
         "get_file_download_url": handle_get_file_download_url,
         "delete_file": handle_delete_file,
         "list_files": handle_list_files,
+        # Issue #1128: zero-knowledge secret store (workspace-scoped).
+        "secret_register_pubkey": handle_secret_register_pubkey,
+        "secret_put": handle_secret_put,
+        "secret_get": handle_secret_get,
+        "secret_list": handle_secret_list,
+        "secret_revoke_grant": handle_secret_revoke_grant,
     }
 
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2067,6 +2067,126 @@ Returns: {status, key, value, found}. found is false (value null) when the key i
                 "required": ["context_id"],
             },
         },
+        # Issue #1128: zero-knowledge secret store. The server stores opaque age
+        # ciphertext + public recipient keys only and NEVER decrypts. Encryption
+        # and decryption happen client-side (the `kagura secret` CLI / SDK).
+        {
+            "name": "secret_register_pubkey",
+            "description": """Register YOUR age recipient public key so secrets can be shared with you (Issue #1128).
+
+You generate an age key pair locally (`age-keygen`). Register ONLY the public
+recipient (age1…); never send your private key anywhere. The key starts pending
+and a workspace owner must approve it before it can receive grants.
+
+SECURITY: this is a PUBLIC key — safe to share. Do NOT pass a private key (AGE-SECRET-KEY-…).
+
+Returns: {status, pubkey_id, fingerprint, status: "pending"}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "pubkey": {
+                        "type": "string",
+                        "description": "Your age recipient public key (age1…). Public, safe to share.",
+                    },
+                    "label": {
+                        "type": "string",
+                        "description": "Optional friendly label (e.g. 'laptop', 'ci-runner').",
+                    },
+                },
+                "required": ["pubkey"],
+            },
+        },
+        {
+            "name": "secret_put",
+            "description": """Store an age-encrypted secret and grant recipients (owner/admin, Issue #1128).
+
+The server receives only OPAQUE CIPHERTEXT — encrypt client-side first
+(`age -r <recipient> …`) to exactly the granted recipients. recipients_snapshot
+(the fingerprints you encrypted to) must match grant_pubkey_ids exactly, and
+every grant target must be an approved (active) pubkey. Putting the same name
+again creates a new version. NEVER pass a plaintext secret value here.
+
+Returns: {status, name, version_number, status, rotation_needed}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Secret name, e.g. 'cloudflare/api-token'.",
+                    },
+                    "ciphertext": {
+                        "type": "string",
+                        "description": "Armored age ciphertext. Opaque to the server; never plaintext.",
+                    },
+                    "recipients_snapshot": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Fingerprints the ciphertext was encrypted to (must match grants).",
+                    },
+                    "grant_pubkey_ids": {
+                        "type": "array",
+                        "items": {"type": "string", "format": "uuid"},
+                        "description": "Recipient pubkey ids to grant (must be approved/active).",
+                    },
+                },
+                "required": ["name", "ciphertext", "recipients_snapshot", "grant_pubkey_ids"],
+            },
+        },
+        {
+            "name": "secret_get",
+            "description": """Fetch an age-encrypted secret you have been granted (Issue #1128).
+
+Returns OPAQUE CIPHERTEXT — decrypt it locally with your age private key
+(`age -d -i <key>`); the server holds no key and cannot read it. Access is
+default-deny: you must hold an active grant via an approved pubkey. Every fetch
+is recorded in a tamper-evident audit log before the ciphertext is returned.
+
+Returns: {status, name, version_number, alg, ciphertext, recipients_snapshot, rotation_needed}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Secret name to fetch."},
+                    "version_number": {
+                        "type": "integer",
+                        "description": "Optional. Pin a specific version; omit for the latest.",
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+        {
+            "name": "secret_list",
+            "description": """List secret names and metadata (owner/admin, Issue #1128).
+
+Returns names, status, version, grant count, and whether rotation is needed —
+NEVER any secret value. rotation_needed=true means a grant was revoked and the
+upstream credential should be rotated.
+
+Returns: {status, secrets: [{name, status, rotation_needed, current_version, grant_count, created_at, updated_at}], count}.""",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "secret_revoke_grant",
+            "description": """Revoke a recipient's grant on a secret (owner/admin, Issue #1128).
+
+Stops FUTURE fetches by that recipient and flags the secret rotation_needed.
+Revocation is not retroactive: a recipient who already fetched the ciphertext
+may still hold it, so rotate the upstream credential afterwards.
+
+Returns: {status, name, rotation_needed: true}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Secret name."},
+                    "recipient_pubkey_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The recipient pubkey id whose grant to revoke.",
+                    },
+                },
+                "required": ["name", "recipient_pubkey_id"],
+            },
+        },
     ]
     # Pre-1.0 schema policy (#990): every tool inputSchema is strict — no
     # undeclared top-level parameters. Applied centrally here so all 45 tools

--- a/backend/src/mcp_server/tools/secrets.py
+++ b/backend/src/mcp_server/tools/secrets.py
@@ -1,0 +1,313 @@
+"""MCP tool handlers for the zero-knowledge secret store (#1128).
+
+Five tools mirroring the REST consumption/management surface:
+
+- ``secret_register_pubkey`` (member) — register the caller's own age recipient
+  pubkey (becomes pending owner approval; approval is a REST/owner-console action,
+  deliberately NOT exposed on the LLM surface).
+- ``secret_put`` (owner/admin) — store opaque ciphertext + grants.
+- ``secret_get`` (member + grant) — fetch ciphertext. The value is opaque ``age``
+  ciphertext the server cannot read; the agent decrypts it locally with its
+  private key. Default-deny + fail-closed audit are enforced in the service.
+- ``secret_list`` (owner/admin) — names + metadata only, never values.
+- ``secret_revoke_grant`` (owner/admin) — revoke a grant + flag rotation.
+
+Workspace gating happens here (role lookup); the value-level default-deny grant
+check lives in :class:`SecretStoreService`. Write tools commit explicitly — the
+``async for db in get_db()`` loop does not auto-commit on early return.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from db.base import get_db
+from mcp_server.tools._helpers import (
+    _check_viewer_permission,
+    _error_response,
+    _get_workspace_member_role,
+    _log_tool_usage,
+    _success_response,
+)
+from services.secret_store_service import (
+    SecretAccessDenied,
+    SecretNotFound,
+    SecretStoreService,
+)
+from utils.datetime import to_utc_iso
+
+logger = logging.getLogger(__name__)
+
+
+def _require_workspace(workspace_id: UUID | None) -> list[TextContent] | None:
+    if workspace_id is None:
+        return _error_response("workspace_required", "No workspace selected for this request.")
+    return None
+
+
+def _parse_uuid_list(raw: Any, field: str) -> list[UUID]:
+    if not isinstance(raw, list) or not raw:
+        raise ValueError(f"'{field}' must be a non-empty array of pubkey ids")
+    out: list[UUID] = []
+    for x in raw:
+        try:
+            out.append(UUID(str(x)))
+        except (ValueError, TypeError) as e:
+            raise ValueError(f"'{field}' contains an invalid UUID: {x!r}") from e
+    return out
+
+
+async def handle_secret_register_pubkey(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Register the caller's own age recipient pubkey (pending owner approval)."""
+    guard = _require_workspace(workspace_id)
+    if guard:
+        return guard
+    pubkey = args.get("pubkey")
+    if not isinstance(pubkey, str) or not pubkey:
+        return _error_response("invalid_arguments", "'pubkey' (age recipient string) is required.")
+    label = args.get("label")
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            viewer = await _check_viewer_permission(
+                db, user_id, workspace_id, "register a secret pubkey"
+            )
+            if viewer:
+                return viewer
+            svc = SecretStoreService(db)
+            row = await svc.register_pubkey(
+                workspace_id=workspace_id, actor_user_id=user_id, pubkey=pubkey, label=label
+            )
+            await db.commit()
+            await _log_tool_usage(
+                db, user_id, "secret_register_pubkey", start_time, 200, None, workspace_id
+            )
+            return _success_response(
+                pubkey_id=str(row.id), fingerprint=row.fingerprint, status=row.status
+            )
+        except ValueError as e:
+            await db.rollback()
+            return _error_response("invalid_arguments", str(e))
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"secret_register_pubkey_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "secret_register_pubkey", start_time, 500, None, workspace_id
+            )
+            return _error_response("secret_register_pubkey_error", "An internal error occurred.")
+    return _error_response("internal_error", "Failed to acquire database session")
+
+
+async def handle_secret_put(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Store a new ciphertext version + grants (owner/admin). Never sees plaintext."""
+    guard = _require_workspace(workspace_id)
+    if guard:
+        return guard
+    name = args.get("name")
+    ciphertext = args.get("ciphertext")
+    if not isinstance(name, str) or not name:
+        return _error_response("invalid_arguments", "'name' is required.")
+    if not isinstance(ciphertext, str) or not ciphertext:
+        return _error_response(
+            "invalid_arguments", "'ciphertext' (armored age ciphertext) is required."
+        )
+    recipients_snapshot = args.get("recipients_snapshot")
+    if not isinstance(recipients_snapshot, list) or not recipients_snapshot:
+        return _error_response(
+            "invalid_arguments", "'recipients_snapshot' must be a non-empty array of fingerprints."
+        )
+    try:
+        grant_ids = _parse_uuid_list(args.get("grant_pubkey_ids"), "grant_pubkey_ids")
+    except ValueError as e:
+        return _error_response("invalid_arguments", str(e))
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            role = await _get_workspace_member_role(db, user_id, workspace_id)
+            if role not in ("owner", "admin"):
+                return _error_response(
+                    "forbidden", "Storing a secret requires workspace owner or admin."
+                )
+            svc = SecretStoreService(db)
+            secret, version = await svc.put_secret(
+                workspace_id=workspace_id,
+                actor_user_id=user_id,
+                name=name,
+                ciphertext=ciphertext,
+                recipients_snapshot=[str(r) for r in recipients_snapshot],
+                grant_pubkey_ids=grant_ids,
+            )
+            await db.commit()
+            await _log_tool_usage(db, user_id, "secret_put", start_time, 200, None, workspace_id)
+            return _success_response(
+                name=secret.name,
+                version_number=version.version_number,
+                status=secret.status,
+                rotation_needed=secret.rotation_needed,
+            )
+        except ValueError as e:
+            await db.rollback()
+            return _error_response("invalid_arguments", str(e))
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"secret_put_failed: {e}", exc_info=True)
+            await _log_tool_usage(db, user_id, "secret_put", start_time, 500, None, workspace_id)
+            return _error_response("secret_put_error", "An internal error occurred.")
+    return _error_response("internal_error", "Failed to acquire database session")
+
+
+async def handle_secret_get(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Fetch a secret's opaque ciphertext (member + grant; default-deny, audit-first).
+
+    The returned ciphertext is decryptable only by the caller's age private key,
+    which never leaves the client; the server holds no key for it.
+    """
+    guard = _require_workspace(workspace_id)
+    if guard:
+        return guard
+    name = args.get("name")
+    if not isinstance(name, str) or not name:
+        return _error_response("invalid_arguments", "'name' is required.")
+    version_number = args.get("version_number")
+    if version_number is not None and (
+        isinstance(version_number, bool) or not isinstance(version_number, int)
+    ):
+        return _error_response("invalid_arguments", "'version_number' must be an integer.")
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            viewer = await _check_viewer_permission(db, user_id, workspace_id, "fetch a secret")
+            if viewer:
+                return viewer
+            svc = SecretStoreService(db)
+            # get_secret commits its own fail-closed audit entry internally.
+            payload = await svc.get_secret(
+                workspace_id=workspace_id,
+                actor_user_id=user_id,
+                name=name,
+                version_number=version_number,
+            )
+            await _log_tool_usage(db, user_id, "secret_get", start_time, 200, None, workspace_id)
+            return _success_response(
+                name=payload["name"],
+                version_number=payload["version_number"],
+                alg=payload["alg"],
+                ciphertext=payload["ciphertext"],
+                recipients_snapshot=payload["recipients_snapshot"],
+                rotation_needed=payload["rotation_needed"],
+            )
+        except SecretAccessDenied:
+            await _log_tool_usage(db, user_id, "secret_get", start_time, 403, None, workspace_id)
+            return _error_response("access_denied", "Access denied.")
+        except SecretNotFound:
+            await _log_tool_usage(db, user_id, "secret_get", start_time, 404, None, workspace_id)
+            return _error_response("not_found", "Secret version not found.")
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"secret_get_failed: {e}", exc_info=True)
+            await _log_tool_usage(db, user_id, "secret_get", start_time, 500, None, workspace_id)
+            return _error_response("secret_get_error", "An internal error occurred.")
+    return _error_response("internal_error", "Failed to acquire database session")
+
+
+async def handle_secret_list(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List secret names + metadata (owner/admin). Never returns values."""
+    guard = _require_workspace(workspace_id)
+    if guard:
+        return guard
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            role = await _get_workspace_member_role(db, user_id, workspace_id)
+            if role not in ("owner", "admin"):
+                return _error_response(
+                    "forbidden", "Listing secrets requires workspace owner or admin."
+                )
+            svc = SecretStoreService(db)
+            rows = await svc.list_secrets(workspace_id=workspace_id)
+            secrets = [
+                {
+                    "name": r["name"],
+                    "status": r["status"],
+                    "rotation_needed": r["rotation_needed"],
+                    "current_version": r["current_version"],
+                    "grant_count": r["grant_count"],
+                    "created_at": to_utc_iso(r["created_at"]),
+                    "updated_at": to_utc_iso(r["updated_at"]),
+                }
+                for r in rows
+            ]
+            await _log_tool_usage(db, user_id, "secret_list", start_time, 200, None, workspace_id)
+            return _success_response(secrets=secrets, count=len(secrets))
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"secret_list_failed: {e}", exc_info=True)
+            await _log_tool_usage(db, user_id, "secret_list", start_time, 500, None, workspace_id)
+            return _error_response("secret_list_error", "An internal error occurred.")
+    return _error_response("internal_error", "Failed to acquire database session")
+
+
+async def handle_secret_revoke_grant(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Revoke one recipient's grant on a secret + flag rotation (owner/admin)."""
+    guard = _require_workspace(workspace_id)
+    if guard:
+        return guard
+    name = args.get("name")
+    if not isinstance(name, str) or not name:
+        return _error_response("invalid_arguments", "'name' is required.")
+    raw_pid = args.get("recipient_pubkey_id")
+    try:
+        pubkey_id = UUID(str(raw_pid))
+    except (ValueError, TypeError):
+        return _error_response("invalid_arguments", "'recipient_pubkey_id' must be a valid UUID.")
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            role = await _get_workspace_member_role(db, user_id, workspace_id)
+            if role not in ("owner", "admin"):
+                return _error_response(
+                    "forbidden", "Revoking a grant requires workspace owner or admin."
+                )
+            svc = SecretStoreService(db)
+            secret = await svc.revoke_grant(
+                workspace_id=workspace_id,
+                actor_user_id=user_id,
+                name=name,
+                recipient_pubkey_id=pubkey_id,
+            )
+            await db.commit()
+            await _log_tool_usage(
+                db, user_id, "secret_revoke_grant", start_time, 200, None, workspace_id
+            )
+            return _success_response(name=secret.name, rotation_needed=secret.rotation_needed)
+        except SecretNotFound as e:
+            await db.rollback()
+            return _error_response("not_found", str(e))
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"secret_revoke_grant_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "secret_revoke_grant", start_time, 500, None, workspace_id
+            )
+            return _error_response("secret_revoke_grant_error", "An internal error occurred.")
+    return _error_response("internal_error", "Failed to acquire database session")

--- a/backend/src/mcp_server/tools/secrets.py
+++ b/backend/src/mcp_server/tools/secrets.py
@@ -13,8 +13,12 @@ Five tools mirroring the REST consumption/management surface:
 - ``secret_revoke_grant`` (owner/admin) — revoke a grant + flag rotation.
 
 Workspace gating happens here (role lookup); the value-level default-deny grant
-check lives in :class:`SecretStoreService`. Write tools commit explicitly — the
-``async for db in get_db()`` loop does not auto-commit on early return.
+check lives in :class:`SecretStoreService`. Write tools commit explicitly:
+``get_db()`` commits only when its generator runs past the ``yield`` to normal
+exhaustion, but these handlers ``return`` from *inside* the ``async for db in
+get_db()`` loop, so the generator is ``aclose``d before that commit runs —
+hence the explicit ``await db.commit()`` on the write paths. (``secret_get``
+commits its own fail-closed audit inside the service.)
 """
 
 from __future__ import annotations
@@ -147,6 +151,7 @@ async def handle_secret_put(
                 ciphertext=ciphertext,
                 recipients_snapshot=[str(r) for r in recipients_snapshot],
                 grant_pubkey_ids=grant_ids,
+                req_meta={"source": "mcp", "tool": "secret_put"},
             )
             await db.commit()
             await _log_tool_usage(db, user_id, "secret_put", start_time, 200, None, workspace_id)
@@ -200,6 +205,7 @@ async def handle_secret_get(
                 actor_user_id=user_id,
                 name=name,
                 version_number=version_number,
+                req_meta={"source": "mcp", "tool": "secret_get"},
             )
             await _log_tool_usage(db, user_id, "secret_get", start_time, 200, None, workspace_id)
             return _success_response(
@@ -207,6 +213,9 @@ async def handle_secret_get(
                 version_number=payload["version_number"],
                 alg=payload["alg"],
                 ciphertext=payload["ciphertext"],
+                # Parity with the REST SecretValueResponse: a future R2-offloaded
+                # version stores blob_ref instead of inline ciphertext.
+                blob_ref=payload["blob_ref"],
                 recipients_snapshot=payload["recipients_snapshot"],
                 rotation_needed=payload["rotation_needed"],
             )

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -14,6 +14,7 @@ import models.file_objects  # noqa: F401  # Issue #485: file storage
 import models.llm_call_log  # noqa: F401  # Issue #474: comprehensive call ledger
 import models.llm_pricing  # noqa: F401
 import models.retrieval_feedback  # noqa: F401  # Issue #888: retrieval feedback signal
+import models.secrets  # noqa: F401  # Issue #1128: zero-knowledge secret store
 import models.sleep  # noqa: F401
 from models.config import ContextSearchConfig
 from models.file_objects import FileObject, WorkspaceStorageUsage

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -91,6 +91,16 @@ OPERATIONAL_TABLES: frozenset[str] = frozenset(
         "indexer_state",
         "resource_tokens",
         "sleep_report_llm_usage",  # cost telemetry, not consolidation output
+        # Zero-knowledge secret store (#1128) — security plumbing, governed by
+        # the auth/security regime + GDPR erasure (cascade on workspace delete).
+        # The server holds only opaque age ciphertext + public keys (never
+        # plaintext); these are operational credentials, not raw user knowledge
+        # (not on the memory export surface) and not learned/derived structure.
+        "recipient_pubkeys",
+        "secrets",
+        "secret_versions",
+        "secret_grants",
+        "secret_access_log",  # append-only, tamper-evident audit (own regime)
     }
 )
 

--- a/backend/src/models/secrets.py
+++ b/backend/src/models/secrets.py
@@ -1,0 +1,384 @@
+"""Zero-knowledge secret store models (Issue #1128).
+
+A **passive, ciphertext-only** store for devops API keys (Cloudflare / Resend /
+GCP / …). The trust model is zero-knowledge: each engineer/agent holds an
+``age`` (X25519) **private** key locally and registers only the **public**
+recipient key here. memory-cloud stores public keys + ciphertext only and **can
+never decrypt** a secret — so a full server compromise leaks ciphertext the
+attacker cannot read, and secrets never touch the LLM / recall surface.
+
+This is the SERVER side. ``age`` encryption/decryption and the ``kagura secret``
+CLI live in ``kagura-ai/kagura-memory-python-sdk``. The server validates the
+*shape* of a recipient key but performs no cryptography on secret values.
+
+Isolation (hard requirement, sibling to #210): these tables are their own models
+with their own ``__tablename__`` and **no ``embedding_status`` column**, so they
+are structurally invisible to the embedding sweep and ``recall()`` — both of
+which are bound to ``models.memory.Memory`` (the ``memories`` table). A stored
+secret can therefore never appear in a recall result nor be enqueued for
+embedding; ``backend/tests`` asserts this in both directions.
+
+Why a dedicated schema rather than the existing credential paths: ``ExternalAPIKey``
++ ``utils.encryption`` (Fernet) and ``MemberCredentialsService`` are
+**server-custody** — the server holds ``API_KEY_SECRET`` and can decrypt. This
+feature deliberately does NOT reuse them; the server holds no key for these
+ciphertexts. The dedicated-table choice mirrors ``ShareKey`` (#1027): security
+invariants are made *structural*, not policy.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+# --- Recipient pubkey lifecycle ------------------------------------------------
+# A registered pubkey starts ``pending`` (TOFU trust root, #1128 gate1) and an
+# owner must ``approve`` it (→ ``active``) before any grant can target it. Owner
+# revocation moves it to ``revoked``. New states are appended, never reordered.
+PUBKEY_STATUS_PENDING = "pending"
+PUBKEY_STATUS_ACTIVE = "active"
+PUBKEY_STATUS_REVOKED = "revoked"
+_ALL_PUBKEY_STATUSES: tuple[str, ...] = (
+    PUBKEY_STATUS_PENDING,
+    PUBKEY_STATUS_ACTIVE,
+    PUBKEY_STATUS_REVOKED,
+)
+
+# --- Secret lifecycle ----------------------------------------------------------
+SECRET_STATUS_ACTIVE = "active"
+SECRET_STATUS_DISABLED = "disabled"
+_ALL_SECRET_STATUSES: tuple[str, ...] = (
+    SECRET_STATUS_ACTIVE,
+    SECRET_STATUS_DISABLED,
+)
+
+# --- Ciphertext algorithm ------------------------------------------------------
+# Only ``age`` is supported. The column exists so a future alg can be added
+# without a schema change, but the server never interprets the ciphertext.
+SECRET_ALG_AGE = "age"
+_ALL_SECRET_ALGS: tuple[str, ...] = (SECRET_ALG_AGE,)
+
+# --- Audit log enums -----------------------------------------------------------
+AUDIT_ACTION_REGISTER = "register"
+AUDIT_ACTION_APPROVE = "approve"
+AUDIT_ACTION_PUT = "put"
+AUDIT_ACTION_GET = "get"
+AUDIT_ACTION_REVOKE = "revoke"
+_ALL_AUDIT_ACTIONS: tuple[str, ...] = (
+    AUDIT_ACTION_REGISTER,
+    AUDIT_ACTION_APPROVE,
+    AUDIT_ACTION_PUT,
+    AUDIT_ACTION_GET,
+    AUDIT_ACTION_REVOKE,
+)
+
+AUDIT_RESULT_OK = "ok"
+AUDIT_RESULT_DENIED = "denied"
+AUDIT_RESULT_ERROR = "error"
+_ALL_AUDIT_RESULTS: tuple[str, ...] = (
+    AUDIT_RESULT_OK,
+    AUDIT_RESULT_DENIED,
+    AUDIT_RESULT_ERROR,
+)
+
+# Genesis link for the first audit entry in a workspace's hash chain.
+AUDIT_GENESIS_HASH = "0" * 64
+
+# Field caps (single source of truth — enforced at API schema + service layer).
+SECRET_NAME_MAX_LEN = 255
+PUBKEY_MAX_LEN = 128
+PUBKEY_LABEL_MAX_LEN = 100
+IDENTITY_MAX_LEN = 255
+
+
+class RecipientPubkey(Base):
+    """An ``age`` recipient (public) key bound to a workspace identity.
+
+    The server stores the public key and a SHA256 ``fingerprint`` of it; it
+    never holds the matching private key. ``status`` gates use: only an
+    ``active`` (owner-approved) pubkey may be a grant target.
+    """
+
+    __tablename__ = "recipient_pubkeys"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        # FK lookups are served by the leading column of ix_recipient_pubkeys_ws_identity.
+    )
+    # The identity (user/agent id) that owns the matching private key.
+    identity_id: Mapped[str] = mapped_column(String(IDENTITY_MAX_LEN), nullable=False)
+    # The ``age`` recipient public key (e.g. ``age1qz...``). Opaque to the server.
+    pubkey: Mapped[str] = mapped_column(String(PUBKEY_MAX_LEN), nullable=False)
+    # SHA256 hex of the pubkey — stable handle used in recipients_snapshot and
+    # audit metadata so the (longer) pubkey need not be echoed everywhere.
+    fingerprint: Mapped[str] = mapped_column(String(64), nullable=False)
+    label: Mapped[str | None] = mapped_column(String(PUBKEY_LABEL_MAX_LEN), nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=PUBKEY_STATUS_PENDING,
+        server_default=PUBKEY_STATUS_PENDING,
+    )
+    created_by: Mapped[str] = mapped_column(String(IDENTITY_MAX_LEN), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    # Set when an owner approves the pending registration (TOFU attestation).
+    attested_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    attested_by: Mapped[str | None] = mapped_column(String(IDENTITY_MAX_LEN), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    __table_args__ = (
+        # One row per (workspace, pubkey): the same recipient key cannot be
+        # registered twice in a workspace.
+        UniqueConstraint("workspace_id", "pubkey", name="uq_recipient_pubkeys_ws_pubkey"),
+        Index("ix_recipient_pubkeys_ws_identity", "workspace_id", "identity_id"),
+        Index("ix_recipient_pubkeys_fingerprint", "fingerprint"),
+        CheckConstraint(
+            f"status IN ({', '.join(repr(s) for s in _ALL_PUBKEY_STATUSES)})",
+            name="valid_recipient_pubkey_status",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<RecipientPubkey(identity='{self.identity_id}', fp='{self.fingerprint[:12]}')>"
+
+
+class Secret(Base):
+    """A named secret. Holds metadata only; ciphertext lives in versions."""
+
+    __tablename__ = "secrets"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        # FK lookups are served by the leading column of uq_secrets_ws_name.
+    )
+    # Logical name, e.g. ``cloudflare/api-token``. Unique per workspace.
+    name: Mapped[str] = mapped_column(String(SECRET_NAME_MAX_LEN), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=SECRET_STATUS_ACTIVE,
+        server_default=SECRET_STATUS_ACTIVE,
+    )
+    # Set true on grant revocation: the stored ciphertext is still readable by
+    # holders who already fetched it, so revoke means "rotate upstream", not
+    # "un-share" (#1128 gate1 finding 4). Cleared when a new version is put.
+    rotation_needed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    created_by: Mapped[str] = mapped_column(String(IDENTITY_MAX_LEN), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "name", name="uq_secrets_ws_name"),
+        CheckConstraint(
+            f"status IN ({', '.join(repr(s) for s in _ALL_SECRET_STATUSES)})",
+            name="valid_secret_status",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<Secret(name='{self.name}')>"
+
+
+class SecretVersion(Base):
+    """One immutable ciphertext version of a secret.
+
+    ``recipients_snapshot`` is the list of pubkey fingerprints the ciphertext
+    was encrypted to at put time — the server checks it equals the granted,
+    active recipient set (grant ⇄ ciphertext integrity, #1128 gate1 finding 6).
+    """
+
+    __tablename__ = "secret_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    secret_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("secrets.id", ondelete="CASCADE"),
+        nullable=False,
+        # FK lookups are served by the leading column of uq_secret_versions_secret_ver.
+    )
+    # Monotonic per secret (1, 2, 3, …). The "current" version is max(version_number).
+    version_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    # Inline armored ``age`` ciphertext. Opaque; the server never decrypts it.
+    ciphertext: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Future: large ciphertext offloaded to R2; one of ciphertext/blob_ref is set.
+    blob_ref: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    alg: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=SECRET_ALG_AGE, server_default=SECRET_ALG_AGE
+    )
+    # list[str] of recipient fingerprints (sha256 hex of each pubkey).
+    recipients_snapshot: Mapped[list] = mapped_column(JSONB, nullable=False)
+    created_by: Mapped[str] = mapped_column(String(IDENTITY_MAX_LEN), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("secret_id", "version_number", name="uq_secret_versions_secret_ver"),
+        CheckConstraint(
+            f"alg IN ({', '.join(repr(a) for a in _ALL_SECRET_ALGS)})",
+            name="valid_secret_version_alg",
+        ),
+        # Exactly-one-of storage: inline ciphertext or an R2 blob ref.
+        CheckConstraint(
+            "(ciphertext IS NOT NULL) <> (blob_ref IS NOT NULL)",
+            name="secret_version_one_storage",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<SecretVersion(secret_id='{self.secret_id}', v={self.version_number})>"
+
+
+class SecretGrant(Base):
+    """An access grant: ``recipient_pubkey_id`` may fetch ``secret_id``.
+
+    Default-deny: a fetch is allowed only when an active (non-revoked) grant
+    links the secret to one of the caller's active recipient pubkeys.
+    """
+
+    __tablename__ = "secret_grants"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    secret_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("secrets.id", ondelete="CASCADE"),
+        nullable=False,
+        # FK lookups are served by the leading column of uq_secret_grants_secret_pubkey.
+    )
+    recipient_pubkey_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("recipient_pubkeys.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    granted_by: Mapped[str] = mapped_column(String(IDENTITY_MAX_LEN), nullable=False)
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint("secret_id", "recipient_pubkey_id", name="uq_secret_grants_secret_pubkey"),
+        # The unique constraint above leads with secret_id; this serves the
+        # recipient_pubkey_id FK (cascade on pubkey delete) and reverse lookups.
+        Index("ix_secret_grants_recipient_pubkey_id", "recipient_pubkey_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SecretGrant(secret_id='{self.secret_id}', pubkey_id='{self.recipient_pubkey_id}')>"
+        )
+
+
+class SecretAccessLog(Base):
+    """Append-only, tamper-evident audit of every secret-store action.
+
+    Append-only is enforced at the **DB level** by a ``BEFORE UPDATE OR DELETE``
+    trigger (see the migration) — application discipline alone is not trusted.
+    Tamper-evidence is a per-workspace HMAC hash chain: ``entry_hash =
+    HMAC(audit_hmac_key, prev_hash || canonical(entry))`` where ``prev_hash`` is
+    the previous entry's ``entry_hash`` for the same workspace (``AUDIT_GENESIS_HASH``
+    for the first). A row mutation breaks the chain and is independently detectable.
+
+    The log is deliberately **decoupled** from the entities it audits: ``secret_id`` /
+    ``version_id`` are plain columns with no FK, so the audit trail survives a
+    secret delete and a secret can never be blocked from deletion by its history.
+    Secret values are **never** written here — only names, ids, identities, and
+    request metadata.
+    """
+
+    __tablename__ = "secret_access_log"
+
+    # BigInteger cursor PK (matches resource_events / llm_call_log append-only logs).
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    # No FK — the audit row outlives the secret/version it references.
+    secret_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    version_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # The recipient/identity the action concerned (e.g. the registered pubkey owner).
+    recipient_identity: Mapped[str | None] = mapped_column(String(IDENTITY_MAX_LEN), nullable=True)
+    # The authenticated caller that performed the action.
+    actor_user_id: Mapped[str] = mapped_column(String(IDENTITY_MAX_LEN), nullable=False)
+    action: Mapped[str] = mapped_column(String(16), nullable=False)
+    result: Mapped[str] = mapped_column(String(16), nullable=False)
+    # Non-secret request metadata (tool/source/ip/ua). NEVER the secret value.
+    req_meta: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    prev_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    entry_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        # Per-workspace chain reads (latest entry by id within a workspace).
+        Index("ix_secret_access_log_ws_id", "workspace_id", "id"),
+        Index("ix_secret_access_log_secret_id", "secret_id"),
+        # Structural anti-fork guard: each prev_hash is used at most once per
+        # workspace, so the chain is strictly linear (a second writer that read
+        # the same tip cannot commit a sibling). Complements the advisory lock
+        # the service takes while appending.
+        UniqueConstraint("workspace_id", "prev_hash", name="uq_secret_access_log_ws_prev"),
+        CheckConstraint(
+            f"action IN ({', '.join(repr(a) for a in _ALL_AUDIT_ACTIONS)})",
+            name="valid_secret_access_log_action",
+        ),
+        CheckConstraint(
+            f"result IN ({', '.join(repr(r) for r in _ALL_AUDIT_RESULTS)})",
+            name="valid_secret_access_log_result",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<SecretAccessLog(id={self.id}, action='{self.action}', result='{self.result}')>"

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -123,10 +123,13 @@ class SecretStoreService:
         ``(workspace_id, prev_hash)`` unique constraint is the backstop). Never
         receives or stores a secret value.
         """
-        # Serialize appends for this workspace within the transaction.
+        # Serialize appends for this workspace within the transaction. Use the
+        # 64-bit hashtextextended (PR #686 standard — hashtext's 32-bit space
+        # birthday-collides across workspaces) with a feature-namespaced key so
+        # secret-audit locks never share a value with quota/connector locks.
         await self.db.execute(
-            text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
-            {"k": str(workspace_id)},
+            text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+            {"k": f"secret_audit:{workspace_id}"},
         )
 
         prev_row = await self.db.execute(
@@ -138,20 +141,17 @@ class SecretStoreService:
         prev_hash = prev_row.scalar_one_or_none() or AUDIT_GENESIS_HASH
 
         created_at = utcnow()
-        meta_canonical = json.dumps(req_meta or {}, sort_keys=True, separators=(",", ":"))
-        payload = "|".join(
-            [
-                prev_hash,
-                str(workspace_id),
-                str(secret_id or ""),
-                str(version_id or ""),
-                recipient_identity or "",
-                actor_user_id,
-                action,
-                result,
-                created_at.isoformat(),
-                meta_canonical,
-            ]
+        payload = self._audit_payload(
+            prev_hash=prev_hash,
+            workspace_id=workspace_id,
+            secret_id=secret_id,
+            version_id=version_id,
+            recipient_identity=recipient_identity,
+            actor_user_id=actor_user_id,
+            action=action,
+            result=result,
+            created_at=created_at,
+            req_meta=req_meta,
         )
         entry_hash = hmac_sha256_hex(payload, get_settings().audit_hmac_key)
 
@@ -171,6 +171,88 @@ class SecretStoreService:
         self.db.add(entry)
         await self.db.flush()
         return entry
+
+    @staticmethod
+    def _audit_payload(
+        *,
+        prev_hash: str,
+        workspace_id: UUID,
+        secret_id: UUID | None,
+        version_id: UUID | None,
+        recipient_identity: str | None,
+        actor_user_id: str,
+        action: str,
+        result: str,
+        created_at: Any,
+        req_meta: dict | None,
+    ) -> str:
+        """Canonical, length-safe HMAC input for one audit entry.
+
+        JSON-encodes the chained fields (rather than a ``|``-join) so a value
+        containing a delimiter cannot shift field boundaries once ``req_meta``
+        carries free-form tool/source metadata. Used identically by append and
+        by :meth:`verify_audit_chain`, so the chain is recomputable.
+        """
+        return json.dumps(
+            [
+                prev_hash,
+                str(workspace_id),
+                str(secret_id or ""),
+                str(version_id or ""),
+                recipient_identity or "",
+                actor_user_id,
+                action,
+                result,
+                created_at.isoformat(),
+                req_meta or {},
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        )
+
+    async def verify_audit_chain(self, *, workspace_id: UUID) -> dict[str, Any]:
+        """Recompute and verify a workspace's tamper-evident audit chain.
+
+        Walks entries id-ascending, recomputing ``entry_hash`` from the stored
+        fields with the same payload construction as the append path, and checks
+        the ``prev_hash`` linkage (genesis for the first). Returns
+        ``{valid, entries, head}`` on success, or ``{valid: False, broken_at,
+        reason}`` at the first entry that fails — catching any out-of-band field
+        edit that left ``entry_hash`` stale. This is the verifier that makes the
+        chain's tamper-evidence usable (not merely latent).
+        """
+        rows = await self.db.execute(
+            select(SecretAccessLog)
+            .where(SecretAccessLog.workspace_id == workspace_id)
+            .order_by(SecretAccessLog.id.asc())
+        )
+        entries = list(rows.scalars().all())
+        key = get_settings().audit_hmac_key
+        expected_prev = AUDIT_GENESIS_HASH
+        for e in entries:
+            if e.prev_hash != expected_prev:
+                return {"valid": False, "broken_at": e.id, "reason": "prev_hash_mismatch"}
+            payload = self._audit_payload(
+                prev_hash=e.prev_hash,
+                workspace_id=e.workspace_id,
+                secret_id=e.secret_id,
+                version_id=e.version_id,
+                recipient_identity=e.recipient_identity,
+                actor_user_id=e.actor_user_id,
+                action=e.action,
+                result=e.result,
+                created_at=e.created_at,
+                req_meta=e.req_meta,
+            )
+            if hmac_sha256_hex(payload, key) != e.entry_hash:
+                return {"valid": False, "broken_at": e.id, "reason": "entry_hash_mismatch"}
+            expected_prev = e.entry_hash
+        return {
+            "valid": True,
+            "entries": len(entries),
+            "head": expected_prev if entries else AUDIT_GENESIS_HASH,
+        }
 
     # -------------------------------------------------------------- pubkeys
     @staticmethod
@@ -386,6 +468,8 @@ class SecretStoreService:
         # granted set exactly (no recipient who can decrypt but lacks a grant,
         # and no grant whose recipient cannot decrypt this ciphertext).
         granted_fps = {p.fingerprint for p in pubkeys}
+        if len(recipients_snapshot) != len(set(recipients_snapshot)):
+            raise ValueError("recipients_snapshot contains duplicate fingerprints")
         snapshot_fps = set(recipients_snapshot or [])
         if snapshot_fps != granted_fps:
             raise ValueError(
@@ -588,6 +672,10 @@ class SecretStoreService:
             .where(
                 SecretGrant.secret_id == secret.id,
                 SecretGrant.revoked_at.is_(None),
+                # Defense-in-depth: the most security-critical query is self-
+                # contained — even though grants are validated same-workspace at
+                # put time, re-assert the workspace on the recipient here.
+                RecipientPubkey.workspace_id == workspace_id,
                 RecipientPubkey.identity_id == actor_user_id,
                 RecipientPubkey.status == PUBKEY_STATUS_ACTIVE,
             )

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -1,0 +1,694 @@
+"""Zero-knowledge secret store service (Issue #1128).
+
+Server-side logic for a passive, ciphertext-only secret store. The server
+**never decrypts**: it validates the *shape* of an ``age`` recipient key and
+stores/returns opaque ciphertext, but performs no cryptography on secret values
+and holds no key that could decrypt them. It deliberately does NOT use
+``utils.encryption`` (Fernet, server-custody) — that path is for credentials the
+server must *use*; these the server only *persists*.
+
+Security invariants enforced here (gate1 #1128):
+- **Default-deny** reads: ``get_secret`` returns ciphertext only when an active
+  grant links the secret to one of the caller's *active* (owner-approved)
+  recipient pubkeys.
+- **Fail-closed audit**: every read writes an audit entry and **commits it
+  before** the ciphertext is returned; a denied or errored read is logged too.
+- **Grant ⇄ ciphertext integrity**: ``put_secret`` rejects a version whose
+  ``recipients_snapshot`` does not exactly match the granted active pubkeys.
+- **Tamper-evident audit**: ``secret_access_log`` is a per-workspace HMAC hash
+  chain; appends are serialized with a per-workspace advisory lock so the chain
+  stays strictly linear. DB-level append-only is enforced by a trigger (migration).
+- **No plaintext in logs**: secret values are never written to the audit log,
+  application logs, or exception text.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.settings import get_settings
+from models.secrets import (
+    AUDIT_ACTION_APPROVE,
+    AUDIT_ACTION_GET,
+    AUDIT_ACTION_PUT,
+    AUDIT_ACTION_REGISTER,
+    AUDIT_ACTION_REVOKE,
+    AUDIT_GENESIS_HASH,
+    AUDIT_RESULT_DENIED,
+    AUDIT_RESULT_OK,
+    PUBKEY_STATUS_ACTIVE,
+    PUBKEY_STATUS_PENDING,
+    PUBKEY_STATUS_REVOKED,
+    SECRET_ALG_AGE,
+    SECRET_STATUS_ACTIVE,
+    RecipientPubkey,
+    Secret,
+    SecretAccessLog,
+    SecretGrant,
+    SecretVersion,
+)
+from utils.datetime import utcnow
+from utils.hashing import hmac_sha256_hex, sha256_hex
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Shape check for an ``age`` X25519 recipient (``age1`` + bech32 lowercase body).
+# This is a sanity gate, not cryptographic validation — the SDK / age library is
+# authoritative. We only reject obviously-wrong input so the store stays clean.
+_AGE_RECIPIENT_RE = re.compile(r"^age1[0-9a-z]{20,110}$")
+
+# Inline ciphertext cap. An ``age``-wrapped API key is small (≲ a few KB); a
+# generous ceiling bounds request bodies without forcing R2 for normal use.
+CIPHERTEXT_MAX_LEN = 256 * 1024
+
+
+class SecretStoreError(Exception):
+    """Base error for the secret store."""
+
+
+class SecretNotFound(SecretStoreError):
+    """A referenced pubkey / secret / grant does not exist (owner-facing 404)."""
+
+
+class SecretAccessDenied(SecretStoreError):
+    """A read was denied by the default-deny grant check (uniform 403).
+
+    Raised identically for "no such secret" and "no grant" so a caller cannot
+    probe which secrets exist in a workspace they lack access to.
+    """
+
+
+def fingerprint_pubkey(pubkey: str) -> str:
+    """Stable SHA256 fingerprint of an ``age`` recipient pubkey."""
+    return sha256_hex(pubkey)
+
+
+class SecretStoreService:
+    """Async service over the ``secret_*`` / ``recipient_pubkeys`` tables.
+
+    Commit policy: management writes (register / approve / revoke / put) only
+    ``flush()`` — the caller (route) commits — mirroring the repo convention.
+    ``get_secret`` is the deliberate exception: it **commits its own audit
+    entry** before returning ciphertext, so a read is never served without a
+    durably-logged access (fail-closed).
+    """
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ------------------------------------------------------------------ audit
+    async def _append_audit(
+        self,
+        *,
+        workspace_id: UUID,
+        actor_user_id: str,
+        action: str,
+        result: str,
+        secret_id: UUID | None = None,
+        version_id: UUID | None = None,
+        recipient_identity: str | None = None,
+        req_meta: dict | None = None,
+    ) -> SecretAccessLog:
+        """Append one tamper-evident entry to the workspace's audit chain.
+
+        Takes a per-workspace transaction-scoped advisory lock so concurrent
+        appends serialize and the hash chain stays strictly linear (the
+        ``(workspace_id, prev_hash)`` unique constraint is the backstop). Never
+        receives or stores a secret value.
+        """
+        # Serialize appends for this workspace within the transaction.
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:k))"),
+            {"k": str(workspace_id)},
+        )
+
+        prev_row = await self.db.execute(
+            select(SecretAccessLog.entry_hash)
+            .where(SecretAccessLog.workspace_id == workspace_id)
+            .order_by(SecretAccessLog.id.desc())
+            .limit(1)
+        )
+        prev_hash = prev_row.scalar_one_or_none() or AUDIT_GENESIS_HASH
+
+        created_at = utcnow()
+        meta_canonical = json.dumps(req_meta or {}, sort_keys=True, separators=(",", ":"))
+        payload = "|".join(
+            [
+                prev_hash,
+                str(workspace_id),
+                str(secret_id or ""),
+                str(version_id or ""),
+                recipient_identity or "",
+                actor_user_id,
+                action,
+                result,
+                created_at.isoformat(),
+                meta_canonical,
+            ]
+        )
+        entry_hash = hmac_sha256_hex(payload, get_settings().audit_hmac_key)
+
+        entry = SecretAccessLog(
+            workspace_id=workspace_id,
+            secret_id=secret_id,
+            version_id=version_id,
+            recipient_identity=recipient_identity,
+            actor_user_id=actor_user_id,
+            action=action,
+            result=result,
+            req_meta=req_meta,
+            prev_hash=prev_hash,
+            entry_hash=entry_hash,
+            created_at=created_at,
+        )
+        self.db.add(entry)
+        await self.db.flush()
+        return entry
+
+    # -------------------------------------------------------------- pubkeys
+    @staticmethod
+    def _validate_pubkey(pubkey: str) -> None:
+        if not _AGE_RECIPIENT_RE.match(pubkey or ""):
+            raise ValueError(
+                "pubkey must be an age recipient key (age1… bech32). "
+                "Generate one with `age-keygen` and register only the public recipient."
+            )
+
+    async def register_pubkey(
+        self,
+        *,
+        workspace_id: UUID,
+        actor_user_id: str,
+        pubkey: str,
+        label: str | None = None,
+    ) -> RecipientPubkey:
+        """Register the caller's own ``age`` recipient pubkey as ``pending``.
+
+        ``identity_id`` is bound to the authenticated caller — a member cannot
+        register a key claiming to be someone else. An owner must ``approve`` it
+        (TOFU attestation) before it can be a grant target.
+        """
+        self._validate_pubkey(pubkey)
+        fp = fingerprint_pubkey(pubkey)
+
+        existing = await self.db.execute(
+            select(RecipientPubkey).where(
+                RecipientPubkey.workspace_id == workspace_id,
+                RecipientPubkey.pubkey == pubkey,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise ValueError("This recipient pubkey is already registered in the workspace")
+
+        row = RecipientPubkey(
+            workspace_id=workspace_id,
+            identity_id=actor_user_id,
+            pubkey=pubkey,
+            fingerprint=fp,
+            label=label,
+            status=PUBKEY_STATUS_PENDING,
+            created_by=actor_user_id,
+        )
+        self.db.add(row)
+        await self.db.flush()
+
+        await self._append_audit(
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            action=AUDIT_ACTION_REGISTER,
+            result=AUDIT_RESULT_OK,
+            recipient_identity=actor_user_id,
+        )
+        logger.info(
+            "secret_pubkey_registered",
+            workspace_id=str(workspace_id),
+            identity_id=actor_user_id,
+            fingerprint=fp[:12],
+        )
+        return row
+
+    async def _load_pubkey(self, workspace_id: UUID, pubkey_id: UUID) -> RecipientPubkey:
+        result = await self.db.execute(
+            select(RecipientPubkey).where(
+                RecipientPubkey.id == pubkey_id,
+                RecipientPubkey.workspace_id == workspace_id,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            raise SecretNotFound("Recipient pubkey not found")
+        return row
+
+    async def approve_pubkey(
+        self, *, workspace_id: UUID, actor_user_id: str, pubkey_id: UUID
+    ) -> RecipientPubkey:
+        """Owner-approve a pending pubkey → ``active`` (the TOFU trust gate)."""
+        row = await self._load_pubkey(workspace_id, pubkey_id)
+        if row.status != PUBKEY_STATUS_PENDING:
+            raise ValueError(f"Pubkey is not pending (status={row.status})")
+        row.status = PUBKEY_STATUS_ACTIVE
+        row.attested_at = utcnow()
+        row.attested_by = actor_user_id
+        await self.db.flush()
+
+        await self._append_audit(
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            action=AUDIT_ACTION_APPROVE,
+            result=AUDIT_RESULT_OK,
+            recipient_identity=row.identity_id,
+        )
+        logger.info(
+            "secret_pubkey_approved",
+            workspace_id=str(workspace_id),
+            identity_id=row.identity_id,
+            approver=actor_user_id,
+        )
+        return row
+
+    async def revoke_pubkey(
+        self, *, workspace_id: UUID, actor_user_id: str, pubkey_id: UUID
+    ) -> RecipientPubkey:
+        """Owner-revoke a pubkey and revoke every grant that targets it.
+
+        Affected secrets are flagged ``rotation_needed`` — the holder may have
+        already fetched ciphertext, so the upstream credential must be rotated
+        (revocation is not retroactive un-sharing).
+        """
+        row = await self._load_pubkey(workspace_id, pubkey_id)
+        if row.status == PUBKEY_STATUS_REVOKED:
+            raise ValueError("Pubkey is already revoked")
+        now = utcnow()
+        row.status = PUBKEY_STATUS_REVOKED
+        row.revoked_at = now
+
+        grants = await self.db.execute(
+            select(SecretGrant).where(
+                SecretGrant.recipient_pubkey_id == pubkey_id,
+                SecretGrant.revoked_at.is_(None),
+            )
+        )
+        for grant in grants.scalars().all():
+            grant.revoked_at = now
+            secret = await self.db.get(Secret, grant.secret_id)
+            if secret is not None:
+                secret.rotation_needed = True
+        await self.db.flush()
+
+        await self._append_audit(
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            action=AUDIT_ACTION_REVOKE,
+            result=AUDIT_RESULT_OK,
+            recipient_identity=row.identity_id,
+        )
+        logger.info(
+            "secret_pubkey_revoked",
+            workspace_id=str(workspace_id),
+            identity_id=row.identity_id,
+            revoker=actor_user_id,
+        )
+        return row
+
+    async def list_pubkeys(
+        self, *, workspace_id: UUID, identity_id: str | None = None
+    ) -> list[RecipientPubkey]:
+        """List recipient pubkeys in a workspace (optionally one identity's)."""
+        stmt = select(RecipientPubkey).where(RecipientPubkey.workspace_id == workspace_id)
+        if identity_id is not None:
+            stmt = stmt.where(RecipientPubkey.identity_id == identity_id)
+        stmt = stmt.order_by(RecipientPubkey.created_at.desc())
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    # --------------------------------------------------------------- secrets
+    async def _active_pubkeys_by_ids(
+        self, workspace_id: UUID, pubkey_ids: list[UUID]
+    ) -> list[RecipientPubkey]:
+        if not pubkey_ids:
+            return []
+        result = await self.db.execute(
+            select(RecipientPubkey).where(
+                RecipientPubkey.workspace_id == workspace_id,
+                RecipientPubkey.id.in_(pubkey_ids),
+            )
+        )
+        return list(result.scalars().all())
+
+    async def put_secret(
+        self,
+        *,
+        workspace_id: UUID,
+        actor_user_id: str,
+        name: str,
+        ciphertext: str,
+        recipients_snapshot: list[str],
+        grant_pubkey_ids: list[UUID],
+        req_meta: dict | None = None,
+    ) -> tuple[Secret, SecretVersion]:
+        """Store a new ciphertext version of ``name`` and reconcile its grants.
+
+        The server never sees plaintext. ``recipients_snapshot`` (the
+        fingerprints the ciphertext was encrypted to) must equal exactly the
+        fingerprints of ``grant_pubkey_ids`` — all of which must be *active*
+        (owner-approved) — or the put is rejected (grant ⇄ ciphertext integrity).
+        After the put, the secret's active grants are exactly ``grant_pubkey_ids``.
+        """
+        if not name or len(name) > 255:
+            raise ValueError("Secret name must be 1–255 characters")
+        if not ciphertext:
+            raise ValueError("ciphertext is required (the server never receives plaintext)")
+        if len(ciphertext) > CIPHERTEXT_MAX_LEN:
+            raise ValueError(f"ciphertext exceeds {CIPHERTEXT_MAX_LEN} bytes")
+        if not grant_pubkey_ids:
+            raise ValueError("At least one grant recipient is required")
+
+        # All grant targets must exist in this workspace and be active (approved).
+        pubkeys = await self._active_pubkeys_by_ids(workspace_id, grant_pubkey_ids)
+        found_ids = {p.id for p in pubkeys}
+        missing = [str(pid) for pid in grant_pubkey_ids if pid not in found_ids]
+        if missing:
+            raise ValueError(f"Unknown recipient pubkey(s) in this workspace: {missing}")
+        not_active = [p.fingerprint[:12] for p in pubkeys if p.status != PUBKEY_STATUS_ACTIVE]
+        if not_active:
+            raise ValueError(
+                f"Grants may only target approved (active) pubkeys; not approved: {not_active}"
+            )
+
+        # Grant ⇄ ciphertext integrity: the encrypted-to set must equal the
+        # granted set exactly (no recipient who can decrypt but lacks a grant,
+        # and no grant whose recipient cannot decrypt this ciphertext).
+        granted_fps = {p.fingerprint for p in pubkeys}
+        snapshot_fps = set(recipients_snapshot or [])
+        if snapshot_fps != granted_fps:
+            raise ValueError(
+                "recipients_snapshot does not match the granted recipients "
+                "(the ciphertext must be encrypted to exactly the granted pubkeys)"
+            )
+
+        # Get-or-create the secret.
+        existing = await self.db.execute(
+            select(Secret).where(Secret.workspace_id == workspace_id, Secret.name == name)
+        )
+        secret = existing.scalar_one_or_none()
+        if secret is None:
+            secret = Secret(
+                workspace_id=workspace_id,
+                name=name,
+                status=SECRET_STATUS_ACTIVE,
+                created_by=actor_user_id,
+            )
+            self.db.add(secret)
+            await self.db.flush()
+        else:
+            secret.status = SECRET_STATUS_ACTIVE
+            # A fresh version supersedes the rotation request.
+            secret.rotation_needed = False
+
+        # Next monotonic version number.
+        max_ver = await self.db.execute(
+            select(SecretVersion.version_number)
+            .where(SecretVersion.secret_id == secret.id)
+            .order_by(SecretVersion.version_number.desc())
+            .limit(1)
+        )
+        next_version = (max_ver.scalar_one_or_none() or 0) + 1
+
+        version = SecretVersion(
+            secret_id=secret.id,
+            version_number=next_version,
+            ciphertext=ciphertext,
+            alg=SECRET_ALG_AGE,
+            recipients_snapshot=sorted(snapshot_fps),
+            created_by=actor_user_id,
+        )
+        self.db.add(version)
+        await self.db.flush()
+
+        await self._reconcile_grants(secret.id, grant_pubkey_ids, actor_user_id)
+
+        await self._append_audit(
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            action=AUDIT_ACTION_PUT,
+            result=AUDIT_RESULT_OK,
+            secret_id=secret.id,
+            version_id=version.id,
+            req_meta=req_meta,
+        )
+        logger.info(
+            "secret_put",
+            workspace_id=str(workspace_id),
+            name=name,
+            version=next_version,
+            recipients=len(granted_fps),
+        )
+        return secret, version
+
+    async def _reconcile_grants(
+        self, secret_id: UUID, grant_pubkey_ids: list[UUID], actor_user_id: str
+    ) -> None:
+        """Make the secret's active grants exactly ``grant_pubkey_ids``."""
+        target = set(grant_pubkey_ids)
+        now = utcnow()
+        result = await self.db.execute(
+            select(SecretGrant).where(SecretGrant.secret_id == secret_id)
+        )
+        existing = {g.recipient_pubkey_id: g for g in result.scalars().all()}
+
+        for pid in target:
+            grant = existing.get(pid)
+            if grant is None:
+                self.db.add(
+                    SecretGrant(
+                        secret_id=secret_id,
+                        recipient_pubkey_id=pid,
+                        granted_by=actor_user_id,
+                    )
+                )
+            elif grant.revoked_at is not None:
+                grant.revoked_at = None  # re-activate
+                grant.granted_by = actor_user_id
+                grant.granted_at = now
+
+        for pid, grant in existing.items():
+            if pid not in target and grant.revoked_at is None:
+                grant.revoked_at = now
+        await self.db.flush()
+
+    async def get_secret(
+        self,
+        *,
+        workspace_id: UUID,
+        actor_user_id: str,
+        name: str,
+        version_number: int | None = None,
+        req_meta: dict | None = None,
+    ) -> dict[str, Any]:
+        """Return the requested ciphertext version — default-deny, audit-first.
+
+        Allowed only when an active grant links the secret to one of the
+        caller's *active* recipient pubkeys. The access (ok **or** denied) is
+        written to the audit chain and **committed before** any ciphertext is
+        returned; a denied read raises :class:`SecretAccessDenied` after logging.
+        The server returns opaque ciphertext and never decrypts it.
+        """
+        secret = await self._resolve_readable_secret(workspace_id, actor_user_id, name)
+        if secret is None:
+            # Uniform denial — do not leak whether the secret exists.
+            await self._append_audit(
+                workspace_id=workspace_id,
+                actor_user_id=actor_user_id,
+                action=AUDIT_ACTION_GET,
+                result=AUDIT_RESULT_DENIED,
+                recipient_identity=actor_user_id,
+                req_meta=req_meta,
+            )
+            await self.db.commit()
+            logger.warning(
+                "secret_get_denied",
+                workspace_id=str(workspace_id),
+                actor=actor_user_id,
+                name=name,
+            )
+            raise SecretAccessDenied("Access denied")
+
+        version = await self._select_version(secret.id, version_number)
+        if version is None:
+            await self._append_audit(
+                workspace_id=workspace_id,
+                actor_user_id=actor_user_id,
+                action=AUDIT_ACTION_GET,
+                result=AUDIT_RESULT_DENIED,
+                secret_id=secret.id,
+                recipient_identity=actor_user_id,
+                req_meta=req_meta,
+            )
+            await self.db.commit()
+            raise SecretNotFound("Secret version not found")
+
+        # Extract the response BEFORE committing so post-commit expiry can't bite.
+        payload: dict[str, Any] = {
+            "name": secret.name,
+            "version_number": version.version_number,
+            "alg": version.alg,
+            "ciphertext": version.ciphertext,
+            "blob_ref": version.blob_ref,
+            "recipients_snapshot": version.recipients_snapshot,
+            "rotation_needed": secret.rotation_needed,
+            "created_at": version.created_at,
+        }
+
+        # Fail-closed: the access is durably logged before the ciphertext leaves.
+        await self._append_audit(
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            action=AUDIT_ACTION_GET,
+            result=AUDIT_RESULT_OK,
+            secret_id=secret.id,
+            version_id=version.id,
+            recipient_identity=actor_user_id,
+            req_meta=req_meta,
+        )
+        await self.db.commit()
+        logger.info(
+            "secret_get",
+            workspace_id=str(workspace_id),
+            actor=actor_user_id,
+            name=name,
+            version=version.version_number,
+        )
+        return payload
+
+    async def _resolve_readable_secret(
+        self, workspace_id: UUID, actor_user_id: str, name: str
+    ) -> Secret | None:
+        """Return the secret iff the caller has an active grant via an active pubkey."""
+        secret_row = await self.db.execute(
+            select(Secret).where(
+                Secret.workspace_id == workspace_id,
+                Secret.name == name,
+                Secret.status == SECRET_STATUS_ACTIVE,
+            )
+        )
+        secret = secret_row.scalar_one_or_none()
+        if secret is None:
+            return None
+
+        grant_row = await self.db.execute(
+            select(SecretGrant.id)
+            .join(RecipientPubkey, SecretGrant.recipient_pubkey_id == RecipientPubkey.id)
+            .where(
+                SecretGrant.secret_id == secret.id,
+                SecretGrant.revoked_at.is_(None),
+                RecipientPubkey.identity_id == actor_user_id,
+                RecipientPubkey.status == PUBKEY_STATUS_ACTIVE,
+            )
+            .limit(1)
+        )
+        if grant_row.scalar_one_or_none() is None:
+            return None
+        return secret
+
+    async def _select_version(
+        self, secret_id: UUID, version_number: int | None
+    ) -> SecretVersion | None:
+        stmt = select(SecretVersion).where(SecretVersion.secret_id == secret_id)
+        if version_number is not None:
+            stmt = stmt.where(SecretVersion.version_number == version_number)
+        else:
+            stmt = stmt.order_by(SecretVersion.version_number.desc())
+        stmt = stmt.limit(1)
+        result = await self.db.execute(stmt)
+        return result.scalar_one_or_none()
+
+    async def revoke_grant(
+        self,
+        *,
+        workspace_id: UUID,
+        actor_user_id: str,
+        name: str,
+        recipient_pubkey_id: UUID,
+    ) -> Secret:
+        """Revoke one recipient's grant on a secret and flag rotation.
+
+        Revocation stops *future* fetches; it does not un-share ciphertext the
+        recipient may already hold, so the secret is flagged ``rotation_needed``.
+        """
+        secret_row = await self.db.execute(
+            select(Secret).where(Secret.workspace_id == workspace_id, Secret.name == name)
+        )
+        secret = secret_row.scalar_one_or_none()
+        if secret is None:
+            raise SecretNotFound("Secret not found")
+
+        grant_row = await self.db.execute(
+            select(SecretGrant).where(
+                SecretGrant.secret_id == secret.id,
+                SecretGrant.recipient_pubkey_id == recipient_pubkey_id,
+                SecretGrant.revoked_at.is_(None),
+            )
+        )
+        grant = grant_row.scalar_one_or_none()
+        if grant is None:
+            raise SecretNotFound("Active grant not found")
+
+        grant.revoked_at = utcnow()
+        secret.rotation_needed = True
+        await self.db.flush()
+
+        await self._append_audit(
+            workspace_id=workspace_id,
+            actor_user_id=actor_user_id,
+            action=AUDIT_ACTION_REVOKE,
+            result=AUDIT_RESULT_OK,
+            secret_id=secret.id,
+        )
+        logger.info(
+            "secret_grant_revoked",
+            workspace_id=str(workspace_id),
+            name=name,
+            revoker=actor_user_id,
+        )
+        return secret
+
+    async def list_secrets(self, *, workspace_id: UUID) -> list[dict[str, Any]]:
+        """List secret names + metadata. **Never** returns ciphertext/values."""
+        result = await self.db.execute(
+            select(Secret).where(Secret.workspace_id == workspace_id).order_by(Secret.name.asc())
+        )
+        secrets = list(result.scalars().all())
+        out: list[dict[str, Any]] = []
+        for s in secrets:
+            ver_row = await self.db.execute(
+                select(SecretVersion.version_number)
+                .where(SecretVersion.secret_id == s.id)
+                .order_by(SecretVersion.version_number.desc())
+                .limit(1)
+            )
+            current_version = ver_row.scalar_one_or_none()
+            grant_rows = await self.db.execute(
+                select(SecretGrant.id).where(
+                    SecretGrant.secret_id == s.id, SecretGrant.revoked_at.is_(None)
+                )
+            )
+            grant_count = len(list(grant_rows.scalars().all()))
+            out.append(
+                {
+                    "name": s.name,
+                    "status": s.status,
+                    "rotation_needed": s.rotation_needed,
+                    "current_version": current_version,
+                    "grant_count": grant_count,
+                    "created_at": s.created_at,
+                    "updated_at": s.updated_at,
+                }
+            )
+        return out

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -29,7 +29,7 @@ import re
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config.settings import get_settings
@@ -377,11 +377,16 @@ class SecretStoreService:
                 SecretGrant.revoked_at.is_(None),
             )
         )
-        for grant in grants.scalars().all():
+        affected = list(grants.scalars().all())
+        secret_ids = {g.secret_id for g in affected}
+        for grant in affected:
             grant.revoked_at = now
-            secret = await self.db.get(Secret, grant.secret_id)
-            if secret is not None:
-                secret.rotation_needed = True
+        if secret_ids:
+            # One bulk UPDATE to flag rotation on every affected secret, instead
+            # of a per-grant SELECT (a shared key may be granted on many secrets).
+            await self.db.execute(
+                update(Secret).where(Secret.id.in_(secret_ids)).values(rotation_needed=True)
+            )
         await self.db.flush()
 
         await self._append_audit(
@@ -476,6 +481,17 @@ class SecretStoreService:
                 "recipients_snapshot does not match the granted recipients "
                 "(the ciphertext must be encrypted to exactly the granted pubkeys)"
             )
+
+        # Serialize concurrent puts to the SAME secret so the get-or-create +
+        # version-number computation cannot race — otherwise two puts of the same
+        # name compute the same version_number / both insert the secret, and the
+        # loser surfaces a raw unique-constraint IntegrityError (an opaque 5xx).
+        # Released at commit. (The audit advisory lock is keyed differently, so
+        # these don't contend with audit appends.)
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+            {"k": f"secret_put:{workspace_id}:{name}"},
+        )
 
         # Get-or-create the secret.
         existing = await self.db.execute(
@@ -584,14 +600,23 @@ class SecretStoreService:
         returned; a denied read raises :class:`SecretAccessDenied` after logging.
         The server returns opaque ciphertext and never decrypts it.
         """
-        secret = await self._resolve_readable_secret(workspace_id, actor_user_id, name)
-        if secret is None:
-            # Uniform denial — do not leak whether the secret exists.
+        secret = await self._load_active_secret(workspace_id, name)
+        authorized = secret is not None and await self._caller_has_active_grant(
+            secret.id, actor_user_id, workspace_id
+        )
+        if not authorized:
+            # Uniform denial to the CALLER (raise the same error whether the
+            # secret is missing or just ungranted) — but record secret_id in the
+            # server-side audit when the secret DOES exist, so an unauthorized
+            # probe of a real secret name is attributable for incident response
+            # and rotation. The audit is never returned to the caller, so this
+            # records nothing the caller doesn't already supply (the name).
             await self._append_audit(
                 workspace_id=workspace_id,
                 actor_user_id=actor_user_id,
                 action=AUDIT_ACTION_GET,
                 result=AUDIT_RESULT_DENIED,
+                secret_id=(secret.id if secret is not None else None),
                 recipient_identity=actor_user_id,
                 req_meta=req_meta,
             )
@@ -601,6 +626,7 @@ class SecretStoreService:
                 workspace_id=str(workspace_id),
                 actor=actor_user_id,
                 name=name,
+                secret_exists=secret is not None,
             )
             raise SecretAccessDenied("Access denied")
 
@@ -651,10 +677,8 @@ class SecretStoreService:
         )
         return payload
 
-    async def _resolve_readable_secret(
-        self, workspace_id: UUID, actor_user_id: str, name: str
-    ) -> Secret | None:
-        """Return the secret iff the caller has an active grant via an active pubkey."""
+    async def _load_active_secret(self, workspace_id: UUID, name: str) -> Secret | None:
+        """Load an active secret by name (existence check; no grant evaluation)."""
         secret_row = await self.db.execute(
             select(Secret).where(
                 Secret.workspace_id == workspace_id,
@@ -662,15 +686,17 @@ class SecretStoreService:
                 Secret.status == SECRET_STATUS_ACTIVE,
             )
         )
-        secret = secret_row.scalar_one_or_none()
-        if secret is None:
-            return None
+        return secret_row.scalar_one_or_none()
 
+    async def _caller_has_active_grant(
+        self, secret_id: UUID, actor_user_id: str, workspace_id: UUID
+    ) -> bool:
+        """True iff an active grant links the secret to one of the caller's active pubkeys."""
         grant_row = await self.db.execute(
             select(SecretGrant.id)
             .join(RecipientPubkey, SecretGrant.recipient_pubkey_id == RecipientPubkey.id)
             .where(
-                SecretGrant.secret_id == secret.id,
+                SecretGrant.secret_id == secret_id,
                 SecretGrant.revoked_at.is_(None),
                 # Defense-in-depth: the most security-critical query is self-
                 # contained — even though grants are validated same-workspace at
@@ -681,9 +707,7 @@ class SecretStoreService:
             )
             .limit(1)
         )
-        if grant_row.scalar_one_or_none() is None:
-            return None
-        return secret
+        return grant_row.scalar_one_or_none() is not None
 
     async def _select_version(
         self, secret_id: UUID, version_number: int | None
@@ -748,35 +772,43 @@ class SecretStoreService:
         return secret
 
     async def list_secrets(self, *, workspace_id: UUID) -> list[dict[str, Any]]:
-        """List secret names + metadata. **Never** returns ciphertext/values."""
+        """List secret names + metadata. **Never** returns ciphertext/values.
+
+        Current-version and active-grant-count are each fetched in ONE grouped
+        query over the whole secret set (not per-secret), so the console/MCP
+        listing stays at 3 round-trips regardless of secret count (no N+1).
+        """
         result = await self.db.execute(
             select(Secret).where(Secret.workspace_id == workspace_id).order_by(Secret.name.asc())
         )
         secrets = list(result.scalars().all())
-        out: list[dict[str, Any]] = []
-        for s in secrets:
-            ver_row = await self.db.execute(
-                select(SecretVersion.version_number)
-                .where(SecretVersion.secret_id == s.id)
-                .order_by(SecretVersion.version_number.desc())
-                .limit(1)
-            )
-            current_version = ver_row.scalar_one_or_none()
-            grant_rows = await self.db.execute(
-                select(SecretGrant.id).where(
-                    SecretGrant.secret_id == s.id, SecretGrant.revoked_at.is_(None)
-                )
-            )
-            grant_count = len(list(grant_rows.scalars().all()))
-            out.append(
-                {
-                    "name": s.name,
-                    "status": s.status,
-                    "rotation_needed": s.rotation_needed,
-                    "current_version": current_version,
-                    "grant_count": grant_count,
-                    "created_at": s.created_at,
-                    "updated_at": s.updated_at,
-                }
-            )
-        return out
+        if not secrets:
+            return []
+        ids = [s.id for s in secrets]
+
+        ver_rows = await self.db.execute(
+            select(SecretVersion.secret_id, func.max(SecretVersion.version_number))
+            .where(SecretVersion.secret_id.in_(ids))
+            .group_by(SecretVersion.secret_id)
+        )
+        ver_map = dict(ver_rows.all())
+
+        grant_rows = await self.db.execute(
+            select(SecretGrant.secret_id, func.count())
+            .where(SecretGrant.secret_id.in_(ids), SecretGrant.revoked_at.is_(None))
+            .group_by(SecretGrant.secret_id)
+        )
+        grant_map = dict(grant_rows.all())
+
+        return [
+            {
+                "name": s.name,
+                "status": s.status,
+                "rotation_needed": s.rotation_needed,
+                "current_version": ver_map.get(s.id),
+                "grant_count": grant_map.get(s.id, 0),
+                "created_at": s.created_at,
+                "updated_at": s.updated_at,
+            }
+            for s in secrets
+        ]

--- a/backend/tests/api/test_secrets_routes.py
+++ b/backend/tests/api/test_secrets_routes.py
@@ -13,9 +13,9 @@ import uuid
 
 import pytest
 import pytest_asyncio
+from fastapi import Request
 from sqlalchemy import text
 
-import models.secrets  # noqa: F401  — register tables for create_all
 from api.routes.secrets import (
     PubkeyRegister,
     RevokeGrant,
@@ -27,6 +27,7 @@ from api.routes.secrets import (
     put_secret,
     register_pubkey,
     revoke_grant,
+    verify_audit_chain,
 )
 from models.auth import Workspace
 from services.secret_store_service import SecretStoreService, fingerprint_pubkey
@@ -34,6 +35,13 @@ from utils.exceptions import AuthorizationError, BadRequestError
 
 PUBKEY_A = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
 CIPHERTEXT = "-----BEGIN AGE ENCRYPTED FILE-----\nopaque==\n-----END AGE ENCRYPTED FILE-----"
+
+
+def _req() -> Request:
+    """Minimal Starlette Request for direct route-function calls (audit req_meta)."""
+    return Request(
+        {"type": "http", "headers": [(b"user-agent", b"pytest")], "client": ("127.0.0.1", 0)}
+    )
 
 
 @pytest_asyncio.fixture(loop_scope="session")
@@ -93,6 +101,7 @@ async def test_put_before_approve_is_400(ctx):
                 recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
                 grant_pubkey_ids=[pk.id],
             ),
+            _req(),
             ctx["admin"],
             svc=ctx["svc"],
             db=ctx["db"],
@@ -111,13 +120,14 @@ async def test_full_flow_register_approve_put_fetch(ctx):
             recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
             grant_pubkey_ids=[pk.id],
         ),
+        _req(),
         ctx["admin"],
         svc=ctx["svc"],
         db=ctx["db"],
     )
     assert put.version_number == 1
 
-    val = await fetch_secret(SecretFetch(name="cf/token"), ctx["member"], svc=ctx["svc"])
+    val = await fetch_secret(SecretFetch(name="cf/token"), _req(), ctx["member"], svc=ctx["svc"])
     assert val.ciphertext == CIPHERTEXT
     assert val.alg == "age"
 
@@ -134,13 +144,14 @@ async def test_fetch_without_grant_is_403(ctx):
             recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
             grant_pubkey_ids=[pk.id],
         ),
+        _req(),
         ctx["admin"],
         svc=ctx["svc"],
         db=ctx["db"],
     )
     bob = {"user_id": "bob", "current_workspace_id": ctx["ws"]}
     with pytest.raises(AuthorizationError):
-        await fetch_secret(SecretFetch(name="cf/token"), bob, svc=ctx["svc"])
+        await fetch_secret(SecretFetch(name="cf/token"), _req(), bob, svc=ctx["svc"])
 
 
 async def test_list_secrets_has_no_value_field(ctx):
@@ -155,6 +166,7 @@ async def test_list_secrets_has_no_value_field(ctx):
             recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
             grant_pubkey_ids=[pk.id],
         ),
+        _req(),
         ctx["admin"],
         svc=ctx["svc"],
         db=ctx["db"],
@@ -178,6 +190,7 @@ async def test_revoke_grant_flags_rotation(ctx):
             recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
             grant_pubkey_ids=[pk.id],
         ),
+        _req(),
         ctx["admin"],
         svc=ctx["svc"],
         db=ctx["db"],
@@ -189,6 +202,28 @@ async def test_revoke_grant_flags_rotation(ctx):
         db=ctx["db"],
     )
     assert resp.rotation_needed is True
+
+
+async def test_verify_audit_chain_endpoint(ctx):
+    pk = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A), ctx["member"], svc=ctx["svc"], db=ctx["db"]
+    )
+    await approve_pubkey(pk.id, ctx["owner"], svc=ctx["svc"], db=ctx["db"])
+    await put_secret(
+        SecretPut(
+            name="cf/token",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        ),
+        _req(),
+        ctx["admin"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    resp = await verify_audit_chain(ctx["admin"], svc=ctx["svc"])
+    assert resp.valid is True
+    assert resp.entries >= 3  # register, approve, put
 
 
 def test_route_auth_gating_wiring():
@@ -216,6 +251,7 @@ def test_route_auth_gating_wiring():
     assert ann(r.list_secrets, "user") is WorkspaceAdmin
     assert ann(r.revoke_grant, "user") is WorkspaceAdmin
     assert ann(r.list_pubkeys, "user") is WorkspaceAdmin
+    assert ann(r.verify_audit_chain, "user") is WorkspaceAdmin
     # Member: register own pubkey / list own / fetch (service grant check gates value).
     assert ann(r.register_pubkey, "user") is WorkspaceMember
     assert ann(r.list_my_pubkeys, "user") is WorkspaceMember

--- a/backend/tests/api/test_secrets_routes.py
+++ b/backend/tests/api/test_secrets_routes.py
@@ -54,9 +54,16 @@ async def ctx(db_session):
         "admin": admin,
         "owner": owner,
     }
-    # Audit log is append-only; TRUNCATE bypasses the migration's row trigger
-    # (the documented test-cleanup escape), so cleanup works with or without it.
+    # Audit log is append-only (row UPDATE/DELETE + TRUNCATE triggers); drop the
+    # triggers (IF EXISTS — harmless when absent) before TRUNCATE so cleanup works
+    # whether or not the migration applied them to this DB.
     await db_session.rollback()
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_no_truncate ON secret_access_log")
+    )
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log")
+    )
     await db_session.execute(text("TRUNCATE secret_access_log"))
     await db_session.execute(text("DELETE FROM workspaces WHERE id = :w"), {"w": str(ws_id)})
     await db_session.commit()
@@ -182,3 +189,34 @@ async def test_revoke_grant_flags_rotation(ctx):
         db=ctx["db"],
     )
     assert resp.rotation_needed is True
+
+
+def test_route_auth_gating_wiring():
+    """Each endpoint is wired to the correct workspace auth dependency (review W6).
+
+    Static pin so a regression that, e.g., loosens approve_pubkey from owner-only
+    to member is caught — the gating itself is the shared, separately-tested
+    require_workspace_* dependency chain.
+    """
+    import inspect
+
+    from api.routes import secrets as r
+    from auth.dependencies import WorkspaceAdmin, WorkspaceMember, WorkspaceOwner
+
+    def ann(fn, param):
+        # eval_str resolves PEP 563 string annotations (the route module uses
+        # `from __future__ import annotations`) back to the alias object.
+        return inspect.signature(fn, eval_str=True).parameters[param].annotation
+
+    # Owner-only: the pubkey trust gate (TOFU).
+    assert ann(r.approve_pubkey, "owner") is WorkspaceOwner
+    assert ann(r.revoke_pubkey, "owner") is WorkspaceOwner
+    # Owner/admin: secret management.
+    assert ann(r.put_secret, "user") is WorkspaceAdmin
+    assert ann(r.list_secrets, "user") is WorkspaceAdmin
+    assert ann(r.revoke_grant, "user") is WorkspaceAdmin
+    assert ann(r.list_pubkeys, "user") is WorkspaceAdmin
+    # Member: register own pubkey / list own / fetch (service grant check gates value).
+    assert ann(r.register_pubkey, "user") is WorkspaceMember
+    assert ann(r.list_my_pubkeys, "user") is WorkspaceMember
+    assert ann(r.fetch_secret, "user") is WorkspaceMember

--- a/backend/tests/api/test_secrets_routes.py
+++ b/backend/tests/api/test_secrets_routes.py
@@ -1,0 +1,184 @@
+"""Route-logic tests for the secret store API (#1128).
+
+Calls the route functions directly (no ASGI client) with constructed auth
+principals and the real service over a Postgres ``db_session`` — the same
+direct-invocation style as ``tests/api/test_share_keys_routes.py``. Verifies
+auth extraction, error mapping (ValueError→400, denied→403, not-found→404), and
+that no response model ever carries a value the server should not expose.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+
+import models.secrets  # noqa: F401  — register tables for create_all
+from api.routes.secrets import (
+    PubkeyRegister,
+    RevokeGrant,
+    SecretFetch,
+    SecretPut,
+    approve_pubkey,
+    fetch_secret,
+    list_secrets,
+    put_secret,
+    register_pubkey,
+    revoke_grant,
+)
+from models.auth import Workspace
+from services.secret_store_service import SecretStoreService, fingerprint_pubkey
+from utils.exceptions import AuthorizationError, BadRequestError
+
+PUBKEY_A = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+CIPHERTEXT = "-----BEGIN AGE ENCRYPTED FILE-----\nopaque==\n-----END AGE ENCRYPTED FILE-----"
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def ctx(db_session):
+    """Fresh workspace + service + auth principals; cascade teardown."""
+    ws_id = uuid.uuid4()
+    db_session.add(Workspace(id=ws_id, name=f"sec-rt-{ws_id}", owner_user_id="owner-1"))
+    await db_session.flush()
+    svc = SecretStoreService(db_session)
+    member = {"user_id": "alice", "current_workspace_id": ws_id}
+    admin = {"user_id": "owner-1", "current_workspace_id": ws_id}
+    owner = ("owner-1", ws_id)
+    yield {
+        "ws": ws_id,
+        "svc": svc,
+        "db": db_session,
+        "member": member,
+        "admin": admin,
+        "owner": owner,
+    }
+    # Audit log is append-only; TRUNCATE bypasses the migration's row trigger
+    # (the documented test-cleanup escape), so cleanup works with or without it.
+    await db_session.rollback()
+    await db_session.execute(text("TRUNCATE secret_access_log"))
+    await db_session.execute(text("DELETE FROM workspaces WHERE id = :w"), {"w": str(ws_id)})
+    await db_session.commit()
+
+
+async def test_register_returns_pending_pubkey(ctx):
+    resp = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A, label="laptop"),
+        ctx["member"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    assert resp.status == "pending"
+    assert resp.identity_id == "alice"
+    assert resp.fingerprint == fingerprint_pubkey(PUBKEY_A)
+
+
+async def test_put_before_approve_is_400(ctx):
+    pk = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A), ctx["member"], svc=ctx["svc"], db=ctx["db"]
+    )
+    with pytest.raises(BadRequestError):
+        await put_secret(
+            SecretPut(
+                name="cf/token",
+                ciphertext=CIPHERTEXT,
+                recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+                grant_pubkey_ids=[pk.id],
+            ),
+            ctx["admin"],
+            svc=ctx["svc"],
+            db=ctx["db"],
+        )
+
+
+async def test_full_flow_register_approve_put_fetch(ctx):
+    pk = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A), ctx["member"], svc=ctx["svc"], db=ctx["db"]
+    )
+    await approve_pubkey(pk.id, ctx["owner"], svc=ctx["svc"], db=ctx["db"])
+    put = await put_secret(
+        SecretPut(
+            name="cf/token",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        ),
+        ctx["admin"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    assert put.version_number == 1
+
+    val = await fetch_secret(SecretFetch(name="cf/token"), ctx["member"], svc=ctx["svc"])
+    assert val.ciphertext == CIPHERTEXT
+    assert val.alg == "age"
+
+
+async def test_fetch_without_grant_is_403(ctx):
+    pk = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A), ctx["member"], svc=ctx["svc"], db=ctx["db"]
+    )
+    await approve_pubkey(pk.id, ctx["owner"], svc=ctx["svc"], db=ctx["db"])
+    await put_secret(
+        SecretPut(
+            name="cf/token",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        ),
+        ctx["admin"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    bob = {"user_id": "bob", "current_workspace_id": ctx["ws"]}
+    with pytest.raises(AuthorizationError):
+        await fetch_secret(SecretFetch(name="cf/token"), bob, svc=ctx["svc"])
+
+
+async def test_list_secrets_has_no_value_field(ctx):
+    pk = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A), ctx["member"], svc=ctx["svc"], db=ctx["db"]
+    )
+    await approve_pubkey(pk.id, ctx["owner"], svc=ctx["svc"], db=ctx["db"])
+    await put_secret(
+        SecretPut(
+            name="cf/token",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        ),
+        ctx["admin"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    listing = await list_secrets(ctx["admin"], svc=ctx["svc"])
+    assert len(listing) == 1
+    dumped = listing[0].model_dump()
+    assert "ciphertext" not in dumped
+    assert CIPHERTEXT not in str(dumped)
+
+
+async def test_revoke_grant_flags_rotation(ctx):
+    pk = await register_pubkey(
+        PubkeyRegister(pubkey=PUBKEY_A), ctx["member"], svc=ctx["svc"], db=ctx["db"]
+    )
+    await approve_pubkey(pk.id, ctx["owner"], svc=ctx["svc"], db=ctx["db"])
+    await put_secret(
+        SecretPut(
+            name="cf/token",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        ),
+        ctx["admin"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    resp = await revoke_grant(
+        RevokeGrant(name="cf/token", recipient_pubkey_id=pk.id),
+        ctx["admin"],
+        svc=ctx["svc"],
+        db=ctx["db"],
+    )
+    assert resp.rotation_needed is True

--- a/backend/tests/integration/test_secret_store_integration.py
+++ b/backend/tests/integration/test_secret_store_integration.py
@@ -18,11 +18,13 @@ import uuid
 import pytest
 import pytest_asyncio
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
 
 import models.secrets  # noqa: F401  — register tables for create_all
 from models.auth import Workspace
 from models.secrets import (
     PUBKEY_STATUS_ACTIVE,
+    PUBKEY_STATUS_PENDING,
     RecipientPubkey,
     Secret,
     SecretAccessLog,
@@ -31,6 +33,7 @@ from models.secrets import (
 )
 from services.secret_store_service import (
     SecretAccessDenied,
+    SecretNotFound,
     SecretStoreService,
     fingerprint_pubkey,
 )
@@ -47,6 +50,23 @@ CIPHERTEXT = (
 )
 
 
+async def _wipe_audit(db):
+    """Clear the append-only audit table for cleanup.
+
+    The migration installs a row UPDATE/DELETE trigger AND a statement TRUNCATE
+    trigger; if either is present (e.g. the drift/migration test applied them to
+    this DB), DELETE and TRUNCATE are both blocked. Drop them first (IF EXISTS —
+    harmless when absent), then TRUNCATE.
+    """
+    await db.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_no_truncate ON secret_access_log")
+    )
+    await db.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log")
+    )
+    await db.execute(text("TRUNCATE secret_access_log"))
+
+
 @pytest_asyncio.fixture(loop_scope="session")
 async def ws(db_session):
     """A fresh workspace per test; teardown cascades the secret tables."""
@@ -57,12 +77,9 @@ async def ws(db_session):
     await db_session.flush()
     yield workspace_id
     # Cleanup: get_secret() commits, so rows may be durable. Delete by workspace
-    # (CASCADE removes pubkeys/secrets/versions/grants); the audit log has no FK
-    # and is append-only — if the migration's trigger is present (e.g. after the
-    # drift test applied it to this DB) DELETE is blocked, so TRUNCATE it (row
-    # triggers do not fire on TRUNCATE — the documented test-cleanup escape).
+    # (CASCADE removes pubkeys/secrets/versions/grants); the audit log is append-only.
     await db_session.rollback()
-    await db_session.execute(text("TRUNCATE secret_access_log"))
+    await _wipe_audit(db_session)
     await db_session.execute(text("DELETE FROM workspaces WHERE id = :w"), {"w": str(workspace_id)})
     await db_session.commit()
 
@@ -288,13 +305,14 @@ async def test_list_secrets_never_returns_ciphertext(db_session, ws):
     assert CIPHERTEXT not in str(entry)
 
 
-async def test_audit_log_append_only_trigger(db_session, ws):
-    """The migration's BEFORE UPDATE OR DELETE trigger blocks row mutation.
+async def test_audit_log_append_only_triggers(db_session, ws):
+    """The migration's triggers block UPDATE, DELETE, AND TRUNCATE.
 
-    create_all does not install triggers, so we install the migration's DDL
-    here, then assert UPDATE and DELETE on a logged row are rejected.
+    create_all does not install triggers, so we install the migration's DDL here,
+    then assert in-band mutation (UPDATE/DELETE) and a full-table TRUNCATE — which
+    would silently reset the hash chain to genesis — are all rejected.
     """
-    # Install the same trigger the migration ships.
+    # Install the same triggers the migration ships (row UPDATE/DELETE + TRUNCATE).
     await db_session.execute(
         text(
             """
@@ -321,6 +339,18 @@ async def test_audit_log_append_only_trigger(db_session, ws):
             """
         )
     )
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_no_truncate ON secret_access_log")
+    )
+    await db_session.execute(
+        text(
+            """
+            CREATE TRIGGER secret_access_log_no_truncate
+            BEFORE TRUNCATE ON secret_access_log
+            FOR EACH STATEMENT EXECUTE FUNCTION secret_access_log_no_mutate();
+            """
+        )
+    )
     await db_session.commit()
     try:
         svc = SecretStoreService(db_session)
@@ -339,8 +369,15 @@ async def test_audit_log_append_only_trigger(db_session, ws):
                 text("DELETE FROM secret_access_log WHERE workspace_id = :w"), {"w": str(ws)}
             )
         await db_session.rollback()
+
+        with pytest.raises(Exception, match="append-only"):
+            await db_session.execute(text("TRUNCATE secret_access_log"))
+        await db_session.rollback()
     finally:
-        # Drop the trigger so other tests / the fixture teardown can DELETE rows.
+        # Drop the triggers so the fixture teardown can wipe rows.
+        await db_session.execute(
+            text("DROP TRIGGER IF EXISTS secret_access_log_no_truncate ON secret_access_log")
+        )
         await db_session.execute(
             text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log")
         )
@@ -403,3 +440,222 @@ async def test_stored_secret_not_enqueued_for_embedding(db_session, ws):
     # And the SecretVersion ciphertext is not stored in any Memory row.
     mem_rows = await db_session.execute(select(Memory).where(Memory.summary == CIPHERTEXT))
     assert mem_rows.scalar_one_or_none() is None
+
+
+# --- all-plans availability (no SKU gate) --------------------------------------
+
+
+async def test_full_flow_works_on_free_plan(db_session):
+    """The secret store has NO plan/SKU gate — the full flow works on 'free'.
+
+    Gating is by workspace role only; nothing in the service or routes branches
+    on plan_name. A free-tier workspace (even with the smallest API limit)
+    completes register → approve → put → get. (The MCP rate-limit exemption that
+    keeps it usable under a low daily quota is pinned in test_secrets_tools.py.)
+    """
+    ws_id = uuid.uuid4()
+    db_session.add(
+        Workspace(
+            id=ws_id,
+            name=f"free-ws-{ws_id}",
+            owner_user_id="owner-1",
+            plan_name="free",
+            daily_api_limit=1,
+        )
+    )
+    await db_session.flush()
+    try:
+        svc = SecretStoreService(db_session)
+        pk = await _register_and_approve(svc, ws_id, "alice", PUBKEY_A)
+        await svc.put_secret(
+            workspace_id=ws_id,
+            actor_user_id="owner-1",
+            name="cloudflare/api-token",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        )
+        got = await svc.get_secret(
+            workspace_id=ws_id, actor_user_id="alice", name="cloudflare/api-token"
+        )
+        assert got["ciphertext"] == CIPHERTEXT
+    finally:
+        await db_session.rollback()
+        await _wipe_audit(db_session)
+        await db_session.execute(text("DELETE FROM workspaces WHERE id = :w"), {"w": str(ws_id)})
+        await db_session.commit()
+
+
+# --- audit chain verification & integrity (review W2/W4/W5/W7/W8) --------------
+
+
+async def test_verify_audit_chain_valid_then_detects_tampering(db_session, ws):
+    """verify_audit_chain recomputes the HMAC chain and catches a stale entry_hash.
+
+    The 'valid is True' assertion also proves created_at round-trips (verify
+    recomputes using the stored created_at.isoformat()).
+    """
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="db/pw",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="db/pw")
+
+    ok = await svc.verify_audit_chain(workspace_id=ws)
+    assert ok["valid"] is True
+    assert ok["entries"] >= 4
+
+    # Tamper a chained field out-of-band (drop the append-only triggers first so
+    # the UPDATE is possible — simulating an attacker who bypassed them).
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_no_truncate ON secret_access_log")
+    )
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log")
+    )
+    await db_session.execute(
+        text(
+            "UPDATE secret_access_log SET recipient_identity = 'evil' "
+            "WHERE id = (SELECT min(id) FROM secret_access_log WHERE workspace_id = :w)"
+        ),
+        {"w": str(ws)},
+    )
+    await db_session.commit()
+
+    bad = await svc.verify_audit_chain(workspace_id=ws)
+    assert bad["valid"] is False
+    assert bad["reason"] == "entry_hash_mismatch"
+
+
+async def test_put_multi_recipient_integrity(db_session, ws):
+    """Grant ⇄ recipients_snapshot equality holds with >1 recipient (both directions)."""
+    svc = SecretStoreService(db_session)
+    pk_a = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    pk_b = await _register_and_approve(svc, ws, "bob", PUBKEY_B)
+    fp_a, fp_b = fingerprint_pubkey(PUBKEY_A), fingerprint_pubkey(PUBKEY_B)
+
+    # Both granted + both in snapshot → ok, two active grants, both can fetch.
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="multi",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fp_a, fp_b],
+        grant_pubkey_ids=[pk_a.id, pk_b.id],
+    )
+    listing = await svc.list_secrets(workspace_id=ws)
+    assert listing[0]["grant_count"] == 2
+    assert (await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="multi"))[
+        "ciphertext"
+    ] == CIPHERTEXT
+    assert (await svc.get_secret(workspace_id=ws, actor_user_id="bob", name="multi"))[
+        "ciphertext"
+    ] == CIPHERTEXT
+
+    # Subset: grants=[A,B] but snapshot=[A] → reject (a grantee who can't decrypt).
+    with pytest.raises(ValueError, match="recipients_snapshot"):
+        await svc.put_secret(
+            workspace_id=ws,
+            actor_user_id="owner-1",
+            name="sub",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fp_a],
+            grant_pubkey_ids=[pk_a.id, pk_b.id],
+        )
+    # Superset: grants=[A] but snapshot=[A,B] → reject (decrypts without a grant).
+    with pytest.raises(ValueError, match="recipients_snapshot"):
+        await svc.put_secret(
+            workspace_id=ws,
+            actor_user_id="owner-1",
+            name="sup",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fp_a, fp_b],
+            grant_pubkey_ids=[pk_a.id],
+        )
+
+
+async def test_default_deny_wrong_recipient_and_inactive_pubkey(db_session, ws):
+    """Default-deny isolates the identity_id and pubkey-status predicates."""
+    svc = SecretStoreService(db_session)
+    pk_a = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await _register_and_approve(svc, ws, "bob", PUBKEY_B)  # bob approved but NOT granted
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="s",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk_a.id],
+    )
+    # bob has an active pubkey but no grant → denied (isolates identity_id match).
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="bob", name="s")
+    # alice works while her pubkey is active.
+    await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="s")
+
+    # Flip alice's pubkey to pending WITHOUT touching the grant → denied (isolates
+    # the status == ACTIVE predicate; recipient_pubkeys has no append-only trigger).
+    pk_a.status = PUBKEY_STATUS_PENDING
+    await db_session.flush()
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="s")
+
+
+async def test_audit_chain_unique_constraint_prevents_fork(db_session, ws):
+    """uq_secret_access_log_ws_prev rejects a second writer on the same chain tip."""
+    db_session.add_all(
+        [
+            SecretAccessLog(
+                workspace_id=ws,
+                actor_user_id="a",
+                action="register",
+                result="ok",
+                prev_hash="0" * 64,
+                entry_hash="a" * 64,
+            ),
+            SecretAccessLog(
+                workspace_id=ws,
+                actor_user_id="b",
+                action="register",
+                result="ok",
+                prev_hash="0" * 64,
+                entry_hash="b" * 64,
+            ),
+        ]
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+async def test_get_missing_version_logs_denied_audit(db_session, ws):
+    """A grant-OK but missing-version get raises SecretNotFound AND commits a denied audit."""
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="s",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    with pytest.raises(SecretNotFound):
+        await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="s", version_number=2)
+
+    rows = await db_session.execute(
+        select(SecretAccessLog).where(
+            SecretAccessLog.workspace_id == ws,
+            SecretAccessLog.action == "get",
+            SecretAccessLog.result == "denied",
+        )
+    )
+    denied = list(rows.scalars().all())
+    assert len(denied) == 1
+    assert denied[0].secret_id is not None  # the secret was found; only the version was missing

--- a/backend/tests/integration/test_secret_store_integration.py
+++ b/backend/tests/integration/test_secret_store_integration.py
@@ -20,7 +20,6 @@ import pytest_asyncio
 from sqlalchemy import select, text
 from sqlalchemy.exc import IntegrityError
 
-import models.secrets  # noqa: F401  — register tables for create_all
 from models.auth import Workspace
 from models.secrets import (
     PUBKEY_STATUS_ACTIVE,
@@ -659,3 +658,68 @@ async def test_get_missing_version_logs_denied_audit(db_session, ws):
     denied = list(rows.scalars().all())
     assert len(denied) == 1
     assert denied[0].secret_id is not None  # the secret was found; only the version was missing
+
+
+async def test_denied_get_audits_secret_id_when_secret_exists(db_session, ws):
+    """An unauthorized probe of a REAL secret name records secret_id server-side.
+
+    The caller still gets a uniform SecretAccessDenied (no existence leak), but
+    the audit attributes the probe to the secret for incident response.
+    """
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="cloudflare/api-token",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    # bob has no grant; probing the REAL name is denied but logged with secret_id.
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="bob", name="cloudflare/api-token")
+    # probing a NON-existent name is denied with secret_id NULL.
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="bob", name="does/not-exist")
+
+    rows = await db_session.execute(
+        select(SecretAccessLog)
+        .where(SecretAccessLog.workspace_id == ws, SecretAccessLog.result == "denied")
+        .order_by(SecretAccessLog.id.asc())
+    )
+    denied = list(rows.scalars().all())
+    assert len(denied) == 2
+    assert denied[0].secret_id is not None  # real-secret probe → attributable
+    assert denied[1].secret_id is None  # nonexistent-name probe → no id
+
+
+async def test_req_meta_persisted_and_chain_still_verifies(db_session, ws):
+    """req_meta (source/ip/ua) is stored and does not break the HMAC chain."""
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="s",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+        req_meta={"source": "rest"},
+    )
+    await svc.get_secret(
+        workspace_id=ws,
+        actor_user_id="alice",
+        name="s",
+        req_meta={"source": "mcp", "tool": "secret_get"},
+    )
+    # The get audit row carries the metadata.
+    get_rows = await db_session.execute(
+        select(SecretAccessLog).where(
+            SecretAccessLog.workspace_id == ws, SecretAccessLog.action == "get"
+        )
+    )
+    get_entry = get_rows.scalar_one()
+    assert get_entry.req_meta == {"source": "mcp", "tool": "secret_get"}
+    # Chain still verifies with req_meta populated (payload includes it).
+    assert (await svc.verify_audit_chain(workspace_id=ws))["valid"] is True

--- a/backend/tests/integration/test_secret_store_integration.py
+++ b/backend/tests/integration/test_secret_store_integration.py
@@ -1,0 +1,405 @@
+"""Integration tests for the zero-knowledge secret store (#1128).
+
+Runs against a real PostgreSQL (the ``db_session`` fixture). Importing
+``models.secrets`` here registers the tables with the shared metadata so
+conftest's ``create_all`` builds them.
+
+Note on the append-only trigger: conftest builds the schema with ``create_all``
+(model metadata), which does NOT include the DB trigger (triggers are not part
+of SQLAlchemy metadata). ``test_audit_log_append_only_trigger`` installs the
+trigger via the same DDL the migration uses and asserts it blocks mutation —
+proving the SQL the migration ships is correct.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+
+import models.secrets  # noqa: F401  — register tables for create_all
+from models.auth import Workspace
+from models.secrets import (
+    PUBKEY_STATUS_ACTIVE,
+    RecipientPubkey,
+    Secret,
+    SecretAccessLog,
+    SecretGrant,
+    SecretVersion,
+)
+from services.secret_store_service import (
+    SecretAccessDenied,
+    SecretStoreService,
+    fingerprint_pubkey,
+)
+
+# asyncio_mode=auto (pyproject) auto-marks async tests; session loop scope is the
+# configured default, so the session-scoped db_session/engine fixtures bind cleanly.
+
+# Shape-valid age recipient keys (distinct). Not real crypto — the server only
+# stores opaque ciphertext and never decrypts.
+PUBKEY_A = "age1ql3z7hjy54pw3hyww5ayyfg7zqgvc7w3j2elw8zmrj2kg5sfn9aqmcac8p"
+PUBKEY_B = "age1lggyhqrw2nlhcxprm67z43rta597azn8gknawjehu9d9dl0jq3yqqvfafg"
+CIPHERTEXT = (
+    "-----BEGIN AGE ENCRYPTED FILE-----\nfakeopaqueciphertext==\n-----END AGE ENCRYPTED FILE-----"
+)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def ws(db_session):
+    """A fresh workspace per test; teardown cascades the secret tables."""
+    workspace_id = uuid.uuid4()
+    db_session.add(
+        Workspace(id=workspace_id, name=f"sec-test-{workspace_id}", owner_user_id="owner-1")
+    )
+    await db_session.flush()
+    yield workspace_id
+    # Cleanup: get_secret() commits, so rows may be durable. Delete by workspace
+    # (CASCADE removes pubkeys/secrets/versions/grants); the audit log has no FK
+    # and is append-only — if the migration's trigger is present (e.g. after the
+    # drift test applied it to this DB) DELETE is blocked, so TRUNCATE it (row
+    # triggers do not fire on TRUNCATE — the documented test-cleanup escape).
+    await db_session.rollback()
+    await db_session.execute(text("TRUNCATE secret_access_log"))
+    await db_session.execute(text("DELETE FROM workspaces WHERE id = :w"), {"w": str(workspace_id)})
+    await db_session.commit()
+
+
+async def _register_and_approve(svc: SecretStoreService, ws_id, identity: str, pubkey: str):
+    pk = await svc.register_pubkey(workspace_id=ws_id, actor_user_id=identity, pubkey=pubkey)
+    await svc.approve_pubkey(workspace_id=ws_id, actor_user_id="owner-1", pubkey_id=pk.id)
+    return pk
+
+
+async def test_register_approve_put_get_happy_path(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    assert pk.status == PUBKEY_STATUS_ACTIVE
+    assert pk.attested_at is not None
+
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="cloudflare/api-token",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+
+    got = await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="cloudflare/api-token")
+    # Server round-trips opaque ciphertext byte-for-byte; never decrypts.
+    assert got["ciphertext"] == CIPHERTEXT
+    assert got["version_number"] == 1
+    assert got["alg"] == "age"
+
+
+async def test_get_default_deny_without_grant(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk_alice = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="resend/key",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk_alice.id],
+    )
+    # Bob has no grant → uniform deny.
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="bob", name="resend/key")
+
+    # The denied attempt is durably logged (fail-closed audit, committed).
+    rows = await db_session.execute(
+        select(SecretAccessLog).where(
+            SecretAccessLog.workspace_id == ws,
+            SecretAccessLog.action == "get",
+            SecretAccessLog.result == "denied",
+        )
+    )
+    assert len(list(rows.scalars().all())) == 1
+
+
+async def test_get_unknown_secret_is_uniform_deny(db_session, ws):
+    svc = SecretStoreService(db_session)
+    # No such secret → same SecretAccessDenied, not a 404 (no existence leak).
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="does/not-exist")
+
+
+async def test_put_rejects_grant_to_unapproved_pubkey(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await svc.register_pubkey(workspace_id=ws, actor_user_id="alice", pubkey=PUBKEY_A)
+    # pk is pending (not approved) → grant rejected.
+    with pytest.raises(ValueError, match="approved"):
+        await svc.put_secret(
+            workspace_id=ws,
+            actor_user_id="owner-1",
+            name="gcp/sa",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+            grant_pubkey_ids=[pk.id],
+        )
+
+
+async def test_put_rejects_recipients_snapshot_mismatch(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    # Snapshot claims a DIFFERENT recipient than the grant → integrity error.
+    with pytest.raises(ValueError, match="recipients_snapshot"):
+        await svc.put_secret(
+            workspace_id=ws,
+            actor_user_id="owner-1",
+            name="gcp/sa",
+            ciphertext=CIPHERTEXT,
+            recipients_snapshot=[fingerprint_pubkey(PUBKEY_B)],
+            grant_pubkey_ids=[pk.id],
+        )
+
+
+async def test_put_rejects_invalid_pubkey(db_session, ws):
+    svc = SecretStoreService(db_session)
+    with pytest.raises(ValueError, match="age recipient"):
+        await svc.register_pubkey(workspace_id=ws, actor_user_id="alice", pubkey="not-an-age-key")
+
+
+async def test_revoke_grant_sets_rotation_and_blocks_future_get(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="cloudflare/api-token",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    # Works before revoke.
+    await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="cloudflare/api-token")
+
+    secret = await svc.revoke_grant(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="cloudflare/api-token",
+        recipient_pubkey_id=pk.id,
+    )
+    assert secret.rotation_needed is True
+
+    # Future fetch denied (revoke stops future reads).
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="cloudflare/api-token")
+
+
+async def test_revoke_pubkey_revokes_dependent_grants(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="cloudflare/api-token",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    await svc.revoke_pubkey(workspace_id=ws, actor_user_id="owner-1", pubkey_id=pk.id)
+
+    with pytest.raises(SecretAccessDenied):
+        await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="cloudflare/api-token")
+
+
+async def test_version_pinning(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    fp = fingerprint_pubkey(PUBKEY_A)
+    v1_ct = CIPHERTEXT + "_v1"
+    v2_ct = CIPHERTEXT + "_v2"
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="db/pw",
+        ciphertext=v1_ct,
+        recipients_snapshot=[fp],
+        grant_pubkey_ids=[pk.id],
+    )
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="db/pw",
+        ciphertext=v2_ct,
+        recipients_snapshot=[fp],
+        grant_pubkey_ids=[pk.id],
+    )
+    latest = await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="db/pw")
+    assert latest["version_number"] == 2
+    assert latest["ciphertext"] == v2_ct
+
+    pinned = await svc.get_secret(
+        workspace_id=ws, actor_user_id="alice", name="db/pw", version_number=1
+    )
+    assert pinned["ciphertext"] == v1_ct
+
+
+async def test_audit_hash_chain_links(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="db/pw",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    await svc.get_secret(workspace_id=ws, actor_user_id="alice", name="db/pw")
+
+    rows = await db_session.execute(
+        select(SecretAccessLog)
+        .where(SecretAccessLog.workspace_id == ws)
+        .order_by(SecretAccessLog.id.asc())
+    )
+    entries = list(rows.scalars().all())
+    assert len(entries) >= 4  # register, approve, put, get
+    # First entry chains from genesis; each subsequent prev_hash == prior entry_hash.
+    assert entries[0].prev_hash == "0" * 64
+    for prev, cur in zip(entries, entries[1:], strict=False):
+        assert cur.prev_hash == prev.entry_hash
+
+
+async def test_list_secrets_never_returns_ciphertext(db_session, ws):
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="db/pw",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    listing = await svc.list_secrets(workspace_id=ws)
+    assert len(listing) == 1
+    entry = listing[0]
+    assert entry["name"] == "db/pw"
+    assert entry["current_version"] == 1
+    assert entry["grant_count"] == 1
+    # No ciphertext / value anywhere in the listing payload.
+    assert "ciphertext" not in entry
+    assert CIPHERTEXT not in str(entry)
+
+
+async def test_audit_log_append_only_trigger(db_session, ws):
+    """The migration's BEFORE UPDATE OR DELETE trigger blocks row mutation.
+
+    create_all does not install triggers, so we install the migration's DDL
+    here, then assert UPDATE and DELETE on a logged row are rejected.
+    """
+    # Install the same trigger the migration ships.
+    await db_session.execute(
+        text(
+            """
+            CREATE OR REPLACE FUNCTION secret_access_log_no_mutate()
+            RETURNS trigger AS $$
+            BEGIN
+                RAISE EXCEPTION
+                    'secret_access_log is append-only; % is not permitted', TG_OP
+                    USING ERRCODE = 'restrict_violation';
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log")
+    )
+    await db_session.execute(
+        text(
+            """
+            CREATE TRIGGER secret_access_log_append_only
+            BEFORE UPDATE OR DELETE ON secret_access_log
+            FOR EACH ROW EXECUTE FUNCTION secret_access_log_no_mutate();
+            """
+        )
+    )
+    await db_session.commit()
+    try:
+        svc = SecretStoreService(db_session)
+        await svc.register_pubkey(workspace_id=ws, actor_user_id="alice", pubkey=PUBKEY_A)
+        await db_session.commit()
+
+        with pytest.raises(Exception, match="append-only"):
+            await db_session.execute(
+                text("UPDATE secret_access_log SET result = 'error' WHERE workspace_id = :w"),
+                {"w": str(ws)},
+            )
+        await db_session.rollback()
+
+        with pytest.raises(Exception, match="append-only"):
+            await db_session.execute(
+                text("DELETE FROM secret_access_log WHERE workspace_id = :w"), {"w": str(ws)}
+            )
+        await db_session.rollback()
+    finally:
+        # Drop the trigger so other tests / the fixture teardown can DELETE rows.
+        await db_session.execute(
+            text("DROP TRIGGER IF EXISTS secret_access_log_append_only ON secret_access_log")
+        )
+        await db_session.execute(text("DROP FUNCTION IF EXISTS secret_access_log_no_mutate()"))
+        await db_session.commit()
+
+
+# --- recall / embedding isolation (gate1 #1128, sibling #210) ------------------
+
+
+def test_secret_models_have_no_embedding_status():
+    """Secret tables must lack an ``embedding_status`` column.
+
+    The embedding sweep query is typed to ``Memory`` and keys off
+    ``Memory.embedding_status``; a secret table that never has that column can
+    never be enqueued for embedding (one half of the isolation guarantee).
+    """
+    for model in (RecipientPubkey, Secret, SecretVersion, SecretGrant, SecretAccessLog):
+        assert "embedding_status" not in model.__table__.columns
+
+
+def test_secret_tables_are_not_the_memories_table():
+    """Recall reads only the ``memories`` table; secret tables are separate."""
+    from models.memory import Memory
+
+    assert Memory.__tablename__ == "memories"
+    secret_tables = {
+        RecipientPubkey.__tablename__,
+        Secret.__tablename__,
+        SecretVersion.__tablename__,
+        SecretGrant.__tablename__,
+        SecretAccessLog.__tablename__,
+    }
+    assert "memories" not in secret_tables
+
+
+async def test_stored_secret_not_enqueued_for_embedding(db_session, ws):
+    """A stored secret never appears among the embedding sweep's candidates."""
+    from models.memory import Memory
+
+    svc = SecretStoreService(db_session)
+    pk = await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await svc.put_secret(
+        workspace_id=ws,
+        actor_user_id="owner-1",
+        name="db/pw",
+        ciphertext=CIPHERTEXT,
+        recipients_snapshot=[fingerprint_pubkey(PUBKEY_A)],
+        grant_pubkey_ids=[pk.id],
+    )
+    # The sweep's candidate query (tasks/embedding_tasks.py) is typed to Memory;
+    # replicate its shape and assert no secret data is reachable through it.
+    candidates = await db_session.execute(
+        select(Memory.id).where(Memory.embedding_status == "pending")
+    )
+    ids = list(candidates.scalars().all())
+    # No Memory rows exist for this workspace's secret — the secret is invisible
+    # to the embedding pipeline (different table, no embedding_status column).
+    assert all(isinstance(i, uuid.UUID) for i in ids)  # type sanity; never a secret id
+    # And the SecretVersion ciphertext is not stored in any Memory row.
+    mem_rows = await db_session.execute(select(Memory).where(Memory.summary == CIPHERTEXT))
+    assert mem_rows.scalar_one_or_none() is None

--- a/backend/tests/mcp_server/test_secrets_tools.py
+++ b/backend/tests/mcp_server/test_secrets_tools.py
@@ -13,7 +13,12 @@ import uuid
 
 import pytest
 
-from mcp_server.tools import _TOOLS_WITHOUT_CONTEXT_ID, _build_registry, get_tool_definitions
+from mcp_server.tools import (
+    _RATE_LIMIT_EXEMPT_TOOLS,
+    _TOOLS_WITHOUT_CONTEXT_ID,
+    _build_registry,
+    get_tool_definitions,
+)
 from mcp_server.tools.secrets import (
     handle_secret_get,
     handle_secret_list,
@@ -44,6 +49,15 @@ def test_secret_tools_registered_and_defined():
         assert name in defs, f"{name} missing from definitions"
         # Workspace-scoped, not memory-context-scoped.
         assert name in _TOOLS_WITHOUT_CONTEXT_ID
+
+
+def test_secret_tools_are_rate_limit_exempt():
+    # Available on every plan (incl. free): secret ops carry no embedding/LLM
+    # cost, so the memory daily quota must not lock a user out of their secrets.
+    for name in SECRET_TOOLS:
+        assert name in _RATE_LIMIT_EXEMPT_TOOLS, (
+            f"{name} should be exempt from the memory rate limit"
+        )
 
 
 def test_definitions_have_required_schema_fields():
@@ -119,3 +133,43 @@ async def test_revoke_grant_validates_uuid():
         )
     )
     assert out["error"] == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_owner_admin_tools_reject_member(monkeypatch):
+    """secret_put/list/revoke_grant return 'forbidden' for a non-admin role.
+
+    Stub the workspace-role lookup (member) and the DB session (the handler
+    returns before touching it), so the deny path is tested without a live DB.
+    """
+    from unittest.mock import AsyncMock
+
+    import mcp_server.tools.secrets as mod
+
+    async def _fake_db():
+        yield None  # the role check is stubbed; db is never used before the deny
+
+    monkeypatch.setattr(mod, "get_db", lambda: _fake_db())
+    monkeypatch.setattr(mod, "_get_workspace_member_role", AsyncMock(return_value="member"))
+
+    ws = uuid.uuid4()
+    put = _decode(
+        await handle_secret_put(
+            {
+                "name": "n",
+                "ciphertext": "c",
+                "recipients_snapshot": ["fp"],
+                "grant_pubkey_ids": [str(uuid.uuid4())],
+            },
+            "u",
+            ws,
+        )
+    )
+    assert put["error"] == "forbidden"
+    assert _decode(await handle_secret_list({}, "u", ws))["error"] == "forbidden"
+    rev = _decode(
+        await handle_secret_revoke_grant(
+            {"name": "n", "recipient_pubkey_id": str(uuid.uuid4())}, "u", ws
+        )
+    )
+    assert rev["error"] == "forbidden"

--- a/backend/tests/mcp_server/test_secrets_tools.py
+++ b/backend/tests/mcp_server/test_secrets_tools.py
@@ -1,0 +1,121 @@
+"""MCP tool tests for the zero-knowledge secret store (#1128).
+
+Covers the MCP-specific surface: registry/definition consistency and the
+workspace-guard + argument-validation branches (which return before any DB
+access). The data path itself is exercised by the service and route integration
+tests — the MCP handlers are thin wrappers over the same ``SecretStoreService``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from mcp_server.tools import _TOOLS_WITHOUT_CONTEXT_ID, _build_registry, get_tool_definitions
+from mcp_server.tools.secrets import (
+    handle_secret_get,
+    handle_secret_list,
+    handle_secret_put,
+    handle_secret_register_pubkey,
+    handle_secret_revoke_grant,
+)
+
+SECRET_TOOLS = [
+    "secret_register_pubkey",
+    "secret_put",
+    "secret_get",
+    "secret_list",
+    "secret_revoke_grant",
+]
+
+
+def _decode(resp):
+    assert len(resp) == 1
+    return json.loads(resp[0].text)
+
+
+def test_secret_tools_registered_and_defined():
+    reg = _build_registry()
+    defs = {d["name"] for d in get_tool_definitions()}
+    for name in SECRET_TOOLS:
+        assert name in reg, f"{name} missing from registry"
+        assert name in defs, f"{name} missing from definitions"
+        # Workspace-scoped, not memory-context-scoped.
+        assert name in _TOOLS_WITHOUT_CONTEXT_ID
+
+
+def test_definitions_have_required_schema_fields():
+    by_name = {d["name"]: d for d in get_tool_definitions()}
+    assert by_name["secret_put"]["inputSchema"]["required"] == [
+        "name",
+        "ciphertext",
+        "recipients_snapshot",
+        "grant_pubkey_ids",
+    ]
+    assert by_name["secret_get"]["inputSchema"]["required"] == ["name"]
+    # secret_list takes no args.
+    assert by_name["secret_list"]["inputSchema"]["properties"] == {}
+
+
+@pytest.mark.asyncio
+async def test_workspace_required_guard():
+    # Every tool fails closed when there is no workspace context.
+    for handler, args in [
+        (handle_secret_register_pubkey, {"pubkey": "age1xxx"}),
+        (handle_secret_put, {"name": "n"}),
+        (handle_secret_get, {"name": "n"}),
+        (handle_secret_list, {}),
+        (handle_secret_revoke_grant, {"name": "n", "recipient_pubkey_id": str(uuid.uuid4())}),
+    ]:
+        out = _decode(await handler(args, "user-1", None))
+        assert out["status"] == "error"
+        assert out["error"] == "workspace_required"
+
+
+@pytest.mark.asyncio
+async def test_register_requires_pubkey():
+    out = _decode(await handle_secret_register_pubkey({}, "user-1", uuid.uuid4()))
+    assert out["status"] == "error"
+    assert out["error"] == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_put_validates_required_args():
+    ws = uuid.uuid4()
+    # Missing ciphertext.
+    out = _decode(await handle_secret_put({"name": "n"}, "u", ws))
+    assert out["error"] == "invalid_arguments"
+    # Bad UUID in grant list.
+    out = _decode(
+        await handle_secret_put(
+            {
+                "name": "n",
+                "ciphertext": "ct",
+                "recipients_snapshot": ["fp"],
+                "grant_pubkey_ids": ["not-a-uuid"],
+            },
+            "u",
+            ws,
+        )
+    )
+    assert out["error"] == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_get_validates_version_number_type():
+    out = _decode(
+        await handle_secret_get({"name": "n", "version_number": "two"}, "u", uuid.uuid4())
+    )
+    assert out["error"] == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+async def test_revoke_grant_validates_uuid():
+    out = _decode(
+        await handle_secret_revoke_grant(
+            {"name": "n", "recipient_pubkey_id": "nope"}, "u", uuid.uuid4()
+        )
+    )
+    assert out["error"] == "invalid_arguments"


### PR DESCRIPTION
Closes #1128

## Summary
- Backend-only **zero-knowledge secret store** for devops API keys: the server stores opaque `age` (X25519) ciphertext + public recipient keys only and **never decrypts** (does not reuse the Fernet/`utils.encryption` server-custody path). Encryption/decryption is client-side (`kagura-memory-python-sdk`, separate repo).
- 5 isolated workspace-scoped tables + Alembic `e50`. Tamper-evident **per-workspace HMAC hash-chain audit** with DB **append-only triggers** (UPDATE/DELETE **and** TRUNCATE), `(workspace_id, prev_hash)` anti-fork constraint, 64-bit `hashtextextended` advisory-lock serialization, and a `verify_audit_chain()` recompute path.
- REST (owner/admin management + member fetch) and **5 MCP tools**. Default-deny reads with **fail-closed audit committed before ciphertext**; grant ⇄ `recipients_snapshot` integrity at put; `revoke` = stop-future-fetch + `rotation_needed` (not retroactive un-share); pubkey register → owner-approve (TOFU).
- **recall/embedding isolation** (own tables, no `embedding_status`; structurally invisible to the Memory-bound sweep/recall). **All plans (free incl.)** — no SKU gate; secret MCP tools exempt from the memory daily rate-limit (zero embedding/LLM cost).

## Implementation notes
- Dedicated-table pattern mirroring the shipped #1027 `share_keys` precedent (security invariants structural, not policy).
- New: `models/secrets.py`, `services/secret_store_service.py`, `api/routes/secrets.py`, `mcp_server/tools/secrets.py`, `alembic/versions/e50_1128_secret_store.py`. Wiring: `alembic/env.py`, `api/main.py`, `models/__init__.py`, `mcp_server/tools/{__init__,_definitions}.py`.
- HMAC hash-chain audit + DB append-only triggers are **net-new patterns** (no prior repo precedent), introduced for tamper-evidence.

## Pre-PR review summary
- gate2 mode: advisor-only — **cso: green**, **qa-lead: green**, **cto: green**
- Prior 25-agent adversarial review: **0 critical / 8 warnings (all fixed) / 10 nits**.
- Verification: **408 backend tests pass** (schema-drift, alembic up/down, integration, route, MCP); `ruff` + `pyright` clean.

## Follow-ups (non-blocking)
- Production boot-guard rejecting the default `audit_hmac_key` / `jwt_secret` (`config/settings.py`; pre-existing, now load-bearing for the audit chain).
- Offsite checkpoint of each workspace's audit head hash (defense against a DDL-privileged trigger DROP).
- Client `kagura secret` CLI + `age` keypair handling in `kagura-memory-python-sdk` (separate repo).

🤖 Generated via /gh-issue-driven:ship
