### PR TITLE
feat(frontend): localize plan tier labels with env override

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
@@ -28,10 +28,13 @@ import { useToast } from "@/hooks/use-toast";
 import { getWorkspacePlan, type WorkspacePlanInfo } from "@/lib/api/workspaces";
 import { mintBillingHandoff } from "@/lib/api/billing";
 import { ApiError } from "@/lib/api/base";
+import { useLocale } from "@/i18n";
+import { planLabelFromEnv, type PlanTier } from "@/lib/utils/planLabel";
 
 export default function WorkspacePlanPage() {
   const t = useTranslations("workspace");
   const tCommon = useTranslations("common");
+  const { locale } = useLocale();
   const { currentWorkspaceId, currentWorkspace } = useWorkspace();
   const { toast } = useToast();
 
@@ -105,8 +108,15 @@ export default function WorkspacePlanPage() {
     );
   }
 
+  // Label precedence: localized tier label (OSS default S/M/L, per-locale
+  // override via env) → backend display_name → raw plan_name → em dash.
+  const canonicalTier = currentWorkspace?.plan_name;
   const planName =
-    plan?.plan_display_name ?? currentWorkspace?.plan_name ?? "—";
+    canonicalTier === "free" ||
+    canonicalTier === "basic" ||
+    canonicalTier === "pro"
+      ? planLabelFromEnv(canonicalTier as PlanTier, locale)
+      : (plan?.plan_display_name ?? canonicalTier ?? "—");
 
   return (
     <PageContainer>

--- a/frontend/src/components/common/PlanBadge.tsx
+++ b/frontend/src/components/common/PlanBadge.tsx
@@ -1,54 +1,57 @@
+"use client";
+
 /**
  * Plan Badge Component
  *
  * Issue #149: Plan tier enforcement
  * Issue #350: Customizable display names (S/M/L default)
  *
- * Displays workspace plan tier with color coding.
- * Display names are configurable for SaaS forks.
+ * Displays workspace plan tier with color coding. The label is resolved by
+ * `planLabelFromEnv` — OSS default S/M/L, with an optional per-locale override
+ * for deployments (see lib/utils/planLabel.ts).
  */
 
-import { Badge } from '@/components/ui/badge';
-import { cn } from '@/styles/design-tokens';
+import { Badge } from "@/components/ui/badge";
+import { useLocale } from "@/i18n";
+import { planLabelFromEnv, type PlanTier } from "@/lib/utils/planLabel";
+import { cn } from "@/styles/design-tokens";
 
-export type PlanTier = 'free' | 'basic' | 'pro';
+export type { PlanTier };
 
 interface PlanBadgeProps {
   planName: PlanTier;
-  size?: 'sm' | 'md' | 'lg';
+  size?: "sm" | "md" | "lg";
   className?: string;
 }
 
 const PLAN_COLORS: Record<PlanTier, string> = {
-  free: 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100',
-  basic: 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100',
-  pro: 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-100',
-};
-
-// Default display names (customizable via NEXT_PUBLIC_PLAN_*_DISPLAY_NAME env vars)
-const PLAN_LABELS: Record<PlanTier, string> = {
-  free: process.env.NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME || 'S',
-  basic: process.env.NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME || 'M',
-  pro: process.env.NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME || 'L',
+  free: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-100",
+  basic: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-100",
+  pro: "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-100",
 };
 
 const SIZE_CLASSES = {
-  sm: 'text-xs px-2 py-0.5',
-  md: 'text-sm px-2.5 py-1',
-  lg: 'text-base px-3 py-1.5',
+  sm: "text-xs px-2 py-0.5",
+  md: "text-sm px-2.5 py-1",
+  lg: "text-base px-3 py-1.5",
 };
 
-export function PlanBadge({ planName, size = 'md', className }: PlanBadgeProps) {
+export function PlanBadge({
+  planName,
+  size = "md",
+  className,
+}: PlanBadgeProps) {
+  const { locale } = useLocale();
   return (
     <Badge
       className={cn(
         PLAN_COLORS[planName],
         SIZE_CLASSES[size],
-        'font-semibold',
-        className
+        "font-semibold",
+        className,
       )}
     >
-      {PLAN_LABELS[planName]}
+      {planLabelFromEnv(planName, locale)}
     </Badge>
   );
 }

--- a/frontend/src/lib/utils/planLabel.test.ts
+++ b/frontend/src/lib/utils/planLabel.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  DEFAULT_PLAN_LABELS,
+  parsePlanDisplayNames,
+  planLabelFromEnv,
+  resolvePlanLabel,
+  type LocalePlanLabelMap,
+} from "./planLabel";
+
+describe("parsePlanDisplayNames", () => {
+  it("returns an empty map for empty / null / undefined input", () => {
+    expect(parsePlanDisplayNames(undefined)).toEqual({});
+    expect(parsePlanDisplayNames(null)).toEqual({});
+    expect(parsePlanDisplayNames("")).toEqual({});
+  });
+
+  it("returns an empty map for malformed JSON instead of throwing", () => {
+    expect(parsePlanDisplayNames("{not json")).toEqual({});
+  });
+
+  it("returns an empty map for non-object JSON (array / scalar)", () => {
+    expect(parsePlanDisplayNames("[1,2,3]")).toEqual({});
+    expect(parsePlanDisplayNames("42")).toEqual({});
+    expect(parsePlanDisplayNames('"hi"')).toEqual({});
+  });
+
+  it("parses a valid locale→tier map", () => {
+    const raw = JSON.stringify({
+      en: { free: "Trial", basic: "Starter", pro: "Pro" },
+      ja: { free: "お試し", basic: "スターター", pro: "プロ" },
+    });
+    expect(parsePlanDisplayNames(raw)).toEqual({
+      en: { free: "Trial", basic: "Starter", pro: "Pro" },
+      ja: { free: "お試し", basic: "スターター", pro: "プロ" },
+    });
+  });
+});
+
+describe("resolvePlanLabel", () => {
+  it("falls back to the OSS S/M/L default when nothing is configured", () => {
+    expect(resolvePlanLabel("free", "ja")).toBe("S");
+    expect(resolvePlanLabel("basic", "en")).toBe("M");
+    expect(resolvePlanLabel("pro", undefined)).toBe("L");
+    expect(resolvePlanLabel("free", "en")).toBe(DEFAULT_PLAN_LABELS.free);
+  });
+
+  it("uses the locale-aware JSON map when present", () => {
+    const map: LocalePlanLabelMap = {
+      en: { free: "Trial", basic: "Starter", pro: "Pro" },
+      ja: { free: "お試し", basic: "スターター", pro: "プロ" },
+    };
+    expect(resolvePlanLabel("free", "ja", map)).toBe("お試し");
+    expect(resolvePlanLabel("basic", "ja", map)).toBe("スターター");
+    expect(resolvePlanLabel("pro", "en", map)).toBe("Pro");
+  });
+
+  it("falls back from a regional locale to its base language (ja-JP → ja)", () => {
+    const map: LocalePlanLabelMap = { ja: { free: "お試し" } };
+    expect(resolvePlanLabel("free", "ja-JP", map)).toBe("お試し");
+  });
+
+  it("prefers the JSON map over the single-string env map", () => {
+    const json: LocalePlanLabelMap = { ja: { pro: "プロ" } };
+    const single = { pro: "L-CUSTOM" };
+    expect(resolvePlanLabel("pro", "ja", json, single)).toBe("プロ");
+  });
+
+  it("falls back to the single-string map when the JSON map lacks the locale/tier", () => {
+    const json: LocalePlanLabelMap = { ja: { free: "お試し" } };
+    const single = { pro: "L-CUSTOM" };
+    // 'pro' is absent from the ja map → single-string override wins over default
+    expect(resolvePlanLabel("pro", "ja", json, single)).toBe("L-CUSTOM");
+  });
+
+  it("falls back to default when neither map has the tier", () => {
+    const json: LocalePlanLabelMap = { ja: { free: "お試し" } };
+    expect(resolvePlanLabel("basic", "ja", json, {})).toBe("M");
+  });
+});
+
+describe("planLabelFromEnv", () => {
+  const ENV_KEYS = [
+    "NEXT_PUBLIC_PLAN_DISPLAY_NAMES",
+    "NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME",
+    "NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME",
+    "NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME",
+  ];
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k];
+  });
+
+  it("returns S/M/L when no env is set", () => {
+    expect(planLabelFromEnv("free", "ja")).toBe("S");
+    expect(planLabelFromEnv("pro", "en")).toBe("L");
+  });
+
+  it("reads the locale-aware JSON env", () => {
+    process.env.NEXT_PUBLIC_PLAN_DISPLAY_NAMES = JSON.stringify({
+      en: { free: "Trial", basic: "Starter", pro: "Pro" },
+      ja: { free: "お試し", basic: "スターター", pro: "プロ" },
+    });
+    expect(planLabelFromEnv("free", "ja")).toBe("お試し");
+    expect(planLabelFromEnv("basic", "en")).toBe("Starter");
+  });
+
+  it("reads the single-string env as a back-compat fallback", () => {
+    process.env.NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME = "Enterprise";
+    expect(planLabelFromEnv("pro", "ja")).toBe("Enterprise");
+  });
+});

