### PR TITLE
docs(plugin): sync smoke-test skill + plugin descriptions to the 50-tool MCP surface

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "kagura-memory",
       "source": "./",
-      "description": "Persistent AI memory with session management, recall/save, and setup tools",
+      "description": "Persistent AI project memory — restore session context, recall & save knowledge, setup, and an MCP smoke test",
       "category": "productivity",
       "homepage": "https://github.com/kagura-ai/memory-cloud"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kagura-memory",
   "version": "0.41.0",
-  "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
+  "description": "Kagura Memory Cloud plugin — restore session context, recall & save durable project knowledge, setup help, and an MCP smoke test",
   "author": {
     "name": "Kagura AI, Inc.",
     "url": "https://github.com/kagura-ai"

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2198,7 +2198,7 @@ Returns: {status, name, rotation_needed: true}.""",
         },
     ]
     # Pre-1.0 schema policy (#990): every tool inputSchema is strict — no
-    # undeclared top-level parameters. Applied centrally here so all 45 tools
+    # undeclared top-level parameters. Applied centrally here so all 50 tools
     # stay uniform and any new tool inherits the policy automatically. This is
     # advisory (handlers read args defensively via ``.get`` and never
     # Pydantic-validate), so it tightens the client-facing contract without

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -8,7 +8,7 @@ lane (`delivery_mode` pinning + `load_pinned`, the agent session-state lane, ret
 and the `trust_tier` recall filter), and owner-scoped binding introspection.
 Optionally exercises PRO-only resource rows (setup_resource, ingest_events, get_resource_impact, get_resource_schema, list_resource_tokens, plus delete_context cleanup) if the workspace has a PRO plan.
 
-The canonical tool registry is `backend/src/mcp_server/tools/__init__.py` (**45 tools**). The
+The canonical tool registry is `backend/src/mcp_server/tools/__init__.py` (**50 tools**). The
 **Coverage cross-check** section near the end mirrors that registry so the "all MCP tools" claim
 stays honest — every registered tool is either exercised here or listed there with a reason. This
 is a live runbook, not a pytest suite, so the cross-check is a manual reconciliation step: when a
@@ -17,6 +17,7 @@ tool is added to the registry, this skill must gain a row or a documented exclus
 Excluded by design (each documented in the Coverage cross-check):
 - `analyze_context` — requires billing, BYOK, workspace owner role, and Pro-tier feature access.
 - File tools (`init_file_upload`, `complete_file_upload`, `get_file_download_url`, `delete_file`, `list_files`) — require multipart S3/R2 upload flows that can't be exercised inline; cover them separately.
+- Secret tools (`secret_register_pubkey`, `secret_put`, `secret_get`, `secret_list`, `secret_revoke_grant`) — zero-knowledge store needing `age` recipient keypairs, owner pubkey approval, and armored ciphertext; exercise via the `kagura secret` CLI/SDK, not inline.
 - `setup_connector` — provisions an external connector (Slack/Discord/Teams) needing platform credentials and a real target; gated-skip inline.
 
 Use this after deployments, tool description changes, or MCP server updates.
@@ -385,16 +386,16 @@ delete_context(context_id=...)
 ### 8. Coverage cross-check (anti-drift)
 
 Reconcile this skill against the canonical registry so the "all MCP tools" claim cannot silently
-rot. The source of truth is `backend/src/mcp_server/tools/__init__.py` (**45 tools**). Every
+rot. The source of truth is `backend/src/mcp_server/tools/__init__.py` (**50 tools**). Every
 registered tool must be in exactly one column below. **If `tools/__init__.py` and this table
 disagree, the skill is out of date — add a row (or a documented exclusion) before merging.**
 
-Optional live assertion: count the keys in the registry and confirm it equals 45 (the number this
+Optional live assertion: count the keys in the registry and confirm it equals 50 (the number this
 table is built for); if it differs, a tool was added/removed and this skill needs updating:
 
 ```
 grep -cE '^\s*"[a-z_]+"\s*:\s*handle_' backend/src/mcp_server/tools/__init__.py
--> Verify: equals 45 (else: reconcile this section with the registry)
+-> Verify: equals 50 (else: reconcile this section with the registry)
 ```
 
 **Exercised inline (33 core tools):** list_contexts, create_context, get_context_info,
@@ -408,7 +409,7 @@ rollback_sleep_run, delete_context.
 **Exercised only on PRO plan, else SKIP (5 tools):** setup_resource, ingest_events,
 get_resource_impact, get_resource_schema, list_resource_tokens.
 
-**Documented exclusions / gated-skip (7 tools) — with reasons:**
+**Documented exclusions / gated-skip (12 tools) — with reasons:**
 
 | Tool | Why not exercised inline |
 |---|---|
@@ -419,9 +420,14 @@ get_resource_impact, get_resource_schema, list_resource_tokens.
 | `get_file_download_url` | Requires an uploaded object to produce a presigned URL. |
 | `delete_file` | Requires an uploaded object to delete. |
 | `list_files` | Grouped with the file-upload flow; covered in the file-tools test suite. |
+| `secret_register_pubkey` | Zero-knowledge secret store: needs an `age` recipient public key. Covered by the secret-store suite / `kagura secret` CLI. |
+| `secret_put` | Requires an owner-approved active recipient pubkey + armored `age` ciphertext encrypted client-side. |
+| `secret_get` | Requires an active grant via an active recipient pubkey; the server never decrypts. |
+| `secret_list` | Owner/admin metadata listing; grouped with the secret-store flow. |
+| `secret_revoke_grant` | Operates on an existing grant produced by `secret_put`. |
 
-33 + 5 + 7 = **45** — the full registry. The gap between "exercised inline" and the registry is
-**only** the 5 PRO-gated rows (run when PRO) and the 7 documented exclusions above.
+33 + 5 + 12 = **50** — the full registry. The gap between "exercised inline" and the registry is
+**only** the 5 PRO-gated rows (run when PRO) and the 12 documented exclusions above.
 
 ### 9. Report
 
@@ -490,7 +496,7 @@ Print a summary table (numbers are illustrative; the executed order follows the 
 
 Note: the 47 rows are test *steps*, not distinct tools — several tools (remember, recall,
 update_memory, forget, delete_context, list_edges, list_tags) are exercised in multiple rows.
-Distinct-tool coverage is reconciled in the Coverage cross-check (33 core + 5 PRO + 7 documented-skip = 45).
+Distinct-tool coverage is reconciled in the Coverage cross-check (33 core + 5 PRO + 12 documented-skip = 50).
 
 Test context: smoke-test-{timestamp} (cleaned up)
 
@@ -498,8 +504,9 @@ Documented exclusions / gated-skip (see Coverage cross-check) — not counted as
 - analyze_context (billing + BYOK + owner + Pro-tier)
 - setup_connector (external connector credentials + live target)
 - File tools: init_file_upload, complete_file_upload, get_file_download_url, delete_file, list_files (multipart S3/R2)
+- Secret tools: secret_register_pubkey, secret_put, secret_get, secret_list, secret_revoke_grant (zero-knowledge: age keypairs + owner approval + ciphertext)
 
-Registry reconciliation: 33 core + 5 PRO + 7 documented-skip = 45 tools in tools/__init__.py.
+Registry reconciliation: 33 core + 5 PRO + 12 documented-skip = 50 tools in tools/__init__.py.
 ```
 
 If any step fails:


### PR DESCRIPTION
## Summary

The v0.39.0 secret-store docs sweep ([#1140](https://github.com/kagura-ai/memory-cloud/pull/1140)) updated the living docs to **50 tools** but missed the **smoke-test skill** and the **plugin manifests** — they still said 45 / undersold the skill set. This syncs them.

## Changes
- **`claude-skills/smoke-test.md`** (the skill): `45` → `50` tools everywhere; the 5 secret tools (`secret_register_pubkey/put/get/list/revoke_grant`) added to the **Coverage cross-check** as documented-skip — the zero-knowledge store needs `age` keypairs + owner pubkey approval + client-side ciphertext, so it's exercised via the `kagura secret` CLI/SDK, not inline. Reconciliation now: **33 core + 5 PRO + 12 documented-skip = 50**.
- **`.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json`** (the plugin description): completed to cover all six skills (restore session context, recall, save, setup, MCP smoke test) — brings them to parity with the already-complete Codex manifest.
- **`_definitions.py`**: schema-policy code comment `45` → `50`.

## Deliberately untouched
- `docs/api-surface-1.0/*` — frozen "N of N enumerated" 1.0 snapshot; bumping its count without re-enumerating each tool's schema would make it internally inconsistent (governance rule).
- The dead `KAGURA_MEMORY_USAGE_GUIDE` constant (still says "32 tools") — it's **unused** (the served guide is `KAGURA_MEMORY_INSTRUCTIONS`); flagged for removal in a separate cleanup rather than maintaining dead code.

No behavior change. `test_codex_plugin_manifest` is unaffected (it checks version lockstep / names / paths, not description text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)