### PR TITLE
feat(credentials): owner-key provisioning of member API keys (#1165)

### DIFF
--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -462,7 +462,10 @@ async def create_api_key(
 
     # Session path (#252 unchanged): self-mint only.
     if user["user_id"] != user_id:
-        raise AuthorizationError(message="Only owner can create API keys")
+        raise AuthorizationError(
+            message="You can only create your own API keys in a session. "
+            "To provision a key for another member, use a workspace-owner API key."
+        )
 
     # Issue #1165: expires_days is an owner-provisioned-only field. Session
     # self-mint keeps its historical "no expiry" behavior and does not plumb
@@ -739,7 +742,10 @@ async def delete_api_key_by_id(
                 )
     elif caller_id != user_id:
         # Session path (#252 unchanged): self-only.
-        raise AuthorizationError(message="Only owner can delete API keys")
+        raise AuthorizationError(
+            message="You can only delete your own API keys in a session. "
+            "To revoke another member's key, use a workspace-owner API key."
+        )
 
     from sqlalchemy import and_, select
 

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -17,7 +17,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.api_keys import APIKeyManager
-from auth.dependencies import SessionUser
+from auth.dependencies import APIKeyOrSessionUser, SessionUser
+from auth.programmatic_workspace_auth import (
+    authorize_workspace_management,
+    is_api_key_principal,
+    is_oauth_principal,
+)
+from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.schemas import (
     CreateAPIKeyRequest,
@@ -28,7 +34,7 @@ from models.schemas import (
 )
 from services.member_credentials_service import MemberCredentialsService
 from utils.datetime import to_utc_iso, utcnow
-from utils.exceptions import AuthorizationError, NotFoundException
+from utils.exceptions import AuthorizationError, BadRequestError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -74,31 +80,146 @@ async def check_permission(
         raise AuthorizationError(message=f"Not authorized to {action} credentials")
 
 
+async def _owner_provisioned_mint(
+    workspace_id: UUID,
+    user_id: str,
+    data: CreateAPIKeyRequest,
+    user: dict,
+    db: AsyncSession,
+) -> dict:
+    """Issue #1165: mint an API key for another member with a workspace-owner key.
+
+    Guardrails (all 403/400 before any write):
+    - owner-only on the PATH workspace (via authorize_workspace_management, which
+      also applies the #963 scoped-key confinement → uniform 404);
+    - 403 when ``target == caller`` (anti self-replication — a leaked owner key
+      must not mint fresh keys for itself and defeat revocation);
+    - 403 unless the target's workspace role is ``member``/``viewer`` (owner-key
+      minting is strictly privilege-DOWNGRADE provisioning for service identities);
+    - 400 if ``expires_days`` omitted (never-expiring CI keys are unacceptable here);
+    - 400 if ``bound_context_id`` set (public-bound keys stay self-only).
+    The minted key is force-hidden (``hidden_at=now``) so ``plaintext_key`` exists
+    only in this single 201 response; a follow-up GET returns it null.
+    """
+    caller_id = user["user_id"]
+
+    # Owner gate on the path workspace (+ #963 confinement). session_required_role
+    # is unused for the API-key principal but must be supplied.
+    await authorize_workspace_management(
+        user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
+    )
+
+    if caller_id == user_id:
+        raise AuthorizationError(
+            message="An owner key cannot mint keys for itself. Use session self-mint."
+        )
+
+    service = MemberCredentialsService(db)
+    target_role = await service.get_workspace_role(user_id, workspace_id)
+    if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
+        raise AuthorizationError(
+            message=(
+                "Owner-provisioned keys can only be minted for member/viewer "
+                f"targets, not role={target_role!r}."
+            )
+        )
+
+    if data.expires_days is None:
+        raise BadRequestError(
+            message="expires_days is required for owner-provisioned API keys (1-3650)."
+        )
+    if data.bound_context_id is not None:
+        raise BadRequestError(
+            message="bound_context_id is not allowed for owner-provisioned keys "
+            "(public-bound keys are self-only)."
+        )
+
+    manager = APIKeyManager(db)
+    try:
+        plaintext_key, new_key = await manager.create_key(
+            name=data.name,
+            user_id=user_id,
+            workspace_id=workspace_id,
+            expires_days=data.expires_days,
+            auto_hide_minutes=0,  # visibility_expires_at = now
+        )
+        # Force-hide immediately so plaintext is never re-revealed via GET.
+        new_key.hidden_at = utcnow()
+        new_key.visibility_expires_at = None
+
+        from models.auth import AuditLog
+
+        db.add(
+            AuditLog(
+                user_email=user.get("email") or f"{caller_id}@api",
+                user_id=caller_id,
+                action="member_api_key_provisioned",
+                resource=f"api_key:{new_key.id}",
+                user_metadata={
+                    "workspace_id": str(workspace_id),
+                    "target": user_id,
+                    "key_prefix": new_key.key_prefix,
+                    "expires_days": data.expires_days,
+                    "via": "api_key",
+                },
+            )
+        )
+        await db.commit()
+
+        logger.info(
+            "member_api_key_provisioned",
+            key_id=new_key.id,
+            actor_id=caller_id,
+            target=user_id,
+            workspace_id=str(workspace_id),
+        )
+        return {
+            "id": new_key.id,
+            "name": new_key.name,
+            "key_prefix": new_key.key_prefix,
+            "plaintext_key": plaintext_key,  # shown once
+            "is_visible": False,
+            "visibility_expires_at": None,
+            "created_at": to_utc_iso(new_key.created_at),
+            "last_used_at": None,
+            "revoked_at": None,
+            "bound_context_id": None,
+        }
+    except ValueError as e:
+        raise BadRequestError(message=str(e)) from e
+
+
 @router.get("/{user_id}/credentials", response_model=MemberCredentialsResponse)
 async def get_member_credentials(
     workspace_id: UUID,
     user_id: str,
-    user: SessionUser,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ) -> MemberCredentialsResponse:
     """Get or create member credentials (Lazy initialization).
 
     Migration 034: Zero-knowledge model.
-    - Owner can view plaintext secrets (if visible)
-    - Others can view metadata only
-
-    Args:
-        workspace_id: Workspace ID
-        user_id: Target user ID
-        user: Current user (from auth)
-        db: Database session
-
-    Returns:
-        Member credentials (API key + OAuth app)
+    - Session owner/admin can view plaintext secrets (if visible), per existing
+      ``_check_can_view`` semantics (unchanged).
+    - Issue #1165: an API-key OWNER principal may also view another member's key
+      METADATA, but the response is ALWAYS metadata-only (``plaintext_key`` is
+      nulled) — programmatic responses get logged, so plaintext must never appear.
+    - OAuth bearer principals are rejected (403).
 
     Raises:
-        HTTPException: If not authorized
+        HTTPException: If not authorized.
     """
+    # Issue #1165: OAuth rejected; API-key principal must be workspace owner.
+    if is_oauth_principal(user):
+        raise AuthorizationError(
+            message="OAuth bearer tokens cannot view member credentials. Use a workspace-owner API key."
+        )
+    programmatic = is_api_key_principal(user)
+    if programmatic:
+        await authorize_workspace_management(
+            user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
+        )
+
     service = MemberCredentialsService(db)
 
     try:
@@ -107,6 +228,13 @@ async def get_member_credentials(
             user_id=user_id,
             requester_id=user["user_id"],
         )
+
+        # Issue #1165: metadata-only for programmatic principals — never leak
+        # plaintext into a response that may be logged.
+        if programmatic:
+            for key in credentials.get("api_keys", []):
+                if isinstance(key, dict):
+                    key["plaintext_key"] = None
 
         # Get target user's workspace role (for permission checks)
         target_role = await service.get_workspace_role(user_id, workspace_id)
@@ -280,10 +408,24 @@ async def create_api_key(
     workspace_id: UUID,
     user_id: str,
     data: CreateAPIKeyRequest,
-    user: SessionUser,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Create new API key (Owner only).
+    """Create new API key.
+
+    Issue #1165: two principals.
+    - **Session** (web UI): self-mint only (``#252`` unchanged) — the caller
+      may only mint their OWN key; ``expires_days`` optional; ``bound_context_id``
+      still allowed (#626 public-bound path).
+    - **API-key owner** (programmatic): may mint for ANOTHER member, gated to
+      workspace-OWNER on the path workspace. Guardrails: 403 when target ==
+      caller (anti self-replication, #252 threat); 403 unless the target's
+      workspace role is ``member``/``viewer`` (privilege-downgrade provisioning
+      only); ``expires_days`` REQUIRED (400 if omitted — never-expiring CI keys
+      are not an acceptable default); ``bound_context_id`` rejected (400 —
+      public-bound keys stay self-only); the minted key is force-hidden so the
+      plaintext exists only in this one 201 response.
+    OAuth bearer principals are rejected (403).
 
     Issue #626: If ``data.bound_context_id`` is supplied, the key is stored
     as a public-bound key (``api_keys.workspace_id`` is left NULL) and is
@@ -306,7 +448,17 @@ async def create_api_key(
         HTTPException: If not owner, name already exists, tier gate fails,
             or the bound context is missing / not public / not in this workspace.
     """
-    # Permission check: only owner can create their own keys
+    # Issue #1165: OAuth bearer tokens must never mint long-lived credentials.
+    if is_oauth_principal(user):
+        raise AuthorizationError(
+            message="OAuth bearer tokens cannot mint API keys. Use a workspace-owner API key."
+        )
+
+    # Issue #1165: owner-provisioned programmatic minting for ANOTHER member.
+    if is_api_key_principal(user):
+        return await _owner_provisioned_mint(workspace_id, user_id, data, user, db)
+
+    # Session path (#252 unchanged): self-mint only.
     if user["user_id"] != user_id:
         raise AuthorizationError(message="Only owner can create API keys")
 
@@ -532,32 +684,49 @@ async def delete_api_key_by_id(
     workspace_id: UUID,
     user_id: str,
     key_id: int,
-    user: SessionUser,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
-    """Delete a specific API key by ID (owner only).
+    """Delete/revoke a specific API key by ID.
 
-    Issue #626: Required for revoking public-bound keys, which have
-    ``workspace_id IS NULL`` and so are invisible to the legacy singleton
-    DELETE endpoint above. This per-id endpoint accepts both regular
-    workspace-scoped keys and public-bound keys belonging to this user;
-    the ``workspace_id`` in the URL is the permission scope (the caller
-    must be the owner) and not a filter on ``api_keys.workspace_id``.
+    Issue #626: per-id endpoint (also revokes public-bound keys). The URL
+    ``workspace_id`` is the permission scope, not a filter on the key's column.
 
-    Args:
-        workspace_id: Workspace ID (permission scope, from URL)
-        user_id: Target user ID (must match the key's ``user_id``)
-        key_id: API key integer ID
-        user: Current user (from auth)
-        db: Database session
-
-    Returns:
-        Status message
+    Issue #1165: two principals.
+    - **Session**: self-only (``#252`` unchanged) — hard delete of your own key.
+    - **API-key OWNER** (programmatic): may revoke ANOTHER member's key (target
+      must be member/viewer). This is a **soft revoke** (``revoked_at=now``, row
+      retained for forensics), and the audit row is written BEFORE the state
+      change. OAuth bearer principals are rejected (403).
 
     Raises:
-        HTTPException: 403 if not owner, 404 if key not found.
+        HTTPException: 403 if not permitted, 404 if key not found.
     """
-    if user["user_id"] != user_id:
+    if is_oauth_principal(user):
+        raise AuthorizationError(
+            message="OAuth bearer tokens cannot revoke API keys. Use a workspace-owner API key."
+        )
+    caller_id = user["user_id"]
+    programmatic = is_api_key_principal(user)
+    if programmatic:
+        # Owner gate on the path workspace (+ #963 confinement).
+        await authorize_workspace_management(
+            user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
+        )
+        if user_id != caller_id:
+            # Cross-member revoke is owner-provisioned; restrict target role.
+            target_role = await MemberCredentialsService(db).get_workspace_role(
+                user_id, workspace_id
+            )
+            if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
+                raise AuthorizationError(
+                    message=(
+                        "Owner-provisioned revocation is limited to member/viewer "
+                        f"targets, not role={target_role!r}."
+                    )
+                )
+    elif caller_id != user_id:
+        # Session path (#252 unchanged): self-only.
         raise AuthorizationError(message="Only owner can delete API keys")
 
     from sqlalchemy import and_, select
@@ -598,16 +767,47 @@ async def delete_api_key_by_id(
     # the URL is purely permission scope; the owner-only check above is
     # the only gate that applies.
 
-    # Capture binding info before delete — the audit-log entry below
-    # needs the original ``bound_context_id`` and the row is about to go.
+    # Capture binding info before mutation — the audit-log entry below
+    # needs the original ``bound_context_id``.
     bound_ctx_id = api_key.bound_context_id
+
+    # Issue #1165: owner-provisioned cross-member revocation is a SOFT revoke
+    # (row retained for forensics) with the audit row written BEFORE the state
+    # change, so the record survives even if the commit partially fails. Session
+    # self-delete keeps the existing hard-delete semantics (#252, #626).
+    owner_provisioned = programmatic and user_id != caller_id
+    from models.auth import AuditLog
+
+    if owner_provisioned:
+        db.add(
+            AuditLog(
+                user_email=user.get("email") or f"{caller_id}@api",
+                user_id=caller_id,
+                action="member_api_key_revoked",
+                resource=f"api_key:{key_id}",
+                user_metadata={
+                    "workspace_id": str(workspace_id),
+                    "target": user_id,
+                    "key_prefix": api_key.key_prefix,
+                    "via": "api_key",
+                },
+            )
+        )
+        api_key.revoked_at = utcnow()
+        await db.commit()
+        logger.info(
+            "member_api_key_revoked",
+            key_id=key_id,
+            actor_id=caller_id,
+            target=user_id,
+            workspace_id=str(workspace_id),
+        )
+        return {"status": "revoked", "key_id": key_id}
 
     await db.delete(api_key)
 
     # Issue #626: audit log entry for public-bound key revocation.
     if bound_ctx_id is not None:
-        from models.auth import AuditLog
-
         db.add(
             AuditLog(
                 user_email=user.get("email") or f"{user_id}@api",

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -198,12 +198,14 @@ async def get_member_credentials(
 ) -> MemberCredentialsResponse:
     """Get or create member credentials (Lazy initialization).
 
-    Migration 034: Zero-knowledge model.
-    - Session owner/admin can view plaintext secrets (if visible), per existing
-      ``_check_can_view`` semantics (unchanged).
-    - Issue #1165: an API-key OWNER principal may also view another member's key
-      METADATA, but the response is ALWAYS metadata-only (``plaintext_key`` is
-      nulled) — programmatic responses get logged, so plaintext must never appear.
+    Migration 034: Zero-knowledge model (unchanged for sessions).
+    - A session caller sees plaintext ONLY for their OWN key while it is still
+      visible (``get_or_create_credentials`` includes ``plaintext_key`` only
+      when ``requester_id == user_id``). Session owner/admin viewing ANOTHER
+      member sees metadata only.
+    - Issue #1165: an API-key OWNER principal may also view another member's key,
+      but the response is ALWAYS metadata-only (``plaintext_key`` nulled) —
+      programmatic responses get logged, so plaintext must never appear.
     - OAuth bearer principals are rejected (403).
 
     Raises:
@@ -461,6 +463,16 @@ async def create_api_key(
     # Session path (#252 unchanged): self-mint only.
     if user["user_id"] != user_id:
         raise AuthorizationError(message="Only owner can create API keys")
+
+    # Issue #1165: expires_days is an owner-provisioned-only field. Session
+    # self-mint keeps its historical "no expiry" behavior and does not plumb
+    # expires_days to APIKeyManager — reject it explicitly rather than silently
+    # ignoring a client-supplied value (Copilot review, PR #1171).
+    if data.expires_days is not None:
+        raise BadRequestError(
+            message="expires_days is only supported for owner-provisioned keys "
+            "(via a workspace-owner API key), not session self-mint."
+        )
 
     # Issue #626: Public-bound key creation gating + scope decision.
     # When ``bound_context_id`` is supplied, the key is public-bound and the
@@ -772,8 +784,10 @@ async def delete_api_key_by_id(
     bound_ctx_id = api_key.bound_context_id
 
     # Issue #1165: owner-provisioned cross-member revocation is a SOFT revoke
-    # (row retained for forensics) with the audit row written BEFORE the state
-    # change, so the record survives even if the commit partially fails. Session
+    # (revoked_at set, row retained for forensics) rather than a row delete.
+    # The audit row and the revoked_at update are added together and committed
+    # in one transaction (atomic — no partial commit); ordering the audit add
+    # before the state change is for readability, not durability. Session
     # self-delete keeps the existing hard-delete semantics (#252, #626).
     owner_provisioned = programmatic and user_id != caller_id
     from models.auth import AuditLog

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -80,6 +80,38 @@ async def check_permission(
         raise AuthorizationError(message=f"Not authorized to {action} credentials")
 
 
+async def _require_downgrade_target(
+    db: AsyncSession,
+    user_id: str,
+    workspace_id: UUID,
+    *,
+    action_desc: str,
+) -> None:
+    """Owner-provisioned mint/revoke may only target a member/viewer.
+
+    Owner-key provisioning is strictly privilege-DOWNGRADE (service identities):
+    the target's workspace role must be ``member``/``viewer``. Shared by
+    ``_owner_provisioned_mint`` and ``delete_api_key_by_id`` so the allowed-target
+    set stays in lockstep across mint and revoke — diverging the two would open a
+    silent authorization gap on one path (max code-review, PR #1171).
+
+    Args:
+        db: Async DB session.
+        user_id: The TARGET member's user id.
+        workspace_id: The PATH workspace id (permission scope).
+        action_desc: Sentence prefix for the 403 message, completed with
+            "member/viewer targets, not role=...".
+
+    Raises:
+        AuthorizationError: 403 if the target's role is not member/viewer.
+    """
+    target_role = await MemberCredentialsService(db).get_workspace_role(user_id, workspace_id)
+    if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
+        raise AuthorizationError(
+            message=f"{action_desc} member/viewer targets, not role={target_role!r}."
+        )
+
+
 async def _owner_provisioned_mint(
     workspace_id: UUID,
     user_id: str,
@@ -116,15 +148,9 @@ async def _owner_provisioned_mint(
             message="An owner key cannot mint keys for itself. Use session self-mint."
         )
 
-    service = MemberCredentialsService(db)
-    target_role = await service.get_workspace_role(user_id, workspace_id)
-    if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
-        raise AuthorizationError(
-            message=(
-                "Owner-provisioned keys can only be minted for member/viewer "
-                f"targets, not role={target_role!r}."
-            )
-        )
+    await _require_downgrade_target(
+        db, user_id, workspace_id, action_desc="Owner-provisioned keys can only be minted for"
+    )
 
     if data.expires_days is None:
         raise BadRequestError(
@@ -145,9 +171,16 @@ async def _owner_provisioned_mint(
             expires_days=data.expires_days,
             auto_hide_minutes=0,  # visibility_expires_at = now
         )
-        # Force-hide immediately so plaintext is never re-revealed via GET.
+        # Force-hide immediately so plaintext is never re-revealed via GET, and
+        # null the encrypted-at-rest copy too (Migration-035 zero-knowledge). The
+        # hourly auto-hide sweeper only clears rows with hidden_at IS NULL, so a
+        # force-hidden row it never touches would otherwise retain a
+        # Fernet-decryptable copy of a live long-lived key indefinitely. This
+        # matches APIKeyManager.hide_key / auto_hide_expired_credentials, which
+        # both null plaintext_encrypted on hide (max code-review, PR #1171).
         new_key.hidden_at = utcnow()
         new_key.visibility_expires_at = None
+        new_key.plaintext_encrypted = None
 
         from models.auth import AuditLog
 
@@ -739,16 +772,9 @@ async def delete_api_key_by_id(
         )
         if user_id != caller_id:
             # Cross-member revoke is owner-provisioned; restrict target role.
-            target_role = await MemberCredentialsService(db).get_workspace_role(
-                user_id, workspace_id
+            await _require_downgrade_target(
+                db, user_id, workspace_id, action_desc="Owner-provisioned revocation is limited to"
             )
-            if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
-                raise AuthorizationError(
-                    message=(
-                        "Owner-provisioned revocation is limited to member/viewer "
-                        f"targets, not role={target_role!r}."
-                    )
-                )
     elif caller_id != user_id:
         # Session path (#252 unchanged): self-only.
         raise AuthorizationError(
@@ -790,9 +816,18 @@ async def delete_api_key_by_id(
             raise AuthorizationError(
                 message="API key is bound to a context in a different workspace"
             )
-    # else: global / owner-scoped key (both columns NULL) — workspace_id in
-    # the URL is purely permission scope; the owner-only check above is
-    # the only gate that applies.
+    else:
+        # Global / owner-scoped key (both columns NULL) — not anchored to any
+        # workspace. For a SESSION self-delete or a programmatic SELF-revoke the
+        # URL workspace is purely permission scope and the owner-only check above
+        # is the only gate. But a programmatic CROSS-member revoke cannot be
+        # anchored here: the path-workspace owner has no proven authority over a
+        # member's account-global key — it may be the key that member uses in
+        # their OTHER workspaces. Refuse with a uniform 404 rather than revoke
+        # across a workspace boundary (and misattribute the audit row to this
+        # workspace) (max code-review, PR #1171).
+        if programmatic and user_id != caller_id:
+            raise NotFoundException("API key")
 
     # Capture binding info before mutation — the audit-log entry below
     # needs the original ``bound_context_id``.

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -158,7 +158,8 @@ async def _owner_provisioned_mint(
                 user_metadata={
                     "workspace_id": str(workspace_id),
                     "target": user_id,
-                    "key_prefix": new_key.key_prefix,
+                    "key_prefix": new_key.key_prefix,  # the MINTED key
+                    "actor_key_prefix": user.get("api_key_prefix"),  # the ACTING owner key
                     "expires_days": data.expires_days,
                     "via": "api_key",
                 },
@@ -417,8 +418,9 @@ async def create_api_key(
 
     Issue #1165: two principals.
     - **Session** (web UI): self-mint only (``#252`` unchanged) — the caller
-      may only mint their OWN key; ``expires_days`` optional; ``bound_context_id``
-      still allowed (#626 public-bound path).
+      may only mint their OWN key. ``expires_days`` is NOT accepted on this path
+      (400 if supplied — session keys keep their historical no-expiry behavior);
+      ``bound_context_id`` is still allowed (#626 public-bound path).
     - **API-key owner** (programmatic): may mint for ANOTHER member, gated to
       workspace-OWNER on the path workspace. Guardrails: 403 when target ==
       caller (anti self-replication, #252 threat); 403 unless the target's
@@ -789,16 +791,16 @@ async def delete_api_key_by_id(
     # needs the original ``bound_context_id``.
     bound_ctx_id = api_key.bound_context_id
 
-    # Issue #1165: owner-provisioned cross-member revocation is a SOFT revoke
-    # (revoked_at set, row retained for forensics) rather than a row delete.
-    # The audit row and the revoked_at update are added together and committed
-    # in one transaction (atomic — no partial commit); ordering the audit add
-    # before the state change is for readability, not durability. Session
+    # Issue #1165: ALL programmatic (API-key) revocations are SOFT revokes
+    # (revoked_at set, row retained for forensics) + audited — including an
+    # owner revoking their OWN key, so a programmatic credential action is
+    # never a silent hard delete (Copilot review, PR #1171). The audit row and
+    # the revoked_at update commit atomically in one transaction. Session
     # self-delete keeps the existing hard-delete semantics (#252, #626).
-    owner_provisioned = programmatic and user_id != caller_id
+    soft_revoke = programmatic
     from models.auth import AuditLog
 
-    if owner_provisioned:
+    if soft_revoke:
         db.add(
             AuditLog(
                 user_email=user.get("email") or f"{caller_id}@api",
@@ -808,7 +810,9 @@ async def delete_api_key_by_id(
                 user_metadata={
                     "workspace_id": str(workspace_id),
                     "target": user_id,
-                    "key_prefix": api_key.key_prefix,
+                    "key_prefix": api_key.key_prefix,  # the REVOKED key
+                    "actor_key_prefix": user.get("api_key_prefix"),  # the ACTING owner key
+                    "self_revoke": user_id == caller_id,
                     "via": "api_key",
                 },
             )

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -101,13 +101,15 @@ async def _owner_provisioned_mint(
     The minted key is force-hidden (``hidden_at=now``) so ``plaintext_key`` exists
     only in this single 201 response; a follow-up GET returns it null.
     """
-    caller_id = user["user_id"]
-
-    # Owner gate on the path workspace (+ #963 confinement). session_required_role
-    # is unused for the API-key principal but must be supplied.
+    # Owner gate FIRST on the path workspace (+ #963 confinement). The helper
+    # fails closed on a malformed principal missing user_id (clean 403, never a
+    # KeyError/500), so read caller_id via .get() only after it passes (Copilot
+    # review, PR #1171). session_required_role is unused for the API-key
+    # principal but must be supplied.
     await authorize_workspace_management(
         user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
     )
+    caller_id = user.get("user_id")
 
     if caller_id == user_id:
         raise AuthorizationError(
@@ -723,7 +725,12 @@ async def delete_api_key_by_id(
         raise AuthorizationError(
             message="OAuth bearer tokens cannot revoke API keys. Use a workspace-owner API key."
         )
-    caller_id = user["user_id"]
+    # Fail closed on a malformed principal missing user_id — .get() (not
+    # indexing) so a bad dict yields a clean 403, never a KeyError/500. The
+    # programmatic branch's authorize_workspace_management re-validates; the
+    # session branch's self-only check (caller_id != user_id) rejects a None
+    # caller (Copilot review, PR #1171).
+    caller_id = user.get("user_id")
     programmatic = is_api_key_principal(user)
     if programmatic:
         # Owner gate on the path workspace (+ #963 confinement).

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -35,6 +35,7 @@ from services.workspace_ownership_service import WorkspaceOwnershipService
 from services.workspace_service import WorkspaceService
 from utils.auth_helpers import get_user_id
 from utils.datetime import to_utc_iso
+from utils.exceptions import ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -718,10 +719,10 @@ async def add_member(
         user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
     )
     if principal.kind == "api_key" and body.role == WorkspaceRole.OWNER:
-        raise HTTPException(
-            status_code=422,
-            detail="Programmatic member management cannot assign the owner role; "
+        raise ValidationError(
+            "Programmatic member management cannot assign the owner role; "
             "use the ownership transfer flow.",
+            field="role",
         )
 
     # Issue #1164: audit programmatic mutations (no-op for session). Added
@@ -770,10 +771,10 @@ async def update_member_role(
     )
 
     if principal.kind == "api_key" and body.role == WorkspaceRole.OWNER:
-        raise HTTPException(
-            status_code=422,
-            detail="Programmatic member management cannot assign the owner role; "
+        raise ValidationError(
+            "Programmatic member management cannot assign the owner role; "
             "use the ownership transfer flow.",
+            field="role",
         )
 
     # Issue #254: Prevent users from changing their own role

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1354,6 +1354,10 @@ class CreateAPIKeyRequest(BaseModel):
     name: str
     auto_hide_minutes: int = 10  # Auto-hide after 10 minutes (default)
     bound_context_id: str | None = None  # Issue #626
+    # Issue #1165: owner-provisioned mints REQUIRE an expiry (the route enforces
+    # 400 if omitted for the programmatic path); session self-mint leaves it None
+    # (unchanged — no expiry, as today). 1–3650 days mirrors /api/v1/config/api-keys.
+    expires_days: int | None = Field(default=None, ge=1, le=3650)
 
 
 class RegenerateAPIKeyResponse(BaseModel):

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -1,0 +1,158 @@
+"""Route-level tests for owner-key member-credential provisioning (#1165).
+
+Covers the programmatic (API-key owner) mint / list / revoke paths and their
+guardrails. Session self-mint/self-delete semantics are unchanged and covered
+by the existing member-credentials tests; here we prove the NEW programmatic
+behavior is wired and gated.
+
+PermissionService (inside the shared auth helper) and MemberCredentialsService /
+APIKeyManager are mocked so no DB is required.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import get_user_from_api_key_or_session
+from db.base import get_db
+
+_WS = uuid.uuid4()
+
+
+def _api_key_owner(*, workspace_id=None, user_id="owner-key") -> dict:
+    return {
+        "user_id": user_id,
+        "email": f"{user_id}@api",
+        "role": "user",
+        "current_workspace_id": workspace_id or _WS,
+        "api_key_workspace_id": workspace_id,
+    }
+
+
+def _oauth() -> dict:
+    return {"user_id": "o", "email": "o@oauth", "role": "user", "oauth_scope": "memory:write"}
+
+
+@pytest.fixture
+def client():
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _override(user: dict) -> None:
+    async def _get():
+        return user
+
+    app.dependency_overrides[get_user_from_api_key_or_session] = _get
+
+    # Stub the DB session — services/manager/permission are all mocked, so the
+    # route never needs a real session. db.commit must be awaitable.
+    fake_db = MagicMock()
+    fake_db.commit = AsyncMock()
+    fake_db.execute = AsyncMock()
+
+    async def _get_db():
+        yield fake_db
+
+    app.dependency_overrides[get_db] = _get_db
+
+
+@pytest.fixture
+def owner_gate(monkeypatch):
+    """Owner check inside the helper passes (mocked); no DB."""
+    from auth import programmatic_workspace_auth as mod
+
+    inst = AsyncMock()
+    inst.check_workspace_owner.return_value = MagicMock(role="owner")
+    monkeypatch.setattr(mod, "PermissionService", lambda db: inst)
+    return inst
+
+
+def _mock_member_service(monkeypatch, *, target_role="member"):
+    from api.routes import member_credentials as mc
+
+    svc = MagicMock()
+    svc.get_workspace_role = AsyncMock(return_value=target_role)
+    monkeypatch.setattr(mc, "MemberCredentialsService", lambda db: svc)
+    return svc
+
+
+def _mock_manager(monkeypatch):
+    from api.routes import member_credentials as mc
+
+    new_key = MagicMock()
+    new_key.id = 42
+    new_key.name = "ci-key"
+    new_key.key_prefix = "kagura_abc"
+    new_key.created_at = __import__("datetime").datetime(2026, 1, 1)
+    mgr = MagicMock()
+    mgr.create_key = AsyncMock(return_value=("kagura_PLAINTEXT", new_key))
+    monkeypatch.setattr(mc, "APIKeyManager", lambda db: mgr)
+    return mgr, new_key
+
+
+MINT_URL = f"/api/v1/workspaces/{_WS}/members/target-user/credentials/api-keys"
+
+
+class TestOwnerProvisionedMint:
+    def test_oauth_rejected(self, client):
+        _override(_oauth())
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 403
+
+    def test_success_for_member_target(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+        mgr, _ = _mock_manager(monkeypatch)
+        # commit / db.add are on the request-scoped session; patch get_db's session
+        # via the manager/audit no-op — the route calls db.add + db.commit which the
+        # real (test) session handles. Use a stub session through dependency_overrides.
+        r = client.post(MINT_URL, json={"name": "ci-key", "expires_days": 30})
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["plaintext_key"] == "kagura_PLAINTEXT"
+        assert body["is_visible"] is False
+        mgr.create_key.assert_awaited_once()
+        # expires_days plumbed; force-hidden via auto_hide_minutes=0
+        kwargs = mgr.create_key.await_args.kwargs
+        assert kwargs["expires_days"] == 30
+        assert kwargs["auto_hide_minutes"] == 0
+
+    def test_self_mint_forbidden(self, client, owner_gate, monkeypatch):
+        # target == caller → anti self-replication 403
+        _override(_api_key_owner(user_id="target-user"))
+        _mock_member_service(monkeypatch, target_role="member")
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 403
+
+    def test_owner_target_forbidden(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="owner")
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 403
+
+    def test_missing_expires_days_400(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+        r = client.post(MINT_URL, json={"name": "k"})
+        assert r.status_code == 400
+
+    def test_bound_context_id_400(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+        r = client.post(
+            MINT_URL,
+            json={"name": "k", "expires_days": 30, "bound_context_id": str(uuid.uuid4())},
+        )
+        assert r.status_code == 400
+
+    def test_scoped_key_foreign_workspace_404(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner(workspace_id=uuid.uuid4()))
+        _mock_member_service(monkeypatch, target_role="member")
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 404

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -238,3 +238,28 @@ class TestOwnerProvisionedRevoke:
         _override(_oauth())
         r = client.delete(REVOKE_URL)
         assert r.status_code == 403
+
+    def test_programmatic_self_revoke_is_soft(self, client, owner_gate, monkeypatch):
+        # #1165 / Copilot #1171: an API-key owner revoking their OWN key is a
+        # soft revoke + audit too — never a silent hard delete.
+        _override(_api_key_owner(user_id="owner-key"))
+        _mock_member_service(monkeypatch, target_role="owner")  # self role irrelevant here
+
+        api_key = MagicMock()
+        api_key.id = 7
+        api_key.workspace_id = _WS
+        api_key.bound_context_id = None
+        api_key.revoked_at = None
+        api_key.key_prefix = "kagura_self"
+        fake_db = self._fake_db_with_key(api_key)
+
+        async def _get_db():
+            yield fake_db
+
+        app.dependency_overrides[get_db] = _get_db
+
+        r = client.delete(f"/api/v1/workspaces/{_WS}/members/owner-key/credentials/api-keys/7")
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "revoked"
+        assert api_key.revoked_at is not None
+        fake_db.delete.assert_not_called()

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -44,14 +44,15 @@ def client():
     app.dependency_overrides.clear()
 
 
-def _override(user: dict) -> None:
+def _override(user: dict) -> MagicMock:
     async def _get():
         return user
 
     app.dependency_overrides[get_user_from_api_key_or_session] = _get
 
     # Stub the DB session — services/manager/permission are all mocked, so the
-    # route never needs a real session. db.commit must be awaitable.
+    # route never needs a real session. db.commit must be awaitable. Returned so
+    # callers can assert on db.add (e.g. the programmatic AuditLog row).
     fake_db = MagicMock()
     fake_db.commit = AsyncMock()
     fake_db.execute = AsyncMock()
@@ -60,6 +61,7 @@ def _override(user: dict) -> None:
         yield fake_db
 
     app.dependency_overrides[get_db] = _get_db
+    return fake_db
 
 
 @pytest.fixture
@@ -106,12 +108,9 @@ class TestOwnerProvisionedMint:
         assert r.status_code == 403
 
     def test_success_for_member_target(self, client, owner_gate, monkeypatch):
-        _override(_api_key_owner())
+        fake_db = _override(_api_key_owner())
         _mock_member_service(monkeypatch, target_role="member")
-        mgr, _ = _mock_manager(monkeypatch)
-        # commit / db.add are on the request-scoped session; patch get_db's session
-        # via the manager/audit no-op — the route calls db.add + db.commit which the
-        # real (test) session handles. Use a stub session through dependency_overrides.
+        mgr, new_key = _mock_manager(monkeypatch)
         r = client.post(MINT_URL, json={"name": "ci-key", "expires_days": 30})
         assert r.status_code == 201, r.text
         body = r.json()
@@ -122,6 +121,21 @@ class TestOwnerProvisionedMint:
         kwargs = mgr.create_key.await_args.kwargs
         assert kwargs["expires_days"] == 30
         assert kwargs["auto_hide_minutes"] == 0
+        # Force-hide must null BOTH the visibility window AND the encrypted-at-rest
+        # copy: the auto-hide sweeper skips already-hidden rows, so a force-hidden
+        # minted key that kept plaintext_encrypted would stay Fernet-decryptable
+        # forever (Migration-035 zero-knowledge). Regression guard for #1171.
+        assert new_key.visibility_expires_at is None
+        assert new_key.plaintext_encrypted is None
+        # A programmatic mint must leave a forensic AuditLog row (#1164/#1165).
+        from models.auth import AuditLog
+
+        audit_rows = [
+            c.args[0] for c in fake_db.add.call_args_list if isinstance(c.args[0], AuditLog)
+        ]
+        assert len(audit_rows) == 1
+        assert audit_rows[0].action == "member_api_key_provisioned"
+        assert audit_rows[0].user_metadata["target"] == "target-user"
 
     def test_self_mint_forbidden(self, client, owner_gate, monkeypatch):
         # target == caller → anti self-replication 403
@@ -232,6 +246,40 @@ class TestOwnerProvisionedRevoke:
         assert r.json()["status"] == "revoked"
         # Soft revoke: revoked_at set, row NOT deleted.
         assert api_key.revoked_at is not None
+        fake_db.delete.assert_not_called()
+        # A programmatic revoke must leave a forensic AuditLog row (#1164/#1165).
+        from models.auth import AuditLog
+
+        audit_rows = [
+            c.args[0] for c in fake_db.add.call_args_list if isinstance(c.args[0], AuditLog)
+        ]
+        assert len(audit_rows) == 1
+        assert audit_rows[0].action == "member_api_key_revoked"
+
+    def test_cross_member_global_key_revoke_404(self, client, owner_gate, monkeypatch):
+        # #1171 max-review: a global key (workspace_id NULL, bound_context_id NULL)
+        # is not anchored to any workspace. An owner of THIS workspace cannot
+        # revoke a member's account-global key across the workspace boundary —
+        # uniform 404, no state change, no misattributed audit row.
+        _override(_api_key_owner())  # caller "owner-key" != target "target-user"
+        _mock_member_service(monkeypatch, target_role="member")
+
+        api_key = MagicMock()
+        api_key.id = 42
+        api_key.workspace_id = None
+        api_key.bound_context_id = None
+        api_key.revoked_at = None
+        api_key.key_prefix = "kagura_global"
+        fake_db = self._fake_db_with_key(api_key)
+
+        async def _get_db():
+            yield fake_db
+
+        app.dependency_overrides[get_db] = _get_db
+
+        r = client.delete(REVOKE_URL)
+        assert r.status_code == 404
+        assert api_key.revoked_at is None
         fake_db.delete.assert_not_called()
 
     def test_oauth_revoke_rejected(self, client):

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -1,7 +1,7 @@
 """Route-level tests for owner-key member-credential provisioning (#1165).
 
-Covers the programmatic (API-key owner) mint / list / revoke paths and their
-guardrails. Session self-mint/self-delete semantics are unchanged and covered
+Covers the programmatic (API-key owner) mint, list, and revoke paths and
+their guardrails. Session self-mint/self-delete semantics are unchanged and covered
 by the existing member-credentials tests; here we prove the NEW programmatic
 behavior is wired and gated.
 
@@ -156,3 +156,85 @@ class TestOwnerProvisionedMint:
         _mock_member_service(monkeypatch, target_role="member")
         r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
         assert r.status_code == 404
+
+
+LIST_URL = f"/api/v1/workspaces/{_WS}/members/target-user/credentials"
+REVOKE_URL = f"/api/v1/workspaces/{_WS}/members/target-user/credentials/api-keys/42"
+
+
+def _member_api_key_dict(plaintext="secret-plain"):
+    return {
+        "id": 42,
+        "name": "k",
+        "key_prefix": "kagura_abc",
+        "plaintext_key": plaintext,
+        "is_visible": True,
+        "visibility_expires_at": None,
+        "created_at": "2026-01-01T00:00:00Z",
+        "last_used_at": None,
+        "revoked_at": None,
+        "bound_context_id": None,
+    }
+
+
+class TestOwnerProvisionedList:
+    def test_programmatic_list_masks_plaintext(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner())
+        from api.routes import member_credentials as mc
+
+        svc = MagicMock()
+        svc.get_or_create_credentials = AsyncMock(
+            return_value={"api_keys": [_member_api_key_dict("secret-plain")]}
+        )
+        svc.get_workspace_role = AsyncMock(return_value="member")
+        monkeypatch.setattr(mc, "MemberCredentialsService", lambda db: svc)
+
+        r = client.get(LIST_URL)
+        assert r.status_code == 200, r.text
+        # Programmatic principal never receives plaintext, even if the service
+        # returned it.
+        assert r.json()["api_keys"][0]["plaintext_key"] is None
+
+    def test_oauth_list_rejected(self, client):
+        _override(_oauth())
+        r = client.get(LIST_URL)
+        assert r.status_code == 403
+
+
+class TestOwnerProvisionedRevoke:
+    def _fake_db_with_key(self, api_key):
+        fake_db = MagicMock()
+        fake_db.commit = AsyncMock()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = api_key
+        fake_db.execute = AsyncMock(return_value=result)
+        return fake_db
+
+    def test_owner_soft_revoke(self, client, owner_gate, monkeypatch):
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+
+        api_key = MagicMock()
+        api_key.id = 42
+        api_key.workspace_id = _WS
+        api_key.bound_context_id = None
+        api_key.revoked_at = None
+        api_key.key_prefix = "kagura_abc"
+        fake_db = self._fake_db_with_key(api_key)
+
+        async def _get_db():
+            yield fake_db
+
+        app.dependency_overrides[get_db] = _get_db
+
+        r = client.delete(REVOKE_URL)
+        assert r.status_code == 200, r.text
+        assert r.json()["status"] == "revoked"
+        # Soft revoke: revoked_at set, row NOT deleted.
+        assert api_key.revoked_at is not None
+        fake_db.delete.assert_not_called()
+
+    def test_oauth_revoke_rejected(self, client):
+        _override(_oauth())
+        r = client.delete(REVOKE_URL)
+        assert r.status_code == 403


### PR DESCRIPTION
Closes #1165
Stacked on #1170 (#1164) — base is the `1164-batch` branch; retarget to `main` once #1170 merges. Reuses the `authorize_workspace_management` helper introduced in #1164.

## Summary
Owner-key **provisioning** of member API keys: a workspace-owner API key can mint / list-metadata / revoke ANOTHER member's keys. Session self-mint/self-delete semantics are **unchanged** (#252 not relaxed); OAuth bearer tokens are rejected (403). Unblocks the SDK `kagura auth create-key` family (#201).

## Implementation notes (`member_credentials.py`)
- **Mint** (`_owner_provisioned_mint`): owner-gated on the path workspace (helper → #963 confinement + owner check). Guardrails, all before any write:
  - 403 when `target == caller` (anti self-replication — a leaked owner key must not mint fresh keys for itself and defeat revocation, the #252 threat);
  - 403 unless target's workspace role is `member`/`viewer` (privilege-DOWNGRADE provisioning only);
  - 400 if `expires_days` omitted (new `CreateAPIKeyRequest.expires_days`, 1–3650) — never-expiring CI keys are not acceptable here;
  - 400 if `bound_context_id` set (public-bound keys stay self-only);
  - the minted key is **force-hidden** (`hidden_at=now`), so `plaintext_key` exists only in the single 201 response; a follow-up GET returns it null.
- **List** (`get_member_credentials`): an API-key owner may view another member's key **metadata**; `plaintext_key` is **always nulled** for programmatic principals (their responses get logged).
- **Revoke** (`delete_api_key_by_id`): self-or-owner. Owner-provisioned cross-member revoke is a **soft revoke** (`revoked_at=now`, row retained for forensics) with the audit row written **before** the state change; session self-delete keeps the existing hard-delete.
- All new mint/revoke actions are audited; new 400/422 sites use canonical `BadRequestError`/`ValidationError` (#992 ratchet — no raw HTTPException growth).

## Web-UI impact: none
Session principals keep the exact existing gates (self-mint / owner-or-admin view). Only a new API-key-owner path is added; OAuth rejected.

## Pre-PR review
- /code-review high: 0 correctness findings (4 finder angles; minor cleanup notes only — audit-shape differs from #1164's helper, force-hidden is a deliberate post-create step).
- Tests: 2683 backend pass; 7 new route tests (mint success + all guardrails: OAuth 403 / self 403 / owner-target 403 / missing-expires 400 / bound_context 400 / foreign-workspace 404); ruff + pyright clean.

🤖 Generated via /gh-issue-driven:ship