--- a/frontend/src/lib/utils/planLabel.test.ts
+++ b/frontend/src/lib/utils/planLabel.test.ts
@@ -108,4 +108,16 @@ describe("planLabelFromEnv", () => {
     process.env.NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME = "Enterprise";
     expect(planLabelFromEnv("pro", "ja")).toBe("Enterprise");
   });
+
+  it("re-parses when the JSON env value changes (cache invalidation)", () => {
+    process.env.NEXT_PUBLIC_PLAN_DISPLAY_NAMES = JSON.stringify({
+      ja: { pro: "プロ" },
+    });
+    expect(planLabelFromEnv("pro", "ja")).toBe("プロ");
+
+    process.env.NEXT_PUBLIC_PLAN_DISPLAY_NAMES = JSON.stringify({
+      ja: { pro: "PRO-2" },
+    });
+    expect(planLabelFromEnv("pro", "ja")).toBe("PRO-2");
+  });
 });

--- a/frontend/src/lib/utils/planLabel.ts
+++ b/frontend/src/lib/utils/planLabel.ts
@@ -78,6 +78,24 @@ export function resolvePlanLabel(
 }
 
 /**
+ * Parse-once cache for the JSON env map. `planLabelFromEnv` runs per render —
+ * once per `PlanBadge`, so many times on a table — but the env is effectively
+ * static at runtime. Keying the cache on the raw env string re-parses only when
+ * the value actually changes, which also keeps tests that mutate `process.env`
+ * correct (a new raw value invalidates the cache).
+ */
+let jsonMapCache: { raw: string | undefined; map: LocalePlanLabelMap } | null =
+  null;
+
+function cachedJsonMapFromEnv(): LocalePlanLabelMap {
+  const raw = process.env.NEXT_PUBLIC_PLAN_DISPLAY_NAMES;
+  if (!jsonMapCache || jsonMapCache.raw !== raw) {
+    jsonMapCache = { raw, map: parsePlanDisplayNames(raw) };
+  }
+  return jsonMapCache.map;
+}
+
+/**
  * Env-wired convenience used by UI components. The `NEXT_PUBLIC_*` references
  * are static member expressions so Next.js inlines them at build time.
  */
