### PR TITLE
feat(rerank): batched /v1/rerank path for the local reranker (RERANK_BASE_URL)

### DIFF
--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -363,6 +363,40 @@ class Settings(BaseSettings):
         """
         return v.rstrip("/") if v else v
 
+    # Local reranker serving override
+    rerank_base_url: str = Field(
+        default="",
+        description=(
+            "OpenAI/Jina-style /v1/rerank endpoint (vLLM --runner pooling, TEI, "
+            "or Infinity) for the local reranker path. When set, the context-"
+            "config 'ollama' reranker posts ONE batched /v1/rerank request here "
+            "instead of per-document Ollama prompt scoring. Empty = keep "
+            "OllamaReranker on ollama_base_url."
+        ),
+    )
+    rerank_model: str = Field(
+        default="qwen3-reranker-0.6b",
+        description=(
+            "Served model name for the local /v1/rerank endpoint (RERANK_BASE_URL). "
+            "Must match the endpoint's model id exactly — e.g. vLLM's "
+            "--served-model-name, or the TEI/Infinity model id. This is the "
+            "ops-level default; a per-context reranker_model (when set and not a "
+            "stale remote-provider default) still overrides it. Only consulted "
+            "when rerank_base_url is set. Keep in sync with "
+            "reranker_service.DEFAULT_VLLM_RERANK_MODEL."
+        ),
+    )
+
+    @field_validator("rerank_base_url", "rerank_model", mode="before")
+    @classmethod
+    def _strip_rerank_fields(cls, v: object) -> object:
+        # rerank_base_url is used as a truthy feature toggle
+        # (`if settings.rerank_base_url:`) and rerank_model is sent verbatim to
+        # the endpoint. Strip surrounding whitespace and collapse a
+        # whitespace-only value to "" so a stray-space env var neither enables
+        # the vLLM path with an invalid URL nor ships a blank model name.
+        return v.strip() if isinstance(v, str) else v
+
     # Search Configuration (Issue #105)
     enable_reranking: bool = Field(
         default=True,

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -369,9 +369,9 @@ class Settings(BaseSettings):
         description=(
             "OpenAI/Jina-style /v1/rerank endpoint (vLLM --runner pooling, TEI, "
             "or Infinity) for the local reranker path. When set, the context-"
-            "config 'ollama' reranker posts ONE batched /v1/rerank request here "
-            "instead of per-document Ollama prompt scoring. Empty = keep "
-            "OllamaReranker on ollama_base_url."
+            "config 'self_hosted' reranker posts ONE batched /v1/rerank request "
+            "here instead of per-document prompt scoring. Empty = keep the "
+            "prompt-scoring SelfHostedReranker on self_hosted_base_url."
         ),
     )
     rerank_model: str = Field(

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -359,11 +359,11 @@ class VLLMReranker(RerankerProvider):
     """True cross-encoder reranker via an OpenAI/Jina-style /v1/rerank endpoint.
 
     One batched HTTP call scores all documents — unlike SelfHostedReranker's
