### PR TITLE
fix(plan): mark Connectors/Analysis/Sleep matrix rows Beta, drop Broadlistening label

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
@@ -238,15 +238,12 @@ export default function WorkspacePlanPage() {
 
       {/* #1138: per-tier comparison matrix (replaces the old flat "Pro
           benefits" bullet list). No price column — pricing lives on the
-          payment side (#1141). Marked Beta. */}
+          payment side (#1141). The Beta tag now sits on the specific Beta
+          capabilities (Connectors / Analysis / Sleep) inside the matrix,
+          rather than on the whole section. */}
       <Section
         title={t("planMatrix.title")}
         description={t("planMatrix.description")}
-        headerActions={
-          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
-            {t("planMatrix.beta")}
-          </span>
-        }
       >
         <PlanFeatureMatrix currentTier={canonicalTier} />
       </Section>

--- a/frontend/src/components/plan/PlanFeatureMatrix.test.tsx
+++ b/frontend/src/components/plan/PlanFeatureMatrix.test.tsx
@@ -137,4 +137,21 @@ describe("PlanFeatureMatrix (#1138)", () => {
     // No price/currency leaks into the matrix.
     expect(document.body.textContent ?? "").not.toMatch(/\$|¥|price/i);
   });
+
+  it("tags Connectors / Analysis / Sleep rows as Beta, not the stable rows", async () => {
+    render(<PlanFeatureMatrix currentTier="pro" />);
+    await screen.findByText("planMatrix.row_connectors");
+
+    for (const key of [
+      "planMatrix.row_connectors",
+      "planMatrix.row_analysisPerDay",
+      "planMatrix.row_sleepContexts",
+    ]) {
+      expect(rowOf(key).getByText("planMatrix.beta")).toBeInTheDocument();
+    }
+    // A stable capability row carries no Beta badge.
+    expect(
+      rowOf("planMatrix.row_memories").queryByText("planMatrix.beta"),
+    ).toBeNull();
+  });
 });

--- a/frontend/src/components/plan/PlanFeatureMatrix.tsx
+++ b/frontend/src/components/plan/PlanFeatureMatrix.tsx
@@ -34,6 +34,7 @@ interface MatrixRow {
   key: string;
   field: keyof PlanTierFeature;
   kind: RowKind;
+  beta?: boolean; // tag this capability as Beta (badge next to the row label)
 }
 
 const ROWS: MatrixRow[] = [
@@ -45,12 +46,18 @@ const ROWS: MatrixRow[] = [
   { key: "restPerDay", field: "rest_calls_per_day", kind: "number" },
   { key: "publicPerDay", field: "public_calls_per_day", kind: "number" },
   { key: "resourceTokens", field: "max_resource_tokens", kind: "number" },
-  { key: "connectors", field: "max_connectors", kind: "number" },
-  { key: "analysisPerDay", field: "analysis_runs_per_day", kind: "number" },
+  { key: "connectors", field: "max_connectors", kind: "number", beta: true },
+  {
+    key: "analysisPerDay",
+    field: "analysis_runs_per_day",
+    kind: "number",
+    beta: true,
+  },
   {
     key: "sleepContexts",
     field: "sleep_enabled_contexts_limit",
     kind: "number",
+    beta: true,
   },
   { key: "reranking", field: "reranking", kind: "bool" },
   { key: "managedEmbeddings", field: "managed_embeddings", kind: "bool" },
@@ -160,7 +167,14 @@ export function PlanFeatureMatrix({
           {ROWS.map((row) => (
             <TableRow key={row.key}>
               <TableCell className="text-sm font-medium">
-                {t(`planMatrix.row_${row.key}`)}
+                <span className="inline-flex items-center gap-2">
+                  {t(`planMatrix.row_${row.key}`)}
+                  {row.beta && (
+                    <span className="rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+                      {t("planMatrix.beta")}
+                    </span>
+                  )}
+                </span>
               </TableCell>
               {tiers.map((tier) => (
                 <TableCell

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1182,7 +1182,7 @@
       "row_publicPerDay": "Public calls / day",
       "row_resourceTokens": "Resource tokens",
       "row_connectors": "Connectors",
-      "row_analysisPerDay": "Analysis (Broadlistening) / day",
+      "row_analysisPerDay": "Analysis / day",
       "row_sleepContexts": "Sleep-enabled contexts",
       "row_reranking": "Reranking",
       "row_managedEmbeddings": "Managed embeddings",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1181,7 +1181,7 @@
       "row_publicPerDay": "公開呼び出し / 日",
       "row_resourceTokens": "リソーストークン",
       "row_connectors": "コネクタ",
-      "row_analysisPerDay": "分析(ブロードリスニング) / 日",
+      "row_analysisPerDay": "分析 / 日",
       "row_sleepContexts": "Sleep対応コンテキスト",
       "row_reranking": "リランキング",
       "row_managedEmbeddings": "マネージド埋め込み",


### PR DESCRIPTION
Refines the owner Plan page feature matrix (#1138).

## Changes

- **Per-row Beta badge** on the specific Beta capabilities — **Connectors**, **Analysis / day**, **Sleep-enabled contexts** — replacing the single section-level "Beta" badge (which implied the *whole* comparison was beta). A `MatrixRow.beta` flag drives the badge.
- **Drop the "(Broadlistening)" qualifier** from the analysis row label: `分析(ブロードリスニング) / 日` → `分析 / 日` (en: `Analysis (Broadlistening) / day` → `Analysis / day`), ja + en.

## Verification

- `PlanFeatureMatrix.test.tsx` (incl. new test asserting the 3 Beta rows + no badge on stable rows) and `plan/page.test.tsx` — **9/9 pass**
- `tsc --noEmit` clean

Frontend-only; no backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)