### PR TITLE
docs: sync docs for secret store + declare secrets OpenAPI tag

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,7 +61,7 @@
 | **AI Reranking** | Ollama (ローカル・無料)、Voyage AI、Cohere — cross-encoder reranker で精度向上 |
 | **Neural Memory Graph** | Hebbian 学習がバックグラウンドで知識グラフを構築。`explore()` がそれを辿り偶発的発見を提供 |
 | **Agent Memory Substrate** | 単なる知識ストアを超えて — delivery mode (pin / 時刻トリガ)、サーバー署名の trust boundary、agent state レーン、retrieval feedback シグナル。自律エージェントのループに必要なプリミティブ群 |
-| **45 の MCP ツール** | Memory、Agent Substrate、Neural edges、Contexts、Tags、Files (R2)、Analyses (broadlistening)、Resources、Sleep Maintenance、Usage、API-Key Bindings |
+| **50 の MCP ツール** | Memory、Agent Substrate、Neural edges、Contexts、Tags、Files (R2)、Analyses (broadlistening)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
 | **マルチプロバイダ** | 埋め込みに OpenAI か Ollama (ローカル・非公開・コストゼロ) |
 | **チーム対応** | Workspace、RBAC、context 分離、共有メモリ |
 | **Web UI** | Next.js ダッシュボード — context、検索設定、メンバー管理 |
@@ -293,7 +293,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP ツール
 
-11 カテゴリ・全 45 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
+12 カテゴリ・全 50 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
 
 ### Memory (6)
 
@@ -378,6 +378,18 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `get_resource_impact` | resource 統計 (token 数、memory 数、schema version) | Viewer+ |
 | `get_resource_schema` | resource のフィールド定義取得 | Viewer+ |
 
+### Secrets (5)
+
+ゼロ知識シークレットストア: サーバーは `age` 公開受信者キーと不透明な ciphertext のみを保持し、**復号は一切行わない**。暗号化・復号はすべてクライアント側 (`kagura secret` CLI / SDK)。`list` はメタデータのみを返し、平文値を返すエンドポイントは存在しない。
+
+| ツール | 説明 | 必要ロール |
+|--------|------|------------|
+| `secret_register_pubkey` | 自分の `age` 受信者公開鍵を登録 (pending で開始、owner 承認後に grant 受領可) | Member+ |
+| `secret_put` | age 暗号化 ciphertext を保存 + 承認済み受信者へ grant (`recipients_snapshot` は `grant_pubkey_ids` と完全一致必須) | Owner/Admin |
+| `secret_get` | 有効な grant を持つ ciphertext を取得 (ローカルで復号、全 fetch は改竄検知監査ログに記録) | Member+ |
+| `secret_list` | secret 名 + メタデータ (status、version、grant 数、rotation フラグ) を列挙 — 値は返さない | Owner/Admin |
+| `secret_revoke_grant` | 受信者の grant を revoke し secret を `rotation_needed` にフラグ (遡及不可 — 上流を rotate) | Owner/Admin |
+
 ### Sleep Maintenance (3)
 
 バックグラウンドでメモリ統合 (decay、edge pruning、テーマ要約) を実行。
@@ -410,6 +422,7 @@ MCP ツールに加えてフル REST API を提供:
 - **Attachments**: メモリ添付ファイル (`/api/v1/attachments/*`、5MB 上限)
 - **Workspaces**: 管理、メンバー、招待 (`/api/v1/workspaces/*`)
 - **Admin**: ユーザ、プラン管理、neural config (`/api/v1/admin/*`)
+- **Secrets**: ゼロ知識シークレットストア — ciphertext のみ、サーバーは復号しない (`/api/v1/config/secrets/*`)
 
 完全な API ドキュメント: `http://localhost:8080/redoc`
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **AI Reranking** | Ollama (local, free), Voyage AI, or Cohere — cross-encoder reranking for precision |
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
 | **Agent Memory Substrate** | Beyond a knowledge store: delivery modes (pinned / time-triggered), a server-stamped trust boundary, an agent state lane, and a retrieval-feedback signal — the primitives an autonomous agent loop needs. |
