### PR TITLE
fix(plan): admin Plan page — actor link + quota usage/effective order

### DIFF
--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -225,7 +225,14 @@ class PlanChangeAuditEntry(BaseModel):
     workspace_name: str
     old_plan: str | None
     new_plan: str
+    # `changed_by` is the actor's stable user_id (OAuth2 sub) as stored — the UI
+    # links it to /admin/users/{changed_by}. `changed_by_name` / `changed_by_email`
+    # are the resolved display labels (name over email); both are None when the
+    # actor no longer resolves to a User row (e.g. account erased → pseudonymized
+    # changed_by), in which case the UI shows the raw id without a link.
     changed_by: str
+    changed_by_name: str | None = None
+    changed_by_email: str | None = None
     changed_at: str
     reason: str | None
 
@@ -558,7 +565,7 @@ async def get_plan_change_audit(
         # that have since been soft-deleted must remain visible so admins can
         # reconcile past billing / plan transitions.
         audit_result = await db.execute(
-            select(PlanChange, Workspace.name, User.name)
+            select(PlanChange, Workspace.name, User.name, User.email)
             .join(Workspace, PlanChange.workspace_id == Workspace.id)
             .outerjoin(User, PlanChange.changed_by == User.user_id)
             .order_by(PlanChange.changed_at.desc())
@@ -566,7 +573,7 @@ async def get_plan_change_audit(
         )
 
         entries = []
-        for audit, workspace_name, user_name in audit_result.all():
+        for audit, workspace_name, user_name, user_email in audit_result.all():
             entries.append(
                 PlanChangeAuditEntry(
                     id=audit.id,
@@ -574,7 +581,11 @@ async def get_plan_change_audit(
                     workspace_name=workspace_name,
                     old_plan=audit.old_plan,
                     new_plan=audit.new_plan,
-                    changed_by=user_name or audit.changed_by,
+                    # Keep the raw user_id in `changed_by` so the UI can link to
+                    # /admin/users/{id}; surface name + email as display labels.
+                    changed_by=audit.changed_by,
+                    changed_by_name=user_name,
+                    changed_by_email=user_email,
                     changed_at=to_utc_iso(audit.changed_at) or "",
                     reason=audit.reason,
                 )

--- a/backend/tests/integration/test_admin_plan_audit_actor.py
+++ b/backend/tests/integration/test_admin_plan_audit_actor.py
@@ -39,6 +39,7 @@ class TestPlanAuditActorResolution:
 
         ws = make_workspace(owner_user_id=user.user_id)
         db_session.add(ws)
+        await db_session.flush()  # insert the workspace before its FK child
         db_session.add(
             PlanChange(
                 workspace_id=ws.id,
@@ -74,6 +75,7 @@ class TestPlanAuditActorResolution:
 
         ws = make_workspace(owner_user_id=user.user_id)
         db_session.add(ws)
+        await db_session.flush()  # insert the workspace before its FK child
         db_session.add(
             PlanChange(
                 workspace_id=ws.id,

--- a/backend/tests/integration/test_admin_plan_audit_actor.py
+++ b/backend/tests/integration/test_admin_plan_audit_actor.py
@@ -1,0 +1,93 @@
+"""``GET /admin/plans/audit`` resolves the actor to email + keeps the user_id.
+
+The "changed by" column must surface the actor's **email** (a stable, unique
+display label) while keeping the raw **user_id** in ``changed_by`` so the admin
+UI can link it to ``/admin/users/{user_id}``.
+
+Regression guard for the bug where the endpoint joined to ``User.name`` — an
+ambiguous display name (e.g. literally "admin") — instead of ``User.email``,
+and overwrote ``changed_by`` with that label so the UI had no id to link to.
+
+Hits a real Postgres test DB because the resolution is a SQL outer-join
+projection that a mock-DB test cannot exercise.
+"""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin_plans import get_plan_change_audit
+from models.auth import PlanChange
+
+from ._admin_helpers import make_user, make_workspace, mock_admin
+
+
+class TestPlanAuditActorResolution:
+    """``changed_by`` = raw user_id (link target); ``changed_by_email`` = label."""
+
+    @pytest.mark.asyncio
+    async def test_resolves_actor_to_email_keeping_user_id_for_linking(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        # Display name is intentionally noise ("admin") to prove we resolve the
+        # *email*, not the name, and that changed_by stays the user_id.
+        user = make_user(name="admin")
+        db_session.add(user)
+        await db_session.flush()
+
+        ws = make_workspace(owner_user_id=user.user_id)
+        db_session.add(ws)
+        db_session.add(
+            PlanChange(
+                workspace_id=ws.id,
+                old_plan="free",
+                new_plan="pro",
+                changed_by=user.user_id,
+                reason="test",
+            )
+        )
+        await db_session.commit()
+
+        entries = await get_plan_change_audit(admin_user=mock_admin(), db=db_session, limit=100)
+        entry = next(e for e in entries if e.workspace_id == str(ws.id))
+
+        # Link target: the raw user_id, NOT the display name.
+        assert entry.changed_by == user.user_id
+        assert entry.changed_by != "admin"
+        # Display labels: resolved name + email (the UI stacks them).
+        assert entry.changed_by_name == user.name == "admin"
+        assert entry.changed_by_email == user.email
+
+    @pytest.mark.asyncio
+    async def test_unresolved_actor_yields_null_email_and_raw_id(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        # An actor id with no matching User row (e.g. account erased →
+        # pseudonymized changed_by) must fall back to the raw id with no email,
+        # so the UI renders plain text without a dangling /admin/users link.
+        user = make_user()
+        db_session.add(user)
+        await db_session.flush()
+
+        ws = make_workspace(owner_user_id=user.user_id)
+        db_session.add(ws)
+        db_session.add(
+            PlanChange(
+                workspace_id=ws.id,
+                old_plan="free",
+                new_plan="pro",
+                changed_by="erased-pseudonym-xyz",
+                reason="test",
+            )
+        )
+        await db_session.commit()
+
+        entries = await get_plan_change_audit(admin_user=mock_admin(), db=db_session, limit=100)
+        entry = next(e for e in entries if e.workspace_id == str(ws.id))
+
+        assert entry.changed_by == "erased-pseudonym-xyz"
+        assert entry.changed_by_name is None
+        assert entry.changed_by_email is None

--- a/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
@@ -410,6 +410,20 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
     await screen.findByText("admin.plans.addonDialog.title");
   }
 
+  it("renders the quota detail as usage / effective (used is the numerator)", async () => {
+    render(<AdminPlansPage />);
+    // Click the workspace row to expand it and load the quota detail.
+    fireEvent.click(await screen.findByText("Pro Workspace"));
+
+    const memoryRow = (
+      await screen.findByText("admin.plans.quota.memory")
+    ).closest("div.grid");
+    // usage (50,000) is the numerator, effective (110,000) the denominator —
+    // matching the summary row's "used / limit", not the old reversed order.
+    expect(memoryRow).toHaveTextContent("50,000 / 110,000");
+    expect(memoryRow).not.toHaveTextContent("110,000 / 50,000");
+  });
+
   it("renders all 10 addon inputs with values pre-populated from quota detail", async () => {
     await openAddonDialog();
 

--- a/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
@@ -317,6 +317,76 @@ describe("AdminPlansPage — tiers tab", () => {
   });
 });
 
+// ----------------------------------------------------------------------
+// Audit tab — the "changed by" actor renders as name + email, linked to the
+// admin user-detail page. `changed_by` carries the raw user_id (link target);
+// `changed_by_name` / `changed_by_email` are the display labels. When the actor
+// no longer resolves (erased → pseudonymized changed_by, null name/email) the
+// raw id renders without a link.
+// ----------------------------------------------------------------------
+describe("AdminPlansPage audit tab — actor link", () => {
+  beforeEach(() => {
+    currentTab = "audit";
+  });
+
+  const auditEntry = (over: Record<string, unknown>) => ({
+    id: 1,
+    workspace_id: "ws-1",
+    workspace_name: "Personal Workspace",
+    old_plan: "free",
+    new_plan: "pro",
+    changed_by: "105867659819019494486",
+    changed_by_name: "Fumikazu Kiyota",
+    changed_by_email: "kiyota@noizz.co.jp",
+    changed_at: "2026-06-02T11:52:41Z",
+    reason: null,
+    ...over,
+  });
+
+  it("renders name + email and links them to /admin/users/{changed_by}", async () => {
+    mockGetAdminPlanAudit.mockResolvedValue([auditEntry({})]);
+
+    render(<AdminPlansPage />);
+
+    // Both lines render...
+    const name = await screen.findByText("Fumikazu Kiyota");
+    expect(screen.getByText("kiyota@noizz.co.jp")).toBeInTheDocument();
+    // ...inside a single link to the user-detail page.
+    const link = name.closest("a");
+    expect(link).toHaveAttribute("href", "/admin/users/105867659819019494486");
+    expect(link).toHaveTextContent("kiyota@noizz.co.jp");
+  });
+
+  it("falls back to email only when the actor has no display name", async () => {
+    mockGetAdminPlanAudit.mockResolvedValue([
+      auditEntry({ changed_by_name: null }),
+    ]);
+
+    render(<AdminPlansPage />);
+
+    const link = await screen.findByRole("link", {
+      name: "kiyota@noizz.co.jp",
+    });
+    expect(link).toHaveAttribute("href", "/admin/users/105867659819019494486");
+    expect(screen.queryByText("Fumikazu Kiyota")).toBeNull();
+  });
+
+  it("shows the raw id without a link when the actor no longer resolves", async () => {
+    mockGetAdminPlanAudit.mockResolvedValue([
+      auditEntry({
+        changed_by: "erased-pseudonym",
+        changed_by_name: null,
+        changed_by_email: null,
+      }),
+    ]);
+
+    render(<AdminPlansPage />);
+
+    expect(await screen.findByText("erased-pseudonym")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "erased-pseudonym" })).toBeNull();
+  });
+});
+
 describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
   beforeEach(() => {
     currentTab = "workspaces";

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -543,7 +543,7 @@ export default function AdminPlansPage() {
                                           {t("quota.addon")}
                                         </div>
                                         <div className="text-right">
-                                          {t("quota.effectiveUsage")}
+                                          {t("quota.usageEffective")}
                                         </div>
                                       </div>
                                       {/* Issue #663: ADDON_TYPES drives the
@@ -587,18 +587,33 @@ export default function AdminPlansPage() {
                                                 </span>
                                               )}
                                             </div>
+                                            {/* Usage / Effective — usage
+                                                (used) is the numerator, matching
+                                                the summary row's used / limit
+                                                ("5,220 / 100,000"). Rows with no
+                                                tracked usage show the effective
+                                                value alone. */}
                                             <div className="text-right">
-                                              <span className="font-medium">
-                                                {formatQuotaValue(
-                                                  meta,
-                                                  effective,
-                                                )}
-                                              </span>
-                                              {usage !== null && (
-                                                <span className="text-muted-foreground">
-                                                  {" "}
-                                                  / {usage.toLocaleString()}{" "}
-                                                  {t("quota.used")}
+                                              {usage !== null ? (
+                                                <>
+                                                  <span className="font-medium">
+                                                    {usage.toLocaleString()}
+                                                  </span>
+                                                  <span className="text-muted-foreground">
+                                                    {" "}
+                                                    /{" "}
+                                                    {formatQuotaValue(
+                                                      meta,
+                                                      effective,
+                                                    )}
+                                                  </span>
+                                                </>
+                                              ) : (
+                                                <span className="font-medium">
+                                                  {formatQuotaValue(
+                                                    meta,
+                                                    effective,
+                                                  )}
                                                 </span>
                                               )}
                                             </div>

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -13,6 +13,7 @@
  */
 
 import React, { useEffect, useState } from "react";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
@@ -482,9 +483,7 @@ export default function AdminPlansPage() {
                               <PlanBadge
                                 planName={
                                   workspace.plan_name as
-                                    | "free"
-                                    | "basic"
-                                    | "pro"
+                                    "free" | "basic" | "pro"
                                 }
                               />
                             </TableCell>
@@ -809,7 +808,25 @@ export default function AdminPlansPage() {
                             size="sm"
                           />
                         </TableCell>
-                        <TableCell>{entry.changed_by}</TableCell>
+                        <TableCell>
+                          {entry.changed_by_email ? (
+                            <Link
+                              href={`/admin/users/${entry.changed_by}`}
+                              className="block hover:underline"
+                            >
+                              {entry.changed_by_name && (
+                                <span className="block font-medium text-sm">
+                                  {entry.changed_by_name}
+                                </span>
+                              )}
+                              <span className="block text-xs text-gray-500">
+                                {entry.changed_by_email}
+                              </span>
+                            </Link>
+                          ) : (
+                            entry.changed_by
+                          )}
+                        </TableCell>
                         <TableCell className="text-sm text-muted-foreground">
                           {entry.reason || "-"}
                         </TableCell>

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -26,7 +26,12 @@ export interface PlanChangeAuditEntry {
   workspace_name: string;
   old_plan: string | null;
   new_plan: string;
+  /** Actor's stable user_id (OAuth2 sub) — links to /admin/users/{changed_by}. */
   changed_by: string;
+  /** Resolved actor display name; null if the user no longer exists. */
+  changed_by_name: string | null;
+  /** Resolved actor email for display; null if the user no longer exists. */
+  changed_by_email: string | null;
   changed_at: string;
   reason: string | null;
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2407,7 +2407,7 @@
         "resource": "Resource",
         "base": "Base",
         "addon": "Addon",
-        "effectiveUsage": "Effective / Usage",
+        "usageEffective": "Usage / Effective",
         "connector": "Connectors"
       },
       "addonDialog": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2407,7 +2407,7 @@
         "resource": "リソース",
         "base": "ベース",
         "addon": "アドオン",
-        "effectiveUsage": "有効値 / 使用量",
+        "usageEffective": "使用量 / 有効値",
         "connector": "コネクタ"
       },
       "addonDialog": {


### PR DESCRIPTION
## Problem

On the admin **Quota/Limits → 監査ログ (audit log)** page, the **変更者 (changed by)** column showed an ambiguous display name (e.g. literally `admin`) instead of identifying who made the change, and it was not clickable.

## Root cause

`GET /api/v1/admin/plans/audit` joined `PlanChange.changed_by` (the actor's `user_id`) to **`User.name`** and overwrote `changed_by` with that label — so the UI had no id to link, and a name like "admin" was uninformative. (The codebase's other audit surface, `AuditLog`, already keys on `user_email`.)

## Fix

Resolve the actor the **same way the admin user pages do** — `User.name` + `User.email` ([admin.py](https://github.com/kagura-ai/memory-cloud/blob/main/backend/src/api/routes/admin.py#L479)) — and **keep the raw `user_id` in `changed_by`** so the UI can link the cell to `/admin/users/{user_id}`.

The 변更者 cell now renders **name over email** (matching the admin users list style), linked to the user-detail page. Actors that no longer resolve (erased → pseudonymized `changed_by`, null name/email) render the raw id as **plain text — no broken link**.

```
Fumikazu Kiyota        ← User.name
kiyota@noizz.co.jp     ← User.email      (whole block links to /admin/users/{user_id})
```

## Changes

- **backend** (`admin_plans.py`): `PlanChangeAuditEntry` gains `changed_by_name` / `changed_by_email`; `changed_by` stays the raw `user_id`. Audit query selects `User.name, User.email`.
- **frontend** (`admin.ts`, `admin/plans/page.tsx`): type fields + 2-line linked actor cell.
- **tests**: backend actor-resolution integration test (`test_admin_plan_audit_actor.py` — name+email + null fallback); frontend audit-tab link tests (name+email / email-only / unresolved).

## Verification

- frontend: `admin/plans/page.test.tsx` **16/16 pass**, `tsc --noEmit` clean
- backend: `py_compile` OK; new integration test runs in CI (`backend-integration`). Existing `test_admin_plans_soft_delete_filter.py` pin test asserts `workspace_id` only — unaffected.

## Note

For an existing audit row to render the linked name+email, its stored `changed_by` must resolve to a current `User` (it does for session-admin changes, which record the real OAuth sub). Rows whose `changed_by` does not resolve degrade gracefully to plain text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)