### PR TITLE
feat(config): ENABLE_BYOK flag to gate BYOK surface (#1167)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,6 +185,13 @@ ENABLE_RESEARCH_TOOLS=true
 # deployments must set this to true or the Plan page silently disappears.
 # ENABLE_PLAN_PAGE=false
 
+# BYOK (bring-your-own-key) surface (#1167). Default is on — OSS/self-hosted
+# keeps external API key management. Set false to hide + block the
+# external-keys console and the workspace cost dashboard (their APIs return
+# 404). Keys stored BEFORE turning this off are still resolved by the
+# LLM/embedding services; only key CRUD and the cost dashboard are blocked.
+# ENABLE_BYOK=true
+
 # Deterministic always-load cap (Issue #886). Max memories returned by the
 # load_pinned read path (delivery_mode='always'). Bounded server-side; when a
 # context has more pinned memories than this, the response flags truncated=true

--- a/.env.example
+++ b/.env.example
@@ -187,8 +187,9 @@ ENABLE_RESEARCH_TOOLS=true
 
 # BYOK (bring-your-own-key) surface (#1167). Default is on — OSS/self-hosted
 # keeps external API key management. Set false to hide + block the
-# external-keys console and the workspace cost dashboard (their APIs return
-# 404). Keys stored BEFORE turning this off are still resolved by the
+# external-keys console, the workspace cost dashboard, and the OpenAI
+# key-status probe (their APIs return 404). Keys stored BEFORE turning
+# this off are still resolved by the
 # LLM/embedding services; only key CRUD and the cost dashboard are blocked.
 # ENABLE_BYOK=true
 

--- a/backend/src/api/routes/cost_aggregation.py
+++ b/backend/src/api/routes/cost_aggregation.py
@@ -31,7 +31,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import AdminUser, get_current_user
+from auth.dependencies import AdminUser, get_current_user, require_byok_enabled
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.sleep import SLEEP_REPORT_PAID_BY_VALUES, SLEEP_REPORT_SOURCES
@@ -293,6 +293,12 @@ async def admin_cost_aggregation(
     response_model=CostAggregationResponse,
     summary="Cost aggregation scoped to one workspace (owner/admin)",
     tags=["workspaces"],
+    # Issue #1167: the workspace cost dashboard is part of the BYOK surface —
+    # 404 when ENABLE_BYOK=false. Listed as a route dependency so it runs
+    # before the auth/permission dependencies (uniform 404 for every caller).
+    # /admin/cost-aggregation stays ungated: platform env-key usage still
+    # accrues cost the system admin may need to see.
+    dependencies=[Depends(require_byok_enabled)],
 )
 async def workspace_cost_aggregation(
     workspace_id: UUID,

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -13,7 +13,11 @@ from sqlalchemy import and_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import APIKeyOrSessionUser, require_workspace_owner
+from auth.dependencies import (
+    APIKeyOrSessionUser,
+    require_byok_enabled,
+    require_workspace_owner,
+)
 from db.base import get_db
 from db.constraint_names import (
     EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE,
@@ -31,10 +35,13 @@ logger = get_logger(__name__)
 # External API keys are workspace-level secrets (OpenAI/Cohere/Anthropic credentials)
 # that should only be managed by the workspace owner. Viewers, members, and admins
 # cannot list/create/update/toggle/delete keys.
+# Issue #1167: require_byok_enabled must stay FIRST so a BYOK-off deployment
+# returns a uniform 404 to every caller before auth/role checks run — a
+# role-dependent 403-vs-404 split would leak the feature's existence.
 router = APIRouter(
     prefix="/external-keys",
     tags=["external-keys"],
-    dependencies=[Depends(require_workspace_owner)],
+    dependencies=[Depends(require_byok_enabled), Depends(require_workspace_owner)],
 )
 
 

--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -99,6 +99,9 @@ async def system_info():
             # Issue #1145: the web UI hides the Plan page + nav entry unless this
             # is true (default-off for OSS).
             "plan_page": settings.enable_plan_page,
+            # Issue #1167: default-on. When false the web UI hides the
+            # external-keys console + workspace cost dashboard (their APIs 404).
+            "byok": settings.enable_byok,
         },
     }
 

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -14,7 +14,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.analysis_allowlist import check_workspace_in_allowlist
-from auth.dependencies import SessionUser, get_current_user
+from auth.dependencies import SessionUser, get_current_user, require_byok_enabled
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
@@ -1097,7 +1097,15 @@ async def get_context_public_api_stats(
 # ============================================================================
 
 
-@router.get("/{workspace_id}/openai-key-status", response_model=OpenAIKeyStatusResponse)
+@router.get(
+    "/{workspace_id}/openai-key-status",
+    response_model=OpenAIKeyStatusResponse,
+    # Issue #1167: this probe is a BYOK read surface — 404 when ENABLE_BYOK
+    # is false. Leaving it up would report has_key=false in deployments where
+    # env keys serve embeddings, and the contexts page blocks creation on
+    # has_key=false. Both frontend consumers degrade gracefully on failure.
+    dependencies=[Depends(require_byok_enabled)],
+)
 async def check_openai_key_status(
     workspace_id: UUID,
     request: Request,

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -565,6 +565,29 @@ async def get_user_from_api_key_or_session(
 
 
 # ============================================================================
+# BYOK feature gate (Issue #1167)
+# ============================================================================
+
+
+async def require_byok_enabled() -> None:
+    """Reject with 404 when the deployment disables the BYOK surface (#1167).
+
+    404 (not 403) is deliberate: feature-not-present semantics matching the
+    plan_page flag (#1145) — a 403 would read as a permission problem and
+    leak the feature's existence. The dependency is parameterless so it can
+    be listed BEFORE auth/role dependencies and every caller (anonymous,
+    member, owner) sees the same uniform 404.
+
+    Raises:
+        HTTPException: 404 when ``ENABLE_BYOK`` is false.
+    """
+    from config.settings import get_settings
+
+    if not get_settings().enable_byok:
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+# ============================================================================
 # Workspace Owner (API Key + Session)
 # ============================================================================
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -418,6 +418,18 @@ class Settings(BaseSettings):
             "Surfaced to the frontend via GET /api/v1/system/info features.plan_page."
         ),
     )
+    enable_byok: bool = Field(
+        default=True,
+        description=(
+            "Enable the BYOK (bring-your-own-key) surface (#1167). ON by default "
+            "so OSS / self-hosted keeps external API key management. When false, "
+            "the /external-keys API and the workspace cost dashboard return 404 "
+            "and the web UI hides their nav entries. Key RESOLUTION is untouched: "
+            "keys stored before turning the flag off are still used by the "
+            "LLM/embedding services. Surfaced to the frontend via "
+            "GET /api/v1/system/info features.byok."
+        ),
+    )
 
     # Environment
     environment: str = Field(

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -423,8 +423,10 @@ class Settings(BaseSettings):
         description=(
             "Enable the BYOK (bring-your-own-key) surface (#1167). ON by default "
             "so OSS / self-hosted keeps external API key management. When false, "
-            "the /external-keys API and the workspace cost dashboard return 404 "
-            "and the web UI hides their nav entries. Key RESOLUTION is untouched: "
+            "the /external-keys API, the workspace cost dashboard "
+            "(GET /workspaces/{id}/cost-aggregation), and the OpenAI key-status "
+            "probe (GET /workspaces/{id}/openai-key-status) return 404 and the "
+            "web UI hides their nav entries. Key RESOLUTION is untouched: "
             "keys stored before turning the flag off are still used by the "
             "LLM/embedding services. Surfaced to the frontend via "
             "GET /api/v1/system/info features.byok."

--- a/backend/tests/api/test_byok_feature_gate.py
+++ b/backend/tests/api/test_byok_feature_gate.py
@@ -1,0 +1,107 @@
+"""Tests for the ENABLE_BYOK deployment flag (#1167).
+
+``ENABLE_BYOK=false`` removes the BYOK surface from the deployment:
+
+- every ``/external-keys`` CRUD endpoint returns 404 (feature-not-present
+  semantics, consistent with plan_page #1145 — 403 would read as a
+  permission problem and leak the feature's existence),
+- ``GET /workspaces/{id}/cost-aggregation`` returns 404,
+- ``GET /admin/cost-aggregation`` stays available (platform env-key usage
+  still accrues cost the system admin may need to see).
+
+The gate must run BEFORE auth/role dependencies so every caller — anonymous,
+member, owner — sees the same 404 (no role-dependent 403-vs-404 split).
+The anonymous-request tests below pin exactly that ordering: 404 when the
+flag is off, the usual 401 when it is on.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+_WORKSPACE_ID = uuid4()
+
+
+@pytest.fixture
+def client():
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def byok_disabled(monkeypatch):
+    """Rebuild the settings singleton with ENABLE_BYOK=false.
+
+    ``monkeypatch`` restores both the env var and the original singleton
+    instance on teardown, so other test modules see the default (BYOK on).
+    """
+    monkeypatch.setenv("ENABLE_BYOK", "false")
+    monkeypatch.setattr("config.settings._settings", None)
+
+
+class TestExternalKeysGate:
+    def test_list_returns_404_when_disabled(self, client, byok_disabled):
+        # Anonymous on purpose: the feature gate must fire before auth,
+        # so even an unauthenticated caller sees 404 (not 401).
+        response = client.get("/api/v1/external-keys")
+        assert response.status_code == 404
+
+    def test_create_returns_404_when_disabled(self, client, byok_disabled):
+        response = client.post(
+            "/api/v1/external-keys",
+            json={"key_name": "OPENAI_API_KEY", "provider": "openai", "value": "sk-x"},
+        )
+        assert response.status_code == 404
+
+    def test_update_returns_404_when_disabled(self, client, byok_disabled):
+        response = client.put("/api/v1/external-keys/OPENAI_API_KEY", json={"value": "sk-y"})
+        assert response.status_code == 404
+
+    def test_delete_returns_404_when_disabled(self, client, byok_disabled):
+        response = client.delete("/api/v1/external-keys/OPENAI_API_KEY")
+        assert response.status_code == 404
+
+    def test_routes_exist_when_enabled(self, client):
+        # Default (flag on): the route exists, so an anonymous caller gets
+        # the normal auth rejection — not 404.
+        response = client.get("/api/v1/external-keys")
+        assert response.status_code == 401
+
+
+class TestCostAggregationGate:
+    def test_workspace_route_returns_404_when_disabled(self, client, byok_disabled):
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 404
+
+    def test_workspace_route_exists_when_enabled(self, client):
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 401
+
+    def test_admin_route_unaffected_when_disabled(self, client, byok_disabled):
+        # /admin/cost-aggregation is intentionally NOT gated: anonymous gets
+        # the normal 401 (route present), never the feature-gate 404.
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 401
+
+
+class TestSystemInfoByokFlag:
+    def test_features_byok_defaults_on(self, client):
+        features = client.get("/api/v1/system/info").json()["features"]
+        assert features.get("byok") is True, "ENABLE_BYOK must default ON (OSS keeps BYOK)"
+
+    def test_features_byok_reflects_disabled(self, client, byok_disabled):
+        features = client.get("/api/v1/system/info").json()["features"]
+        assert features.get("byok") is False

--- a/backend/tests/api/test_byok_feature_gate.py
+++ b/backend/tests/api/test_byok_feature_gate.py
@@ -29,6 +29,7 @@ _WORKSPACE_ID = uuid4()
 
 @pytest.fixture
 def client():
+    """TestClient that auto-clears dependency overrides on teardown."""
     yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 

--- a/backend/tests/api/test_byok_feature_gate.py
+++ b/backend/tests/api/test_byok_feature_gate.py
@@ -73,6 +73,25 @@ class TestExternalKeysGate:
         assert response.status_code == 401
 
 
+class TestOpenAIKeyStatusGate:
+    """The key-status probe is a BYOK read surface too (#1167 gate1 finding).
+
+    With BYOK off it must 404: leaving it up would report has_key=false in a
+    deployment where env keys serve embeddings, and the contexts page blocks
+    context creation on has_key=false. Both frontend consumers degrade
+    gracefully on a failed probe (contexts page → null → creation enabled;
+    OnboardingCard → .catch(() => null) → normal onboarding).
+    """
+
+    def test_returns_404_when_disabled(self, client, byok_disabled):
+        response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/openai-key-status")
+        assert response.status_code == 404
+
+    def test_route_exists_when_enabled(self, client):
+        response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/openai-key-status")
+        assert response.status_code == 401
+
+
 class TestCostAggregationGate:
     def test_workspace_route_returns_404_when_disabled(self, client, byok_disabled):
         response = client.get(

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.test.tsx
@@ -72,6 +72,12 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }));
 
+// #1167: the OpenAI key probe is gated on features.byok; default on.
+let mockFeatures: Record<string, boolean> | null = { byok: true };
+vi.mock("@/hooks/useSystemFeatures", () => ({
+  useSystemFeatures: () => mockFeatures,
+}));
+
 // ---------- Helpers ----------------------------------------------------------
 
 type Role = "owner" | "admin" | "member" | "viewer";
@@ -116,6 +122,7 @@ beforeEach(() => {
   mockToast.mockReset();
   mockPush.mockReset();
   mockReplace.mockReset();
+  mockFeatures = { byok: true };
 });
 
 afterEach(() => {
@@ -123,6 +130,28 @@ afterEach(() => {
 });
 
 // ---------- Tests ------------------------------------------------------------
+
+describe("ContextsPage BYOK gating (#1167)", () => {
+  it("skips the OpenAI key probe when byok is off — no setup-needed block", async () => {
+    mockFeatures = { byok: false };
+    setupWithRole("owner");
+    render(<ContextsPage />);
+
+    // Neutral empty state (blue), not the amber "key required" gate — env
+    // keys serve embeddings in a BYOK-off deployment.
+    await waitFor(() =>
+      expect(screen.getByText("noContextsYet")).toBeInTheDocument(),
+    );
+    expect(mockCheckOpenAIKeyStatus).not.toHaveBeenCalled();
+    expect(screen.queryByText("setupNeededOpenAI")).toBeNull();
+  });
+
+  it("still probes the key when byok is on", async () => {
+    setupWithRole("owner");
+    render(<ContextsPage />);
+    await waitFor(() => expect(mockCheckOpenAIKeyStatus).toHaveBeenCalled());
+  });
+});
 
 describe("ContextsPage empty-state CTA role gating (#382)", () => {
   it("renders the Create button for owner", async () => {

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -90,6 +90,7 @@ import {
   type EmbeddingModel,
 } from "@/lib/api/contexts";
 import { checkOpenAIKeyStatus } from "@/lib/api/workspaces";
+import { useSystemFeatures } from "@/hooks/useSystemFeatures";
 import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { ApiError } from "@/lib/api/base";
 import type { Context, ContextStats } from "@/lib/types/context";
@@ -201,8 +202,14 @@ export default function ContextsPage() {
     }
   }, []);
 
+  // Issue #1167: with BYOK off the key-status probe 404s and env keys serve
+  // embeddings — skip the check so hasOpenAIKey stays null (creation enabled,
+  // no "configure key" CTA pointing at a disabled page).
+  const systemFeatures = useSystemFeatures();
+  const byokEnabled = systemFeatures?.byok === true;
   const checkApiKey = useCallback(async () => {
     if (!user?.current_workspace_id) return;
+    if (!byokEnabled) return;
 
     try {
       const status = await checkOpenAIKeyStatus(user.current_workspace_id);
@@ -210,7 +217,7 @@ export default function ContextsPage() {
     } catch (err) {
       setHasOpenAIKey(null);
     }
-  }, [user?.current_workspace_id]);
+  }, [user?.current_workspace_id, byokEnabled]);
 
   useEffect(() => {
     fetchContexts();

--- a/frontend/src/app/(authenticated)/workspace/cost/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Workspace cost page — ENABLE_BYOK gate (#1167).
+ *
+ * The page is gated behind the backend byok feature flag (plan-page pattern
+ * #1145): spinner while flags load, "not available" notice when off, and the
+ * dashboard only renders (and fetches) when the flag resolves enabled.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns?: string) => (k: string) => k,
+}));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+let mockFeatures: Record<string, boolean> | null = { byok: true };
+vi.mock("@/hooks/useSystemFeatures", () => ({
+  useSystemFeatures: () => mockFeatures,
+}));
+
+const mockFetchCost = vi.fn();
+vi.mock("@/lib/api", () => ({
+  fetchWorkspaceCostAggregation: (...a: unknown[]) => mockFetchCost(...a),
+}));
+
+vi.mock("@/components/cost/CostDashboard", () => ({
+  CostDashboard: () => <div data-testid="cost-dashboard" />,
+}));
+
+import WorkspaceCostPage from "./page";
+
+function setWorkspace(role: string = "admin") {
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: { id: "ws-1", current_user_role: role },
+    currentWorkspaceId: "ws-1",
+    loading: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFeatures = { byok: true };
+  setWorkspace("admin");
+});
+
+afterEach(() => cleanup());
+
+describe("WorkspaceCostPage BYOK gate (#1167)", () => {
+  it("renders the dashboard when byok is enabled", () => {
+    render(<WorkspaceCostPage />);
+    expect(screen.getByTestId("cost-dashboard")).toBeInTheDocument();
+  });
+
+  it("renders the not-available notice when byok is off", () => {
+    mockFeatures = { byok: false };
+    render(<WorkspaceCostPage />);
+    expect(screen.getByText("featureDisabled")).toBeInTheDocument();
+    expect(screen.queryByTestId("cost-dashboard")).toBeNull();
+  });
+
+  it("renders a loader (not the dashboard) while feature flags load", () => {
+    mockFeatures = null;
+    render(<WorkspaceCostPage />);
+    expect(screen.queryByTestId("cost-dashboard")).toBeNull();
+    expect(screen.queryByText("featureDisabled")).toBeNull();
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.tsx
@@ -26,17 +26,24 @@ import { useTranslations } from "next-intl";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { SpinnerLoading } from "@/components/common/LoadingState";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   CostDashboard,
   type CostDashboardFetchParams,
 } from "@/components/cost/CostDashboard";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { useSystemFeatures } from "@/hooks/useSystemFeatures";
 import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { fetchWorkspaceCostAggregation } from "@/lib/api";
 
 export default function WorkspaceCostPage() {
   const t = useTranslations("admin.cost");
+  const tCommon = useTranslations("common");
   const { currentWorkspace, currentWorkspaceId, loading } = useWorkspace();
+  // Issue #1167: gated behind the backend ENABLE_BYOK flag (like the plan
+  // page #1145) — the workspace cost API returns 404 when BYOK is off.
+  const systemFeatures = useSystemFeatures();
 
   const allowed = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
@@ -54,6 +61,23 @@ export default function WorkspaceCostPage() {
       fetchWorkspaceCostAggregation(currentWorkspaceId ?? "", params),
     [currentWorkspaceId],
   );
+
+  // Issue #1167: wait for the feature flags, then render a "not available"
+  // notice when byok is off (the sidebar entry is hidden too, so this only
+  // fires on direct navigation).
+  if (systemFeatures === null) {
+    return <SpinnerLoading size="lg" message={tCommon("loading")} />;
+  }
+  if (!systemFeatures.byok) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} />
+        <Alert>
+          <AlertDescription>{t("featureDisabled")}</AlertDescription>
+        </Alert>
+      </PageContainer>
+    );
+  }
 
   // Distinguish "no workspace exists / selected" from "wrong role".
   // Without this branch a brand-new account with zero workspaces would

--- a/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * External API keys page — ENABLE_BYOK gate (#1167).
+ *
+ * The page is gated behind the backend byok feature flag (plan-page pattern
+ * #1145): skeleton while flags load, "not available" notice when off, and the
+ * key list only fetches when the flag resolves enabled (the API 404s when
+ * BYOK is disabled).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns?: string) => (k: string) => k,
+}));
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+vi.mock("@/contexts/MemoryContextContext", () => ({
+  useMemoryContext: () => ({ contextId: null }),
+}));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+let mockFeatures: Record<string, boolean> | null = { byok: true };
+vi.mock("@/hooks/useSystemFeatures", () => ({
+  useSystemFeatures: () => mockFeatures,
+}));
+
+const mockListKeys = vi.fn();
+vi.mock("@/lib/api/external-keys", () => ({
+  listExternalAPIKeys: (...a: unknown[]) => mockListKeys(...a),
+  createExternalAPIKey: vi.fn(),
+  updateExternalAPIKey: vi.fn(),
+  deleteExternalAPIKey: vi.fn(),
+  toggleExternalAPIKey: vi.fn(),
+}));
+
+import ExternalKeysPage from "./page";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFeatures = { byok: true };
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: { id: "ws-1", current_user_role: "owner" },
+    currentWorkspaceId: "ws-1",
+  });
+  mockListKeys.mockResolvedValue([]);
+});
+
+afterEach(() => cleanup());
+
+describe("ExternalKeysPage BYOK gate (#1167)", () => {
+  it("fetches and renders the page when byok is enabled", async () => {
+    render(<ExternalKeysPage />);
+    await waitFor(() => expect(mockListKeys).toHaveBeenCalled());
+    expect(screen.queryByText("featureDisabled")).toBeNull();
+  });
+
+  it("renders the not-available notice and never fetches when byok is off", async () => {
+    mockFeatures = { byok: false };
+    render(<ExternalKeysPage />);
+    expect(screen.getByText("featureDisabled")).toBeInTheDocument();
+    expect(mockListKeys).not.toHaveBeenCalled();
+  });
+
+  it("holds fetches while feature flags load", () => {
+    mockFeatures = null;
+    render(<ExternalKeysPage />);
+    expect(mockListKeys).not.toHaveBeenCalled();
+    expect(screen.queryByText("featureDisabled")).toBeNull();
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
@@ -82,6 +82,7 @@ import { useToast } from "@/hooks/use-toast";
 import { InlineSpinner } from "@/components/common/LoadingState";
 import { useMemoryContext } from "@/contexts/MemoryContextContext";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { useSystemFeatures } from "@/hooks/useSystemFeatures";
 
 export default function ExternalKeysPage() {
   const t = useTranslations("externalKeys");
@@ -143,6 +144,11 @@ export default function ExternalKeysPage() {
 
   const { contextId } = useMemoryContext(); // For context-scoped keys
   const { currentWorkspaceId, currentWorkspace } = useWorkspace(); // For workspace-scoped keys
+  // Issue #1167: gated behind the backend ENABLE_BYOK flag (like the plan
+  // page #1145). null while loading → hold fetches; false → not-available
+  // notice (the /external-keys API returns 404 in that deployment).
+  const systemFeatures = useSystemFeatures();
+  const byokEnabled = systemFeatures?.byok === true;
   const [keys, setKeys] = useState<ExternalAPIKey[]>([]);
   const [loading, setLoading] = useState(true);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -198,10 +204,12 @@ export default function ExternalKeysPage() {
     // Workspace-scoped keys are shown for all contexts in the workspace
     // Context-scoped keys are shown for specific context only
     // Issue #213: contextId can be null (user may not have context yet)
-    if (currentWorkspaceId !== null) {
+    // Issue #1167: don't fetch until the byok flag resolves enabled — when
+    // BYOK is off the page short-circuits to a notice and the API 404s.
+    if (currentWorkspaceId !== null && byokEnabled) {
       loadKeys();
     }
-  }, [contextId, currentWorkspaceId]);
+  }, [contextId, currentWorkspaceId, byokEnabled]);
 
   const loadKeys = async () => {
     try {
@@ -347,6 +355,28 @@ export default function ExternalKeysPage() {
     setFormData({ key_name: key.key_name, provider: key.provider, value: "" });
     setEditDialogOpen(true);
   };
+
+  // Issue #1167: the page is gated behind the backend ENABLE_BYOK flag. Wait
+  // for it, then render a "not available" notice when it's off (the sidebar
+  // entry is hidden too, so this only fires on direct navigation).
+  if (systemFeatures === null) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} description={t("description")} />
+        <LoadingState lines={3} />
+      </PageContainer>
+    );
+  }
+  if (!systemFeatures.byok) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} description={t("description")} />
+        <Alert>
+          <AlertDescription>{t("featureDisabled")}</AlertDescription>
+        </Alert>
+      </PageContainer>
+    );
+  }
 
   if (loading && keys.length === 0) {
     return (

--- a/frontend/src/components/contexts/SearchSettingsSection.test.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * SearchSettingsSection — ENABLE_BYOK gate (#1167).
+ *
+ * The reranker-keys probe hits the owner-only /external-keys API, which 404s
+ * when BYOK is off; and the "configure reranker keys" CTA links to the
+ * external-keys page, which shows a not-available notice in that deployment.
+ * Both must be suppressed when features.byok is off.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns?: string) => (k: string) => k,
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+let mockFeatures: Record<string, boolean> | null = { byok: true };
+vi.mock("@/hooks/useSystemFeatures", () => ({
+  useSystemFeatures: () => mockFeatures,
+}));
+
+const mockGetConfig = vi.fn();
+vi.mock("@/lib/api/contexts", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    getContextSearchConfig: (...a: unknown[]) => mockGetConfig(...a),
+    updateContextSearchConfig: vi.fn(),
+  };
+});
+
+const mockListKeys = vi.fn();
+vi.mock("@/lib/api/external-keys", () => ({
+  listExternalAPIKeys: (...a: unknown[]) => mockListKeys(...a),
+}));
+
+const mockApiGet = vi.fn();
+vi.mock("@/lib/api/base", () => ({
+  apiClient: { get: (...a: unknown[]) => mockApiGet(...a) },
+  ApiError: class ApiError extends Error {},
+}));
+
+import { SearchSettingsSection } from "./SearchSettingsSection";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFeatures = { byok: true };
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: { id: "ws-1", plan_name: "basic" },
+  });
+  mockGetConfig.mockResolvedValue({
+    context_id: "ctx-1",
+    semantic_weight: 0.6,
+    bm25_weight: 0.4,
+    fetch_factor: 3,
+    use_rerank: false,
+    reranker_provider: "voyage",
+    reranker_model: "rerank-2",
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  });
+  mockListKeys.mockResolvedValue([]);
+  // telemetry probe: self-hosted reranker not available
+  mockApiGet.mockResolvedValue({ services: {} });
+});
+
+afterEach(() => cleanup());
+
+describe("SearchSettingsSection BYOK gate (#1167)", () => {
+  it("probes external keys and shows the configure-keys CTA when byok is on", async () => {
+    render(<SearchSettingsSection contextId="ctx-1" />);
+    await waitFor(() => expect(mockListKeys).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText("noRerankerKeys")).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByRole("link", { name: "External API Keys" }),
+    ).toHaveAttribute("href", "/workspace/integrations/external-keys");
+  });
+
+  it("skips the probe and renders no external-keys link when byok is off", async () => {
+    mockFeatures = { byok: false };
+    const { container } = render(<SearchSettingsSection contextId="ctx-1" />);
+    // Let the config/telemetry loads settle.
+    await waitFor(() => expect(mockGetConfig).toHaveBeenCalled());
+    expect(mockListKeys).not.toHaveBeenCalled();
+    expect(
+      container.querySelector(
+        'a[href="/workspace/integrations/external-keys"]',
+      ),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/components/contexts/SearchSettingsSection.test.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.test.tsx
@@ -11,7 +11,18 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 
 vi.mock("next-intl", () => ({
-  useTranslations: (_ns?: string) => (k: string) => k,
+  // Identity translator + a t.rich that invokes the <link> tag renderer with
+  // the key as chunks, so the CTA Link actually renders in tests.
+  useTranslations: (_ns?: string) => {
+    const t = ((k: string) => k) as ((k: string) => string) & {
+      rich: (
+        k: string,
+        values?: Record<string, (chunks: string) => unknown>,
+      ) => unknown;
+    };
+    t.rich = (k, values) => (values?.link ? values.link(k) : k);
+    return t;
+  },
 }));
 
 const mockToast = vi.fn();
@@ -83,8 +94,9 @@ describe("SearchSettingsSection BYOK gate (#1167)", () => {
     await waitFor(() =>
       expect(screen.getByText("noRerankerKeys")).toBeInTheDocument(),
     );
+    // The mocked t.rich renders the <link> tag with the message key as chunks.
     expect(
-      screen.getByRole("link", { name: "External API Keys" }),
+      screen.getByRole("link", { name: "configureRerankerKeys" }),
     ).toHaveAttribute("href", "/workspace/integrations/external-keys");
   });
 

--- a/frontend/src/components/contexts/SearchSettingsSection.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.tsx
@@ -54,6 +54,7 @@ import {
 import { apiClient } from "@/lib/api/base";
 import { useToast } from "@/hooks/use-toast";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { useSystemFeatures } from "@/hooks/useSystemFeatures";
 import { cn } from "@/styles/design-tokens";
 
 interface TelemetryServiceStatus {
@@ -113,6 +114,10 @@ export function SearchSettingsSection({
   const [selfHostedAvailable, setSelfHostedAvailable] = useState(false);
   const { toast } = useToast();
   const { currentWorkspace } = useWorkspace();
+  // Issue #1167: the /external-keys API 404s when BYOK is off, and the
+  // "configure reranker keys" CTA would point at a disabled page — gate both.
+  const systemFeatures = useSystemFeatures();
+  const byokEnabled = systemFeatures?.byok === true;
 
   const isFree = currentWorkspace?.plan_name === "free";
   const isDirty = Object.keys(editedConfig).length > 0;
@@ -171,9 +176,16 @@ export function SearchSettingsSection({
   }, [contextId]);
 
   useEffect(() => {
-    Promise.all([loadConfig(), loadExternalKeys(), loadTelemetry()]);
+    Promise.all([loadConfig(), loadTelemetry()]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contextId]);
+
+  // Issue #1167: probe external keys only once the byok flag resolves enabled
+  // (kept out of the effect above so a late flag resolution doesn't re-fire
+  // the config/telemetry loads).
+  useEffect(() => {
+    if (byokEnabled) loadExternalKeys();
+  }, [byokEnabled, loadExternalKeys]);
 
   const handleSave = useCallback(async () => {
     if (!contextId || Object.keys(editedConfig).length === 0) return;
@@ -458,21 +470,26 @@ export function SearchSettingsSection({
               </Alert>
             )}
 
+            {/* #1167: only offer the configure-keys CTA when BYOK is on —
+                with BYOK off the external-keys page is disabled, so show the
+                headline without a dangling link. */}
             {!isFree && !hasAnyRerankerAvailable && (
               <Alert>
                 <AlertCircle className="h-4 w-4" />
                 <AlertDescription>
                   <p className="font-medium mb-2">{t("noRerankerKeys")}</p>
-                  <p className="text-sm">
-                    {t("configureRerankerKeys").split("External API Keys")[0]}
-                    <Link
-                      href="/workspace/integrations/external-keys"
-                      className="underline font-medium"
-                    >
-                      External API Keys
-                    </Link>
-                    {t("configureRerankerKeys").split("External API Keys")[1]}
-                  </p>
+                  {byokEnabled && (
+                    <p className="text-sm">
+                      {t("configureRerankerKeys").split("External API Keys")[0]}
+                      <Link
+                        href="/workspace/integrations/external-keys"
+                        className="underline font-medium"
+                      >
+                        External API Keys
+                      </Link>
+                      {t("configureRerankerKeys").split("External API Keys")[1]}
+                    </p>
+                  )}
                 </AlertDescription>
               </Alert>
             )}
@@ -563,7 +580,7 @@ export function SearchSettingsSection({
                             <p className="text-sm">
                               {t("selfHostedUnavailableDetail")}
                             </p>
-                          ) : (
+                          ) : byokEnabled ? (
                             <p className="text-sm">
                               {
                                 t("configureRerankerKeys").split(
@@ -582,6 +599,10 @@ export function SearchSettingsSection({
                                 )[1]
                               }
                             </p>
+                          ) : (
+                            // #1167: BYOK off — key setup is not available in
+                            // this deployment, so no configure link.
+                            <p className="text-sm">{t("noRerankerKeys")}</p>
                           )}
                         </AlertDescription>
                       </Alert>

--- a/frontend/src/components/contexts/SearchSettingsSection.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.tsx
@@ -480,14 +480,18 @@ export function SearchSettingsSection({
                   <p className="font-medium mb-2">{t("noRerankerKeys")}</p>
                   {byokEnabled && (
                     <p className="text-sm">
-                      {t("configureRerankerKeys").split("External API Keys")[0]}
-                      <Link
-                        href="/workspace/integrations/external-keys"
-                        className="underline font-medium"
-                      >
-                        External API Keys
-                      </Link>
-                      {t("configureRerankerKeys").split("External API Keys")[1]}
+                      {/* t.rich with a <link> tag in the message — splitting
+                          on an English substring broke non-English locales. */}
+                      {t.rich("configureRerankerKeys", {
+                        link: (chunks) => (
+                          <Link
+                            href="/workspace/integrations/external-keys"
+                            className="underline font-medium"
+                          >
+                            {chunks}
+                          </Link>
+                        ),
+                      })}
                     </p>
                   )}
                 </AlertDescription>
@@ -582,22 +586,16 @@ export function SearchSettingsSection({
                             </p>
                           ) : byokEnabled ? (
                             <p className="text-sm">
-                              {
-                                t("configureRerankerKeys").split(
-                                  "External API Keys",
-                                )[0]
-                              }
-                              <Link
-                                href="/workspace/integrations/external-keys"
-                                className="underline font-medium"
-                              >
-                                External API Keys
-                              </Link>
-                              {
-                                t("configureRerankerKeys").split(
-                                  "External API Keys",
-                                )[1]
-                              }
+                              {t.rich("configureRerankerKeys", {
+                                link: (chunks) => (
+                                  <Link
+                                    href="/workspace/integrations/external-keys"
+                                    className="underline font-medium"
+                                  >
+                                    {chunks}
+                                  </Link>
+                                ),
+                              })}
                             </p>
                           ) : (
                             // #1167: BYOK off — key setup is not available in

--- a/frontend/src/components/dashboard/Sidebar.test.tsx
+++ b/frontend/src/components/dashboard/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Hoisted so the vi.mock factory below can reference it (vi.mock is hoisted).
@@ -77,17 +77,22 @@ vi.mock("@/components/icons/KaguraLogo", () => ({
 
 // #1145: feature flags gate certain nav items (e.g. Plan). Mock the hook so the
 // suite doesn't hit the network; default to plan_page enabled, flip per-test.
-let mockFeatures: Record<string, boolean> | null = { plan_page: true };
+// #1167: byok gates the externalKeys + workspace cost entries; default on.
+let mockFeatures: Record<string, boolean> | null = {
+  plan_page: true,
+  byok: true,
+};
 vi.mock("@/hooks/useSystemFeatures", () => ({
   useSystemFeatures: () => mockFeatures,
 }));
 
+import { listExternalAPIKeys } from "@/lib/api/external-keys";
 import { Sidebar } from "./Sidebar";
 
 describe("Sidebar", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockFeatures = { plan_page: true };
+    mockFeatures = { plan_page: true, byok: true };
   });
 
   it("renders the Kagura logo at the top, linked to dashboard", () => {
@@ -117,6 +122,67 @@ describe("Sidebar", () => {
     mockFeatures = null;
     render(<Sidebar />);
     expect(screen.queryByRole("link", { name: "plan" })).toBeNull();
+  });
+
+  it("shows externalKeys and workspace cost links when byok is enabled (#1167)", () => {
+    render(<Sidebar />);
+    expect(screen.getByRole("link", { name: "externalKeys" })).toHaveAttribute(
+      "href",
+      "/workspace/integrations/external-keys",
+    );
+    expect(screen.getByRole("link", { name: "cost" })).toHaveAttribute(
+      "href",
+      "/workspace/cost",
+    );
+  });
+
+  it("hides externalKeys and workspace cost when byok is off; sleepReports stays (#1167)", () => {
+    mockFeatures = { plan_page: true, byok: false };
+    render(<Sidebar />);
+    expect(screen.queryByRole("link", { name: "externalKeys" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "cost" })).toBeNull();
+    expect(
+      screen.getByRole("link", { name: "sleepReports" }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides externalKeys and cost while feature flags are loading (fail closed) (#1167)", () => {
+    mockFeatures = null;
+    render(<Sidebar />);
+    expect(screen.queryByRole("link", { name: "externalKeys" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "cost" })).toBeNull();
+  });
+
+  it("skips the owner external-keys warning fetch when byok is off (#1167)", () => {
+    mockFeatures = { plan_page: true, byok: false };
+    render(<Sidebar />);
+    expect(listExternalAPIKeys).not.toHaveBeenCalled();
+  });
+
+  it("still probes external keys for owners when byok is on (#1167)", () => {
+    render(<Sidebar />);
+    expect(listExternalAPIKeys).toHaveBeenCalledTimes(1);
+  });
+
+  it("orders the workspace group: stores first, reporting last (#1167)", () => {
+    render(<Sidebar />);
+    const expected = [
+      "/workspace/dashboard",
+      "/workspace/contexts",
+      "/workspace/resources",
+      "/workspace/storage",
+      "/workspace/secrets",
+      "/workspace/members",
+      "/workspace/sleep-reports",
+      "/workspace/cost",
+    ];
+    // Scope to the <nav> so the logo link (also /workspace/dashboard) is
+    // not counted twice.
+    const hrefs = within(screen.getByRole("navigation"))
+      .getAllByRole("link")
+      .map((a) => a.getAttribute("href"))
+      .filter((h): h is string => h !== null && expected.includes(h));
+    expect(hrefs).toEqual(expected);
   });
 
   it("user menu trigger button shows user name", () => {

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -121,32 +121,6 @@ const navigationGroups: NavGroup[] = [
         requiredWorkspaceRole: WorkspaceRole.Owner, // Issue #389: Owner-only (resource tokens + schema decisions)
       },
       {
-        nameKey: "members",
-        href: "/workspace/members",
-        icon: Users,
-        showMemberCount: true,
-        requiredWorkspaceRole: WorkspaceRole.Admin, // Issue #398: hide from member/viewer
-      },
-      {
-        // Issue #473: workspace-scoped cost dashboard.
-        // Backend gates owner/admin via check_workspace_admin (#472);
-        // mirror that here so member/viewer don't see a nav entry that
-        // would 403 on click.
-        nameKey: "cost",
-        href: "/workspace/cost",
-        icon: DollarSign,
-        requiredWorkspaceRole: WorkspaceRole.Admin,
-      },
-      {
-        // Issue #526: workspace-scoped sleep reports view.
-        // Backend gates owner/admin; sidebar mirrors so member/viewer
-        // don't see a nav entry that would 403 on click.
-        nameKey: "sleepReports",
-        href: "/workspace/sleep-reports",
-        icon: Moon,
-        requiredWorkspaceRole: WorkspaceRole.Admin,
-      },
-      {
         // Issue #955: workspace-scoped file objects (R2 storage). Backend
         // lists/downloads at viewer+, so the entry is visible to every
         // workspace role; delete is gated to member+ inside the page.
@@ -165,6 +139,36 @@ const navigationGroups: NavGroup[] = [
         href: "/workspace/secrets",
         icon: Lock,
         requiredWorkspaceRole: WorkspaceRole.Admin,
+      },
+      {
+        nameKey: "members",
+        href: "/workspace/members",
+        icon: Users,
+        showMemberCount: true,
+        requiredWorkspaceRole: WorkspaceRole.Admin, // Issue #398: hide from member/viewer
+      },
+      {
+        // Issue #526: workspace-scoped sleep reports view.
+        // Backend gates owner/admin; sidebar mirrors so member/viewer
+        // don't see a nav entry that would 403 on click.
+        nameKey: "sleepReports",
+        href: "/workspace/sleep-reports",
+        icon: Moon,
+        requiredWorkspaceRole: WorkspaceRole.Admin,
+      },
+      {
+        // Issue #473: workspace-scoped cost dashboard.
+        // Backend gates owner/admin via check_workspace_admin (#472);
+        // mirror that here so member/viewer don't see a nav entry that
+        // would 403 on click.
+        // Issue #1167: part of the BYOK surface — hidden when ENABLE_BYOK
+        // is off (the backing API 404s). Reporting entries stay last in
+        // the group: sleepReports, then cost.
+        nameKey: "cost",
+        href: "/workspace/cost",
+        icon: DollarSign,
+        requiredWorkspaceRole: WorkspaceRole.Admin,
+        requiredFeature: "byok",
       },
     ],
   },
@@ -218,6 +222,9 @@ const navigationGroups: NavGroup[] = [
         href: "/workspace/integrations/external-keys",
         icon: KeyRound,
         requiredWorkspaceRole: WorkspaceRole.Owner, // Issue #381: Owner-only (workspace-level secrets)
+        // Issue #1167: the BYOK console itself — hidden when ENABLE_BYOK is
+        // off (its API returns 404).
+        requiredFeature: "byok",
       },
     ],
   },
@@ -359,10 +366,14 @@ export function Sidebar() {
   // The AlertTriangle indicator on the nav item is owner-only too, so this also
   // keeps the `hasExternalKeys=null` path unreachable for non-owners.
   const currentWorkspaceRole = currentWorkspace?.current_user_role;
+  const byokEnabled = systemFeatures?.byok === true;
   useEffect(() => {
     setHasExternalKeys(null);
     if (!currentWorkspaceId) return;
     if (currentWorkspaceRole !== "owner") return;
+    // Issue #1167: with BYOK off the external-keys API 404s and the nav entry
+    // is hidden anyway — skip the probe (also while features are loading).
+    if (!byokEnabled) return;
 
     let cancelled = false;
     listExternalAPIKeys()
@@ -376,7 +387,7 @@ export function Sidebar() {
     return () => {
       cancelled = true;
     };
-  }, [currentWorkspaceId, currentWorkspaceRole]);
+  }, [currentWorkspaceId, currentWorkspaceRole, byokEnabled]);
 
   // Sync collapse state across browser tabs
   useEffect(() => {

--- a/frontend/src/components/onboarding/OnboardingCard.test.tsx
+++ b/frontend/src/components/onboarding/OnboardingCard.test.tsx
@@ -54,6 +54,12 @@ vi.mock("@/lib/api/workspaces", () => ({
   checkOpenAIKeyStatus: (...a: unknown[]) => mockCheckKey(...a),
 }));
 
+// #1167: the key probe is gated on features.byok; default on, flip per-test.
+let mockFeatures: Record<string, boolean> | null = { byok: true };
+vi.mock("@/hooks/useSystemFeatures", () => ({
+  useSystemFeatures: () => mockFeatures,
+}));
+
 import { OnboardingCard } from "./OnboardingCard";
 
 function setWorkspace(role: string = "owner") {
@@ -68,6 +74,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   window.localStorage.clear();
   setWorkspace("owner");
+  mockFeatures = { byok: true };
   mockGetContexts.mockResolvedValue({ contexts: [], total: 0 });
   mockCheckKey.mockResolvedValue({
     has_key: true,
@@ -109,6 +116,18 @@ describe("OnboardingCard trigger gating", () => {
     const { container } = render(<OnboardingCard />);
     await waitFor(() => expect(container).toBeEmptyDOMElement());
     expect(mockGetContexts).not.toHaveBeenCalled();
+  });
+
+  it("skips the key probe and shows the normal flow when byok is off (#1167)", async () => {
+    mockFeatures = { byok: false };
+    render(<OnboardingCard />);
+    await waitFor(() =>
+      expect(screen.getByText("context.createButton")).toBeInTheDocument(),
+    );
+    // Probe never fired — the API 404s in a BYOK-off deployment and env
+    // keys serve embeddings, so no needsKey notice either.
+    expect(mockCheckKey).not.toHaveBeenCalled();
+    expect(screen.queryByText("needsKey.title")).toBeNull();
   });
 
   it("shows the embedding-key notice (not the flow) when no key is configured, and its CTA uses the real /workspace route (not the backend value)", async () => {

--- a/frontend/src/components/onboarding/OnboardingCard.tsx
+++ b/frontend/src/components/onboarding/OnboardingCard.tsx
@@ -44,6 +44,7 @@ import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { getContexts, createContext } from "@/lib/api/contexts";
 import { rememberMemory, recallMemories } from "@/lib/api/memory";
 import { checkOpenAIKeyStatus } from "@/lib/api/workspaces";
+import { useSystemFeatures } from "@/hooks/useSystemFeatures";
 import type { RecallResultItem } from "@/lib/types/memory";
 
 import {
@@ -92,10 +93,19 @@ export function OnboardingCard() {
   const [results, setResults] = useState<RecallResultItem[]>([]);
   const [busy, setBusy] = useState(false);
 
+  // Issue #1167: with BYOK off the key-status probe 404s and env keys serve
+  // embeddings — skip the probe (hasKey keeps its default true → normal
+  // onboarding, no "configure key" CTA pointing at a disabled page).
+  const systemFeatures = useSystemFeatures();
+  const byokEnabled = systemFeatures?.byok === true;
+
   useEffect(() => {
     let alive = true;
     // Wait for the workspace to hydrate — current_user_role is null mid-load.
+    // Also wait for the feature flags (#1167) so the byok gate below reads a
+    // resolved value instead of skipping the probe on the loading state.
     if (workspaceLoading || !currentWorkspace || !currentWorkspaceId) return;
+    if (systemFeatures === null) return;
 
     const dismissed =
       typeof window !== "undefined" &&
@@ -116,9 +126,10 @@ export function OnboardingCard() {
         if (ctx.contexts.length === 0) {
           // Only probe the embedding key when the card will actually show —
           // users with contexts (the vast majority of loads) never see it.
-          const keyStatus = await checkOpenAIKeyStatus(currentWorkspaceId).catch(
-            () => null,
-          );
+          // #1167: skip the probe entirely when BYOK is off (API 404s).
+          const keyStatus = byokEnabled
+            ? await checkOpenAIKeyStatus(currentWorkspaceId).catch(() => null)
+            : null;
           if (!alive) return;
           if (keyStatus) setHasKey(keyStatus.has_key);
           setVisible(true);
@@ -134,7 +145,13 @@ export function OnboardingCard() {
     return () => {
       alive = false;
     };
-  }, [workspaceLoading, currentWorkspace, currentWorkspaceId]);
+  }, [
+    workspaceLoading,
+    currentWorkspace,
+    currentWorkspaceId,
+    systemFeatures,
+    byokEnabled,
+  ]);
 
   const dismiss = useCallback(() => {
     if (typeof window !== "undefined") {
@@ -322,7 +339,9 @@ export function OnboardingCard() {
                 </div>
                 <Button
                   onClick={handleSaveMemory}
-                  disabled={busy || summary.trim().length < 10 || !content.trim()}
+                  disabled={
+                    busy || summary.trim().length < 10 || !content.trim()
+                  }
                 >
                   {busy && <InlineSpinner />}
                   {t("memory.saveButton")}

--- a/frontend/src/components/onboarding/OnboardingCard.tsx
+++ b/frontend/src/components/onboarding/OnboardingCard.tsx
@@ -145,13 +145,9 @@ export function OnboardingCard() {
     return () => {
       alive = false;
     };
-  }, [
-    workspaceLoading,
-    currentWorkspace,
-    currentWorkspaceId,
-    systemFeatures,
-    byokEnabled,
-  ]);
+    // byokEnabled is derived from systemFeatures, so listing systemFeatures
+    // alone covers both.
+  }, [workspaceLoading, currentWorkspace, currentWorkspaceId, systemFeatures]);
 
   const dismiss = useCallback(() => {
     if (typeof window !== "undefined") {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2197,6 +2197,7 @@
   "externalKeys": {
     "title": "External API Keys",
     "description": "Manage your API keys for OpenAI, Anthropic, Gemini, Self-hosted, Cohere, Voyage, and other services",
+    "featureDisabled": "External API keys (BYOK) are not enabled on this deployment.",
     "featureGuide": {
       "title": "What are External API Keys?",
       "overview": "External API Keys are workspace-scoped and let you configure third-party service credentials (OpenAI, Anthropic, Google Gemini, Self-hosted, Cohere, Voyage). LLM completions are supported by OpenAI, Anthropic, Gemini, and Self-hosted. Embedding generation is supported by OpenAI. Reranking is supported by Cohere and Voyage.",
@@ -2754,6 +2755,7 @@
       "title": "Cost Aggregation",
       "description": "LLM and embedding cost ($) breakdown across all workspaces",
       "descriptionWorkspace": "LLM and embedding cost ($) breakdown for this workspace",
+      "featureDisabled": "The workspace cost dashboard is not enabled on this deployment.",
       "actions": {
         "refresh": "Refresh"
       },

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2146,7 +2146,7 @@
     "rerankerNotAvailableFree": "Reranking not available on Free plan",
     "upgradeToBasic": "Upgrade to Basic plan to enable AI-powered reranking for improved search quality.",
     "noRerankerKeys": "No reranker API keys configured",
-    "configureRerankerKeys": "Please configure a Voyage AI or Cohere API key in External API Keys to enable reranking.",
+    "configureRerankerKeys": "Please configure a Voyage AI or Cohere API key in <link>External API Keys</link> to enable reranking.",
     "enableReranking": "Enable Reranking",
     "enableRerankingDesc": "Use AI reranking to improve search result relevance",
     "provider": "Provider",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2197,6 +2197,7 @@
   "externalKeys": {
     "title": "外部APIキー",
     "description": "OpenAI、Anthropic、Google Gemini、セルフホスト、Cohere、Voyageなどのサービス用APIキーを管理",
+    "featureDisabled": "この環境では外部APIキー（BYOK）が有効化されていません。",
     "featureGuide": {
       "title": "外部APIキーとは？",
       "overview": "外部APIキーはワークスペース単位で管理され、OpenAI、Anthropic、Google Gemini、セルフホスト、Cohere、Voyageなどの認証情報を設定できます。LLM推論はOpenAI・Anthropic・Gemini・セルフホストで利用可能。エンベディング生成はOpenAIで利用可能。リランキングはCohere・Voyageで利用可能です。",
@@ -2754,6 +2755,7 @@
       "title": "コスト集計",
       "description": "全 workspace の LLM・embedding コスト ($) ブレイクダウン",
       "descriptionWorkspace": "この workspace の LLM・embedding コスト ($) ブレイクダウン",
+      "featureDisabled": "この環境ではワークスペースのコストダッシュボードが有効化されていません。",
       "actions": {
         "refresh": "更新"
       },

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2146,7 +2146,7 @@
     "rerankerNotAvailableFree": "無料プランではリランキングは利用できません",
     "upgradeToBasic": "Basicプランにアップグレードして、AI搭載リランキングで検索品質を向上させましょう。",
     "noRerankerKeys": "リランカーAPIキーが設定されていません",
-    "configureRerankerKeys": "リランキングを有効にするには、外部APIキーでVoyage AIまたはCohere APIキーを設定してください。",
+    "configureRerankerKeys": "リランキングを有効にするには、<link>外部APIキー</link>でVoyage AIまたはCohere APIキーを設定してください。",
     "enableReranking": "リランキングを有効化",
     "enableRerankingDesc": "AIリランキングを使用して検索結果の関連性を向上",
     "provider": "プロバイダー",

--- a/terraform/single-server/.env.prod.example
+++ b/terraform/single-server/.env.prod.example
@@ -118,7 +118,8 @@ ENABLE_RERANKING=false
 # or the Plan page silently disappears for owners.
 ENABLE_PLAN_PAGE=true
 # BYOK surface (#1167). Default true (BYOK available). Set false to hide +
-# block the external-keys console and the workspace cost dashboard (404).
+# block the external-keys console, workspace cost dashboard, and key-status
+# probe (all 404).
 # Already-stored keys are still resolved; only key CRUD + cost UI are blocked.
 ENABLE_BYOK=true
 

--- a/terraform/single-server/.env.prod.example
+++ b/terraform/single-server/.env.prod.example
@@ -117,6 +117,10 @@ ENABLE_RERANKING=false
 # false (OSS/self-hosted has no billing) — managed/SaaS prod MUST set true
 # or the Plan page silently disappears for owners.
 ENABLE_PLAN_PAGE=true
+# BYOK surface (#1167). Default true (BYOK available). Set false to hide +
+# block the external-keys console and the workspace cost dashboard (404).
+# Already-stored keys are still resolved; only key CRUD + cost UI are blocked.
+ENABLE_BYOK=true
 
 # Neural memory sub-features
 TRACK_CO_ACTIVATION=true


### PR DESCRIPTION
Closes #1167

## Summary
- Adds `ENABLE_BYOK` (default **true** — OSS/self-hosted behavior unchanged). Setting it to `false` removes the BYOK surface: every `/external-keys` CRUD endpoint, `GET /workspaces/{id}/cost-aggregation`, and `GET /workspaces/{id}/openai-key-status` return a uniform **404** (feature-not-present semantics, consistent with `ENABLE_PLAN_PAGE` #1145), and the web UI hides the external-keys console + workspace cost dashboard.
- `GET /admin/cost-aggregation` intentionally stays open — platform env-key usage still accrues cost the system admin may need to see.
- Reorders the Workspace sidebar group: dashboard → contexts → resources → storage → secrets → members → sleepReports → cost (stores first, reporting last; order pinned by test).

## Implementation notes
- Reuses the #1145 three-piece deployment-toggle pattern verbatim: `settings.enable_byok` → `/system/info features.byok` → sidebar `requiredFeature` + page-level gates.
- New `require_byok_enabled` dependency (`auth/dependencies.py`) is listed **before** auth/role dependencies so every caller — anonymous, member, owner — sees the same 404 (no role-dependent 403-vs-404 split that would leak the feature's existence). Ordering is pinned by tests (anonymous → 404 when off, 401 when on).
- Key **resolution** is deliberately untouched: keys stored before turning the flag off are still used by the LLM/embedding services; only key CRUD and the cost dashboard are blocked. A deployment that starts with `ENABLE_BYOK=false` never accumulates keys. Documented in the settings docstring and `.env.example`.
- Frontend consumers of the key-status probe (contexts page, OnboardingCard, SearchSettingsSection) skip the probe and suppress "configure key" CTAs when the flag is off, so no dangling links point at the disabled surface.
- No schema change, no migration, no new dependencies.

## Deploy note
`useSystemFeatures` is fail-closed (missing flag = disabled), so during blue-green roll-out deploy the **backend first** — a new frontend against an old backend hides the BYOK menus until `/system/info` exposes `features.byok`.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1167-feat-feat-config-enable-byok-flag-gate-byok-s.gate1.md
- ~/.claude/cache/gh-issue-driven/1167-feat-feat-config-enable-byok-flag-gate-byok-s.gate2.md

🤖 Generated via /gh-issue-driven:ship
