### PR TITLE
fix(eval): stamp context embedding config from settings + ensure its collection

### DIFF
--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -308,23 +308,36 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
         settings = get_settings()
         emb_model = settings.embedding_model
         emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        # Mirror ContextService.create_context's defaults (not just the
+        # embedding fields) so an eval context behaves like a production one if
+        # any reranking / weighting default is ever consulted.
         db.add(
             ContextSearchConfig(
                 context_id=ctx.id,
+                semantic_weight=0.6,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2-lite",
                 embedding_model=emb_model,
                 embedding_dimensions=emb_dims,
             )
         )
         await db.flush()
         await db.commit()
-        await ensure_kagura_memories_collection(emb_dims, get_collection_name(emb_model, emb_dims))
 
         svc = MemoryService(db)
         # id_map is owned here and populated incrementally by _ingest_corpus, so
         # the finally below ALWAYS cleans up whatever was created — even if
         # ingest itself raises partway through (no leaked workspace/context/rows).
+        # ensure_kagura_memories_collection is INSIDE the try so that if it
+        # raises (e.g. Qdrant unavailable), _teardown still removes the
+        # already-committed workspace/context/config rows instead of leaking them.
         id_map: dict[str, str] = {}
         try:
+            await ensure_kagura_memories_collection(
+                emb_dims, get_collection_name(emb_model, emb_dims)
+            )
             await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
             return await _run_queries_and_score(
                 svc, corpus, docs_by_id, id_map, owner, ctx.id, ws.id, run_date, write

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -260,8 +260,12 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
     Returns the results dict (also written to disk when ``write``).
     """
     from auth.workspace_roles import WorkspaceRole
+    from config.constants import EMBEDDING_MODEL_REGISTRY
+    from config.settings import get_settings
     from db.base import get_db
+    from db.qdrant import ensure_kagura_memories_collection, get_collection_name
     from models.auth import Context, Workspace, WorkspaceMember
+    from models.config import ContextSearchConfig
     from services.memory_service import MemoryService
     from utils.datetime import utcnow
 
@@ -293,8 +297,27 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
         # checks workspace_members — owner_user_id alone is NOT a membership, so
         # without this row get_context raises NotFoundException on first ingest.
         db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        # The raw ORM Context above bypasses ContextService.create_context, which
+        # is where the per-context embedding config is stamped from settings and
+        # the model-specific Qdrant collection is ensured. Without an explicit
+        # ContextSearchConfig row, the lazy create_or_get defaults to
+        # text-embedding-3-small/512 and ingest routes to a collection that does
+        # not exist on non-default embedding stacks (e.g. a local
+        # qwen3-embedding:0.6b/1024 rig) — stamp the config and ensure the
+        # collection exactly like the production create path.
+        settings = get_settings()
+        emb_model = settings.embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        db.add(
+            ContextSearchConfig(
+                context_id=ctx.id,
+                embedding_model=emb_model,
+                embedding_dimensions=emb_dims,
+            )
+        )
         await db.flush()
         await db.commit()
+        await ensure_kagura_memories_collection(emb_dims, get_collection_name(emb_model, emb_dims))
 
         svc = MemoryService(db)
         # id_map is owned here and populated incrementally by _ingest_corpus, so


### PR DESCRIPTION
## Summary
The retrieval-eval runner builds its throwaway `Context` as a raw ORM row, bypassing `ContextService.create_context` — which is where the per-context embedding config is stamped from settings and the model-specific Qdrant collection is ensured. The lazy `ContextSearchConfigRepository.create_or_get` then defaults to `text-embedding-3-small/512`, so ingest routes to `kagura_memories` — which does not exist on a non-default embedding stack. Observed on the kagura-memory-eval GB10 rig (`EMBEDDING_MODEL=qwen3-embedding:0.6b`, 1024 dims): every corpus doc failed with `Collection kagura_memories doesn't exist`.

## Fix
Mirror the production create path inside the runner: add an explicit `ContextSearchConfig` row stamped from `settings.embedding_model` (+ `EMBEDDING_MODEL_REGISTRY` dims) and call `ensure_kagura_memories_collection(get_collection_name(...))` before ingest.

## Verification
Live `KAGURA_EVAL_LIVE=1 python -m tests.eval.runner` on the GB10 stack (qwen3-embedding:0.6b/1024 via vLLM): previously failed on every doc; now all 4 arms complete in 9.95 s and `results/2026-07-02.json` is written. Arm ordering keyword < semantic < hybrid = hybrid_neural (cold graph) matches the committed-baseline regime. Default-embedding stacks are unaffected (the stamped config equals what create_or_get would have defaulted to, and the ensure is idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)