### PR TITLE
fix(auth): reject role=owner workspace invitations (#1166)

### DIFF
--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1158,7 +1158,7 @@ class WorkspaceInvitationCreate(BaseModel):
     )
     role: WorkspaceRole = Field(
         WorkspaceRole.MEMBER,
-        description="Role to assign upon acceptance",
+        description="Role to assign upon acceptance (owner is not invitable — #1166)",
     )
     expires_in_days: int | None = Field(
         None,
@@ -1170,6 +1170,21 @@ class WorkspaceInvitationCreate(BaseModel):
         None,
         description="Context IDs to allow (required for member/viewer, minimum 1)",
     )
+
+    @field_validator("role")
+    @classmethod
+    def _reject_owner_role(cls, v: WorkspaceRole) -> WorkspaceRole:
+        """Issue #1166: invitations must never grant the owner role.
+
+        The sanctioned owner-change path is the ownership transfer flow;
+        rejecting here surfaces a 422 before any route/service code runs
+        (the service re-checks as defense in depth for non-HTTP callers).
+        """
+        if v == WorkspaceRole.OWNER:
+            raise ValueError(
+                "role=owner invitations are not supported; use the ownership transfer flow instead"
+            )
+        return v
 
 
 class WorkspaceInvitationResponse(TZAwareBaseModel):

--- a/backend/src/services/invitation_service.py
+++ b/backend/src/services/invitation_service.py
@@ -390,6 +390,16 @@ class InvitationService:
         if invitation.is_expired():
             raise ValidationError("This invitation has expired. Please request a new invitation.")
 
+        # Issue #1166 defense in depth: refuse pending owner-role invitations.
+        # create_invitation now rejects them, but rows minted before the fix
+        # (or via direct DB access) may still exist — accept must not grant
+        # the owner role. This policy rejection runs BEFORE the email-restriction
+        # check: the invitation is invalid by policy regardless of who presents
+        # it, and checking email first would leak the restricted address to a
+        # wrong-email caller via the mismatch error (Copilot review, PR #1169).
+        if invitation.role == WorkspaceRole.OWNER:
+            raise ValidationError(OWNER_INVITE_REJECTED_MSG)
+
         # Check email restriction (case-insensitive)
         if invitation.email:
             if invitation.email.lower() != user_email.lower():
@@ -397,13 +407,6 @@ class InvitationService:
                     f"This invitation is restricted to {invitation.email}. "
                     f"You are logged in as {user_email}."
                 )
