### PR TITLE
fix(frontend): apply UI language from profile preference

### DIFF
--- a/frontend/src/app/(authenticated)/layout.tsx
+++ b/frontend/src/app/(authenticated)/layout.tsx
@@ -12,6 +12,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLocale } from "@/i18n";
 import { WorkspaceProvider, useWorkspace } from "@/contexts/WorkspaceContext";
 import { MemoryContextProvider } from "@/contexts/MemoryContextContext";
 import { Sidebar } from "@/components/dashboard/Sidebar";
@@ -136,9 +137,21 @@ function WorkspaceGuard({ children }: { children: React.ReactNode }) {
 
 function DashboardContent({ children }: { children: React.ReactNode }) {
   const { user, isLoading } = useAuth();
+  const { locale: uiLocale, setLocale: setUiLocale } = useLocale();
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  // The signed-in user's saved `locale` is the source of truth for the UI
+  // language. The i18n provider only hydrates from localStorage, so without
+  // this sync the Profile > Language preference never reaches the interface
+  // (it would just sit in the backend record). Apply it whenever it differs.
+  useEffect(() => {
+    const pref = user?.locale;
+    if ((pref === "en" || pref === "ja") && pref !== uiLocale) {
+      setUiLocale(pref);
+    }
+  }, [user?.locale, uiLocale, setUiLocale]);
 
   // Check if on workspace creation page. Mirrors WorkspaceGuard's logic so the
   // create form renders in the minimal layout even after the compatibility

--- a/frontend/src/app/(authenticated)/profile/page.tsx
+++ b/frontend/src/app/(authenticated)/profile/page.tsx
@@ -30,6 +30,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLocale, type Locale } from "@/i18n";
 import { useToast } from "@/hooks/use-toast";
 import { User, Moon, Sun, Save, RefreshCw } from "lucide-react";
 import { COMMON_TIMEZONES } from "@/lib/utils/datetime";
@@ -164,6 +165,10 @@ export default function ProfilePage() {
   const email = user?.email || "";
   const [timezone, setTimezone] = useState(user?.timezone || "UTC");
   const [locale, setLocale] = useState(user?.locale || "en");
+  // i18n provider's locale setter (localStorage + context) — distinct from the
+  // local form state `setLocale` above. Saving the profile must drive this so
+  // the running UI actually switches language, not just the backend record.
+  const { setLocale: applyUiLocale } = useLocale();
 
   useEffect(() => {
     if (user) {
@@ -183,6 +188,10 @@ export default function ProfilePage() {
 
       // Refresh user data to get updated timezone
       await refetchUser();
+
+      // Apply the chosen UI language immediately (localStorage + context), so
+      // the interface switches now instead of only persisting to the backend.
+      applyUiLocale(locale as Locale);
 
       toast({
         title: t("profileUpdated"),


### PR DESCRIPTION
## Bug
Changing the language on **Profile > Settings** had no visible effect — the UI stayed in Japanese even with the preference set to English (reported: "言語が切り替わらなくなった").

## Root cause
The saved preference and the live UI locale were decoupled:
- `handleSaveProfile` PUT `locale` to the backend (`user.locale`) but never called the i18n provider's `setLocale` (the `localStorage`+context setter that drives the UI). The page's `setLocale` is just a local `useState` setter.
- `I18nProvider` only hydrates from `localStorage`, never from `user.locale`. The working `LanguageSelector` (provider-backed) is mounted **only on unauthenticated pages** (login / device / invite), so inside the authenticated app there was no path from the saved preference to the live locale.

## Fix
- **`profile/page.tsx`** — on save, apply the chosen locale to the i18n provider (`applyUiLocale`), so the UI switches immediately and persists to `localStorage`.
- **`(authenticated)/layout.tsx`** — sync the UI locale from `user.locale` (backend = source of truth) whenever they differ, so the preference reaches the UI on load / reload / cross-device, and the current `profile=English / UI=Japanese` mismatch self-heals.

Not related to the recent label/logo changes (different files).

## Verification
- `tsc --noEmit` — clean
- `profile/page.test.tsx` — **23/23**
- full frontend Vitest suite — **green**

Final visual confirmation on deploy (toggle JA↔EN in Profile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
