### PR TITLE
chore(infra): wire NEXT_PUBLIC_PLAN_DISPLAY_NAMES build arg for prod web

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -31,9 +31,13 @@ ENV NODE_ENV=production
 ARG NEXT_PUBLIC_API_URL
 ARG NEXT_PUBLIC_APP_URL
 ARG NEXT_PUBLIC_ENABLE_GRAPH_VIZ
+# Optional per-deployment plan-tier label override (locale-aware JSON).
+# Unset → empty → the app keeps the OSS default S/M/L (lib/utils/planLabel.ts).
+ARG NEXT_PUBLIC_PLAN_DISPLAY_NAMES
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
 ENV NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
 ENV NEXT_PUBLIC_ENABLE_GRAPH_VIZ=${NEXT_PUBLIC_ENABLE_GRAPH_VIZ}
+ENV NEXT_PUBLIC_PLAN_DISPLAY_NAMES=${NEXT_PUBLIC_PLAN_DISPLAY_NAMES}
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry

--- a/terraform/single-server/docker-compose.prod.yml
+++ b/terraform/single-server/docker-compose.prod.yml
@@ -129,6 +129,10 @@ services:
         NEXT_PUBLIC_API_URL: https://${KAGURA_DOMAIN}
         NEXT_PUBLIC_APP_URL: https://${KAGURA_DOMAIN}
         NEXT_PUBLIC_ENABLE_GRAPH_VIZ: ${NEXT_PUBLIC_ENABLE_GRAPH_VIZ:-}
+        # Per-deployment plan-tier label override (locale-aware JSON). Unset →
+        # empty → app keeps the OSS default S/M/L. Build-time only (NEXT_PUBLIC_*
+        # is inlined by `next build`); changing it needs a web image rebuild.
+        NEXT_PUBLIC_PLAN_DISPLAY_NAMES: ${NEXT_PUBLIC_PLAN_DISPLAY_NAMES:-}
     container_name: kagura-web
     restart: always
     environment:


### PR DESCRIPTION
## What
Exposes `NEXT_PUBLIC_PLAN_DISPLAY_NAMES` to the **production frontend build** so a deployment can actually activate localized plan-tier labels (お試し/スターター/プロ). Follow-up to #1130, which added the resolver but left this build-arg unwired.

- `frontend/Dockerfile` (builder): `ARG` + `ENV NEXT_PUBLIC_PLAN_DISPLAY_NAMES` before `npm run build`
- `terraform/single-server/docker-compose.prod.yml`: `web.build.args` gains `NEXT_PUBLIC_PLAN_DISPLAY_NAMES: ${NEXT_PUBLIC_PLAN_DISPLAY_NAMES:-}`

## Why it's needed
`NEXT_PUBLIC_*` is **inlined by `next build`** — runtime env on the running container has no effect. Without this wiring, prod always falls back to the OSS default `S/M/L` regardless of any env set on the VM.

## OSS-neutral
The `:-` empty default means an un-set value builds to empty → resolver keeps `S/M/L`. No operator labels enter the repo; a deployment supplies the JSON via `.env.prod`.

## Activating in prod (deployment-side, not in this PR)
1. Set in `.env.prod`:
   `NEXT_PUBLIC_PLAN_DISPLAY_NAMES={"en":{"free":"Trial","basic":"Starter","pro":"Pro"},"ja":{"free":"お試し","basic":"スターター","pro":"プロ"}}`
2. **Rebuild** the web image + redeploy (`docker compose build web` → `up -d`, or deploy.sh).

## Validation
`docker compose -f docker-compose.prod.yml config` resolves the new arg through to the web build (verified locally); empty default leaves it blank. No app-code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