@@ -85,14 +103,9 @@ export function planLabelFromEnv(
   planName: PlanTier,
   locale: string | undefined,
 ): string {
-  return resolvePlanLabel(
-    planName,
-    locale,
-    parsePlanDisplayNames(process.env.NEXT_PUBLIC_PLAN_DISPLAY_NAMES),
-    {
-      free: process.env.NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME,
-      basic: process.env.NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME,
-      pro: process.env.NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME,
-    },
-  );
+  return resolvePlanLabel(planName, locale, cachedJsonMapFromEnv(), {
+    free: process.env.NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME,
+    basic: process.env.NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME,
+    pro: process.env.NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME,
+  });
 }

--- a/frontend/src/lib/utils/planLabel.ts
+++ b/frontend/src/lib/utils/planLabel.ts
@@ -1,0 +1,98 @@
+/**
+ * Plan-tier display-label resolution.
+ *
+ * Issue #350 established customizable plan display names for SaaS forks. The
+ * OSS default stays **S / M / L** (neutral, locale-independent) so the public
+ * Apache-2.0 repo carries no operator-specific branding. A deployment (e.g.
+ * Kagura's own site) overrides the labels — optionally per-locale — entirely
+ * through `NEXT_PUBLIC_*` env, so its commercial labels never live in the repo.
+ *
+ * Resolution order (first hit wins):
+ *   1. Locale-aware JSON map  — NEXT_PUBLIC_PLAN_DISPLAY_NAMES
+ *      e.g. {"en":{"free":"Trial","basic":"Starter","pro":"Pro"},
+ *            "ja":{"free":"お試し","basic":"スターター","pro":"プロ"}}
+ *      (exact locale, then its base language: "ja-JP" → "ja")
+ *   2. Single-string env (locale-blind, back-compat with #350)
+ *      — NEXT_PUBLIC_PLAN_{FREE,BASIC,PRO}_DISPLAY_NAME
+ *   3. OSS default — S / M / L
+ */
+
+export type PlanTier = "free" | "basic" | "pro";
+
+/** OSS default labels — intentionally neutral. Do not localize these. */
+export const DEFAULT_PLAN_LABELS: Record<PlanTier, string> = {
+  free: "S",
+  basic: "M",
+  pro: "L",
+};
+
+export type LocalePlanLabelMap = Record<
+  string,
+  Partial<Record<PlanTier, string>>
+>;
+
+/**
+ * Parse the NEXT_PUBLIC_PLAN_DISPLAY_NAMES JSON env value into a locale→tier
+ * label map. Tolerant by design: any malformed / non-object / array input
+ * yields an empty map so resolution falls back to S/M/L rather than throwing.
+ */
+export function parsePlanDisplayNames(
+  raw: string | null | undefined,
+): LocalePlanLabelMap {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as LocalePlanLabelMap;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Pure label resolver. Sources are injected so this is trivially testable
+ * without touching the environment.
+ */
+export function resolvePlanLabel(
+  planName: PlanTier,
+  locale: string | undefined,
+  jsonMap: LocalePlanLabelMap = {},
+  singleMap: Partial<Record<PlanTier, string>> = {},
+): string {
+  if (locale) {
+    const exact = jsonMap[locale]?.[planName];
+    if (exact) return exact;
+    const base = locale.split("-")[0];
+    if (base && base !== locale) {
+      const byBase = jsonMap[base]?.[planName];
+      if (byBase) return byBase;
+    }
+  }
+
+  const single = singleMap[planName];
+  if (single) return single;
+
+  return DEFAULT_PLAN_LABELS[planName];
+}
+
+/**
+ * Env-wired convenience used by UI components. The `NEXT_PUBLIC_*` references
+ * are static member expressions so Next.js inlines them at build time.
+ */
+export function planLabelFromEnv(
+  planName: PlanTier,
+  locale: string | undefined,
+): string {
+  return resolvePlanLabel(
+    planName,
+    locale,
+    parsePlanDisplayNames(process.env.NEXT_PUBLIC_PLAN_DISPLAY_NAMES),
+    {
+      free: process.env.NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME,
+      basic: process.env.NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME,
+      pro: process.env.NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME,
+    },
+  );
+}


### PR DESCRIPTION
## What

Plan tier display labels (the `PlanBadge` chip and **Settings > Plan**) are now resolved through a small, OSS-neutral helper instead of the hardcoded `S/M/L` map.

Resolution order (`frontend/src/lib/utils/planLabel.ts`):
1. **Locale-aware JSON env** `NEXT_PUBLIC_PLAN_DISPLAY_NAMES`
   `{"en":{"free":"Trial","basic":"Starter","pro":"Pro"},"ja":{"free":"お試し","basic":"スターター","pro":"プロ"}}`
   (exact locale, then base language: `ja-JP` → `ja`)
2. **Single-string env** `NEXT_PUBLIC_PLAN_{FREE,BASIC,PRO}_DISPLAY_NAME` (back-compat with #350)
3. **OSS default `S` / `M` / `L`** — unchanged

## Why this shape

The public Apache-2.0 repo keeps the neutral **S/M/L** default and carries **no operator-specific labels or prices**. A deployment (e.g. Kagura's site) supplies localized names — per locale (EN/JA) — entirely via env, so its commercial branding never lives in the repo. This honors the #350 fork-customization contract and adds localization on top.

## Changes
- `lib/utils/planLabel.ts` (new) — `parsePlanDisplayNames` / `resolvePlanLabel` / `planLabelFromEnv`
- `lib/utils/planLabel.test.ts` (new) — 13 unit tests (default / JSON / base-locale / single-string / precedence)
- `PlanBadge.tsx` — `'use client'` + `useLocale()` + `planLabelFromEnv`; re-exports `PlanTier`
- `settings/plan/page.tsx` — label resolved from canonical `plan_name` per locale; backend `plan_display_name` kept as fallback
- backend `plan_tiers.py` **unchanged** (default `display_name` stays `S/M/L`, now an API fallback only)

## Verification
- `planLabel.test.ts` — **13/13 pass**
- Full frontend Vitest — **green (exit 0)**
- `tsc --noEmit` — **clean (exit 0)**

## Out of scope (other repos)
- **Prices** are handled on www.kagura-ai.com (display) + payment.kagura-ai.com (Stripe, JPY) — memory-cloud stays Stripe-agnostic (#1096).
- To activate localized labels on a deployment, set `NEXT_PUBLIC_PLAN_DISPLAY_NAMES` at **frontend build time** (`NEXT_PUBLIC_*` is build-inlined). Wiring it into `docker-compose.prod.yml` web build args is a small optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
