### PR TITLE
fix(frontend): make sidebar Kagura logo theme-adaptive

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -460,7 +460,7 @@ export function Sidebar() {
         )}
         onClick={() => setIsOpen(false)}
       >
-        <KaguraLogo className="h-6 w-auto" variant="image" surface="dark" />
+        <KaguraLogo className="h-6 w-auto" variant="image" surface="auto" />
       </Link>
 
       {/* Workspace Switcher at Top - Minimal padding */}

--- a/frontend/src/components/icons/KaguraLogo.test.tsx
+++ b/frontend/src/components/icons/KaguraLogo.test.tsx
@@ -1,0 +1,46 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { KaguraLogo } from "./KaguraLogo";
+
+/** SVG <image> hrefs live in the `href` attribute (SVG 2) — read it directly. */
+function wordmarkImages(container: HTMLElement) {
+  return Array.from(container.querySelectorAll("image")).filter((el) =>
+    (el.getAttribute("href") ?? "").includes("wordmark"),
+  );
+}
+
+describe("KaguraLogo image variant", () => {
+  it('surface="auto" renders BOTH wordmarks, toggled by dark mode', () => {
+    const { container } = render(<KaguraLogo variant="image" surface="auto" />);
+    const wordmarks = wordmarkImages(container);
+    expect(wordmarks).toHaveLength(2);
+
+    const dark = wordmarks.find((el) =>
+      (el.getAttribute("href") ?? "").includes("wordmark-light"),
+    );
+    const lightInk = wordmarks.find(
+      (el) => !(el.getAttribute("href") ?? "").includes("wordmark-light"),
+    );
+
+    // Dark-ink wordmark shows in light mode, hides in dark mode.
+    expect(lightInk?.getAttribute("class")).toContain("dark:hidden");
+    // White wordmark hidden in light mode, shown in dark mode.
+    expect(dark?.getAttribute("class")).toContain("hidden");
+    expect(dark?.getAttribute("class")).toContain("dark:block");
+  });
+
+  it('surface="dark" renders only the white wordmark', () => {
+    const { container } = render(<KaguraLogo variant="image" surface="dark" />);
+    const wordmarks = wordmarkImages(container);
+    expect(wordmarks).toHaveLength(1);
+    expect(wordmarks[0].getAttribute("href")).toContain("wordmark-light");
+  });
+
+  it('surface="light" (default) renders only the dark-ink wordmark', () => {
+    const { container } = render(<KaguraLogo variant="image" />);
+    const wordmarks = wordmarkImages(container);
+    expect(wordmarks).toHaveLength(1);
+    expect(wordmarks[0].getAttribute("href")).toContain("kagura-wordmark.png");
+    expect(wordmarks[0].getAttribute("href")).not.toContain("wordmark-light");
+  });
+});

--- a/frontend/src/components/icons/KaguraLogo.tsx
+++ b/frontend/src/components/icons/KaguraLogo.tsx
@@ -22,8 +22,14 @@ interface KaguraLogoProps {
    * surface → white wordmark (e.g. the dashboard sidebar).
    */
   variant?: "full" | "mark" | "image";
-  /** For variant="image": tone of the surface behind the lockup. Default "light". */
-  surface?: "light" | "dark";
+  /**
+   * For variant="image": tone of the surface behind the lockup. Default
+   * "light". Use "auto" on theme-adaptive surfaces (e.g. the dashboard
+   * sidebar, which is light in light mode and dark in dark mode): the
+   * dark-ink wordmark shows in light mode and the white wordmark in dark
+   * mode, so the lockup never goes invisible-on-same-tone.
+   */
+  surface?: "light" | "dark" | "auto";
 }
 
 const PETALS = [
@@ -133,10 +139,15 @@ export function KaguraLogo({
     // scales with `className` and avoids the next/image <img> lint rule. On dark
     // surfaces (e.g. the sidebar) the black wordmark is swapped for a white one;
     // the mark PNG is theme-independent (transparent pinwheel) so it needs none.
-    const wordmark =
-      surface === "dark"
-        ? "/brand/kagura-wordmark-light.png"
-        : "/brand/kagura-wordmark.png";
+    const mark = (
+      <image
+        href="/brand/kagura-mark.png"
+        x="6"
+        y="8"
+        width="108"
+        height="104"
+      />
+    );
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -145,14 +156,41 @@ export function KaguraLogo({
         role="img"
         aria-label="Kagura AI"
       >
-        <image
-          href="/brand/kagura-mark.png"
-          x="6"
-          y="8"
-          width="108"
-          height="104"
-        />
-        <image href={wordmark} x="146" y="23" width="408" height="102" />
+        {mark}
+        {surface === "auto" ? (
+          // Theme-adaptive: render both wordmarks and let dark mode toggle them
+          // (display:none vs visible) so neither goes same-tone-on-same-tone.
+          <>
+            <image
+              className="dark:hidden"
+              href="/brand/kagura-wordmark.png"
+              x="146"
+              y="23"
+              width="408"
+              height="102"
+            />
+            <image
+              className="hidden dark:block"
+              href="/brand/kagura-wordmark-light.png"
+              x="146"
+              y="23"
+              width="408"
+              height="102"
+            />
+          </>
+        ) : (
+          <image
+            href={
+              surface === "dark"
+                ? "/brand/kagura-wordmark-light.png"
+                : "/brand/kagura-wordmark.png"
+            }
+            x="146"
+            y="23"
+            width="408"
+            height="102"
+          />
+        )}
       </svg>
     );
   }


### PR DESCRIPTION
## Bug
On the light-mode (white) sidebar, the Kagura wordmark was invisible — white-on-white. (Reported with a screenshot: only the petal mark + faint gold "AI" were visible; "Kagura" disappeared.)

## Root cause
The sidebar is theme-adaptive (`hover:bg-slate-100 dark:hover:bg-slate-800` → light surface in light mode, dark in dark mode), but the logo was hardcoded:
```tsx
<KaguraLogo variant="image" surface="dark" />
```
`surface="dark"` always loads the **white** wordmark PNG (`kagura-wordmark-light.png`). On the light-mode white sidebar that's white-on-white. A static flip to `surface="light"` would just break dark mode instead — the logo needs to be theme-adaptive.

## Fix
Add `surface="auto"` to `KaguraLogo`'s `image` variant: render **both** wordmark PNGs and toggle by dark mode —
- dark-ink `kagura-wordmark.png` shown in light mode (`dark:hidden`)
- white `kagura-wordmark-light.png` shown in dark mode (`hidden dark:block`)

The mark PNG is theme-independent. Brand PNGs are preserved (no switch to SVG-text). Sidebar now uses `surface="auto"`.

## Changes
- `icons/KaguraLogo.tsx` — `surface` gains `"auto"`
- `dashboard/Sidebar.tsx` — logo `surface="dark"` → `"auto"`
- `icons/KaguraLogo.test.tsx` (new) — 3 tests

## Verification
- `KaguraLogo.test.tsx` — **3/3** (auto renders both wordmarks with the toggle classes; dark = white only; light = dark-ink only)
- `Sidebar.test.tsx` — **5/5**
- `tsc --noEmit` — clean

Final visual confirmation (light + dark) on deploy. Existing `surface="light"`/`"dark"` call sites (auth pages) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
