### PR TITLE
feat(workspaces): owner-key programmatic access to member + invitation endpoints (#1164)

### DIFF
--- a/backend/src/api/routes/invitations.py
+++ b/backend/src/api/routes/invitations.py
@@ -15,7 +15,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import get_current_user
+from auth.dependencies import APIKeyOrSessionUser, get_current_user
+from auth.programmatic_workspace_auth import authorize_workspace_management
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.auth import Workspace, WorkspaceInvitation, WorkspaceMember
@@ -28,7 +29,6 @@ from models.schemas import (
     WorkspaceInvitationResponse,
 )
 from services.invitation_service import InvitationService, build_invitation_url
-from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
@@ -53,7 +53,7 @@ __all__ = ["router", "build_invitation_url"]
 async def create_invitation(
     workspace_id: UUID,
     request: WorkspaceInvitationCreate,
-    current_user: dict = Depends(get_current_user),
+    current_user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ) -> WorkspaceInvitationResponse:
     """Create workspace invitation.
@@ -77,13 +77,11 @@ async def create_invitation(
     user_id = current_user.get("user_id")
 
     try:
-        perm_service = PermissionService(db)
-
-        # SECURITY: Workspace boundary check
-        # Issue #268/#269: Membership verification is sufficient
-        # check_workspace_access ensures user is admin of this workspace
-        await perm_service.check_workspace_access(
-            user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+        # Issue #1164: session admin+ (unchanged) OR workspace-owner API key;
+        # OAuth 403. role=owner is already rejected at the schema layer (#1166),
+        # so no programmatic owner-invite branch is needed here.
+        await authorize_workspace_management(
+            current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
         )
 
         # Check plan tier (Issue #165 - invitations require Pro plan)
@@ -178,35 +176,25 @@ async def create_invitation(
 )
 async def list_invitations(
     workspace_id: UUID,
+    current_user: APIKeyOrSessionUser,
     include_accepted: bool = False,
-    current_user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[WorkspaceInvitationResponse]:
     """List workspace invitations.
 
-    Permission: Requires workspace owner or admin role.
-
-    Args:
-        workspace_id: Workspace ID
-        include_accepted: Include accepted invitations (default: False)
-        current_user: Authenticated user
-        db: Database session
-
-    Returns:
-        List of invitations
+    Issue #1164: session admin+ (unchanged) OR workspace-owner API key.
+    For PROGRAMMATIC principals the live ``token`` / ``invitation_url``
+    (bearer join-credentials) are omitted — the token is only ever returned
+    in the POST create response — so CI logs never become a workspace-join
+    credential dump.
 
     Raises:
-        HTTPException 403: Insufficient permissions
+        HTTPException 403: Insufficient permissions.
     """
-    user_id = current_user.get("user_id")
-
-    perm_service = PermissionService(db)
-
-    # SECURITY: Workspace boundary check
-    # Issue #268/#269: Membership verification is sufficient
-    await perm_service.check_workspace_access(
-        user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+    principal = await authorize_workspace_management(
+        current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
     )
+    expose_token = principal.kind == "session"
 
     invitation_service = InvitationService(db)
     invitations = await invitation_service.list_invitations(
@@ -217,7 +205,7 @@ async def list_invitations(
         WorkspaceInvitationResponse(
             id=inv.id,
             workspace_id=inv.workspace_id,
-            token=inv.token,
+            token=inv.token if expose_token else None,
             email=inv.email,
             role=inv.role,
             invited_by=inv.invited_by,
@@ -225,7 +213,7 @@ async def list_invitations(
             accepted_at=inv.accepted_at,
             accepted_by=inv.accepted_by,
             created_at=inv.created_at,
-            invitation_url=build_invitation_url(inv.token),
+            invitation_url=build_invitation_url(inv.token) if expose_token else None,
             is_expired=inv.is_expired(),
             is_accepted=inv.is_accepted(),
             allowed_context_ids=(
@@ -246,21 +234,12 @@ async def list_invitations(
 async def delete_invitation(
     workspace_id: UUID,
     invitation_id: int,
-    current_user: dict = Depends(get_current_user),
+    current_user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Delete (revoke) invitation.
 
-    Permission: Requires workspace owner or admin role.
-
-    Args:
-        workspace_id: Workspace ID
-        invitation_id: Invitation ID
-        current_user: Authenticated user
-        db: Database session
-
-    Returns:
-        Success response
+    Issue #1164: session admin+ (unchanged) OR workspace-owner API key.
 
     Raises:
         HTTPException 403: Insufficient permissions
@@ -269,12 +248,8 @@ async def delete_invitation(
     user_id = current_user.get("user_id")
 
     try:
-        perm_service = PermissionService(db)
-
-        # SECURITY: Workspace boundary check
-        # Issue #268/#269: Membership verification is sufficient
-        await perm_service.check_workspace_access(
-            user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+        await authorize_workspace_management(
+            current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
         )
 
         invitation_service = InvitationService(db)
@@ -504,7 +479,7 @@ async def get_invitation_info(
 )
 async def get_member_quota(
     workspace_id: UUID,
-    current_user: dict = Depends(get_current_user),
+    current_user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Get member quota status for frontend display.
@@ -512,31 +487,14 @@ async def get_member_quota(
     Returns current members, pending invitations, and available seats.
 
     Issue #229: Display seat usage in UI.
-
-    Args:
-        workspace_id: Workspace ID
-        current_user: Current authenticated user
-        db: Database session
-
-    Returns:
-        Dictionary with quota information:
-            - current_members: Number of current workspace members
-            - pending_invitations: Number of pending (non-expired) invitations
-            - total_used: Sum of members + pending invitations
-            - limit: Maximum members allowed for plan
-            - available: Remaining seats available
-            - percentage: Usage percentage
-            - can_invite: Whether more invitations can be created
+    Issue #1164: session member+ (unchanged) OR workspace-owner API key.
 
     Raises:
         HTTPException: 403 if user lacks access, 404 if workspace not found
     """
-    user_id = current_user.get("user_id")
-
-    # Check permission (at least member access required)
-    perm_service = PermissionService(db)
-    await perm_service.check_workspace_access(
-        user_id, workspace_id, required_role=WorkspaceRole.MEMBER
+    # Issue #1164: session member+ gate; API key requires owner; OAuth 403.
+    await authorize_workspace_management(
+        current_user, workspace_id, db, session_required_role=WorkspaceRole.MEMBER
     )
 
     # Count current members

--- a/backend/src/api/routes/invitations.py
+++ b/backend/src/api/routes/invitations.py
@@ -16,7 +16,10 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser, get_current_user
-from auth.programmatic_workspace_auth import authorize_workspace_management
+from auth.programmatic_workspace_auth import (
+    audit_programmatic_workspace_action,
+    authorize_workspace_management,
+)
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.auth import Workspace, WorkspaceInvitation, WorkspaceMember
@@ -80,7 +83,7 @@ async def create_invitation(
         # Issue #1164: session admin+ (unchanged) OR workspace-owner API key;
         # OAuth 403. role=owner is already rejected at the schema layer (#1166),
         # so no programmatic owner-invite branch is needed here.
-        await authorize_workspace_management(
+        principal = await authorize_workspace_management(
             current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
         )
 
@@ -127,6 +130,17 @@ async def create_invitation(
             email=request.email,
             expires_in_days=request.expires_in_days,
             allowed_context_ids=allowed_context_ids,  # Migration 042
+        )
+
+        # Issue #1164: audit programmatic invitation creation (no-op for session).
+        await audit_programmatic_workspace_action(
+            db,
+            principal,
+            current_user,
+            workspace_id,
+            action="workspace_invitation_created",
+            target=request.email,
+            metadata={"role": str(request.role)},
         )
 
         await db.commit()
@@ -248,12 +262,22 @@ async def delete_invitation(
     user_id = current_user.get("user_id")
 
     try:
-        await authorize_workspace_management(
+        principal = await authorize_workspace_management(
             current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
         )
 
         invitation_service = InvitationService(db)
         await invitation_service.delete_invitation(invitation_id, workspace_id)
+
+        # Issue #1164: audit programmatic invitation revocation (no-op for session).
+        await audit_programmatic_workspace_action(
+            db,
+            principal,
+            current_user,
+            workspace_id,
+            action="workspace_invitation_revoked",
+            target=str(invitation_id),
+        )
 
         await db.commit()
 

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -20,7 +20,10 @@ from auth.dependencies import (
     get_current_user,
     require_byok_enabled,
 )
-from auth.programmatic_workspace_auth import authorize_workspace_management
+from auth.programmatic_workspace_auth import (
+    audit_programmatic_workspace_action,
+    authorize_workspace_management,
+)
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
@@ -721,6 +724,18 @@ async def add_member(
             "use the ownership transfer flow.",
         )
 
+    # Issue #1164: audit programmatic mutations (no-op for session). Added
+    # before the service call so it commits atomically with the membership.
+    await audit_programmatic_workspace_action(
+        db,
+        principal,
+        user,
+        workspace_id,
+        action="workspace_member_added",
+        target=body.user_id,
+        metadata={"role": str(body.role)},
+    )
+
     member = await workspace_service.add_member(
         workspace_id=workspace_id,
         user_id=body.user_id,
@@ -779,6 +794,16 @@ async def update_member_role(
             status_code=403,
             detail="Only the owner can change the owner's role.",
         )
+
+    await audit_programmatic_workspace_action(
+        db,
+        principal,
+        current_user,
+        workspace_id,
+        action="workspace_member_role_changed",
+        target=user_id,
+        metadata={"new_role": str(body.role)},
+    )
 
     member = await workspace_service.update_member_role(
         workspace_id=workspace_id,
@@ -879,8 +904,17 @@ async def remove_member(
     workspace_service = WorkspaceService(db)
 
     # Both session and API-key principals must be owner here (#217).
-    await authorize_workspace_management(
+    principal = await authorize_workspace_management(
         current_user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
+    )
+
+    await audit_programmatic_workspace_action(
+        db,
+        principal,
+        current_user,
+        workspace_id,
+        action="workspace_member_removed",
+        target=user_id,
     )
 
     await workspace_service.remove_member(workspace_id, user_id)

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -14,7 +14,13 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.analysis_allowlist import check_workspace_in_allowlist
-from auth.dependencies import SessionUser, get_current_user, require_byok_enabled
+from auth.dependencies import (
+    APIKeyOrSessionUser,
+    SessionUser,
+    get_current_user,
+    require_byok_enabled,
+)
+from auth.programmatic_workspace_auth import authorize_workspace_management
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
@@ -574,17 +580,18 @@ async def switch_workspace(
 @router.get("/{workspace_id}/members", response_model=list[WorkspaceMemberResponse])
 async def list_members(
     workspace_id: UUID,
-    request: Request,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
-    """List all members of workspace."""
-    user = await get_current_user(request)
-    workspace_service = WorkspaceService(db)
-    perm_service = PermissionService(db)
+    """List all members of workspace.
 
-    # Check access
-    await perm_service.check_workspace_access(
-        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    Issue #1164: session member+ (unchanged) OR workspace-owner API key.
+    """
+    workspace_service = WorkspaceService(db)
+
+    # Issue #1164: session keeps member+ gate; API key requires owner; OAuth 403.
+    await authorize_workspace_management(
+        user, workspace_id, db, session_required_role=WorkspaceRole.MEMBER
     )
 
     members = await workspace_service.list_members(workspace_id)
@@ -693,19 +700,26 @@ async def list_members(
 async def add_member(
     workspace_id: UUID,
     body: AddMemberRequest,
-    request: Request,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
     """Add a member to workspace.
 
-    Requires admin or owner role.
+    Issue #1164: session admin+ (unchanged) OR workspace-owner API key.
+    Programmatic principals cannot assign ``owner`` (422) — owner assignment
+    stays with the ownership-transfer flow.
     """
-    user = await get_current_user(request)
     workspace_service = WorkspaceService(db)
-    perm_service = PermissionService(db)
 
-    # Check admin access
-    await perm_service.check_workspace_admin(user["user_id"], workspace_id)
+    principal = await authorize_workspace_management(
+        user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
+    )
+    if principal.kind == "api_key" and body.role == WorkspaceRole.OWNER:
+        raise HTTPException(
+            status_code=422,
+            detail="Programmatic member management cannot assign the owner role; "
+            "use the ownership transfer flow.",
+        )
 
     member = await workspace_service.add_member(
         workspace_id=workspace_id,
@@ -726,19 +740,26 @@ async def update_member_role(
     workspace_id: UUID,
     user_id: str,
     body: UpdateMemberRoleRequest,
-    request: Request,
+    current_user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
     """Update member's role.
 
-    Requires admin or owner role.
+    Issue #1164: session admin+ (unchanged) OR workspace-owner API key.
+    Programmatic principals cannot assign ``owner`` (422).
     """
-    current_user = await get_current_user(request)
     workspace_service = WorkspaceService(db)
-    perm_service = PermissionService(db)
 
-    # Check admin access
-    current_member = await perm_service.check_workspace_admin(current_user["user_id"], workspace_id)
+    principal = await authorize_workspace_management(
+        current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
+    )
+
+    if principal.kind == "api_key" and body.role == WorkspaceRole.OWNER:
+        raise HTTPException(
+            status_code=422,
+            detail="Programmatic member management cannot assign the owner role; "
+            "use the ownership transfer flow.",
+        )
 
     # Issue #254: Prevent users from changing their own role
     if user_id == current_user["user_id"]:
@@ -747,9 +768,13 @@ async def update_member_role(
             detail="Cannot modify your own role. Another administrator must change your role.",
         )
 
-    # Issue #254: Prevent non-owners from changing owner's role
+    # Issue #254: Prevent non-owners from changing owner's role. The caller's
+    # membership comes from the authorization result (owner for the API-key
+    # principal by construction; the session caller's own row otherwise) — no
+    # second lookup needed.
+    caller_is_owner = principal.member.role == WorkspaceRole.OWNER
     target_member = await workspace_service.get_member(workspace_id, user_id)
-    if target_member.role == WorkspaceRole.OWNER and current_member.role != WorkspaceRole.OWNER:
+    if target_member.role == WorkspaceRole.OWNER and not caller_is_owner:
         raise HTTPException(
             status_code=403,
             detail="Only the owner can change the owner's role.",
@@ -843,19 +868,20 @@ async def update_member_context_access(
 async def remove_member(
     workspace_id: UUID,
     user_id: str,
-    request: Request,
+    current_user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
     """Remove member from workspace.
 
-    Issue #217: Requires owner role only. Cannot remove owner.
+    Issue #217: owner role only. Cannot remove owner.
+    Issue #1164: session owner (unchanged) OR workspace-owner API key.
     """
-    current_user = await get_current_user(request)
     workspace_service = WorkspaceService(db)
-    perm_service = PermissionService(db)
 
-    # Issue #217: Only owner can remove members
-    await perm_service.check_workspace_owner(current_user["user_id"], workspace_id)
+    # Both session and API-key principals must be owner here (#217).
+    await authorize_workspace_management(
+        current_user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
+    )
 
     await workspace_service.remove_member(workspace_id, user_id)
 

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -272,10 +272,18 @@ async def _build_api_key_user_dict(
     user_id: str,
     api_key_workspace_id: UUID | None,
     db: AsyncSession,
+    *,
+    api_key_prefix: str | None = None,
 ) -> dict:
     """Build user info dict from verified API key data.
 
     Shared by verify_api_key_user and get_user_from_api_key_or_session.
+
+    ``api_key_prefix`` (Issue #1164): the verified key's non-secret prefix
+    (``VerifiedKey.key_prefix``), surfaced on the principal so audit trails for
+    programmatic workspace-management actions can attribute the acting key
+    without a second lookup. Safe to log (it is only the prefix, never the
+    secret).
 
     Note (Issue #626): callers MUST reject public-bound keys
     (``VerifiedKey.bound_context_id is not None``) BEFORE invoking this
@@ -313,6 +321,7 @@ async def _build_api_key_user_dict(
         "current_context_id": None,  # Issue #246: always None, must be explicit
         "current_workspace_id": current_workspace_id,
         "api_key_workspace_id": api_key_workspace_id,
+        "api_key_prefix": api_key_prefix,  # Issue #1164: audit attribution
     }
 
 
@@ -391,7 +400,9 @@ async def verify_api_key_user(
             ),
         )
 
-    return await _build_api_key_user_dict(result.user_id, result.workspace_id, db)
+    return await _build_api_key_user_dict(
+        result.user_id, result.workspace_id, db, api_key_prefix=result.key_prefix
+    )
 
 
 async def require_session_auth(
@@ -547,7 +558,9 @@ async def get_user_from_api_key_or_session(
                         "they are only valid on /api/v1/public/{context_id}/* endpoints"
                     ),
                 )
-            return await _build_api_key_user_dict(result.user_id, result.workspace_id, db)
+            return await _build_api_key_user_dict(
+                result.user_id, result.workspace_id, db, api_key_prefix=result.key_prefix
+            )
 
         logger.warning("invalid_api_key_attempt", key_prefix=api_key[:16])
         raise HTTPException(status_code=401, detail="Invalid or expired API key")

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -200,18 +200,26 @@ async def audit_programmatic_workspace_action(
 
     from models.auth import AuditLog
 
+    # Issue #1164: attribute the acting API key by its non-secret prefix (from
+    # the authenticated principal — safe to log) so a stolen-owner-key incident
+    # is traceable to the specific key, not just the owner user_id.
+    audit_metadata = {
+        "workspace_id": str(workspace_id),
+        "target": target,
+        "via": "api_key",
+        **(metadata or {}),
+    }
+    key_prefix = user.get("api_key_prefix")
+    if key_prefix:
+        audit_metadata["key_prefix"] = key_prefix
+
     db.add(
         AuditLog(
             user_email=user.get("email") or f"{actor_id}@api",
             user_id=actor_id,
             action=action,
             resource=f"workspace:{workspace_id}",
-            user_metadata={
-                "workspace_id": str(workspace_id),
-                "target": target,
-                "via": "api_key",
-                **(metadata or {}),
-            },
+            user_metadata=audit_metadata,
         )
     )
     logger.info(

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -112,6 +112,12 @@ async def authorize_workspace_management(
             workspace differs from the path workspace (#963 confinement).
     """
     user_id = user.get("user_id")
+    # Fail closed on a malformed principal: a missing user_id must produce a
+    # clean 403, never a 500 from PermissionService querying with None
+    # (Copilot review, PR #1170).
+    if not user_id:
+        logger.warning("workspace_mgmt_missing_user_id", workspace_id=str(workspace_id))
+        raise AuthorizationError("Unrecognized principal for workspace management")
     perm_service = PermissionService(db)
 
     # OAuth → reject before any lookup.
@@ -176,9 +182,24 @@ async def audit_programmatic_workspace_action(
     """
     if principal.kind != "api_key":
         return
-    from models.auth import AuditLog
 
     actor_id = user.get("user_id")
+    if not actor_id:
+        # AuditLog.user_id is non-nullable — a missing actor would raise a DB
+        # integrity error and fail the (already-authorized) mutation. Audit is
+        # best-effort observability, so skip-with-warning instead of crashing.
+        # In practice authorize_workspace_management already rejected a
+        # principal without user_id, so this is defense in depth (Copilot
+        # review, PR #1170).
+        logger.warning(
+            "workspace_mgmt_audit_skipped_no_actor",
+            action=action,
+            workspace_id=str(workspace_id),
+        )
+        return
+
+    from models.auth import AuditLog
+
     db.add(
         AuditLog(
             user_email=user.get("email") or f"{actor_id}@api",

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -1,0 +1,130 @@
+"""Programmatic (API-key) authorization for workspace-management endpoints.
+
+Issue #1164 / #1165: the member/invitation endpoints (`workspaces.py`,
+`invitations.py`) and the member-credential endpoints (`member_credentials.py`)
+open to programmatic auth. This module centralizes the principal-discrimination
+rule so all of those routes gate identically:
+
+- **Session principal** (carries the OIDC ``sub`` claim): behavior unchanged —
+  the endpoint's existing role gate is applied via ``session_required_role``.
+- **API-key principal** (carries ``api_key_workspace_id`` — a *presence* test,
+  never truthiness, because global keys carry the key with value ``None``):
+  accepted, **workspace-OWNER only**, on the PATH ``workspace_id`` (not the
+  principal's ``current_workspace_id``). A workspace-scoped key bound to a
+  different workspace is confined to a **uniform 404** (Issue #963 pattern),
+  checked BEFORE the owner lookup so it cannot be used to probe existence.
+- **OAuth Bearer principal** (carries ``oauth_scope``): **403** on every
+  endpoint in this release — every ``kagura auth login`` device token carries
+  ``memory:read memory:write``, so accepting OAuth here would silently turn
+  every user's ordinary MCP token into a member-management credential. Rejected
+  until a dedicated ``workspace:admin`` scope exists.
+- **Fail closed**: any principal not positively identified as a session is
+  treated as programmatic (owner-required or, if unidentifiable, rejected).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.workspace_roles import WorkspaceRole
+from services.permission_service import PermissionService
+from utils.exceptions import AuthorizationError, NotFoundException
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# OAuth bearer tokens are rejected on these surfaces until a dedicated
+# workspace-admin scope is designed (see module docstring).
+_OAUTH_REJECTED_MSG = (
+    "OAuth bearer tokens cannot manage workspace members or credentials. "
+    "Use a workspace-owner API key."
+)
+
+
+def is_session_principal(user: dict) -> bool:
+    """True iff ``user`` is a session principal (carries the OIDC ``sub``)."""
+    return "sub" in user
+
+
+def is_oauth_principal(user: dict) -> bool:
+    """True iff ``user`` is an OAuth bearer principal."""
+    return "oauth_scope" in user
+
+
+def is_api_key_principal(user: dict) -> bool:
+    """True iff ``user`` is an API-key principal (presence, not truthiness)."""
+    return "api_key_workspace_id" in user
+
+
+async def authorize_workspace_management(
+    user: dict,
+    workspace_id: UUID,
+    db: AsyncSession,
+    *,
+    session_required_role: WorkspaceRole,
+) -> str:
+    """Authorize a workspace-management request across auth modes.
+
+    Args:
+        user: The authenticated principal dict (session / API-key / OAuth).
+        workspace_id: The PATH workspace id — the resource being managed. This
+            is deliberately NOT the principal's ``current_workspace_id``:
+            ``require_workspace_owner`` reads only the latter and is the wrong
+            gate for a path-parameterized route.
+        db: Async DB session for the permission lookup.
+        session_required_role: The role a SESSION principal must hold for this
+            endpoint (unchanged per-endpoint semantics). Ignored for API-key
+            principals, which are always owner-gated.
+
+    Returns:
+        The principal kind that was authorized: ``"api_key"`` or ``"session"``.
+        (Callers use this to vary response shape — e.g. omit invitation tokens
+        for programmatic principals.)
+
+    Raises:
+        AuthorizationError: 403 — OAuth principal, non-owner API key, session
+            below the required role, or an unidentifiable principal.
+        NotFoundException: 404 — a workspace-scoped API key whose bound
+            workspace differs from the path workspace (#963 confinement).
+    """
+    user_id = user.get("user_id")
+    perm_service = PermissionService(db)
+
+    # OAuth → reject before any lookup.
+    if is_oauth_principal(user):
+        logger.warning(
+            "workspace_mgmt_oauth_denied", user_id=user_id, workspace_id=str(workspace_id)
+        )
+        raise AuthorizationError(_OAUTH_REJECTED_MSG)
+
+    # API-key → owner-only, with #963 confinement first.
+    if is_api_key_principal(user):
+        key_workspace_id = user.get("api_key_workspace_id")
+        if key_workspace_id is not None and key_workspace_id != workspace_id:
+            # Uniform 404 — never reveal that the path workspace exists to a
+            # key bound elsewhere (no existence probing).
+            logger.warning(
+                "workspace_mgmt_scoped_key_confined",
+                user_id=user_id,
+                key_workspace_id=str(key_workspace_id),
+                path_workspace_id=str(workspace_id),
+            )
+            raise NotFoundException("Workspace not found")
+        await perm_service.check_workspace_owner(user_id, workspace_id)
+        return "api_key"
+
+    # Session → unchanged endpoint role gate.
+    if is_session_principal(user):
+        await perm_service.check_workspace_access(
+            user_id, workspace_id, required_role=session_required_role
+        )
+        return "session"
+
+    # Fail closed: not positively a session, not a recognized programmatic
+    # principal → deny.
+    logger.warning(
+        "workspace_mgmt_unrecognized_principal", user_id=user_id, workspace_id=str(workspace_id)
+    )
+    raise AuthorizationError("Unrecognized principal for workspace management")

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -24,16 +24,37 @@ rule so all of those routes gate identically:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.workspace_roles import WorkspaceRole
+from models.auth import WorkspaceMember
 from services.permission_service import PermissionService
 from utils.exceptions import AuthorizationError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class AuthorizedPrincipal:
+    """Result of a successful workspace-management authorization.
+
+    Attributes:
+        kind: ``"api_key"`` or ``"session"`` — callers vary response shape on
+            this (e.g. programmatic principals get token-less invitation lists).
+        member: The caller's ``WorkspaceMember`` row (from the permission
+            lookup). For an API-key principal this is the owner membership;
+            for a session it is the caller's membership at ``session_required_role``
+            or above. Callers reuse ``member.role`` for downstream guards (e.g.
+            the #254 owner-change check) without a second DB lookup.
+    """
+
+    kind: str
+    member: WorkspaceMember
+
 
 # OAuth bearer tokens are rejected on these surfaces until a dedicated
 # workspace-admin scope is designed (see module docstring).
@@ -64,7 +85,7 @@ async def authorize_workspace_management(
     db: AsyncSession,
     *,
     session_required_role: WorkspaceRole,
-) -> str:
+) -> AuthorizedPrincipal:
     """Authorize a workspace-management request across auth modes.
 
     Args:
@@ -79,9 +100,10 @@ async def authorize_workspace_management(
             principals, which are always owner-gated.
 
     Returns:
-        The principal kind that was authorized: ``"api_key"`` or ``"session"``.
-        (Callers use this to vary response shape — e.g. omit invitation tokens
-        for programmatic principals.)
+        An ``AuthorizedPrincipal`` carrying the principal ``kind``
+        (``"api_key"`` / ``"session"``) and the caller's ``WorkspaceMember``
+        row, so callers can vary response shape and reuse ``member.role`` for
+        downstream guards without a second lookup.
 
     Raises:
         AuthorizationError: 403 — OAuth principal, non-owner API key, session
@@ -112,15 +134,15 @@ async def authorize_workspace_management(
                 path_workspace_id=str(workspace_id),
             )
             raise NotFoundException("Workspace not found")
-        await perm_service.check_workspace_owner(user_id, workspace_id)
-        return "api_key"
+        member = await perm_service.check_workspace_owner(user_id, workspace_id)
+        return AuthorizedPrincipal(kind="api_key", member=member)
 
     # Session → unchanged endpoint role gate.
     if is_session_principal(user):
-        await perm_service.check_workspace_access(
+        member = await perm_service.check_workspace_access(
             user_id, workspace_id, required_role=session_required_role
         )
-        return "session"
+        return AuthorizedPrincipal(kind="session", member=member)
 
     # Fail closed: not positively a session, not a recognized programmatic
     # principal → deny.

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -150,3 +150,53 @@ async def authorize_workspace_management(
         "workspace_mgmt_unrecognized_principal", user_id=user_id, workspace_id=str(workspace_id)
     )
     raise AuthorizationError("Unrecognized principal for workspace management")
+
+
+async def audit_programmatic_workspace_action(
+    db: AsyncSession,
+    principal: AuthorizedPrincipal,
+    user: dict,
+    workspace_id: UUID,
+    *,
+    action: str,
+    target: str,
+    metadata: dict | None = None,
+) -> None:
+    """Write an AuditLog row for a PROGRAMMATIC workspace-management mutation.
+
+    Issue #1164: today ``AuditLog`` only records public-bound key creation, so a
+    stolen-owner-key incident on the member/invitation surface would be
+    forensically invisible. This records programmatic (API-key) successes with
+    the actor, workspace, action, and target. Session actions are intentionally
+    NOT audited here — this call is a no-op for session principals so the web-UI
+    path keeps its existing (unaudited) behavior unchanged.
+
+    The row is added to the session but NOT committed — the caller commits it
+    atomically with the mutation it is auditing.
+    """
+    if principal.kind != "api_key":
+        return
+    from models.auth import AuditLog
+
+    actor_id = user.get("user_id")
+    db.add(
+        AuditLog(
+            user_email=user.get("email") or f"{actor_id}@api",
+            user_id=actor_id,
+            action=action,
+            resource=f"workspace:{workspace_id}",
+            user_metadata={
+                "workspace_id": str(workspace_id),
+                "target": target,
+                "via": "api_key",
+                **(metadata or {}),
+            },
+        )
+    )
+    logger.info(
+        "workspace_mgmt_programmatic_action",
+        action=action,
+        actor_id=actor_id,
+        workspace_id=str(workspace_id),
+        target=target,
+    )

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1195,7 +1195,11 @@ class WorkspaceInvitationResponse(TZAwareBaseModel):
 
     id: int
     workspace_id: UUID
-    token: str
+    # Issue #1164: token / invitation_url are bearer join-credentials. They are
+    # populated in the POST create response and in session-principal list
+    # responses, but OMITTED (None) for programmatic (API-key) list responses so
+    # CI logs never become a workspace-join credential dump.
+    token: str | None
     email: str | None
     role: str
     invited_by: str
@@ -1203,7 +1207,7 @@ class WorkspaceInvitationResponse(TZAwareBaseModel):
     accepted_at: datetime | None
     accepted_by: str | None
     created_at: datetime
-    invitation_url: str  # Full URL to accept invitation
+    invitation_url: str | None  # Full URL to accept invitation (None when omitted)
     is_expired: bool
     is_accepted: bool
     allowed_context_ids: list[str] | None = Field(

--- a/backend/tests/api/test_programmatic_member_access.py
+++ b/backend/tests/api/test_programmatic_member_access.py
@@ -1,0 +1,147 @@
+"""Route-level integration tests for programmatic member/invitation access (#1164).
+
+Proves the auth contract is WIRED into the actual endpoints (the discrimination
+logic itself is unit-tested in tests/auth/test_programmatic_workspace_auth.py):
+
+- OAuth Bearer principal → 403 on every gated endpoint (rejected before any DB
+  lookup, so no permission mocking needed).
+- API-key owner → success; the permission lookup is mocked so no DB is needed.
+- API-key non-owner → 403.
+- Workspace-scoped key bound to a foreign workspace → uniform 404.
+- Programmatic invitation list omits token / invitation_url.
+- Programmatic add_member with role=owner → 422.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import get_user_from_api_key_or_session
+from utils.exceptions import AuthorizationError
+
+_WS = uuid.uuid4()
+
+
+def _api_key_user(*, workspace_id=None, user_id="owner-key") -> dict:
+    return {
+        "user_id": user_id,
+        "email": f"{user_id}@api",
+        "role": "user",
+        "current_workspace_id": workspace_id or _WS,
+        "api_key_workspace_id": workspace_id,
+    }
+
+
+def _oauth_user() -> dict:
+    return {
+        "user_id": "oauth-user",
+        "email": "o@oauth",
+        "role": "user",
+        "current_workspace_id": _WS,
+        "oauth_scope": "memory:read memory:write",
+    }
+
+
+@pytest.fixture
+def client():
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _override_user(user: dict) -> None:
+    async def _get_user():
+        return user
+
+    app.dependency_overrides[get_user_from_api_key_or_session] = _get_user
+
+
+@pytest.fixture
+def perm(monkeypatch):
+    """Mock PermissionService inside the helper module (owner check passes)."""
+    from auth import programmatic_workspace_auth as mod
+
+    inst = AsyncMock()
+    inst.check_workspace_owner.return_value = MagicMock(role="owner")
+    monkeypatch.setattr(mod, "PermissionService", lambda db: inst)
+    return inst
+
+
+class TestOAuthRejected:
+    """OAuth bearer tokens are 403 on the member/invitation surface (#1164)."""
+
+    def test_list_members_oauth_403(self, client):
+        _override_user(_oauth_user())
+        r = client.get(f"/api/v1/workspaces/{_WS}/members")
+        assert r.status_code == 403
+
+    def test_create_invitation_oauth_403(self, client):
+        _override_user(_oauth_user())
+        r = client.post(
+            f"/api/v1/workspaces/{_WS}/invitations",
+            json={"email": "x@example.com", "role": "member"},
+        )
+        assert r.status_code == 403
+
+
+class TestApiKeyConfinement:
+    def test_scoped_key_foreign_workspace_404(self, client, perm):
+        # Key bound to another workspace hitting this path → uniform 404,
+        # never reaches the owner lookup.
+        _override_user(_api_key_user(workspace_id=uuid.uuid4()))
+        r = client.get(f"/api/v1/workspaces/{_WS}/members")
+        assert r.status_code == 404
+        perm.check_workspace_owner.assert_not_called()
+
+    def test_api_key_non_owner_403(self, client, perm):
+        perm.check_workspace_owner.side_effect = AuthorizationError("not owner")
+        _override_user(_api_key_user(workspace_id=None))
+        r = client.get(f"/api/v1/workspaces/{_WS}/members")
+        assert r.status_code == 403
+
+
+class TestProgrammaticInvitationList:
+    def test_list_omits_token_for_api_key(self, client, perm, monkeypatch):
+        _override_user(_api_key_user(workspace_id=None))
+
+        inv = MagicMock()
+        inv.id = 1
+        inv.workspace_id = _WS
+        inv.token = "secret-token"
+        inv.email = "x@example.com"
+        inv.role = "member"
+        inv.invited_by = "owner-key"
+        inv.expires_at = None
+        inv.accepted_at = None
+        inv.accepted_by = None
+        inv.created_at = __import__("datetime").datetime(2026, 1, 1)
+        inv.is_expired.return_value = False
+        inv.is_accepted.return_value = False
+        inv.allowed_context_ids = None
+
+        from api.routes import invitations as inv_mod
+
+        svc = MagicMock()
+        svc.list_invitations = AsyncMock(return_value=[inv])
+        monkeypatch.setattr(inv_mod, "InvitationService", lambda db: svc)
+
+        r = client.get(f"/api/v1/workspaces/{_WS}/invitations")
+        assert r.status_code == 200
+        body = r.json()[0]
+        # Bearer join-credentials are omitted for programmatic principals.
+        assert body["token"] is None
+        assert body["invitation_url"] is None
+
+
+class TestProgrammaticOwnerRoleRejected:
+    def test_add_member_role_owner_422(self, client, perm):
+        _override_user(_api_key_user(workspace_id=None))
+        r = client.post(
+            f"/api/v1/workspaces/{_WS}/members",
+            json={"user_id": "target", "role": "owner"},
+        )
+        assert r.status_code == 422

--- a/backend/tests/api/test_workspace.py
+++ b/backend/tests/api/test_workspace.py
@@ -253,159 +253,121 @@ class TestUpdateMemberRole:
         """Mock database session."""
         return AsyncMock()
 
+    # Issue #1164: update_member_role now takes ``current_user`` (APIKeyOrSessionUser)
+    # and gates via the shared ``authorize_workspace_management`` helper. These
+    # unit tests target the #254 owner-change / self-change guards, so they patch
+    # the helper to return a session principal carrying the caller's membership
+    # and drive the target role via WorkspaceService.get_member.
+
+    def _session_user(self, user_id):
+        return {"user_id": user_id, "sub": user_id, "email": f"{user_id}@x"}
+
+    def _authorized(self, role):
+        from auth.programmatic_workspace_auth import AuthorizedPrincipal
+
+        caller_member = MagicMock()
+        caller_member.role = role
+        return AuthorizedPrincipal(kind="session", member=caller_member)
+
     @pytest.mark.asyncio
-    async def test_update_own_role_forbidden(self, workspace_id, admin_user, mock_request, mock_db):
-        """Test that users cannot change their own role (Issue #254)."""
-        # Mock current user
-        with patch("api.routes.workspaces.get_current_user", return_value=admin_user):
-            # Mock permission check to return admin member
-            mock_admin_member = MagicMock()
-            mock_admin_member.role = WorkspaceRole.ADMIN
-
-            with patch("api.routes.workspaces.PermissionService") as mock_perm_service:
-                mock_perm_service.return_value.check_workspace_admin = AsyncMock(
-                    return_value=mock_admin_member
+    async def test_update_own_role_forbidden(self, workspace_id, admin_user, mock_db):
+        """Users cannot change their own role (Issue #254)."""
+        current_user = self._session_user(admin_user["user_id"])
+        with patch(
+            "api.routes.workspaces.authorize_workspace_management",
+            AsyncMock(return_value=self._authorized(WorkspaceRole.ADMIN)),
+        ):
+            body = UpdateMemberRoleRequest(role=WorkspaceRole.MEMBER)
+            with pytest.raises(HTTPException) as exc_info:
+                await update_member_role(
+                    workspace_id=workspace_id,
+                    user_id=current_user["user_id"],  # same as caller
+                    body=body,
+                    current_user=current_user,
+                    db=mock_db,
                 )
-
-                # Try to change own role
-                body = UpdateMemberRoleRequest(role=WorkspaceRole.MEMBER)
-
-                with pytest.raises(HTTPException) as exc_info:
-                    await update_member_role(
-                        workspace_id=workspace_id,
-                        user_id=admin_user["user_id"],  # Same as current user
-                        body=body,
-                        request=mock_request,
-                        db=mock_db,
-                    )
-
-                assert exc_info.value.status_code == 403
-                assert "own role" in exc_info.value.detail.lower()
+            assert exc_info.value.status_code == 403
+            assert "own role" in exc_info.value.detail.lower()
 
     @pytest.mark.asyncio
     async def test_admin_cannot_change_owner_role(
-        self, workspace_id, admin_user, target_user_id, mock_request, mock_db
+        self, workspace_id, admin_user, target_user_id, mock_db
     ):
-        """Test that admins cannot change owner's role (Issue #254)."""
-        # Mock current user as admin
-        with patch("api.routes.workspaces.get_current_user", return_value=admin_user):
-            # Mock permission check to return admin member
-            mock_admin_member = MagicMock()
-            mock_admin_member.role = WorkspaceRole.ADMIN
-
-            # Mock target member as owner
-            mock_owner_member = MagicMock()
-            mock_owner_member.role = WorkspaceRole.OWNER
-
-            with patch("api.routes.workspaces.PermissionService") as mock_perm_service:
-                mock_perm_service.return_value.check_workspace_admin = AsyncMock(
-                    return_value=mock_admin_member
-                )
-
-                with patch("api.routes.workspaces.WorkspaceService") as mock_workspace_service:
-                    mock_workspace_service.return_value.get_member = AsyncMock(
-                        return_value=mock_owner_member
+        """Admins cannot change an owner's role (Issue #254)."""
+        current_user = self._session_user(admin_user["user_id"])
+        target_owner = MagicMock()
+        target_owner.role = WorkspaceRole.OWNER
+        with patch(
+            "api.routes.workspaces.authorize_workspace_management",
+            AsyncMock(return_value=self._authorized(WorkspaceRole.ADMIN)),
+        ):
+            with patch("api.routes.workspaces.WorkspaceService") as mock_ws:
+                mock_ws.return_value.get_member = AsyncMock(return_value=target_owner)
+                body = UpdateMemberRoleRequest(role=WorkspaceRole.ADMIN)
+                with pytest.raises(HTTPException) as exc_info:
+                    await update_member_role(
+                        workspace_id=workspace_id,
+                        user_id=target_user_id,
+                        body=body,
+                        current_user=current_user,
+                        db=mock_db,
                     )
-
-                    body = UpdateMemberRoleRequest(role=WorkspaceRole.ADMIN)
-
-                    with pytest.raises(HTTPException) as exc_info:
-                        await update_member_role(
-                            workspace_id=workspace_id,
-                            user_id=target_user_id,
-                            body=body,
-                            request=mock_request,
-                            db=mock_db,
-                        )
-
-                    assert exc_info.value.status_code == 403
-                    assert "owner" in exc_info.value.detail.lower()
+                assert exc_info.value.status_code == 403
+                assert "owner" in exc_info.value.detail.lower()
 
     @pytest.mark.asyncio
     async def test_owner_can_change_owner_role(
-        self, workspace_id, owner_user, target_user_id, mock_request, mock_db
+        self, workspace_id, owner_user, target_user_id, mock_db
     ):
-        """Test that owners can change owner's role (Issue #254)."""
-        # Mock current user as owner
-        with patch("api.routes.workspaces.get_current_user", return_value=owner_user):
-            # Mock permission check to return owner member
-            mock_owner_member = MagicMock()
-            mock_owner_member.role = WorkspaceRole.OWNER
-
-            # Mock target member as owner
-            mock_target_owner = MagicMock()
-            mock_target_owner.role = "owner"
-            mock_target_owner.user_id = target_user_id
-            mock_target_owner.joined_at = None
-
-            with patch("api.routes.workspaces.PermissionService") as mock_perm_service:
-                mock_perm_service.return_value.check_workspace_admin = AsyncMock(
-                    return_value=mock_owner_member
+        """Owners can change an owner's role (Issue #254)."""
+        current_user = self._session_user(owner_user["user_id"])
+        target_owner = MagicMock()
+        target_owner.role = "owner"
+        target_owner.user_id = target_user_id
+        target_owner.joined_at = None
+        with patch(
+            "api.routes.workspaces.authorize_workspace_management",
+            AsyncMock(return_value=self._authorized(WorkspaceRole.OWNER)),
+        ):
+            with patch("api.routes.workspaces.WorkspaceService") as mock_ws:
+                mock_ws.return_value.get_member = AsyncMock(return_value=target_owner)
+                mock_ws.return_value.update_member_role = AsyncMock(return_value=target_owner)
+                body = UpdateMemberRoleRequest(role=WorkspaceRole.ADMIN)
+                response = await update_member_role(
+                    workspace_id=workspace_id,
+                    user_id=target_user_id,
+                    body=body,
+                    current_user=current_user,
+                    db=mock_db,
                 )
-
-                with patch("api.routes.workspaces.WorkspaceService") as mock_workspace_service:
-                    mock_workspace_service.return_value.get_member = AsyncMock(
-                        return_value=mock_target_owner
-                    )
-                    mock_workspace_service.return_value.update_member_role = AsyncMock(
-                        return_value=mock_target_owner
-                    )
-
-                    body = UpdateMemberRoleRequest(role=WorkspaceRole.ADMIN)
-
-                    # Should succeed
-                    response = await update_member_role(
-                        workspace_id=workspace_id,
-                        user_id=target_user_id,
-                        body=body,
-                        request=mock_request,
-                        db=mock_db,
-                    )
-
-                    assert response.user_id == target_user_id
+                assert response.user_id == target_user_id
 
     @pytest.mark.asyncio
     async def test_admin_can_change_member_role(
-        self, workspace_id, admin_user, target_user_id, mock_request, mock_db
+        self, workspace_id, admin_user, target_user_id, mock_db
     ):
-        """Test that admins can change member's role (Issue #254)."""
-        # Mock current user as admin
-        with patch("api.routes.workspaces.get_current_user", return_value=admin_user):
-            # Mock permission check to return admin member
-            mock_admin_member = MagicMock()
-            mock_admin_member.role = WorkspaceRole.ADMIN
-
-            # Mock target member as regular member
-            mock_target_member = MagicMock()
-            mock_target_member.role = "member"
-            mock_target_member.user_id = target_user_id
-            mock_target_member.joined_at = None
-
-            with patch("api.routes.workspaces.PermissionService") as mock_perm_service:
-                mock_perm_service.return_value.check_workspace_admin = AsyncMock(
-                    return_value=mock_admin_member
+        """Admins can change a regular member's role (Issue #254)."""
+        current_user = self._session_user(admin_user["user_id"])
+        target_member = MagicMock()
+        target_member.role = "member"
+        target_member.user_id = target_user_id
+        target_member.joined_at = None
+        with patch(
+            "api.routes.workspaces.authorize_workspace_management",
+            AsyncMock(return_value=self._authorized(WorkspaceRole.ADMIN)),
+        ):
+            with patch("api.routes.workspaces.WorkspaceService") as mock_ws:
+                mock_ws.return_value.get_member = AsyncMock(return_value=target_member)
+                mock_ws.return_value.update_member_role = AsyncMock(return_value=target_member)
+                body = UpdateMemberRoleRequest(role=WorkspaceRole.VIEWER)
+                response = await update_member_role(
+                    workspace_id=workspace_id,
+                    user_id=target_user_id,
+                    body=body,
+                    current_user=current_user,
+                    db=mock_db,
                 )
-
-                with patch("api.routes.workspaces.WorkspaceService") as mock_workspace_service:
-                    mock_workspace_service.return_value.get_member = AsyncMock(
-                        return_value=mock_target_member
-                    )
-                    mock_workspace_service.return_value.update_member_role = AsyncMock(
-                        return_value=mock_target_member
-                    )
-
-                    body = UpdateMemberRoleRequest(role=WorkspaceRole.VIEWER)
-
-                    # Should succeed
-                    response = await update_member_role(
-                        workspace_id=workspace_id,
-                        user_id=target_user_id,
-                        body=body,
-                        request=mock_request,
-                        db=mock_db,
-                    )
-
-                    assert response.user_id == target_user_id
+                assert response.user_id == target_user_id
 
 
 class TestSwitchWorkspace:

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -66,7 +66,8 @@ class TestApiKeyPrincipal:
             db=None,
             session_required_role=WorkspaceRole.MEMBER,
         )
-        assert who == "api_key"
+        assert who.kind == "api_key"
+        assert who.member is perm.check_workspace_owner.return_value
         perm.check_workspace_owner.assert_awaited_once_with("u-key", _WS)
         perm.check_workspace_access.assert_not_called()
 
@@ -108,7 +109,8 @@ class TestSessionPrincipal:
         who = await authorize_workspace_management(
             _session_user(), _WS, db=None, session_required_role=WorkspaceRole.ADMIN
         )
-        assert who == "session"
+        assert who.kind == "session"
+        assert who.member is perm.check_workspace_access.return_value
         # Session keeps its endpoint-specific role gate; owner-only does NOT apply.
         perm.check_workspace_access.assert_awaited_once_with(
             "u-session", _WS, required_role=WorkspaceRole.ADMIN

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -166,7 +166,11 @@ class TestAuditProgrammaticAction:
         db = MagicMock()
         principal = AuthorizedPrincipal(kind="session", member=MagicMock())
         await audit_programmatic_workspace_action(
-            db, principal, _session_user(), _WS,
-            action="workspace_member_added", target="member-1",
+            db,
+            principal,
+            _session_user(),
+            _WS,
+            action="workspace_member_added",
+            target="member-1",
         )
         db.add.assert_not_called()

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -10,11 +10,15 @@ principal-discrimination rule (key-PRESENCE tests, fail closed) and the
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from auth.programmatic_workspace_auth import authorize_workspace_management
+from auth.programmatic_workspace_auth import (
+    AuthorizedPrincipal,
+    audit_programmatic_workspace_action,
+    authorize_workspace_management,
+)
 from auth.workspace_roles import WorkspaceRole
 from utils.exceptions import AuthorizationError, NotFoundException
 
@@ -137,3 +141,32 @@ class TestFailClosed:
             )
         perm.check_workspace_owner.assert_not_called()
         perm.check_workspace_access.assert_not_called()
+
+
+class TestAuditProgrammaticAction:
+    async def test_api_key_principal_writes_audit_row(self):
+        db = MagicMock()  # db.add is sync
+        principal = AuthorizedPrincipal(kind="api_key", member=MagicMock())
+        await audit_programmatic_workspace_action(
+            db,
+            principal,
+            _api_key_user(),
+            _WS,
+            action="workspace_member_added",
+            target="member-1",
+            metadata={"role": "member"},
+        )
+        assert db.add.call_count == 1
+        row = db.add.call_args[0][0]
+        assert row.action == "workspace_member_added"
+        assert row.user_metadata["target"] == "member-1"
+        assert row.user_metadata["via"] == "api_key"
+
+    async def test_session_principal_is_noop(self):
+        db = MagicMock()
+        principal = AuthorizedPrincipal(kind="session", member=MagicMock())
+        await audit_programmatic_workspace_action(
+            db, principal, _session_user(), _WS,
+            action="workspace_member_added", target="member-1",
+        )
+        db.add.assert_not_called()

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -1,0 +1,137 @@
+"""Unit tests for the shared programmatic-workspace authorization helper.
+
+Issue #1164 / #1165: member/invitation and member-credential endpoints accept
+API-key principals at workspace-OWNER role, keep session role semantics
+unchanged, and reject OAuth Bearer tokens. This helper centralizes the
+principal-discrimination rule (key-PRESENCE tests, fail closed) and the
+#963 workspace-scoped-key confinement.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+
+from auth.programmatic_workspace_auth import authorize_workspace_management
+from auth.workspace_roles import WorkspaceRole
+from utils.exceptions import AuthorizationError, NotFoundException
+
+_WS = uuid.uuid4()
+
+
+def _session_user(user_id: str = "u-session") -> dict:
+    # Session principal carries the OIDC 'sub' claim (set at session creation).
+    return {"user_id": user_id, "sub": user_id, "email": "s@x", "role": "user"}
+
+
+def _api_key_user(user_id: str = "u-key", *, workspace_id=None) -> dict:
+    # API-key principal always carries 'api_key_workspace_id' (None for global
+    # keys) — presence, not truthiness, is the discriminator.
+    return {"user_id": user_id, "api_key_workspace_id": workspace_id, "role": "user"}
+
+
+def _oauth_user(user_id: str = "u-oauth") -> dict:
+    return {"user_id": user_id, "oauth_scope": "memory:read memory:write", "role": "user"}
+
+
+@pytest.fixture
+def perm(monkeypatch):
+    """Patch PermissionService so no DB is needed; assert which gate ran."""
+    from auth import programmatic_workspace_auth as mod
+
+    inst = AsyncMock()
+    monkeypatch.setattr(mod, "PermissionService", lambda db: inst)
+    return inst
+
+
+class TestOAuthRejected:
+    async def test_oauth_always_403(self, perm):
+        with pytest.raises(AuthorizationError):
+            await authorize_workspace_management(
+                _oauth_user(), _WS, db=None, session_required_role=WorkspaceRole.MEMBER
+            )
+        # OAuth is rejected before any permission lookup.
+        perm.check_workspace_owner.assert_not_called()
+        perm.check_workspace_access.assert_not_called()
+
+
+class TestApiKeyPrincipal:
+    async def test_global_key_owner_check(self, perm):
+        # Global key (workspace_id None): no confinement, owner-only.
+        who = await authorize_workspace_management(
+            _api_key_user(workspace_id=None),
+            _WS,
+            db=None,
+            session_required_role=WorkspaceRole.MEMBER,
+        )
+        assert who == "api_key"
+        perm.check_workspace_owner.assert_awaited_once_with("u-key", _WS)
+        perm.check_workspace_access.assert_not_called()
+
+    async def test_scoped_key_matching_path_owner_check(self, perm):
+        await authorize_workspace_management(
+            _api_key_user(workspace_id=_WS),
+            _WS,
+            db=None,
+            session_required_role=WorkspaceRole.MEMBER,
+        )
+        perm.check_workspace_owner.assert_awaited_once_with("u-key", _WS)
+
+    async def test_scoped_key_foreign_path_uniform_404(self, perm):
+        # #963 confinement: scoped key bound to a different workspace → 404,
+        # BEFORE the owner lookup (no existence probing).
+        other = uuid.uuid4()
+        with pytest.raises(NotFoundException):
+            await authorize_workspace_management(
+                _api_key_user(workspace_id=other),
+                _WS,
+                db=None,
+                session_required_role=WorkspaceRole.MEMBER,
+            )
+        perm.check_workspace_owner.assert_not_called()
+
+    async def test_api_key_non_owner_denied(self, perm):
+        perm.check_workspace_owner.side_effect = AuthorizationError("not owner")
+        with pytest.raises(AuthorizationError):
+            await authorize_workspace_management(
+                _api_key_user(workspace_id=None),
+                _WS,
+                db=None,
+                session_required_role=WorkspaceRole.MEMBER,
+            )
+
+
+class TestSessionPrincipal:
+    async def test_session_uses_supplied_role_gate(self, perm):
+        who = await authorize_workspace_management(
+            _session_user(), _WS, db=None, session_required_role=WorkspaceRole.ADMIN
+        )
+        assert who == "session"
+        # Session keeps its endpoint-specific role gate; owner-only does NOT apply.
+        perm.check_workspace_access.assert_awaited_once_with(
+            "u-session", _WS, required_role=WorkspaceRole.ADMIN
+        )
+        perm.check_workspace_owner.assert_not_called()
+
+    async def test_session_denied_propagates(self, perm):
+        perm.check_workspace_access.side_effect = AuthorizationError("role too low")
+        with pytest.raises(AuthorizationError):
+            await authorize_workspace_management(
+                _session_user(), _WS, db=None, session_required_role=WorkspaceRole.OWNER
+            )
+
+
+class TestFailClosed:
+    async def test_unrecognized_principal_denied(self, perm):
+        # No 'sub', no 'oauth_scope', no 'api_key_workspace_id' → fail closed.
+        with pytest.raises(AuthorizationError):
+            await authorize_workspace_management(
+                {"user_id": "u-x", "role": "user"},
+                _WS,
+                db=None,
+                session_required_role=WorkspaceRole.MEMBER,
+            )
+        perm.check_workspace_owner.assert_not_called()
+        perm.check_workspace_access.assert_not_called()

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -162,6 +162,25 @@ class TestAuditProgrammaticAction:
         assert row.user_metadata["target"] == "member-1"
         assert row.user_metadata["via"] == "api_key"
 
+    async def test_records_api_key_prefix_when_present(self):
+        # Issue #1164: the acting key's non-secret prefix is attributed.
+        db = MagicMock()
+        principal = AuthorizedPrincipal(kind="api_key", member=MagicMock())
+        user = {**_api_key_user(), "api_key_prefix": "kagura_abc123"}
+        await audit_programmatic_workspace_action(
+            db, principal, user, _WS, action="workspace_member_added", target="m1"
+        )
+        row = db.add.call_args[0][0]
+        assert row.user_metadata["key_prefix"] == "kagura_abc123"
+
+    async def test_omits_key_prefix_when_absent(self):
+        db = MagicMock()
+        principal = AuthorizedPrincipal(kind="api_key", member=MagicMock())
+        await audit_programmatic_workspace_action(
+            db, principal, _api_key_user(), _WS, action="x", target="m1"
+        )
+        assert "key_prefix" not in db.add.call_args[0][0].user_metadata
+
     async def test_session_principal_is_noop(self):
         db = MagicMock()
         principal = AuthorizedPrincipal(kind="session", member=MagicMock())


### PR DESCRIPTION
Closes #1164

## Summary
- Opens the 8 workspace member + invitation endpoints to **programmatic auth** — **API keys only, gated at workspace-OWNER**, keeping session (web-UI) semantics identical. Unblocks the Python SDK / CLI (`kagura workspace member` / `invite`, SDK #225).
- OAuth Bearer tokens are **rejected (403)** on this surface — a `memory:read/write` device token must not become a member-management credential (no `workspace:admin` scope exists yet).

## Implementation notes
New `auth/programmatic_workspace_auth.py` centralizes the rule in one helper, `authorize_workspace_management(user, workspace_id, db, *, session_required_role) -> AuthorizedPrincipal(kind, member)`:
- **Principal discrimination by key-presence** (never truthiness): `oauth_scope` → 403; `api_key_workspace_id` → owner-only on the **path** workspace (not `current_workspace_id`); `sub` → session keeps its existing per-endpoint role gate; else **fail-closed** 403.
- **#963 confinement**: a workspace-scoped key bound to a different workspace gets a **uniform 404** *before* the owner lookup (no existence probing).
- Returns the caller's `WorkspaceMember` so `update_member_role`'s #254 owner-change guard reuses it without a second lookup.

Wired into `workspaces.py` (GET/POST/PUT/DELETE members) and `invitations.py` (POST/GET/DELETE invitations, GET member-quota). Session role gates are **byte-preserved** (member/admin/admin/owner/admin/admin/admin/member). Programmatic add/set-role reject `role=owner` (422). Programmatic invitation-list responses **omit** `token`/`invitation_url` (now `str | None`) so CI logs never leak workspace-join credentials. `audit_programmatic_workspace_action` writes an `AuditLog` row for programmatic mutations (no-op for session, committed atomically with the mutation).

## Web-UI impact: none
The web UI authenticates via session cookie (`sub`), so it always takes the session branch with the identical role gate. Only a new programmatic path is added; OAuth is rejected.

## Deferred (follow-up)
**Rate limiting** for the programmatic mutations: the current limiter is path-prefix-only and the `{workspace_id}` sits mid-path, so no literal prefix targets "POST invitations + member mutations" without also throttling reads (member list, quota polling, stats). A method-aware matcher is needed — filed as a follow-up rather than shipping a coarse prefix that regresses read UX.

## Pre-PR review
- gate2 advisor-only: cso green / qa-lead green / cto green
- gate1: green via /ask (CSO lens)
- /code-review high: 0 findings (8 finder angles, all empty)
- Tests: 1304 backend pass; 10 helper unit tests + 6 route integration tests + migrated #254 tests; ruff + pyright clean.

🤖 Generated via /gh-issue-driven:ship