-
-        # Issue #1166 defense in depth: refuse pending owner-role invitations.
-        # create_invitation now rejects them, but rows minted before the fix
-        # (or via direct DB access) may still exist — accept must not grant
-        # the owner role.
-        if invitation.role == WorkspaceRole.OWNER:
-            raise ValidationError(OWNER_INVITE_REJECTED_MSG)
 
         # Check if user is already a member
         stmt = select(WorkspaceMember).where(

--- a/backend/src/services/invitation_service.py
+++ b/backend/src/services/invitation_service.py
@@ -18,6 +18,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import WorkspaceRole
 from models.auth import User, Workspace, WorkspaceInvitation, WorkspaceMember
 from services.email_service import EmailService, get_email_service
 from utils.datetime import to_utc_iso, utcnow
@@ -165,21 +166,17 @@ class InvitationService:
             if invalid_ids:
                 raise ValidationError(f"Invalid or private context IDs: {list(invalid_ids)}")
 
-        # Validate single owner constraint (Issue #165 - only one owner per workspace)
-        if role == "owner":
-            stmt = select(WorkspaceMember).where(
-                WorkspaceMember.workspace_id == workspace_id,
-                WorkspaceMember.role == "owner",
+        # Issue #1166: owner invitations are rejected outright. The previous
+        # single-owner check (#165) only fired when an OWNER row existed, so an
+        # invitation minted in a zero-owner state — or racing
+        # transfer_ownership — could still grant the owner role at accept.
+        # Owner changes go through the ownership transfer flow; an owner
+        # invitation is never meaningful under the single-owner invariant.
+        if role == WorkspaceRole.OWNER:
+            raise ValidationError(
+                "Invitations cannot grant the owner role. "
+                "Use the ownership transfer flow to change the workspace owner."
             )
-            result = await self.db.execute(stmt)
-            existing_owners = result.scalars().all()
-
-            if existing_owners:
-                raise ValidationError(
-                    "Workspace already has an owner. "
-                    "Only one owner is allowed per workspace. "
-                    "Please transfer ownership first if you want to change the owner."
-                )
 
         # Generate unique token (32 bytes = 43 chars base64)
         token = secrets.token_urlsafe(32)
@@ -396,6 +393,17 @@ class InvitationService:
                     f"This invitation is restricted to {invitation.email}. "
                     f"You are logged in as {user_email}."
                 )
+
+        # Issue #1166 defense in depth: refuse pending owner-role invitations.
+        # create_invitation now rejects them, but rows minted before the fix
+        # (or via direct DB access) may still exist — accept must not grant
+        # the owner role.
+        if invitation.role == WorkspaceRole.OWNER:
+            raise ValidationError(
+                "This invitation would grant the owner role, which is not "
+                "supported. Use the ownership transfer flow to change the "
+                "workspace owner."
+            )
 
         # Check if user is already a member
         stmt = select(WorkspaceMember).where(

--- a/backend/src/services/invitation_service.py
+++ b/backend/src/services/invitation_service.py
@@ -27,6 +27,13 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Issue #1166: single message for the owner-invitation rejection, shared by the
+# create and accept guards so the two layers cannot drift.
+OWNER_INVITE_REJECTED_MSG = (
+    "Invitations cannot grant the owner role. "
+    "Use the ownership transfer flow to change the workspace owner."
+)
+
 # Invitation expiry presets (days)
 EXPIRY_PRESETS = {
     7: timedelta(days=7),
@@ -173,10 +180,7 @@ class InvitationService:
         # Owner changes go through the ownership transfer flow; an owner
         # invitation is never meaningful under the single-owner invariant.
         if role == WorkspaceRole.OWNER:
-            raise ValidationError(
-                "Invitations cannot grant the owner role. "
-                "Use the ownership transfer flow to change the workspace owner."
-            )
+            raise ValidationError(OWNER_INVITE_REJECTED_MSG)
 
         # Generate unique token (32 bytes = 43 chars base64)
         token = secrets.token_urlsafe(32)
@@ -399,11 +403,7 @@ class InvitationService:
         # (or via direct DB access) may still exist — accept must not grant
         # the owner role.
         if invitation.role == WorkspaceRole.OWNER:
-            raise ValidationError(
-                "This invitation would grant the owner role, which is not "
-                "supported. Use the ownership transfer flow to change the "
-                "workspace owner."
-            )
+            raise ValidationError(OWNER_INVITE_REJECTED_MSG)
 
         # Check if user is already a member
         stmt = select(WorkspaceMember).where(

--- a/backend/tests/services/test_invitation_service_coverage.py
+++ b/backend/tests/services/test_invitation_service_coverage.py
@@ -252,12 +252,12 @@ class TestCreateInvitation:
         assert inv.allowed_context_ids is None
 
     async def test_owner_role_with_existing_owner_raises(self, db_session):
-        """Single-owner constraint blocks a second owner invite."""
+        """#1166: owner invitations are rejected outright (existing owner)."""
         owner = await _make_user(db_session)
         ws = await _make_workspace(db_session, owner_user_id=owner.user_id)
         await _make_member(db_session, workspace_id=ws.id, user_id=owner.user_id, role="owner")
         svc = _service(db_session)
-        with pytest.raises(ValidationError, match="already has an owner"):
+        with pytest.raises(ValidationError, match="ownership transfer"):
             await svc.create_invitation(
                 workspace_id=ws.id,
                 invited_by=owner.user_id,
@@ -265,18 +265,25 @@ class TestCreateInvitation:
                 role="owner",
             )
 
-    async def test_owner_role_without_existing_owner_succeeds(self, db_session):
-        """An owner invite is allowed when no owner member exists yet."""
+    async def test_owner_role_rejected_even_without_existing_owner(self, db_session):
+        """#1166: owner invitations are rejected even in a zero-owner state.
+
+        Before #1166 this path SUCCEEDED (the #165 single-owner check only
+        fired when an owner row existed), which was the escalation edge: an
+        invitation minted in a corrupted zero-owner state — or racing
+        transfer_ownership — granted the owner role on accept. The sanctioned
+        owner-change path is the ownership-transfer flow.
+        """
         owner = await _make_user(db_session)
         ws = await _make_workspace(db_session, owner_user_id=owner.user_id)
         svc = _service(db_session)
-        inv = await svc.create_invitation(
-            workspace_id=ws.id,
-            invited_by=owner.user_id,
-            email="owner@example.com",
-            role="owner",
-        )
-        assert inv.role == "owner"
+        with pytest.raises(ValidationError, match="ownership transfer"):
+            await svc.create_invitation(
+                workspace_id=ws.id,
+                invited_by=owner.user_id,
+                email="owner@example.com",
+                role="owner",
+            )
 
     async def test_invalid_expires_in_days_raises(self, db_session):
         """An expiry not in EXPIRY_PRESETS is rejected."""
@@ -679,6 +686,32 @@ class TestAcceptInvitation:
                 token=inv.token, user_id=accepter.user_id, user_email="invitee@example.com"
             )
 
+    async def test_accept_owner_role_invitation_rejected(self, db_session):
+        """#1166: a pending role=owner invitation is refused at accept.
+
+        Defense in depth: create now rejects owner invitations, but rows
+        minted before the fix (or via direct DB access) may still exist.
+        Accept must not grant the owner role — the ownership-transfer flow
+        is the only sanctioned path.
+        """
+        owner = await _make_user(db_session)
+        ws = await _make_workspace(db_session, owner_user_id=owner.user_id, plan_name="pro")
+        inv = WorkspaceInvitation(
+            workspace_id=ws.id,
+            token=uuid.uuid4().hex + uuid.uuid4().hex,
+            email=None,
+            role="owner",
+            invited_by=owner.user_id,
+        )
+        db_session.add(inv)
+        await db_session.flush()
+        accepter = await _make_user(db_session)
+        svc = _service(db_session)
+        with pytest.raises(ValidationError, match="ownership transfer"):
+            await svc.accept_invitation(
+                token=inv.token, user_id=accepter.user_id, user_email="anyone@example.com"
+            )
+
     async def test_accept_with_no_email_restriction(self, db_session):
         """An invitation with no email restriction can be accepted by anyone."""
         owner = await _make_user(db_session)
@@ -900,3 +933,27 @@ class TestGetPendingInvitationsForEmail:
         assert live.id in ids
         assert accepted.id not in ids
         assert expired.id not in ids
+
+
+class TestInvitationSchemaOwnerRejection:
+    """#1166: the request schema refuses role=owner at the validation layer.
+
+    FastAPI surfaces this as a 422 on POST /workspaces/{id}/invitations —
+    before any route or service code runs — pointing the caller at the
+    ownership-transfer flow.
+    """
+
+    def test_role_owner_rejected(self):
+        from pydantic import ValidationError as PydanticValidationError
+
+        from models.schemas import WorkspaceInvitationCreate
+
+        with pytest.raises(PydanticValidationError, match="ownership transfer"):
+            WorkspaceInvitationCreate(email="x@example.com", role="owner")
+
+    def test_non_owner_roles_accepted(self):
+        from models.schemas import WorkspaceInvitationCreate
+
+        for role in ("admin", "member", "viewer"):
+            req = WorkspaceInvitationCreate(email="x@example.com", role=role)
+            assert req.role == role

--- a/backend/tests/services/test_invitation_service_coverage.py
+++ b/backend/tests/services/test_invitation_service_coverage.py
@@ -712,6 +712,34 @@ class TestAcceptInvitation:
                 token=inv.token, user_id=accepter.user_id, user_email="anyone@example.com"
             )
 
+    async def test_accept_owner_role_rejected_before_email_check(self, db_session):
+        """#1166 / PR #1169: the owner-policy rejection fires BEFORE the email check.
+
+        A legacy owner invitation WITH an email restriction, presented by a
+        wrong-email caller, must surface the owner-policy rejection — not the
+        email-mismatch error, which would leak the restricted address for an
+        invitation that is invalid by policy regardless of who presents it.
+        """
+        owner = await _make_user(db_session)
+        ws = await _make_workspace(db_session, owner_user_id=owner.user_id, plan_name="pro")
+        inv = WorkspaceInvitation(
+            workspace_id=ws.id,
+            token=uuid.uuid4().hex + uuid.uuid4().hex,
+            email="restricted@example.com",
+            role="owner",
+            invited_by=owner.user_id,
+        )
+        db_session.add(inv)
+        await db_session.flush()
+        accepter = await _make_user(db_session)
+        svc = _service(db_session)
+        with pytest.raises(ValidationError, match="ownership transfer") as exc_info:
+            await svc.accept_invitation(
+                token=inv.token, user_id=accepter.user_id, user_email="wrong@example.com"
+            )
+        # The restricted email must NOT appear in the error (no leak).
+        assert "restricted@example.com" not in str(exc_info.value)
+
     async def test_accept_with_no_email_restriction(self, db_session):
         """An invitation with no email restriction can be accepted by anyone."""
         owner = await _make_user(db_session)


### PR DESCRIPTION
Closes #1166

## Summary
- Workspace invitations can no longer grant the **owner** role at any layer. The sanctioned owner-change path remains the ownership transfer flow (#1094/#1102).
- Closes an escalation/persistence edge: a workspace admin could create a `role=owner` invitation that, once accepted, minted a second owner — bypassing the #254 owner-change guard on the role-update path.

## Implementation notes
Three-layer rejection (defense in depth):
1. **Schema** — `WorkspaceInvitationCreate` gains a `field_validator("role")` that raises for `owner`, so `POST /workspaces/{id}/invitations` returns **422** before any route/service code runs.
2. **create_invitation** — replaces the emergent #165 single-owner check (which only fired when an OWNER row already existed) with an outright `ValidationError`. This closes the zero-owner / `transfer_ownership`-race edge where an owner invitation could be minted and then granted at accept.
3. **accept_invitation** — defense-in-depth guard that refuses a pending invitation whose `role == owner`, neutralizing rows minted before this fix or via direct DB access.

Shared wording is centralized in `OWNER_INVITE_REJECTED_MSG` so the two service-layer guards cannot drift.

## Severity note
In a *consistent* workspace the admin escalation described in the issue was already blocked at create by the #165 guard (an owner row exists → "already has an owner"). This PR closes the **zero-owner / race** edge that guard missed and makes the policy explicit at the schema boundary — treat it as defense-in-depth + policy hardening rather than a live P0.

## Pre-PR review summary
- gate2 mode: advisor-only
- cso: green / qa-lead: green / cto: green
- gate1: green via /ask (CSO lens)
- review provider: code-review (medium — backend-only 3-file diff)

Tests: 49 in test_invitation_service_coverage.py (schema 422, create reject with & without existing owner, accept reject); full backend api+services+config+auth suite 2692 passed; ruff + pyright clean.

🤖 Generated via /gh-issue-driven:ship
