### PR TITLE
fix(plan): address v0.40.0 max-review follow-ups (#1138/#1145)

### DIFF
--- a/backend/src/api/routes/workspace_plan.py
+++ b/backend/src/api/routes/workspace_plan.py
@@ -23,7 +23,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import SessionUser
-from config.plan_tiers import PLAN_TIERS, PlanName, PlanTier, get_plan_tier
+from config.plan_tiers import PLAN_TIERS, PlanTier, get_plan_tier
 from db.base import get_db
 from models.auth import (
     Context,
@@ -271,5 +271,6 @@ async def get_plan_tier_matrix(
     ``/workspaces/plan-tiers`` would be shadowed by the earlier-registered
     ``GET /workspaces/{workspace_id}`` route and 422 on the UUID parse.
     """
-    order = [PlanName.FREE, PlanName.BASIC, PlanName.PRO]
-    return [_plan_tier_feature(PLAN_TIERS[name]) for name in order]
+    # Iterate PLAN_TIERS directly (insertion order = free → basic → pro) so a
+    # custom/added tier is never silently dropped — mirrors get_available_plans.
+    return [_plan_tier_feature(tier) for tier in PLAN_TIERS.values()]

--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.test.tsx
@@ -104,6 +104,8 @@ describe("WorkspacePlanPage (#1141)", () => {
       await screen.findByText("planPage.featureDisabled"),
     ).toBeInTheDocument();
     expect(screen.queryByText("planPage.currentPlan")).toBeNull();
+    // Disabled → the owner-only plan fetch must be skipped (no wasted call).
+    expect(mockGetWorkspacePlan).not.toHaveBeenCalled();
   });
 
   it("never renders a hardcoded $ price", async () => {

--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
@@ -63,8 +63,12 @@ export default function WorkspacePlanPage() {
   }, [currentWorkspaceId]);
 
   useEffect(() => {
+    // #1145: don't fetch plan data until the feature flag resolves enabled —
+    // when ENABLE_PLAN_PAGE is off the page short-circuits to a notice, so the
+    // owner-only getWorkspacePlan call would otherwise be wasted.
+    if (!systemFeatures?.plan_page) return;
     loadPlan();
-  }, [loadPlan]);
+  }, [loadPlan, systemFeatures]);
 
   const handleManageBilling = async () => {
     if (!currentWorkspaceId) return;

--- a/frontend/src/hooks/useSystemFeatures.ts
+++ b/frontend/src/hooks/useSystemFeatures.ts
@@ -33,9 +33,14 @@ export function useSystemFeatures(): Features | null {
           cache = info.features ?? {};
           return cache;
         })
-        .catch(() => {
-          // Fetch failure → treat as no features (everything default-off). Don't
-          // cache, so a later component mount can retry (a re-render won't).
+        .catch((e) => {
+          // Fetch failure → treat as no features (everything default-off, fail
+          // closed). Surface it in dev so a /system/info outage isn't silently
+          // invisible. Don't cache, so a later component mount can retry.
+          if (process.env.NODE_ENV === "development") {
+            // eslint-disable-next-line no-console
+            console.error("useSystemFeatures: /system/info fetch failed", e);
+          }
           inflight = null;
           return {} as Features;
         });


### PR DESCRIPTION
Follow-ups from the max-effort multi-agent review of the v0.40.0 milestone (PRs #1142/#1143/#1144/#1146). No critical bugs were found; these are the three clear, low-risk improvements.

## Fixes
1. **Tier-order hole** (`workspace_plan.py`) — `GET /api/v1/workspaces/plans/tiers` iterated a hardcoded `[FREE, BASIC, PRO]`, so any tier added to `PLAN_TIERS` would be silently dropped. Now iterates `PLAN_TIERS.values()` (insertion order = free → basic → pro), matching the sibling `get_available_plans`; the now-unused `PlanName` import is removed. (Existing test still asserts the `["free","basic","pro"]` order.)
2. **Silent `/system/info` failure** (`useSystemFeatures.ts`) — the fetch error was swallowed with no signal, making a backend outage indistinguishable from "flag off". Added a dev-gated `console.error` (the established `APIKeysTabPanel` pattern); prod behavior stays fail-closed.
3. **Wasted fetch when disabled** (`plan/page.tsx`) — `loadPlan()` ran on mount even when `ENABLE_PLAN_PAGE=false` (the guard is in render, the effect was already scheduled). The effect now gates on `systemFeatures.plan_page`; the disabled-notice test asserts `getWorkspacePlan` is **not** called.

## Reviewed, judged non-issues (not changed)
- `shared_contexts` derived from `allows_shared_contexts` vs the others from the `features` set — currently consistent; pure style.
- `formatStorage` duplicating the admin GiB formatter — the admin one isn't exported; extracting a shared util is a separate cleanup.
- Secrets page stale-on-concurrent-edit — standard non-realtime behavior; backend errors surface as toasts.

## Verification
`ruff`, `tsc --noEmit`, `prettier --check`, and the affected vitest suites (useSystemFeatures / plan page / Sidebar) pass locally; backend covered by CI `backend-unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)