-| **45 MCP Tools** | Memory, Agent Substrate, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Sleep Maintenance, Usage, API-Key Bindings |
+| **50 MCP Tools** | Memory, Agent Substrate, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
 | **Multi-Provider** | OpenAI or Ollama (local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |
@@ -418,7 +418,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP Tools
 
-45 tools across 11 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+50 tools across 12 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
 
 ### Memory (6)
 
@@ -503,6 +503,18 @@ Cluster memories into themes (kouchou-ai-style UMAP + KMeans + LLM labeling) for
 | `get_resource_impact` | Resource stats (tokens, memories, schema version) | Viewer+ |
 | `get_resource_schema` | Field definitions for a resource | Viewer+ |
 
+### Secrets (5)
+
+Zero-knowledge secret store: the server holds only `age` public recipient keys and opaque ciphertext, and **never decrypts**. Encryption/decryption happen client-side (the `kagura secret` CLI / SDK). `list` returns metadata only — there is no endpoint that returns a plaintext value.
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `secret_register_pubkey` | Register your own `age` recipient public key (starts pending; an owner approves it before it can receive grants) | Member+ |
+| `secret_put` | Store age-encrypted ciphertext + grant approved recipients (`recipients_snapshot` must match `grant_pubkey_ids`) | Owner/Admin |
+| `secret_get` | Fetch ciphertext you hold an active grant for (decrypt locally; every fetch is recorded in a tamper-evident audit log) | Member+ |
+| `secret_list` | List secret names + metadata (status, version, grant count, rotation flag) — never values | Owner/Admin |
+| `secret_revoke_grant` | Revoke a recipient's grant and flag the secret `rotation_needed` (not retroactive — rotate upstream) | Owner/Admin |
+
 ### Sleep Maintenance (3)
 
 Background consolidation of memories (decay, edge pruning, theme summarization).
@@ -535,6 +547,7 @@ In addition to MCP tools, a full REST API is available:
 - **Attachments**: File upload/download for memories (`/api/v1/attachments/*`, 5MB limit)
 - **Workspaces**: Management, members, invitations (`/api/v1/workspaces/*`)
 - **Admin**: Users, plan management, neural config (`/api/v1/admin/*`)
+- **Secrets**: Zero-knowledge secret store — ciphertext-only, server never decrypts (`/api/v1/config/secrets/*`)
 
 Full API documentation: `http://localhost:8080/redoc`
 

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -191,6 +191,10 @@ openapi_tags = [
     {"name": "api-keys", "description": "MCP API key management"},
     {"name": "oauth2-server", "description": "OAuth2 client management"},
     {"name": "external-keys", "description": "External API keys (OpenAI, Cohere, etc.)"},
+    {
+        "name": "secrets",
+        "description": "Zero-knowledge secret store (age ciphertext; server never decrypts)",
+    },
     {"name": "resource-tokens", "description": "Resource token management"},
     {"name": "resource-ingest", "description": "External data ingestion API"},
     {"name": "resource-schema", "description": "Resource schema registry"},

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -942,7 +942,7 @@ Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, 
 
 ## MCP Tools
 
-Kagura Memory Cloud provides 45 MCP tools for AI assistants across 11 categories (Memory, Agent Substrate, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
+Kagura Memory Cloud provides 50 MCP tools for AI assistants across 12 categories (Memory, Agent Substrate, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
 
 ### 1. remember
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ Karpathy's pattern describes any "living knowledge base" as 5 layers. Kagura's i
                               ↓
 ┌──────────────────────┬──────────────────────────────────────┐
 │   MCP Server (HTTP)  │          REST API (FastAPI)          │
-│  - 45 MCP Tools      │  - Memory CRUD                       │
+│  - 50 MCP Tools      │  - Memory CRUD                       │
 │    (memory / agent   │  - OAuth2 endpoints                  │
 │     substrate / edges│  - API Key management                │
 │     / contexts / tags│  - Agent state + feedback lanes      │

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -215,7 +215,7 @@ See [Architecture › Agent Memory Substrate](architecture.md#agent-memory-subst
 
 ## MCP Tools
 
-Kagura Memory Cloud exposes 45 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), grouped into 11 categories:
+Kagura Memory Cloud exposes 50 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), grouped into 12 categories:
 
 | Category | Tools | Purpose |
 |----------|-------|---------|
@@ -227,6 +227,7 @@ Kagura Memory Cloud exposes 45 tools via the [Model Context Protocol (MCP)](http
 | Files / R2 | 5 | `init_file_upload`, `complete_file_upload`, `list_files`, `get_file_download_url`, `delete_file` — binary attachments via R2 |
 | Analyses (Broadlistening) | 5 | `analyze_context`, `list_analyses`, `get_analysis`, `get_active_analysis`, `get_cluster` — large-scale qualitative clustering (Owner + Pro plan) |
 | Resources | 6 | `setup_resource`, `setup_connector`, `list_resource_tokens`, `ingest_events`, `get_resource_impact`, `get_resource_schema` — external data ingestion + connector provisioning |
+| Secrets | 5 | `secret_register_pubkey`, `secret_put`, `secret_get`, `secret_list`, `secret_revoke_grant` — zero-knowledge secret store (age ciphertext; server never decrypts) |
 | Sleep Maintenance | 3 | `get_sleep_history`, `get_sleep_report`, `rollback_sleep_run` — background consolidation observability |
 | Usage | 1 | `get_usage` — workspace quota and usage queries |
 | API-Key Bindings | 2 | `list_my_bindings`, `describe_binding` — introspect public-bound API keys (read-only, owner-scoped) |


### PR DESCRIPTION
## Summary

The zero-knowledge secret store (#1128, v0.39.0) shipped to `main` with **5 new MCP tools** (`secret_register_pubkey/put/get/list/revoke_grant`) and a `/config/secrets` REST surface, but the documentation drifted:

- All docs still claimed **"45 MCP tools across 11 categories"** (real count is now **50 / 12**).
- The `secrets` router tag (`tags=["secrets"]`) was **never declared in `openapi_tags`**, so the secret-store routes were **orphaned in ReDoc** (the canonical API docs at `/redoc`).
- No doc surface mentioned the secret store at all.

## Changes

| File | Change |
|------|--------|
| `backend/src/api/main.py` | Declare the `secrets` OpenAPI tag → fixes the ReDoc orphan |
| `README.md` / `README.ja.md` | 45→50 tools, 11→12 categories, new **Secrets (5)** tool table, Secrets REST API entry |
| `docs/concepts.md` | 45→50 / 11→12 + a **Secrets** category row |
| `docs/api-reference.md`, `docs/architecture.md` | 45→50 / 11→12 |

Tool count verified against `get_tool_definitions()` (50 tools). Category tables re-tally to exactly 50. Roles taken from the route handlers: `register_pubkey`/`get` = Member+, `put`/`list`/`revoke_grant` = Owner/Admin.

## Out of scope (noted, not done)

`docs/api-surface-1.0/*` is a **frozen "45 of 45 enumerated" 1.0-surface snapshot** that predates the secret store. Bumping it to 50 without enumerating each new tool's input schema would make it internally inconsistent — left as a separate follow-up.

## Verification

- `ruff check` + `ruff format --check` on `main.py`: pass / already formatted
- `python -m ast` syntax check: OK
- No backend test couples to the tool count or the openapi tag set (`test_system_openapi_tags` only asserts `len(paths) > 0`)
- Grep sweep confirms no stale `45 tools` / `11 categories` remain in living docs

Follow-up to #1128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)