### PR TITLE
fix(api): allow viewers to switch into a workspace (VIEWER, not MEMBER)

### DIFF
--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -530,14 +530,21 @@ async def switch_workspace(
     """Switch to a different workspace.
 
     Updates the user's current_workspace_id to the specified workspace.
-    Requires the user to be a member of the workspace.
+    Requires the user to have at least viewer access to the workspace.
     """
     user = await get_current_user(request)
     perm_service = PermissionService(db)
 
-    # Verify user is a member of this workspace
+    # Verify the user can access this workspace. VIEWER is the floor on purpose:
+    # the workspace switcher lists every workspace the user belongs to (incl.
+    # viewer-role memberships), and switching only sets current_workspace_id — a
+    # mutable UI preference that is never trusted for authorization (see
+    # PermissionService.resolve_resource_by_slug contract). A viewer who can
+    # already read the workspace must be able to enter it; requiring MEMBER here
+    # left viewers listed-but-unenterable (403 role_too_low). All real access is
+    # still enforced per-operation downstream.
     await perm_service.check_workspace_access(
-        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+        user["user_id"], workspace_id, required_role=WorkspaceRole.VIEWER
     )
 
     # Update user's current workspace

--- a/backend/tests/api/test_workspace.py
+++ b/backend/tests/api/test_workspace.py
@@ -20,7 +20,11 @@ from api.routes.workspace import (
     get_workspace_stats,
     get_workspace_usage_current,
 )
-from api.routes.workspaces import UpdateMemberRoleRequest, update_member_role
+from api.routes.workspaces import (
+    UpdateMemberRoleRequest,
+    switch_workspace,
+    update_member_role,
+)
 from auth.workspace_roles import WorkspaceRole
 from utils.exceptions import AuthenticationError
 
@@ -402,6 +406,54 @@ class TestUpdateMemberRole:
                     )
 
                     assert response.user_id == target_user_id
+
+
+class TestSwitchWorkspace:
+    """PUT /workspaces/{id}/switch — workspace-switch-403 fix.
+
+    The workspace switcher lists every workspace the user belongs to,
+    including viewer-role memberships, so switching must accept VIEWER.
+    Previously it required MEMBER and viewers got 403 role_too_low.
+    """
+
+    @pytest.mark.asyncio
+    async def test_switch_requires_only_viewer_role(self):
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+        # User row looked up to update current_workspace_id.
+        user_record = MagicMock()
+        mock_db.execute.return_value = MagicMock(
+            scalar_one_or_none=MagicMock(return_value=user_record)
+        )
+
+        perm_instance = MagicMock()
+        perm_instance.check_workspace_access = AsyncMock()
+
+        with (
+            patch(
+                "api.routes.workspaces.get_current_user",
+                AsyncMock(return_value={"user_id": "viewer_user"}),
+            ),
+            patch(
+                "api.routes.workspaces.PermissionService",
+                return_value=perm_instance,
+            ),
+        ):
+            response = await switch_workspace(
+                workspace_id=workspace_id,
+                request=MagicMock(),
+                db=mock_db,
+            )
+
+        assert response["status"] == "ok"
+        assert response["workspace_id"] == str(workspace_id)
+        assert user_record.current_workspace_id == workspace_id
+
+        # The required role must be the VIEWER floor (not MEMBER), so a
+        # viewer listed in the switcher can actually enter the workspace.
+        perm_instance.check_workspace_access.assert_awaited_once()
+        _, kwargs = perm_instance.check_workspace_access.call_args
+        assert kwargs["required_role"] == WorkspaceRole.VIEWER
 
 
 class TestWorkspaceUsageCurrent:


### PR DESCRIPTION
## Bug
Switching to a workspace shown in the switcher fails with "Failed to switch workspace".

## Root cause (confirmed on prod)
`PUT /api/v1/workspaces/{id}/switch` ([workspaces.py](backend/src/api/routes/workspaces.py)) called `check_workspace_access(..., required_role=WorkspaceRole.MEMBER)`. But the workspace **switcher lists every workspace the user belongs to, including `viewer`-role memberships**. So a viewer:
- sees the workspace in the switcher (`listWorkspaces` includes viewer rows), but
- gets **403 `role_too_low`** on switch ([permission_service.py:149-153](backend/src/services/permission_service.py)).

Prod evidence: the reporting session was `kiyota@noizz.co.jp`, whose role in the target "kagura" workspace is **viewer** (the `…gmail.com` account, an `admin` there, switched fine). Confirmed via API logs (403 AUTH-101 on `/switch`) + DB (`workspace_members.role = viewer`).

**Not a regression** from the recent label/logo/language PRs (#1130–#1133, frontend only; the API container wasn't rebuilt). This endpoint last changed in #794. Verified by a 3-agent investigation + git history.

## Fix
Lower the switch gate to `WorkspaceRole.VIEWER`. Switching only sets `users.current_workspace_id` — a mutable UI preference that is **never trusted for authorization** (per `PermissionService` contract; all real access is enforced per-operation downstream). A viewer who can already read the workspace must be able to enter it. This aligns the switch gate with what the switcher lists.

- `workspaces.py` — `switch_workspace` requires `VIEWER`
- `test_workspace.py` — regression test asserting the `VIEWER` floor

## Verification
- `py_compile` clean on both files; full backend suite runs in CI (this is a backend change — no frontend impact).

## Deploy note
This is a **backend** change → needs an **API blue-green deploy** (`./scripts/deploy.sh`, no `--web`), not the frontend rebuild path. No DB migration.

## Follow-ups (optional, not in this PR)
- `WorkspaceSwitcher.tsx` toast is a hardcoded literal that discards `error.status`/reason — surfacing the real status (and i18n) would make such failures self-diagnosing.
- `switch_workspace` returns a silent 200 no-op if the `User` row is missing (latent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