-    per-document /api/generate prompt scoring. Served by vLLM (``--runner
+    per-document /v1/completions prompt scoring. Served by vLLM (``--runner
     pooling`` sequence-classification), HF TEI, or Infinity. Selected by
     setting ``settings.rerank_base_url``; the context config stays
-    ``reranker_provider="ollama"`` — the context declares "local rerank on",
-    the deployment decides how it is served (kagura-memory-eval GB10 rig).
+    ``reranker_provider="self_hosted"`` — the context declares "local rerank
+    on", the deployment decides how it is served (kagura-memory-eval GB10 rig).
     """
 
     provider_name = "vllm"

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -397,6 +397,7 @@ class VLLMReranker(RerankerProvider):
         Raises:
             ValueError: If top_n is non-positive or the /v1/rerank response has an unexpected shape
             httpx.HTTPError: If the rerank endpoint call fails
+        """
         if not documents:
             return []
         if top_n <= 0:

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -395,8 +395,8 @@ class VLLMReranker(RerankerProvider):
             Reranked results with index and relevance_score (descending)
 
         Raises:
+            ValueError: If top_n is non-positive or the /v1/rerank response has an unexpected shape
             httpx.HTTPError: If the rerank endpoint call fails
-        """
         if not documents:
             return []
         if top_n <= 0:

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -13,6 +13,8 @@ Architecture:
 - CohereReranker: Cohere implementation (rerank-multilingual-v3.0)
 - SelfHostedReranker: Self-hosted OpenAI-compatible reranker (registers under
   the "self_hosted" provider key; no API key needed for keyless backends)
+- VLLMReranker: Local true cross-encoder via an OpenAI/Jina-style /v1/rerank
+  endpoint (vLLM/TEI/Infinity); selected when settings.rerank_base_url is set
 - RerankerService: Factory pattern to select active provider from DB
 """
 
@@ -43,6 +45,13 @@ RERANKER_PROVIDERS = {"cohere", "voyage"}
 # Ollama-registry model id; a vLLM deployment would set an HF repo id via
 # the context search config's reranker_model.
 DEFAULT_SELF_HOSTED_RERANK_MODEL = "dengcao/Qwen3-Reranker-8B:Q5_K_M"
+
+# Built-in fallback model name served behind settings.rerank_base_url
+# (e.g. vLLM `--served-model-name`). The ops-level default is
+# settings.rerank_model (env RERANK_MODEL, same default value); this constant
+# is the hard floor used when RERANK_MODEL is explicitly blanked. Keep the two
+# literals in sync.
+DEFAULT_VLLM_RERANK_MODEL = "qwen3-reranker-0.6b"
 
 
 class RerankerProvider(ABC):
@@ -346,6 +355,124 @@ class SelfHostedReranker(RerankerProvider):
         return scored[:top_n]
 
 
+class VLLMReranker(RerankerProvider):
+    """True cross-encoder reranker via an OpenAI/Jina-style /v1/rerank endpoint.
+
+    One batched HTTP call scores all documents — unlike SelfHostedReranker's
+    per-document /api/generate prompt scoring. Served by vLLM (``--runner
+    pooling`` sequence-classification), HF TEI, or Infinity. Selected by
+    setting ``settings.rerank_base_url``; the context config stays
+    ``reranker_provider="ollama"`` — the context declares "local rerank on",
+    the deployment decides how it is served (kagura-memory-eval GB10 rig).
+    """
+
+    provider_name = "vllm"
+
+    def __init__(self, base_url: str, model: str = DEFAULT_VLLM_RERANK_MODEL):
+        """Initialize the /v1/rerank client.
+
+        Args:
+            base_url: Endpoint base URL (e.g. http://gpu:8002); /v1/rerank is appended.
+            model: Served model name on the rerank endpoint.
+        """
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    async def rerank(
+        self,
+        query: str,
+        documents: list[str],
+        top_n: int,
+    ) -> list[dict[str, Any]]:
+        """Rerank all documents with one batched /v1/rerank request.
+
+        Args:
+            query: Search query
+            documents: Documents to rerank
+            top_n: Number of results
+
+        Returns:
+            Reranked results with index and relevance_score (descending)
+
+        Raises:
+            httpx.HTTPError: If the rerank endpoint call fails
+        """
+        if not documents:
+            return []
+        if top_n <= 0:
+            raise ValueError("top_n must be positive")
+
+        # Clamp to the candidate count: some OpenAI/Jina-style rerank servers
+        # reject top_n > len(documents) with a 4xx. Mirrors the Ollama path,
+        # which never asks for more results than it has documents.
+        effective_top_n = min(top_n, len(documents))
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{self.base_url}/v1/rerank",
+                json={
+                    "model": self.model,
+                    "query": query,
+                    "documents": documents,
+                    "top_n": effective_top_n,
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+            # Validate the OpenAI/Jina-style shape before indexing so an
+            # unexpected body (proxy error page, different schema) fails with a
+            # clear message instead of an opaque KeyError/TypeError.
+            results = payload.get("results") if isinstance(payload, dict) else None
+            if not isinstance(results, list):
+                keys = list(payload)[:5] if isinstance(payload, dict) else None
+                raise ValueError(
+                    f"Unexpected /v1/rerank response from {self.base_url}: "
+                    f"expected a 'results' list, got {type(payload).__name__}"
+                    + (f" with keys {keys}" if keys is not None else "")
+                )
+
+        # Validate each item's shape too — a list whose elements lack
+        # 'index'/'relevance_score' (or have a non-numeric score, or an index
+        # that isn't an in-range int) would otherwise raise an opaque
+        # KeyError/TypeError/IndexError downstream (RerankerService does
+        # ``candidates[idx]``), losing the clear diagnostics added for the
+        # top-level shape check. Coerce + bounds-check the index here.
+        scored: list[dict[str, Any]] = []
+        n = len(documents)
+        for i, r in enumerate(results):
+            if not isinstance(r, dict) or "index" not in r or "relevance_score" not in r:
+                raise ValueError(
+                    f"Unexpected /v1/rerank result item {i} from {self.base_url}: "
+                    "expected an object with 'index' and 'relevance_score'"
+                )
+            # index must be an int (reject bool, which is an int subclass) in
+            # [0, len(documents)) so the downstream candidates[idx] is safe.
+            idx = r["index"]
+            if isinstance(idx, bool) or not isinstance(idx, int) or not (0 <= idx < n):
+                raise ValueError(
+                    f"Unexpected /v1/rerank result item {i} from {self.base_url}: "
+                    f"'index' must be an int in [0, {n}), got {idx!r}"
+                )
+            try:
+                score = float(r["relevance_score"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Unexpected /v1/rerank result item {i} from {self.base_url}: "
+                    f"'relevance_score' is not a number ({r.get('relevance_score')!r})"
+                ) from exc
+            scored.append({"index": idx, "relevance_score": score})
+        scored.sort(key=lambda x: x["relevance_score"], reverse=True)
+
+        logger.debug(
+            "vllm_rerank_completed",
+            model=self.model,
+            doc_count=len(documents),
+            top_n=effective_top_n,
+        )
+
+        return scored[:effective_top_n]
+
+
 def _parse_relevance_score(text: str) -> float:
     """Parse a relevance score from model output.
 
@@ -452,9 +579,33 @@ class RerankerService:
                 and ctx_config.use_rerank
             ):
                 settings = get_settings()
-                # Avoid non-self-hosted default models (e.g. "rerank-2" from a previous provider)
-                non_self_hosted_defaults = {"rerank-2", "rerank-2-lite", "rerank-multilingual-v3.0"}
+                # Avoid non-local default models left over from a previous
+                # remote provider (Voyage / Cohere) — otherwise a stale remote
+                # default model name would be sent to the local reranker. Keep
+                # this in sync with the remote providers' default models
+                # (VoyageReranker "rerank-2.5-lite", CohereReranker
+                # "rerank-multilingual-v3.0") and the _get_reranker_model table.
+                non_self_hosted_defaults = {
+                    "rerank-2",
+                    "rerank-2-lite",
+                    "rerank-2.5",
+                    "rerank-2.5-lite",
+                    "rerank-multilingual-v3.0",
+                    "rerank-english-v3.0",
+                }
                 model = ctx_config.reranker_model
+                if settings.rerank_base_url:
+                    # Ops-level override: a true cross-encoder is served behind an
+                    # OpenAI/Jina-style /v1/rerank endpoint. One batched call
+                    # replaces per-doc prompt scoring; context config unchanged.
+                    # Model resolution: an explicit, non-stale per-context
+                    # reranker_model wins; otherwise fall back to the ops-level
+                    # RERANK_MODEL (settings.rerank_model), then the built-in
+                    # default (guards an explicitly-blanked RERANK_MODEL).
+                    if not model or model in non_self_hosted_defaults:
+                        model = settings.rerank_model or DEFAULT_VLLM_RERANK_MODEL
+                    logger.debug("using_vllm_reranker", user_id=user_id, model=model)
+                    return VLLMReranker(base_url=settings.rerank_base_url, model=model)
                 if not model or model in non_self_hosted_defaults:
                     model = DEFAULT_SELF_HOSTED_RERANK_MODEL
                 logger.debug("using_self_hosted_reranker", user_id=user_id, model=model)

--- a/backend/tests/config/test_rerank_settings.py
+++ b/backend/tests/config/test_rerank_settings.py
@@ -1,0 +1,57 @@
+"""Rerank settings validation (#1161 review).
+
+``rerank_base_url`` is used as a truthy feature toggle (``if
+settings.rerank_base_url:``) and ``rerank_model`` is sent verbatim to the
+endpoint, so a stray-whitespace env value must not enable the vLLM path with an
+invalid URL nor ship a blank model name. These pin the strip/normalize contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from config.settings import Settings
+
+_RERANK_ENV_KEYS = ["RERANK_BASE_URL", "RERANK_MODEL"]
+
+
+@pytest.fixture
+def clean_rerank_env(monkeypatch):
+    for k in _RERANK_ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    return monkeypatch
+
+
+def _fresh_settings() -> Settings:
+    # _env_file=None ignores .env.dev so only os.environ (monkeypatched) is read.
+    return Settings(_env_file=None)
+
+
+def test_defaults_when_unset(clean_rerank_env):
+    s = _fresh_settings()
+    assert s.rerank_base_url == ""  # empty = local vLLM path disabled
+    assert s.rerank_model == "qwen3-reranker-0.6b"
+
+
+def test_whitespace_only_base_url_collapses_to_empty(clean_rerank_env):
+    """A whitespace-only RERANK_BASE_URL must NOT enable the vLLM path."""
+    clean_rerank_env.setenv("RERANK_BASE_URL", "   ")
+    s = _fresh_settings()
+    assert s.rerank_base_url == ""
+    assert not s.rerank_base_url  # truthy-toggle stays off
+
+
+def test_surrounding_whitespace_stripped(clean_rerank_env):
+    clean_rerank_env.setenv("RERANK_BASE_URL", "  http://gpu:8002\n")
+    clean_rerank_env.setenv("RERANK_MODEL", "  qwen3-reranker-4b  ")
+    s = _fresh_settings()
+    assert s.rerank_base_url == "http://gpu:8002"
+    assert s.rerank_model == "qwen3-reranker-4b"
+
+
+def test_whitespace_only_model_collapses_to_empty(clean_rerank_env):
+    """A blank RERANK_MODEL collapses to '' so the resolver falls back to the
+    built-in default instead of shipping a whitespace model name."""
+    clean_rerank_env.setenv("RERANK_MODEL", "  ")
+    s = _fresh_settings()
+    assert s.rerank_model == ""

--- a/backend/tests/services/test_reranker_service_coverage.py
+++ b/backend/tests/services/test_reranker_service_coverage.py
@@ -548,6 +548,7 @@ class TestRerankerServiceOllamaContextConfig:
         settings = MagicMock()
         settings.self_hosted_base_url = "http://ollama:11434"
         settings.self_hosted_api_key = ""
+        settings.rerank_base_url = ""  # not set → SelfHostedReranker, not the vLLM path
         monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
 
         cfg = self._ctx_config("self_hosted", True, "custom-ollama-model")
@@ -569,6 +570,7 @@ class TestRerankerServiceOllamaContextConfig:
         settings = MagicMock()
         settings.self_hosted_base_url = "http://ollama:11434"
         settings.self_hosted_api_key = ""
+        settings.rerank_base_url = ""  # not set → SelfHostedReranker, not the vLLM path
         monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
 
         cfg = self._ctx_config("self_hosted", True, "rerank-multilingual-v3.0")
@@ -585,6 +587,7 @@ class TestRerankerServiceOllamaContextConfig:
         settings = MagicMock()
         settings.self_hosted_base_url = "http://ollama:11434"
         settings.self_hosted_api_key = ""
+        settings.rerank_base_url = ""  # not set → SelfHostedReranker, not the vLLM path
         monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
 
         cfg = self._ctx_config("self_hosted", True, None)

--- a/backend/tests/services/test_vllm_reranker.py
+++ b/backend/tests/services/test_vllm_reranker.py
@@ -1,0 +1,384 @@
+"""Unit tests for the OpenAI/Jina-style /v1/rerank path of the local reranker.
+
+When ``settings.rerank_base_url`` is set, the local (context-config "ollama")
+reranker path returns a ``VLLMReranker`` that makes ONE batched POST to
+``{base}/v1/rerank`` (vLLM ``--runner pooling`` seq-cls, TEI, or Infinity)
+instead of SelfHostedReranker's per-document ``/api/generate`` prompt scoring.
+
+House style follows test_reranker_service_coverage.py: httpx.AsyncClient.post
+is patched with canned responses (never a real network call); RerankerService
+DB access goes through a MagicMock AsyncSession.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import httpx
+import pytest
+
+from services.reranker_service import (
+    DEFAULT_VLLM_RERANK_MODEL,
+    RerankerService,
+    SelfHostedReranker,
+    VLLMReranker,
+)
+
+
+def _result_scalar_one_or_none(value):
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=value)
+    return result
+
+
+class _FakeHttpResponse:
+    def __init__(self, *, json_data=None, raise_exc=None):
+        self._json_data = json_data
+        self._raise_exc = raise_exc
+
+    def raise_for_status(self):
+        if self._raise_exc is not None:
+            raise self._raise_exc
+
+    def json(self):
+        return self._json_data
+
+
+class TestVLLMReranker:
+    """VLLMReranker: batched /v1/rerank call, sorting, validation, errors."""
+
+    def test_init_defaults(self):
+        r = VLLMReranker(base_url="http://gpu:8002/")
+        assert r.provider_name == "vllm"
+        assert r.base_url == "http://gpu:8002"  # trailing slash stripped
+        assert r.model == DEFAULT_VLLM_RERANK_MODEL
+
+    async def test_empty_documents_returns_empty(self):
+        r = VLLMReranker(base_url="http://gpu:8002")
+        assert await r.rerank("q", [], top_n=5) == []
+
+    async def test_non_positive_top_n_raises_value_error(self):
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(ValueError):
+            await r.rerank("q", ["doc"], top_n=0)
+
+    async def test_posts_v1_rerank_once_and_sorts(self, monkeypatch):
+        """One batched POST to {base}/v1/rerank; results sorted by score desc."""
+        calls: list[tuple[str, dict]] = []
+
+        async def fake_post(self, url, json=None, **kwargs):
+            calls.append((url, json))
+            return _FakeHttpResponse(
+                json_data={
+                    "results": [
+                        {"index": 0, "relevance_score": 0.2},
+                        {"index": 1, "relevance_score": 0.9},
+                    ]
+                }
+            )
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002", model="qwen3-reranker-0.6b")
+        out = await r.rerank("q", ["a", "b"], top_n=2)
+
+        assert len(calls) == 1  # batched: one HTTP call for all documents
+        url, body = calls[0]
+        assert url == "http://gpu:8002/v1/rerank"
+        assert body == {
+            "model": "qwen3-reranker-0.6b",
+            "query": "q",
+            "documents": ["a", "b"],
+            "top_n": 2,
+        }
+        assert out[0] == {"index": 1, "relevance_score": 0.9}
+        assert out[1] == {"index": 0, "relevance_score": 0.2}
+
+    async def test_top_n_truncates_after_sort(self, monkeypatch):
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(
+                json_data={
+                    "results": [
+                        {"index": 0, "relevance_score": 0.5},
+                        {"index": 1, "relevance_score": 0.9},
+                        {"index": 2, "relevance_score": 0.1},
+                    ]
+                }
+            )
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        out = await r.rerank("q", ["a", "b", "c"], top_n=1)
+        assert out == [{"index": 1, "relevance_score": 0.9}]
+
+    async def test_http_error_propagates(self, monkeypatch):
+        exc = httpx.HTTPStatusError("boom", request=MagicMock(), response=MagicMock())
+
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(raise_exc=exc)
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(httpx.HTTPStatusError):
+            await r.rerank("q", ["a"], top_n=1)
+
+    async def test_malformed_response_raises_clear_value_error(self, monkeypatch):
+        """A 200 body without a 'results' list fails with a clear ValueError.
+
+        Guards against opaque KeyError/TypeError when the endpoint returns an
+        unexpected shape (proxy error page, different schema).
+        """
+
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(json_data={"error": "bad gateway"})
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(ValueError, match="results"):
+            await r.rerank("q", ["a"], top_n=1)
+
+    async def test_top_n_clamped_to_document_count(self, monkeypatch):
+        """top_n > len(documents) is clamped in the request body (some servers
+        reject top_n > candidates with a 4xx)."""
+        calls: list[tuple[str, dict]] = []
+
+        async def fake_post(self, url, json=None, **kwargs):
+            calls.append((url, json))
+            return _FakeHttpResponse(json_data={"results": [{"index": 0, "relevance_score": 0.5}]})
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        out = await r.rerank("q", ["only-one"], top_n=10)
+
+        assert calls[0][1]["top_n"] == 1  # clamped to len(documents), not 10
+        assert out == [{"index": 0, "relevance_score": 0.5}]
+
+    async def test_malformed_result_item_raises_clear_value_error(self, monkeypatch):
+        """A 'results' list whose items lack index/relevance_score fails with a
+        clear ValueError naming the offending item, not an opaque KeyError."""
+
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(
+                json_data={"results": [{"idx": 0, "score": 0.9}]}  # wrong keys
+            )
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(ValueError, match="result item 0"):
+            await r.rerank("q", ["a"], top_n=1)
+
+    async def test_non_numeric_relevance_score_raises_clear_value_error(self, monkeypatch):
+        """A non-numeric relevance_score fails with a clear ValueError, not an
+        opaque float() ValueError."""
+
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(
+                json_data={"results": [{"index": 0, "relevance_score": "high"}]}
+            )
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(ValueError, match="not a number"):
+            await r.rerank("q", ["a"], top_n=1)
+
+    async def test_out_of_range_index_raises_clear_value_error(self, monkeypatch):
+        """A server 'index' outside [0, len(documents)) fails with a clear
+        ValueError instead of an opaque downstream IndexError (candidates[idx])."""
+
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(
+                json_data={"results": [{"index": 5, "relevance_score": 0.9}]}  # only 2 docs
+            )
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(ValueError, match="index"):
+            await r.rerank("q", ["a", "b"], top_n=2)
+
+    async def test_non_int_index_raises_clear_value_error(self, monkeypatch):
+        """A non-int 'index' (string, or bool) fails with a clear ValueError
+        instead of an opaque downstream TypeError (candidates[idx])."""
+
+        async def fake_post(self, url, json=None, **kwargs):
+            return _FakeHttpResponse(
+                json_data={"results": [{"index": "0", "relevance_score": 0.9}]}  # str, not int
+            )
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002")
+        with pytest.raises(ValueError, match="index"):
+            await r.rerank("q", ["a"], top_n=1)
+
+
+class TestRerankBaseUrlSelection:
+    """get_active_provider: rerank_base_url switches the local path to VLLMReranker."""
+
+    @pytest.fixture
+    def mock_db(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def service(self, mock_db):
+        return RerankerService(mock_db)
+
+    def _ctx_config(self, provider, use_rerank, model):
+        cfg = MagicMock()
+        cfg.reranker_provider = provider
+        cfg.use_rerank = use_rerank
+        cfg.reranker_model = model
+        return cfg
+
+    async def test_rerank_base_url_set_returns_vllm_reranker(self, service, mock_db, monkeypatch):
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = "http://gpu:8002"
+        settings.rerank_model = "qwen3-reranker-0.6b"
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, "qwen3-reranker-0.6b")
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, VLLMReranker)
+        assert provider.base_url == "http://gpu:8002"
+        assert provider.model == "qwen3-reranker-0.6b"
+
+    async def test_rerank_base_url_empty_keeps_self_hosted_reranker(
+        self, service, mock_db, monkeypatch
+    ):
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = ""
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, "custom-ollama-model")
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, SelfHostedReranker)
+        assert provider.model == "custom-ollama-model"
+
+    async def test_vllm_path_replaces_stale_non_local_default_model(
+        self, service, mock_db, monkeypatch
+    ):
+        """A stale voyage/cohere default model falls back to the built-in
+        default when RERANK_MODEL is explicitly blanked (the `or DEFAULT` floor)."""
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = "http://gpu:8002"
+        settings.rerank_model = ""  # blanked → fall through to the built-in floor
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, "rerank-2")
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, VLLMReranker)
+        assert provider.model == DEFAULT_VLLM_RERANK_MODEL
+
+    async def test_vllm_path_replaces_stale_voyage_2_5_default_model(
+        self, service, mock_db, monkeypatch
+    ):
+        """A stale Voyage 'rerank-2.5-lite' default is filtered → vllm default.
+
+        Regression for the non_ollama_defaults gap: Voyage's documented default
+        must not leak to the local reranker.
+        """
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = "http://gpu:8002"
+        settings.rerank_model = ""  # blanked → exercise the built-in floor
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, "rerank-2.5-lite")
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, VLLMReranker)
+        assert provider.model == DEFAULT_VLLM_RERANK_MODEL
+
+    async def test_rerank_model_env_is_the_ops_default_for_unset_context(
+        self, service, mock_db, monkeypatch
+    ):
+        """When the context has no reranker_model, the ops-level RERANK_MODEL
+        (settings.rerank_model) is used — not the hardcoded built-in."""
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = "http://gpu:8002"
+        settings.rerank_model = "qwen3-reranker-4b"
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, None)  # context model unset
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, VLLMReranker)
+        assert provider.model == "qwen3-reranker-4b"
+
+    async def test_stale_context_model_falls_back_to_rerank_model_env(
+        self, service, mock_db, monkeypatch
+    ):
+        """A stale remote-provider default is replaced by the ops-level
+        RERANK_MODEL (not the built-in) when RERANK_MODEL is set."""
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = "http://gpu:8002"
+        settings.rerank_model = "bge-reranker-v2-m3"
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, "rerank-multilingual-v3.0")  # stale
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, VLLMReranker)
+        assert provider.model == "bge-reranker-v2-m3"
+
+    async def test_explicit_context_model_wins_over_rerank_model_env(
+        self, service, mock_db, monkeypatch
+    ):
+        """An explicit, non-stale per-context reranker_model overrides the
+        ops-level RERANK_MODEL (finer-grained config wins)."""
+        settings = MagicMock()
+        settings.self_hosted_base_url = "http://ollama:11434"
+        settings.rerank_base_url = "http://gpu:8002"
+        settings.rerank_model = "qwen3-reranker-4b"
+        monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
+
+        cfg = self._ctx_config("self_hosted", True, "my-finetuned-xenc")
+        mock_db.execute.return_value = _result_scalar_one_or_none(cfg)
+
+        provider = await service.get_active_provider(
+            "user-1", context_id=str(uuid4()), workspace_id=None
+        )
+
+        assert isinstance(provider, VLLMReranker)
+        assert provider.model == "my-finetuned-xenc"

--- a/backend/tests/services/test_vllm_reranker.py
+++ b/backend/tests/services/test_vllm_reranker.py
@@ -1,9 +1,9 @@
 """Unit tests for the OpenAI/Jina-style /v1/rerank path of the local reranker.
 
-When ``settings.rerank_base_url`` is set, the local (context-config "ollama")
-reranker path returns a ``VLLMReranker`` that makes ONE batched POST to
-``{base}/v1/rerank`` (vLLM ``--runner pooling`` seq-cls, TEI, or Infinity)
-instead of SelfHostedReranker's per-document ``/api/generate`` prompt scoring.
+When ``settings.rerank_base_url`` is set, the local (context-config
+"self_hosted") reranker path returns a ``VLLMReranker`` that makes ONE batched
+POST to ``{base}/v1/rerank`` (vLLM ``--runner pooling`` seq-cls, TEI, or
+Infinity) instead of SelfHostedReranker's per-document prompt scoring.
 
 House style follows test_reranker_service_coverage.py: httpx.AsyncClient.post
 is patched with canned responses (never a real network call); RerankerService


### PR DESCRIPTION
## Summary
- Adds `settings.rerank_base_url` (env `RERANK_BASE_URL`, default empty = no behaviour change).
- When set, the context-config `ollama` reranker path returns a new `VLLMReranker` that scores **all candidates with one batched** OpenAI/Jina-style `POST {base}/v1/rerank` (vLLM `--runner pooling` seq-cls / TEI / Infinity), replacing `OllamaReranker`'s per-document `/api/generate` prompt scoring (`Semaphore(5)`, one HTTP call per doc).

## Design
The DB CheckConstraint (`reranker_provider IN ('voyage','cohere','ollama')`), API schemas, and MCP tool definitions are deliberately untouched: the context config declares *local rerank on*; the deployment decides *how* it is served. No migration, no API surface change, fully backward compatible.

## Tests
- New `tests/services/test_vllm_reranker.py`: batched call contract (URL/body, single POST), sort + top_n truncation, empty-docs / top_n validation, HTTP error propagation, provider selection (set vs empty `rerank_base_url`, stale non-local default model fallback).
- Existing `test_reranker_service_coverage.py` ollama-path fixtures now pin `rerank_base_url=""` (MagicMock auto-attr would otherwise be truthy).
- `pytest tests/services/test_vllm_reranker.py tests/services/test_reranker_service_coverage.py` → 65 passed; `tests/config` → 29 passed.

## Motivation
kagura-memory-eval GB10 2-server rig: the retrieval eval needs a true cross-encoder on the recall hot path (eval repo ISSUES.md reranker item). Verified live against vLLM 0.22.1 serving Qwen3-Reranker-0.6B (`--runner pooling` + seq-cls hf-overrides) on NVIDIA GB10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)