### PR TITLE
eval: Day-2 placebo kill-shot harness (compounding → edge_spray)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ eval-compounding:
 
 .PHONY: eval-placebo
 eval-placebo:
+	@echo "Running live Day-2 placebo kill-shot (directional de-risk, needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/placebo-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.placebo_runner
 
 .PHONY: eval-reinforce

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ eval-compounding:
 	@echo "Writes backend/tests/eval/results/compounding-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.replay_runner
 
+.PHONY: eval-placebo
+eval-placebo:
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.placebo_runner
+
 .PHONY: eval-reinforce
 eval-reinforce:
 	@echo "Running live reinforce ON-vs-OFF rollout gate (Issue #1069, needs the stack: make up)..."

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -1,0 +1,77 @@
+"""Pure logic for the Day-2 placebo kill-shot (directional de-risk).
+
+Infrastructure-free and deterministic — runs in normal CI (test_placebo.py).
+The live cold→warm→placebo orchestration lives in tests.eval.placebo_runner.
+
+Realizes the descriptive half of prereg-v1 H2: three arms (real-warm,
+density-matched random-edge placebo, shuffled-gold placebo) scored on companion
+recovery, compared by paired point estimates with DESCRIPTIVE bootstrap
+intervals. No inferential claim, no gated CI — that is the Day-3 confirmatory
+run at the single committed τ.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from statistics import median
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class Edge:
+    """One neural-memory edge, reduced to what the null model needs. The
+    non-endpoint attributes travel with the edge through a rewire (only src/dst
+    change), so the placebo differs from real-warm in exactly which endpoints
+    are connected — density, degree sequence and attribute multisets are held."""
+
+    src: str
+    dst: str
+    weight: float
+    origin: str
+    confidence: float
+    edge_type: str
+
+
+def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int = 10) -> list[Edge]:
+    """Maslov-Sneppen directed double-edge-swap null graph.
+
+    Repeatedly picks two edges (s1->d1),(s2->d2) and swaps their destinations to
+    (s1->d2),(s2->d1) — preserving every node's out-degree (src) and in-degree
+    (dst), the edge count, and each edge's own weight/origin/confidence/edge_type
+    (hence the exact attribute multisets). Rejects any swap that would create a
+    self-loop or a parallel edge. Attempts ``swap_factor * len(edges)`` accepted
+    swaps for mixing. Raises if fewer than two edges (nothing to swap).
+    """
+    if len(edges) < 2:
+        raise ValueError(f"need >= 2 edges to rewire, got {len(edges)}")
+
+    rng = random.Random(seed)
+    current = list(edges)
+    present = {(e.src, e.dst) for e in current}
+    target = swap_factor * len(current)
+    done = 0
+    attempts = 0
+    max_attempts = target * 20
+    while done < target and attempts < max_attempts:
+        attempts += 1
+        i = rng.randrange(len(current))
+        j = rng.randrange(len(current))
+        if i == j:
+            continue
+        e1, e2 = current[i], current[j]
+        new1 = (e1.src, e2.dst)
+        new2 = (e2.src, e1.dst)
+        if new1[0] == new1[1] or new2[0] == new2[1]:
+            continue  # self-loop
+        if new1 == new2 or new1 in present or new2 in present:
+            continue  # parallel edge
+        present.discard((e1.src, e1.dst))
+        present.discard((e2.src, e2.dst))
+        present.add(new1)
+        present.add(new2)
+        current[i] = replace(e1, dst=e2.dst)
+        current[j] = replace(e2, dst=e1.dst)
+        done += 1
+    return current

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -171,7 +171,12 @@ def median_cross_topic_gold_pair_cosine(
     """
     cosines: list[float] = []
     for pair in gold_pairs:
+        if len(pair) != 2:
+            continue  # a gold "pair" that collapsed to <2 distinct docs (e.g. seed==companion) is not a pair
         a, b = tuple(pair)
+        # Same-source pairs are not cross-topic. If exactly one doc is missing
+        # from source_by_doc, .get() yields None vs a real source → treated as
+        # cross-topic (included); both missing → None==None → skipped.
         if source_by_doc.get(a) == source_by_doc.get(b):
             continue
         if a not in doc_vec or b not in doc_vec:

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -75,3 +75,43 @@ def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int =
         current[j] = replace(e2, dst=e1.dst)
         done += 1
     return current
+
+
+def _derangement(n: int, rng: random.Random) -> list[int]:
+    """A permutation of range(n) with no fixed point (n >= 2)."""
+    while True:
+        perm = list(range(n))
+        rng.shuffle(perm)
+        if all(perm[i] != i for i in range(n)):
+            return perm
+
+
+def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
+    """Permute which companion set each probe seed is scored against.
+
+    Preserves each probe's companion-set SIZE. Probes are grouped by companion
+    count; groups of >= 2 are deranged among themselves (no probe keeps its own
+    gold). A singleton size-class draws its companions from the global gold-doc
+    pool (all probes' seeds + companions) excluding the probe's own docs, so it
+    is still "not own gold". Deterministic under ``seed``.
+    """
+    rng = random.Random(seed)
+    groups: dict[int, list[int]] = defaultdict(list)
+    for idx, p in enumerate(probes):
+        groups[len(p.companion_docs)].append(idx)
+
+    all_gold = sorted({d for p in probes for d in p.companion_docs} | {p.seed_doc for p in probes})
+
+    result: dict[str, tuple[str, ...]] = {}
+    for size, idxs in groups.items():
+        if len(idxs) >= 2:
+            originals = [probes[i].companion_docs for i in idxs]
+            perm = _derangement(len(idxs), rng)
+            for pos, i in enumerate(idxs):
+                result[probes[i].query_id] = originals[perm[pos]]
+        else:
+            i = idxs[0]
+            own = set(probes[i].companion_docs) | {probes[i].seed_doc}
+            pool = [d for d in all_gold if d not in own]
+            result[probes[i].query_id] = tuple(rng.sample(pool, size))
+    return result

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -126,7 +126,7 @@ def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
 
 def paired_delta_bootstrap(
     per_probe_a: list[float], per_probe_b: list[float], *, seed: int, resamples: int = 10_000
-) -> dict[str, float]:
+) -> dict[str, float | int]:
     """Paired (a - b) point estimate + DESCRIPTIVE percentile bootstrap interval.
 
     Point estimate is the paired mean of the per-probe differences. The interval

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 
 import random
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from statistics import median
-from typing import Callable
 
 from tests.eval.compounding import recall_at_k
 from tests.eval.metrics import mrr_at_k
@@ -145,7 +145,7 @@ def paired_delta_bootstrap(
     if n == 0:
         raise ValueError("paired inputs are empty — nothing to bootstrap")
 
-    diffs = [a - b for a, b in zip(per_probe_a, per_probe_b)]
+    diffs = [a - b for a, b in zip(per_probe_a, per_probe_b, strict=True)]
     point = sum(diffs) / n
 
     rng = random.Random(seed)

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -18,6 +18,9 @@ from dataclasses import dataclass, replace
 from statistics import median
 from typing import Callable
 
+from tests.eval.compounding import recall_at_k
+from tests.eval.metrics import mrr_at_k
+
 
 @dataclass(frozen=True)
 class Edge:
@@ -185,3 +188,23 @@ def median_cross_topic_gold_pair_cosine(
     if not cosines:
         return None
     return median(cosines)
+
+
+def recovery_from_rankings(
+    rankings: list[tuple[str, list[str]]],
+    gold_map: dict[str, tuple[str, ...]],
+    *,
+    at: tuple[int, ...] = (5, 10),
+    mrr_at: int = 10,
+) -> dict:
+    """Score explore() rankings against a gold assignment (one scorer for all
+    three arms). ``rankings`` is [(query_id, ranked_docs)] in probe order;
+    ``gold_map`` maps query_id -> gold companion docs. Returns mean recovery@k,
+    mrr@k, and the per-probe recovery@10 list (paired-bootstrap input)."""
+    pairs = [(ranked, set(gold_map[qid])) for qid, ranked in rankings]
+    result: dict = {"n": len(pairs)}
+    for k in at:
+        result[f"recovery@{k}"] = round(sum(recall_at_k(r, g, k) for r, g in pairs) / len(pairs), 4)
+    result[f"mrr@{mrr_at}"] = round(mrr_at_k(pairs, mrr_at), 4)
+    result["per_probe@10"] = [round(recall_at_k(r, g, 10), 4) for r, g in pairs]
+    return result

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -122,3 +122,34 @@ def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
                 )
             result[probes[i].query_id] = tuple(rng.sample(pool, size))
     return result
+
+
+def paired_delta_bootstrap(
+    per_probe_a: list[float], per_probe_b: list[float], *, seed: int, resamples: int = 10_000
+) -> dict[str, float]:
+    """Paired (a - b) point estimate + DESCRIPTIVE percentile bootstrap interval.
+
+    Point estimate is the paired mean of the per-probe differences. The interval
+    is the 2.5/97.5 percentile of the resampled paired means — a shape aid, NOT
+    an inferential CI (percentile method, not BCa; the gated inferential test is
+    Day-3). Deterministic under ``seed``. Raises on length mismatch or empty.
+    """
+    if len(per_probe_a) != len(per_probe_b):
+        raise ValueError(
+            f"paired inputs differ in length: {len(per_probe_a)} vs {len(per_probe_b)}"
+        )
+    n = len(per_probe_a)
+    if n == 0:
+        raise ValueError("paired inputs are empty — nothing to bootstrap")
+
+    diffs = [a - b for a, b in zip(per_probe_a, per_probe_b)]
+    point = sum(diffs) / n
+
+    rng = random.Random(seed)
+    means: list[float] = []
+    for _ in range(resamples):
+        means.append(sum(diffs[rng.randrange(n)] for _ in range(n)) / n)
+    means.sort()
+    lo = means[int(0.025 * resamples)]
+    hi = means[int(0.975 * resamples)]
+    return {"delta": round(point, 4), "lo": round(lo, 4), "hi": round(hi, 4), "n": n}

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -153,3 +153,30 @@ def paired_delta_bootstrap(
     lo = means[int(0.025 * resamples)]
     hi = means[int(0.975 * resamples)]
     return {"delta": round(point, 4), "lo": round(lo, 4), "hi": round(hi, 4), "n": n}
+
+
+def median_cross_topic_gold_pair_cosine(
+    doc_vec: dict[str, list[float]],
+    gold_pairs: set[frozenset[str]],
+    source_by_doc: dict[str, str],
+    *,
+    cosine_fn: Callable[[list[float], list[float]], float],
+) -> float | None:
+    """Provisional τ = median cosine over CROSS-TOPIC gold pairs (prereg §3).
+
+    A gold pair is cross-topic when its two docs have different ``Document.source``
+    values. Pairs missing a vector are skipped. ``cosine_fn`` is injected so this
+    stays infra-free; the live caller passes ``neural.utils.cosine_similarity``.
+    Returns ``None`` when no cross-topic gold pair has both vectors.
+    """
+    cosines: list[float] = []
+    for pair in gold_pairs:
+        a, b = tuple(pair)
+        if source_by_doc.get(a) == source_by_doc.get(b):
+            continue
+        if a not in doc_vec or b not in doc_vec:
+            continue
+        cosines.append(cosine_fn(doc_vec[a], doc_vec[b]))
+    if not cosines:
+        return None
+    return median(cosines)

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -113,5 +113,12 @@ def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
             i = idxs[0]
             own = set(probes[i].companion_docs) | {probes[i].seed_doc}
             pool = [d for d in all_gold if d not in own]
+            if len(pool) < size:
+                raise ValueError(
+                    f"cannot build a size-{size} foreign gold set for probe "
+                    f"{probes[i].query_id!r}: only {len(pool)} non-own gold docs "
+                    f"available — corpus too small for a size-preserving "
+                    f"shuffled-gold placebo for this probe"
+                )
             result[probes[i].query_id] = tuple(rng.sample(pool, size))
     return result

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -102,8 +102,12 @@ async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> d
     """Provision an isolated workspace, build the warm graph once, run every
     seed's placebo arms off it, tear down."""
     from auth.workspace_roles import WorkspaceRole
+    from config.constants import EMBEDDING_MODEL_REGISTRY
+    from config.settings import get_settings
     from db.base import get_db
+    from db.qdrant import ensure_kagura_memories_collection, get_collection_name
     from models.auth import Context, Workspace, WorkspaceMember
+    from models.config import ContextSearchConfig
     from services.memory_service import MemoryService
 
     async for db in get_db():
@@ -128,12 +132,36 @@ async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> d
         await db.flush()
         db.add(ctx)
         db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        # The raw ORM Context bypasses ContextService.create_context, which stamps
+        # the per-context embedding config and ensures the model-specific Qdrant
+        # collection. Without an explicit ContextSearchConfig the lazy create_or_get
+        # defaults to text-embedding-3-small/512 and ingest routes to a collection
+        # that does not exist on a qwen3-embedding:0.6b/1024 rig — stamp it exactly
+        # like the production create path (mirrors runner.py's eval provisioning).
+        settings = get_settings()
+        emb_model = settings.embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        db.add(
+            ContextSearchConfig(
+                context_id=ctx.id,
+                semantic_weight=0.6,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2-lite",
+                embedding_model=emb_model,
+                embedding_dimensions=emb_dims,
+            )
+        )
         await db.flush()
         await db.commit()
 
         svc = MemoryService(db)
         id_map: dict[str, str] = {}
         try:
+            await ensure_kagura_memories_collection(
+                emb_dims, get_collection_name(emb_model, emb_dims)
+            )
             await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
             return await _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
         finally:

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -1,0 +1,474 @@
+"""Live Day-2 placebo kill-shot orchestration (directional de-risk).
+
+Builds ONE warm graph at a provisional τ (prereg-v1 §3 procedure on the current
+corpus), then measures companion recovery@10 for three arms off it:
+
+    real-warm            — true warm graph, true gold
+    shuffled-gold        — same rankings, size-preserving permuted gold
+    random-edge placebo  — degree-preserving rewired graph, true gold
+
+Reports paired point-estimate deltas with DESCRIPTIVE bootstrap intervals. This
+is NOT the inferential kill-shot (no gated CI, no accept/reject, τ untagged) —
+that runs at Day-3 on the grown corpus at the single committed τ.
+
+Writes results/placebo-<YYYY-MM-DD>.json from a REAL run only. Heavy imports are
+function-local (same convention as replay_runner) so importing this module is
+cheap and CI-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from tests.eval.compounding import MODE_EXCLUDE_PROBES, build_replay_plan
+from tests.eval.placebo import (
+    Edge,
+    degree_preserving_rewire,
+    median_cross_topic_gold_pair_cosine,
+    paired_delta_bootstrap,
+    permute_gold,
+    recovery_from_rankings,
+)
+from tests.eval.replay_runner import (
+    _EXPLORE_DEPTH,
+    _EXPLORE_MIN_WEIGHT,
+    _REPLAY_ROUNDS,
+    _gold_pairs_from_plan,
+    _replay,
+    _restore_env,
+    _run_sleep,
+)
+from tests.eval.runner import _ingest_corpus, _sudachi_version, _teardown
+from tests.eval.tools.corpus import load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+_DELTA_COMPOUND = 0.10  # directional keep/pivot threshold (prereg δ_compound)
+
+
+async def run_placebo_eval(
+    write: bool = True,
+    run_date: str | None = None,
+    seeds: tuple[int, ...] = (1, 2, 3),
+    rounds: int = _REPLAY_ROUNDS,
+    mode: str = MODE_EXCLUDE_PROBES,
+) -> dict[str, Any]:
+    from utils.datetime import utcnow
+
+    corpus = load_corpus()
+    run_date = run_date or utcnow().strftime("%Y-%m-%d")
+    plan = build_replay_plan(corpus, mode=mode, rounds=rounds)
+
+    block = await _run_placebo_mode(corpus, plan, seeds)
+
+    probe_count = len(plan.probes)
+    results: dict[str, Any] = {
+        "run_date": run_date,
+        "experiment": "day2-placebo",
+        "issue": None,
+        "sudachi_version": _sudachi_version(),
+        "corpus_version": corpus.meta.get("version"),
+        "doc_count": len(corpus.documents),
+        "query_count": len(corpus.queries),
+        "probe_count": probe_count,
+        "probe_underpowered": probe_count < 50,
+        "rounds": rounds,
+        "explore_depth": _EXPLORE_DEPTH,
+        "explore_min_weight": _EXPLORE_MIN_WEIGHT,
+        "seeds": list(seeds),
+        "design_note": (
+            "Descriptive/directional de-risk (week1-derisk Day 2). Provisional τ "
+            "(prereg §3 procedure on the CURRENT corpus), untagged. Percentile "
+            "bootstrap intervals are shape aids, NOT gated CIs; no accept/reject. "
+            "The inferential H2 kill-shot runs at Day-3 (prereg-v1-frozen)."
+        ),
+        **block,
+    }
+    if probe_count < 50:
+        print(
+            f"eval-placebo: WARNING probe_count={probe_count} << 50 — directional read only, underpowered"
+        )
+
+    if write:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out = _RESULTS_DIR / f"placebo-{run_date}.json"
+        out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"eval-placebo: wrote {out}")
+    return results
+
+
+async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> dict[str, Any]:
+    """Provision an isolated workspace, build the warm graph once, run every
+    seed's placebo arms off it, tear down."""
+    from auth.workspace_roles import WorkspaceRole
+    from db.base import get_db
+    from models.auth import Context, Workspace, WorkspaceMember
+    from services.memory_service import MemoryService
+
+    async for db in get_db():
+        owner = f"eval_{uuid4().hex[:8]}"
+        ws = Workspace(
+            id=uuid4(),
+            name=f"eval-ws-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=10_000_000,
+            weekly_api_limit=50_000_000,
+        )
+        ctx = Context(
+            id=uuid4(),
+            workspace_id=ws.id,
+            name=f"eval-ctx-{uuid4().hex[:8]}",
+            created_by=owner,
+            is_private=False,
+            sleep_mode="edges_only",
+        )
+        db.add(ws)
+        await db.flush()
+        db.add(ctx)
+        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        await db.flush()
+        await db.commit()
+
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+            return await _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+
+    raise RuntimeError("database session unavailable — is the stack up?")
+
+
+async def _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds) -> dict[str, Any]:
+    seed_mem_by_doc = {doc_id: mem_id for mem_id, doc_id in id_map.items()}
+    true_gold = {p.query_id: p.companion_docs for p in plan.probes}
+
+    # --- warm build (once, seed-independent): provisional τ -> replay -> sleep ---
+    tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
+    sleep_info: dict[str, Any]
+    try:
+        await _replay(svc, corpus, plan, owner, ctx, ws)
+        sleep_info = await _run_sleep(db, owner, ctx, ws)
+        real_rankings, seeds_in_graph = await _explore_rankings(
+            svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+        )
+        real_warm = recovery_from_rankings(real_rankings, true_gold)
+        snapshot = await _snapshot_edges(db, ctx.id)
+
+        per_seed = []
+        for s in seeds:
+            per_seed.append(
+                await _placebo_arms_for_seed(
+                    svc,
+                    db,
+                    plan,
+                    id_map,
+                    seed_mem_by_doc,
+                    owner,
+                    ctx,
+                    ws,
+                    real_rankings,
+                    real_warm,
+                    true_gold,
+                    snapshot,
+                    s,
+                )
+            )
+    finally:
+        if tau_info.get("seeded"):
+            await _delete_provisional_tau(db, tau_info["model"], tau_info["dimensions"])
+
+    d_rand = sorted(
+        b["deltas"]["random_edge"]["delta"] for b in per_seed if b["deltas"].get("random_edge")
+    )
+    d_shuf = sorted(b["deltas"]["shuffled_gold"]["delta"] for b in per_seed)
+    across = {
+        "delta_random_edge": _min_med_max(d_rand),
+        "delta_shuffled_gold": _min_med_max(d_shuf),
+    }
+    return {
+        "tau": tau_info,
+        "seeds_in_graph": seeds_in_graph,
+        "sleep": sleep_info,
+        "real_warm": real_warm,
+        "edge_count": len(snapshot),
+        "per_seed": per_seed,
+        "across_seeds": across,
+        "directional_read": _directional_read(real_warm, across),
+    }
+
+
+async def _placebo_arms_for_seed(
+    svc,
+    db,
+    plan,
+    id_map,
+    seed_mem_by_doc,
+    owner,
+    ctx,
+    ws,
+    real_rankings,
+    real_warm,
+    true_gold,
+    snapshot,
+    seed,
+) -> dict[str, Any]:
+    # shuffled-gold: same real-warm rankings, permuted gold
+    shuffled_map = permute_gold(plan.probes, seed=seed)
+    shuffled = recovery_from_rankings(real_rankings, shuffled_map)
+
+    # random-edge: degree-preserving rewire of the snapshot, re-explore, restore
+    if len(snapshot) < 2:
+        random_edge: dict[str, Any] = {"n": 0, "reason": "graph_too_sparse_to_rewire"}
+        rewire_swaps = 0
+    else:
+        placebo_edges = [
+            Edge(
+                str(r["src_id"]),
+                str(r["dst_id"]),
+                r["weight"],
+                r["origin"],
+                r["confidence"],
+                r["edge_type"],
+            )
+            for r in snapshot
+        ]
+        rewired = degree_preserving_rewire(placebo_edges, seed=seed)
+        rewire_swaps = len(rewired)
+        template = {"user_id": owner, "workspace_id": ws.id, "context_id": ctx.id}
+        rewired_rows = [
+            {
+                "src_id": UUID(e.src),
+                "dst_id": UUID(e.dst),
+                "weight": e.weight,
+                "confidence": e.confidence,
+                "origin": e.origin,
+                "edge_type": e.edge_type,
+                **template,
+            }
+            for e in rewired
+        ]
+        await _replace_edges(db, ctx.id, rewired_rows)
+        re_rankings, _ = await _explore_rankings(
+            svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+        )
+        random_edge = recovery_from_rankings(re_rankings, true_gold)
+        await _replace_edges(db, ctx.id, snapshot)  # restore for the next seed
+
+    deltas: dict[str, Any] = {
+        "shuffled_gold": paired_delta_bootstrap(
+            real_warm["per_probe@10"], shuffled["per_probe@10"], seed=seed
+        ),
+        "random_edge": (
+            paired_delta_bootstrap(
+                real_warm["per_probe@10"], random_edge["per_probe@10"], seed=seed
+            )
+            if random_edge.get("n")
+            else None
+        ),
+    }
+    return {
+        "seed": seed,
+        "arms": {"real_warm": real_warm, "shuffled_gold": shuffled, "random_edge": random_edge},
+        "deltas": deltas,
+        "gold_permutation": {k: list(v) for k, v in shuffled_map.items()},
+        "edge_snapshot": {"count": len(snapshot), "rewire_swaps_done": rewire_swaps},
+    }
+
+
+async def _explore_rankings(svc, probes, seed_mem_by_doc, id_map, owner, ctx, ws):
+    """Explore from each probe seed; return [(query_id, ranked_docs)] in probe
+    order + a seeds-in-graph count. Mirrors replay_runner._measure_graph_lane's
+    explore loop but returns the raw rankings so all arms can re-score them."""
+    from models.schemas import ExploreRequest
+
+    out: list[tuple[str, list[str]]] = []
+    seeds_in_graph = 0
+    for probe in probes:
+        resp = await svc.explore(
+            request=ExploreRequest(
+                memory_id=UUID(seed_mem_by_doc[probe.seed_doc]),
+                depth=_EXPLORE_DEPTH,
+                min_weight=_EXPLORE_MIN_WEIGHT,
+            ),
+            user_id=owner,
+            current_context_id=ctx.id,
+            current_workspace_id=ws.id,
+        )
+        if resp.metadata.get("reason") != "seed_not_in_graph":
+            seeds_in_graph += 1
+        related = sorted(resp.related_memories, key=lambda m: m.activation, reverse=True)
+        out.append((probe.query_id, [id_map.get(str(m.memory_id), "?") for m in related]))
+    return out, seeds_in_graph
+
+
+async def _snapshot_edges(db, ctx_id) -> list[dict[str, Any]]:
+    from sqlalchemy import select
+
+    from models.memory import NeuralMemoryEdge
+
+    rows = (
+        (await db.execute(select(NeuralMemoryEdge).where(NeuralMemoryEdge.context_id == ctx_id)))
+        .scalars()
+        .all()
+    )
+    return [
+        {
+            "src_id": r.src_id,
+            "dst_id": r.dst_id,
+            "weight": r.weight,
+            "confidence": r.confidence,
+            "origin": r.origin,
+            "edge_type": r.edge_type,
+            "user_id": r.user_id,
+            "workspace_id": r.workspace_id,
+            "context_id": r.context_id,
+        }
+        for r in rows
+    ]
+
+
+async def _replace_edges(db, ctx_id, rows: list[dict[str, Any]]) -> None:
+    from sqlalchemy import delete as sa_delete
+
+    from models.memory import NeuralMemoryEdge
+
+    await db.execute(sa_delete(NeuralMemoryEdge).where(NeuralMemoryEdge.context_id == ctx_id))
+    for r in rows:
+        db.add(
+            NeuralMemoryEdge(**r)
+        )  # fresh autoincrement id; created_at/last_updated default now()
+    await db.commit()
+
+
+async def _seed_provisional_tau(db, corpus, plan, id_map, ctx) -> dict[str, Any]:
+    """Compute provisional τ (median cross-topic gold-pair cosine) and seed a
+    transient model-global edge_gate calibration row so resolve_edge_threshold
+    returns max(τ, floor). Mirrors replay_runner._seed_edge_calibration but
+    substitutes τ for the non-gold percentile: compute_percentiles([τ]*N) makes
+    every stored percentile τ, so percentile(95) == τ."""
+    from datetime import timedelta
+
+    from db.qdrant import get_qdrant_client
+    from models.neural import CALIBRATION_KIND_EDGE_GATE
+    from neural.calibration import resolve_edge_threshold
+    from neural.config import NeuralMemoryConfig
+    from neural.utils import cosine_similarity
+    from tasks.neural_calibration import _load_measure_script, _upsert_calibration
+    from utils.datetime import utcnow
+
+    script = _load_measure_script()
+    model_name, dims, collection = await script.resolve_embedding_model(db, ctx.id)
+    qdrant = get_qdrant_client()
+    vecs_by_mem = await script.fetch_vectors(qdrant, collection, [UUID(m) for m in id_map])
+    doc_vec = {id_map[m]: v for m, v in vecs_by_mem.items() if m in id_map}
+    source_by_doc = {d.id: d.source for d in corpus.documents}
+    gold_pairs = _gold_pairs_from_plan(plan)
+
+    tau = median_cross_topic_gold_pair_cosine(
+        doc_vec, gold_pairs, source_by_doc, cosine_fn=cosine_similarity
+    )
+    cross_topic_count = sum(
+        1 for pr in gold_pairs if len(pr) == 2 and len({source_by_doc.get(d) for d in pr}) == 2
+    )
+    if tau is None:
+        return {
+            "seeded": False,
+            "reason": "no_cross_topic_gold_pair",
+            "model": model_name,
+            "dimensions": dims,
+            "tau_provisional": None,
+            "cross_topic_gold_pair_count": cross_topic_count,
+        }
+
+    percentiles = script.compute_percentiles([tau] * 128)
+    config = await NeuralMemoryConfig.from_db(db)
+    now = utcnow()
+    await _upsert_calibration(
+        db,
+        model_name,
+        dims,
+        None,
+        kind=CALIBRATION_KIND_EDGE_GATE,
+        percentiles=percentiles,
+        observations=cross_topic_count,
+        now=now,
+        valid_until=now + timedelta(days=config.calibration_ttl_days),
+    )
+    await db.commit()
+
+    result: dict[str, Any] = {
+        "seeded": True,
+        "model": model_name,
+        "dimensions": dims,
+        "tau_provisional": round(tau, 4),
+        "tau_method": "median_cross_topic_gold_pair_cosine",
+        "cross_topic_gold_pair_count": cross_topic_count,
+        "floor": config.min_similarity_for_edge_floor,
+        "resolved_edge_threshold": None,
+    }
+    try:
+        resolved = await resolve_edge_threshold(
+            db=db, config=config, model_name=model_name, dimensions=dims
+        )
+        result["resolved_edge_threshold"] = round(resolved, 4)
+    except Exception:  # noqa: BLE001 — diagnostic only; row stays cleanable
+        pass
+    return result
+
+
+async def _delete_provisional_tau(db, model_name, dimensions) -> None:
+    from sqlalchemy import delete as sa_delete
+
+    from models.neural import CALIBRATION_KIND_EDGE_GATE, EmbeddingCalibration
+
+    await db.execute(
+        sa_delete(EmbeddingCalibration).where(
+            EmbeddingCalibration.model_name == model_name,
+            EmbeddingCalibration.dimensions == dimensions,
+            EmbeddingCalibration.context_id.is_(None),
+            EmbeddingCalibration.kind == CALIBRATION_KIND_EDGE_GATE,
+        )
+    )
+    await db.commit()
+
+
+def _min_med_max(values: list[float]) -> dict[str, float | None]:
+    from statistics import median
+
+    if not values:
+        return {"min": None, "median": None, "max": None}
+    return {
+        "min": round(min(values), 4),
+        "median": round(median(values), 4),
+        "max": round(max(values), 4),
+    }
+
+
+def _directional_read(real_warm: dict[str, Any], across: dict[str, Any]) -> str:
+    med_rand = across["delta_random_edge"]["median"]
+    med_shuf = across["delta_shuffled_gold"]["median"]
+    if med_rand is None:
+        return "inconclusive"
+    if med_rand >= _DELTA_COMPOUND and med_shuf is not None and med_shuf >= _DELTA_COMPOUND:
+        return "alive"
+    if med_rand <= 0.0:
+        return "edge_spray"
+    return "inconclusive"
+
+
+def _main() -> int:
+    import asyncio
+
+    results = asyncio.run(run_placebo_eval())
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -19,7 +19,6 @@ cheap and CI-safe.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -39,7 +38,6 @@ from tests.eval.replay_runner import (
     _REPLAY_ROUNDS,
     _gold_pairs_from_plan,
     _replay,
-    _restore_env,
     _run_sleep,
 )
 from tests.eval.runner import _ingest_corpus, _sudachi_version, _teardown
@@ -254,11 +252,13 @@ async def _placebo_arms_for_seed(
             for e in rewired
         ]
         await _replace_edges(db, ctx.id, rewired_rows)
-        re_rankings, _ = await _explore_rankings(
-            svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
-        )
-        random_edge = recovery_from_rankings(re_rankings, true_gold)
-        await _replace_edges(db, ctx.id, snapshot)  # restore for the next seed
+        try:
+            re_rankings, _ = await _explore_rankings(
+                svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+            )
+            random_edge = recovery_from_rankings(re_rankings, true_gold)
+        finally:
+            await _replace_edges(db, ctx.id, snapshot)  # always restore the true warm graph
 
     deltas: dict[str, Any] = {
         "shuffled_gold": paired_delta_bootstrap(

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -147,9 +147,10 @@ async def _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
     true_gold = {p.query_id: p.companion_docs for p in plan.probes}
 
     # --- warm build (once, seed-independent): provisional τ -> replay -> sleep ---
-    tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
+    tau_info: dict[str, Any] = {"seeded": False}
     sleep_info: dict[str, Any]
     try:
+        tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
         await _replay(svc, corpus, plan, owner, ctx, ws)
         sleep_info = await _run_sleep(db, owner, ctx, ws)
         real_rankings, seeds_in_graph = await _explore_rankings(

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -147,8 +147,8 @@ async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> d
                 semantic_weight=0.6,
                 fetch_factor=3,
                 use_rerank=False,
-                reranker_provider="voyage",
-                reranker_model="rerank-2-lite",
+                reranker_provider="self_hosted",
+                reranker_model="qwen3-reranker-4b",
                 embedding_model=emb_model,
                 embedding_dimensions=emb_dims,
             )

--- a/backend/tests/eval/results/placebo-2026-07-02.json
+++ b/backend/tests/eval/results/placebo-2026-07-02.json
@@ -1,0 +1,349 @@
+{
+  "run_date": "2026-07-02",
+  "experiment": "day2-placebo",
+  "issue": null,
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "doc_count": 16,
+  "query_count": 30,
+  "probe_count": 5,
+  "probe_underpowered": true,
+  "rounds": 8,
+  "explore_depth": 2,
+  "explore_min_weight": 0.05,
+  "seeds": [
+    1,
+    2,
+    3
+  ],
+  "design_note": "Descriptive/directional de-risk (week1-derisk Day 2). Provisional τ (prereg §3 procedure on the CURRENT corpus), untagged. Percentile bootstrap intervals are shape aids, NOT gated CIs; no accept/reject. The inferential H2 kill-shot runs at Day-3 (prereg-v1-frozen).",
+  "tau": {
+    "seeded": true,
+    "model": "qwen3-embedding:0.6b",
+    "dimensions": 1024,
+    "tau_provisional": 0.5082,
+    "tau_method": "median_cross_topic_gold_pair_cosine",
+    "cross_topic_gold_pair_count": 5,
+    "floor": 0.3,
+    "resolved_edge_threshold": 0.5082
+  },
+  "seeds_in_graph": 4,
+  "sleep": {
+    "ok": true,
+    "status": "completed",
+    "edge_discovery": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 0,
+      "memories_processed": 16,
+      "details": {
+        "sampled": 16,
+        "candidates": 3,
+        "filtered": 1,
+        "edges_created": 1,
+        "llm_accepted": 0,
+        "llm_rejected": 0,
+        "llm_call_failures": 0,
+        "auto_accepted": 1,
+        "edge_type_dist": {},
+        "avg_confidence": 0.0,
+        "median_confidence": 0.0,
+        "p25_confidence": 0.0,
+        "p75_confidence": 0.0,
+        "confidence_n": 0,
+        "confidence_imputed": 0,
+        "confidence_histogram": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "avg_confidence_rejected": 0.0,
+        "median_confidence_rejected": 0.0,
+        "p25_confidence_rejected": 0.0,
+        "p75_confidence_rejected": 0.0,
+        "confidence_n_rejected": 0,
+        "confidence_imputed_rejected": 0,
+        "confidence_histogram_rejected": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "llm_model": "gpt-5-nano",
+        "prompt_revision": "v3"
+      },
+      "llm_breakdown": [],
+      "embedding_calls": 16,
+      "embedding_tokens": 0
+    }
+  },
+  "real_warm": {
+    "n": 5,
+    "recovery@5": 0.4,
+    "recovery@10": 0.4,
+    "mrr@10": 0.2667,
+    "per_probe@10": [
+      1.0,
+      1.0,
+      0.0,
+      0.0,
+      0.0
+    ]
+  },
+  "edge_count": 23,
+  "per_seed": [
+    {
+      "seed": 1,
+      "arms": {
+        "real_warm": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.2667,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "shuffled_gold": {
+          "n": 5,
+          "recovery@5": 0.2,
+          "recovery@10": 0.2,
+          "mrr@10": 0.05,
+          "per_probe@10": [
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "random_edge": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.24,
+          "per_probe@10": [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ]
+        }
+      },
+      "deltas": {
+        "shuffled_gold": {
+          "delta": 0.2,
+          "lo": 0.0,
+          "hi": 0.6,
+          "n": 5
+        },
+        "random_edge": {
+          "delta": 0.0,
+          "lo": -0.6,
+          "hi": 0.6,
+          "n": 5
+        }
+      },
+      "gold_permutation": {
+        "q_cross_01": [
+          "doc_res_apikey"
+        ],
+        "q_cross_02": [
+          "doc_res_chunking"
+        ],
+        "q_cross_03": [
+          "doc_mem_context"
+        ],
+        "q_cross_04": [
+          "doc_mem_hybrid"
+        ],
+        "q_cross_05": [
+          "doc_mem_context"
+        ]
+      },
+      "edge_snapshot": {
+        "count": 23,
+        "rewire_swaps_done": 23
+      }
+    },
+    {
+      "seed": 2,
+      "arms": {
+        "real_warm": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.2667,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "shuffled_gold": {
+          "n": 5,
+          "recovery@5": 0.2,
+          "recovery@10": 0.2,
+          "mrr@10": 0.1,
+          "per_probe@10": [
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "random_edge": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.3,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        }
+      },
+      "deltas": {
+        "shuffled_gold": {
+          "delta": 0.2,
+          "lo": 0.0,
+          "hi": 0.6,
+          "n": 5
+        },
+        "random_edge": {
+          "delta": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n": 5
+        }
+      },
+      "gold_permutation": {
+        "q_cross_01": [
+          "doc_res_chunking"
+        ],
+        "q_cross_02": [
+          "doc_mem_hybrid"
+        ],
+        "q_cross_03": [
+          "doc_mem_context"
+        ],
+        "q_cross_04": [
+          "doc_res_apikey"
+        ],
+        "q_cross_05": [
+          "doc_mem_context"
+        ]
+      },
+      "edge_snapshot": {
+        "count": 23,
+        "rewire_swaps_done": 23
+      }
+    },
+    {
+      "seed": 3,
+      "arms": {
+        "real_warm": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.2667,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "shuffled_gold": {
+          "n": 5,
+          "recovery@5": 0.2,
+          "recovery@10": 0.2,
+          "mrr@10": 0.1,
+          "per_probe@10": [
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "random_edge": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.1,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        }
+      },
+      "deltas": {
+        "shuffled_gold": {
+          "delta": 0.2,
+          "lo": 0.0,
+          "hi": 0.6,
+          "n": 5
+        },
+        "random_edge": {
+          "delta": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n": 5
+        }
+      },
+      "gold_permutation": {
+        "q_cross_01": [
+          "doc_mem_context"
+        ],
+        "q_cross_02": [
+          "doc_mem_hybrid"
+        ],
+        "q_cross_03": [
+          "doc_mem_context"
+        ],
+        "q_cross_04": [
+          "doc_res_apikey"
+        ],
+        "q_cross_05": [
+          "doc_res_chunking"
+        ]
+      },
+      "edge_snapshot": {
+        "count": 23,
+        "rewire_swaps_done": 23
+      }
+    }
+  ],
+  "across_seeds": {
+    "delta_random_edge": {
+      "min": 0.0,
+      "median": 0.0,
+      "max": 0.0
+    },
+    "delta_shuffled_gold": {
+      "min": 0.2,
+      "median": 0.2,
+      "max": 0.2
+    }
+  },
+  "directional_read": "edge_spray"
+}

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -308,17 +308,19 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
         settings = get_settings()
         emb_model = settings.embedding_model
         emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
-        # Mirror ContextService.create_context's defaults (not just the
-        # embedding fields) so an eval context behaves like a production one if
-        # any reranking / weighting default is ever consulted.
+        # Stamp the full ContextSearchConfig (not just the embedding fields) so
+        # an eval context behaves like a created one if any reranking / weighting
+        # default is ever consulted. Reranker fields target the local self_hosted
+        # rig (qwen3-reranker), keeping the eval path all-local-OSS; inert here
+        # since use_rerank=False.
         db.add(
             ContextSearchConfig(
                 context_id=ctx.id,
                 semantic_weight=0.6,
                 fetch_factor=3,
                 use_rerank=False,
-                reranker_provider="voyage",
-                reranker_model="rerank-2-lite",
+                reranker_provider="self_hosted",
+                reranker_model="qwen3-reranker-4b",
                 embedding_model=emb_model,
                 embedding_dimensions=emb_dims,
             )

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -14,8 +14,13 @@ import pytest
 from tests.eval.placebo import Edge, degree_preserving_rewire
 
 
-def _edges(pairs, *, weight=0.5, origin="hebbian", edge_type="neural_association"):
-    return [Edge(s, d, weight, origin, confidence=1.0, edge_type=edge_type) for s, d in pairs]
+def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
+    # Distinct weight per edge so a test can verify the non-dst attribute
+    # bundle travels with its OWN edge through a rewire (only dst changes).
+    return [
+        Edge(s, d, 0.1 * (i + 1), origin, confidence=1.0, edge_type=edge_type)
+        for i, (s, d) in enumerate(pairs)
+    ]
 
 
 def _src_deg(edges):
@@ -33,8 +38,11 @@ def test_rewire_preserves_degree_count_and_attribute_multisets():
     assert len(out) == len(edges)
     assert _src_deg(out) == _src_deg(edges)
     assert _dst_deg(out) == _dst_deg(edges)
-    assert Counter((e.weight, e.origin, e.confidence, e.edge_type) for e in out) == Counter(
-        (e.weight, e.origin, e.confidence, e.edge_type) for e in edges
+    # Non-dst attributes travel with their own edge (only dst changes): the
+    # (src, weight, origin, confidence, edge_type) bundle multiset is invariant.
+    # Distinct per-edge weights make this discriminating, not tautological.
+    assert Counter((e.src, e.weight, e.origin, e.confidence, e.edge_type) for e in out) == Counter(
+        (e.src, e.weight, e.origin, e.confidence, e.edge_type) for e in edges
     )
 
 
@@ -61,3 +69,12 @@ def test_rewire_is_deterministic_under_seed():
 def test_rewire_raises_below_two_edges():
     with pytest.raises(ValueError):
         degree_preserving_rewire(_edges([("a", "b")]), seed=1)
+
+
+def test_rewire_returns_pure_star_unchanged():
+    """A pure out-star has exactly one graph with its degree sequence, so a
+    degree-preserving rewire correctly returns it unchanged — this is correct
+    behavior (a unique realization), not a failure to mix."""
+    star = _edges([("h", x) for x in "abcdef"])
+    out = degree_preserving_rewire(star, seed=1)
+    assert {(e.src, e.dst) for e in out} == {(e.src, e.dst) for e in star}

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -149,7 +149,9 @@ def test_bootstrap_point_estimate_is_the_paired_mean():
     a = [1.0, 0.8, 0.6, 0.4]
     b = [0.0, 0.2, 0.1, 0.0]
     out = paired_delta_bootstrap(a, b, seed=1, resamples=2000)
-    assert out["delta"] == pytest.approx(sum(x - y for x, y in zip(a, b)) / len(a), abs=1e-9)
+    assert out["delta"] == pytest.approx(
+        sum(x - y for x, y in zip(a, b, strict=True)) / len(a), abs=1e-9
+    )
     assert out["n"] == 4
     assert out["lo"] <= out["delta"] <= out["hi"]
     assert out["lo"] < out["hi"]  # non-degenerate data -> real interval width (not a stub)
@@ -183,8 +185,11 @@ def test_bootstrap_raises_on_length_mismatch_or_empty():
 
 def test_median_cross_topic_ignores_same_source_pairs():
     doc_vec = {"a": [1.0], "b": [2.0], "c": [3.0]}
+
     # cosine_fn returns the product of the single components (a stand-in metric)
-    cos = lambda u, v: u[0] * v[0]
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory", "b": "resource", "c": "memory"}
     gold_pairs = {frozenset(("a", "b")), frozenset(("a", "c")), frozenset(("b", "c"))}
     # cross-topic pairs: a-b (1*2=2), b-c (2*3=6); a-c is same-source -> skipped
@@ -194,7 +199,10 @@ def test_median_cross_topic_ignores_same_source_pairs():
 
 def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
     doc_vec = {"a": [1.0], "b": [2.0]}
-    cos = lambda u, v: u[0] * v[0]
+
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory", "b": "memory"}
     gold_pairs = {frozenset(("a", "b"))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
@@ -202,7 +210,10 @@ def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
 
 def test_median_cross_topic_skips_pair_missing_a_vector():
     doc_vec = {"a": [1.0]}  # b has no vector -> the only gold pair is skipped
-    cos = lambda u, v: u[0] * v[0]
+
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory", "b": "resource"}
     gold_pairs = {frozenset(("a", "b"))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
@@ -211,7 +222,10 @@ def test_median_cross_topic_skips_pair_missing_a_vector():
 def test_median_cross_topic_skips_degenerate_single_element_pair():
     # A gold "pair" that collapsed to one doc (seed == companion) must be skipped, not crash.
     doc_vec = {"a": [1.0]}
-    cos = lambda u, v: u[0] * v[0]
+
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory"}
     gold_pairs = {frozenset(("a",))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -197,3 +197,20 @@ def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
     source = {"a": "memory", "b": "memory"}
     gold_pairs = {frozenset(("a", "b"))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
+
+
+def test_median_cross_topic_skips_pair_missing_a_vector():
+    doc_vec = {"a": [1.0]}  # b has no vector -> the only gold pair is skipped
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory", "b": "resource"}
+    gold_pairs = {frozenset(("a", "b"))}
+    assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
+
+
+def test_median_cross_topic_skips_degenerate_single_element_pair():
+    # A gold "pair" that collapsed to one doc (seed == companion) must be skipped, not crash.
+    doc_vec = {"a": [1.0]}
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory"}
+    gold_pairs = {frozenset(("a",))}
+    assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -1,0 +1,63 @@
+"""Deterministic tests for the Day-2 placebo kill-shot pure layer.
+
+Everything here is infrastructure-free (no DB/Qdrant) and runs in normal CI.
+The live orchestration is exercised by test_placebo_live.py (gated behind
+KAGURA_EVAL_LIVE=1).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from tests.eval.placebo import Edge, degree_preserving_rewire
+
+
+def _edges(pairs, *, weight=0.5, origin="hebbian", edge_type="neural_association"):
+    return [Edge(s, d, weight, origin, confidence=1.0, edge_type=edge_type) for s, d in pairs]
+
+
+def _src_deg(edges):
+    return Counter(e.src for e in edges)
+
+
+def _dst_deg(edges):
+    return Counter(e.dst for e in edges)
+
+
+def test_rewire_preserves_degree_count_and_attribute_multisets():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out = degree_preserving_rewire(edges, seed=7)
+
+    assert len(out) == len(edges)
+    assert _src_deg(out) == _src_deg(edges)
+    assert _dst_deg(out) == _dst_deg(edges)
+    assert Counter((e.weight, e.origin, e.confidence, e.edge_type) for e in out) == Counter(
+        (e.weight, e.origin, e.confidence, e.edge_type) for e in edges
+    )
+
+
+def test_rewire_has_no_self_loops_or_parallel_edges():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out = degree_preserving_rewire(edges, seed=3)
+
+    assert all(e.src != e.dst for e in out)
+    assert len({(e.src, e.dst) for e in out}) == len(out)
+
+
+def test_rewire_actually_moves_endpoints():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out = degree_preserving_rewire(edges, seed=1)
+
+    assert {(e.src, e.dst) for e in out} != {(e.src, e.dst) for e in edges}
+
+
+def test_rewire_is_deterministic_under_seed():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    assert degree_preserving_rewire(edges, seed=42) == degree_preserving_rewire(edges, seed=42)
+
+
+def test_rewire_raises_below_two_edges():
+    with pytest.raises(ValueError):
+        degree_preserving_rewire(_edges([("a", "b")]), seed=1)

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -12,7 +12,7 @@ from collections import Counter
 import pytest
 
 from tests.eval.compounding import ProbeSpec
-from tests.eval.placebo import Edge, degree_preserving_rewire, permute_gold
+from tests.eval.placebo import Edge, degree_preserving_rewire, paired_delta_bootstrap, permute_gold
 
 
 def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
@@ -136,3 +136,27 @@ def test_permute_gold_raises_when_singleton_pool_too_small():
     )
     with pytest.raises(ValueError, match="corpus too small"):
         permute_gold(probes, seed=1)
+
+
+def test_bootstrap_point_estimate_is_the_paired_mean():
+    a = [1.0, 0.8, 0.6, 0.4]
+    b = [0.0, 0.2, 0.1, 0.0]
+    out = paired_delta_bootstrap(a, b, seed=1, resamples=2000)
+    assert out["delta"] == pytest.approx(sum(x - y for x, y in zip(a, b)) / len(a), abs=1e-9)
+    assert out["n"] == 4
+    assert out["lo"] <= out["delta"] <= out["hi"]
+
+
+def test_bootstrap_is_deterministic_under_seed():
+    a = [0.9, 0.7, 0.5, 0.3, 0.6]
+    b = [0.1, 0.0, 0.2, 0.1, 0.0]
+    assert paired_delta_bootstrap(a, b, seed=11, resamples=1500) == paired_delta_bootstrap(
+        a, b, seed=11, resamples=1500
+    )
+
+
+def test_bootstrap_raises_on_length_mismatch_or_empty():
+    with pytest.raises(ValueError):
+        paired_delta_bootstrap([0.1, 0.2], [0.1], seed=1)
+    with pytest.raises(ValueError):
+        paired_delta_bootstrap([], [], seed=1)

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -11,7 +11,8 @@ from collections import Counter
 
 import pytest
 
-from tests.eval.placebo import Edge, degree_preserving_rewire
+from tests.eval.compounding import ProbeSpec
+from tests.eval.placebo import Edge, degree_preserving_rewire, permute_gold
 
 
 def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
@@ -78,3 +79,49 @@ def test_rewire_returns_pure_star_unchanged():
     star = _edges([("h", x) for x in "abcdef"])
     out = degree_preserving_rewire(star, seed=1)
     assert {(e.src, e.dst) for e in out} == {(e.src, e.dst) for e in star}
+
+
+def _probe(qid, seed_doc, companions):
+    return ProbeSpec(
+        query_id=qid,
+        text=qid,
+        bucket="cross-source",
+        seed_doc=seed_doc,
+        companion_docs=tuple(companions),
+    )
+
+
+def test_permute_gold_preserves_sizes_and_is_a_derangement_within_a_group():
+    probes = (
+        _probe("q1", "s1", ["c1a", "c1b"]),
+        _probe("q2", "s2", ["c2a", "c2b"]),
+        _probe("q3", "s3", ["c3a", "c3b"]),
+    )
+    out = permute_gold(probes, seed=5)
+
+    for p in probes:
+        assert len(out[p.query_id]) == len(p.companion_docs)  # size preserved
+        assert set(out[p.query_id]) != set(p.companion_docs)  # not own gold
+
+
+def test_permute_gold_is_deterministic_under_seed():
+    probes = (
+        _probe("q1", "s1", ["c1a", "c1b"]),
+        _probe("q2", "s2", ["c2a", "c2b"]),
+        _probe("q3", "s3", ["c3a", "c3b"]),
+    )
+    assert permute_gold(probes, seed=9) == permute_gold(probes, seed=9)
+
+
+def test_permute_gold_singleton_size_class_draws_excluding_own():
+    # q3 has a unique companion count (1) -> singleton class -> pool-draw path.
+    probes = (
+        _probe("q1", "s1", ["c1a", "c1b"]),
+        _probe("q2", "s2", ["c2a", "c2b"]),
+        _probe("q3", "s3", ["c3a"]),
+    )
+    out = permute_gold(probes, seed=2)
+
+    assert len(out["q3"]) == 1
+    assert "c3a" not in out["q3"]
+    assert "s3" not in out["q3"]

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -145,6 +145,7 @@ def test_bootstrap_point_estimate_is_the_paired_mean():
     assert out["delta"] == pytest.approx(sum(x - y for x, y in zip(a, b)) / len(a), abs=1e-9)
     assert out["n"] == 4
     assert out["lo"] <= out["delta"] <= out["hi"]
+    assert out["lo"] < out["hi"]  # non-degenerate data -> real interval width (not a stub)
 
 
 def test_bootstrap_is_deterministic_under_seed():
@@ -153,6 +154,17 @@ def test_bootstrap_is_deterministic_under_seed():
     assert paired_delta_bootstrap(a, b, seed=11, resamples=1500) == paired_delta_bootstrap(
         a, b, seed=11, resamples=1500
     )
+
+
+def test_bootstrap_interval_reacts_to_seed():
+    # Different seeds must produce different resampled intervals — guards against
+    # a degenerate implementation that ignores the resampling loop.
+    a = [0.9, 0.7, 0.5, 0.3, 0.6]
+    b = [0.1, 0.0, 0.2, 0.1, 0.0]
+    out1 = paired_delta_bootstrap(a, b, seed=1, resamples=2000)
+    out2 = paired_delta_bootstrap(a, b, seed=2, resamples=2000)
+    assert out1["delta"] == out2["delta"]  # point estimate is seed-independent
+    assert (out1["lo"], out1["hi"]) != (out2["lo"], out2["hi"])  # interval is seed-driven
 
 
 def test_bootstrap_raises_on_length_mismatch_or_empty():

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -18,6 +18,7 @@ from tests.eval.placebo import (
     median_cross_topic_gold_pair_cosine,
     paired_delta_bootstrap,
     permute_gold,
+    recovery_from_rankings,
 )
 
 
@@ -214,3 +215,15 @@ def test_median_cross_topic_skips_degenerate_single_element_pair():
     source = {"a": "memory"}
     gold_pairs = {frozenset(("a",))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
+
+
+def test_recovery_from_rankings_scores_against_the_gold_map():
+    # probe q1: gold {b, c}; ranked [b, x, c] -> recovery@10 = 2/2 = 1.0
+    # probe q2: gold {d};    ranked [x, y]    -> recovery@10 = 0/1 = 0.0
+    rankings = [("q1", ["b", "x", "c"]), ("q2", ["x", "y"])]
+    gold_map = {"q1": ("b", "c"), "q2": ("d",)}
+    out = recovery_from_rankings(rankings, gold_map)
+
+    assert out["n"] == 2
+    assert out["recovery@10"] == pytest.approx((1.0 + 0.0) / 2)
+    assert out["per_probe@10"] == [pytest.approx(1.0), pytest.approx(0.0)]

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -12,7 +12,13 @@ from collections import Counter
 import pytest
 
 from tests.eval.compounding import ProbeSpec
-from tests.eval.placebo import Edge, degree_preserving_rewire, paired_delta_bootstrap, permute_gold
+from tests.eval.placebo import (
+    Edge,
+    degree_preserving_rewire,
+    median_cross_topic_gold_pair_cosine,
+    paired_delta_bootstrap,
+    permute_gold,
+)
 
 
 def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
@@ -172,3 +178,22 @@ def test_bootstrap_raises_on_length_mismatch_or_empty():
         paired_delta_bootstrap([0.1, 0.2], [0.1], seed=1)
     with pytest.raises(ValueError):
         paired_delta_bootstrap([], [], seed=1)
+
+
+def test_median_cross_topic_ignores_same_source_pairs():
+    doc_vec = {"a": [1.0], "b": [2.0], "c": [3.0]}
+    # cosine_fn returns the product of the single components (a stand-in metric)
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory", "b": "resource", "c": "memory"}
+    gold_pairs = {frozenset(("a", "b")), frozenset(("a", "c")), frozenset(("b", "c"))}
+    # cross-topic pairs: a-b (1*2=2), b-c (2*3=6); a-c is same-source -> skipped
+    out = median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos)
+    assert out == pytest.approx((2.0 + 6.0) / 2)
+
+
+def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
+    doc_vec = {"a": [1.0], "b": [2.0]}
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory", "b": "memory"}
+    gold_pairs = {frozenset(("a", "b"))}
+    assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -125,3 +125,14 @@ def test_permute_gold_singleton_size_class_draws_excluding_own():
     assert len(out["q3"]) == 1
     assert "c3a" not in out["q3"]
     assert "s3" not in out["q3"]
+
+
+def test_permute_gold_raises_when_singleton_pool_too_small():
+    # q2's size-3 singleton class cannot be satisfied: after excluding q2's own
+    # 3 companions + seed, only {s1, c1a} (2 < 3) remain in the foreign pool.
+    probes = (
+        _probe("q1", "s1", ["c1a"]),
+        _probe("q2", "s2", ["c2a", "c2b", "c2c"]),
+    )
+    with pytest.raises(ValueError, match="corpus too small"):
+        permute_gold(probes, seed=1)

--- a/backend/tests/eval/test_placebo_live.py
+++ b/backend/tests/eval/test_placebo_live.py
@@ -1,0 +1,34 @@
+"""Live-stack Day-2 placebo kill-shot driver (directional de-risk).
+
+Needs the full stack (Postgres + Qdrant + Redis + embedding provider + Sudachi),
+so it is skip-guarded behind KAGURA_EVAL_LIVE=1 exactly like the compounding
+live test (the ``make eval-placebo`` target sets it).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("KAGURA_EVAL_LIVE") != "1",
+    reason="live placebo eval requires the full stack; set KAGURA_EVAL_LIVE=1 (make eval-placebo)",
+)
+
+
+@pytest.mark.asyncio
+async def test_placebo_live():
+    from tests.eval.placebo_runner import run_placebo_eval
+
+    results = await run_placebo_eval(seeds=(1, 2))
+
+    assert results["experiment"] == "day2-placebo"
+    assert results["real_warm"]["n"] > 0
+    assert len(results["per_seed"]) == 2
+    for block in results["per_seed"]:
+        assert block["arms"]["shuffled_gold"]["n"] > 0
+        # random_edge is n==0 only when the graph is too sparse to rewire
+        assert "random_edge" in block["arms"]
+    assert "tau" in results
+    assert results["directional_read"] in {"alive", "edge_spray", "inconclusive"}


### PR DESCRIPTION
## What

Adds the **Day-2 placebo kill-shot** eval harness — a directional de-risk that tests whether the neural-graph "compounding" companion-recovery lift survives a **density-matched random-edge placebo** and a **shuffled-gold placebo**, before committing Day-3+ compute to the compounding headline.

- `backend/tests/eval/placebo.py` — pure, infra-free logic (CI-safe): `Edge` + degree-preserving double-edge-swap rewire (Maslov–Sneppen), size-preserving gold permutation, paired **descriptive** percentile bootstrap, provisional-τ (median cross-topic gold-pair cosine), and a shared recovery scorer.
- `backend/tests/eval/placebo_runner.py` — live orchestration: builds **one** warm graph at a provisional τ, then measures `recovery@10` for three arms (**real-warm / density-matched random-edge placebo / shuffled-gold placebo**) through the real `explore()` read surface, restoring the edge snapshot between seeds. Reports paired point-estimate deltas with descriptive bootstrap intervals + a `directional_read`.
- `backend/tests/eval/test_placebo.py` (19 pure tests) + `backend/tests/eval/test_placebo_live.py` (gated behind `KAGURA_EVAL_LIVE=1`) + `make eval-placebo`.

Design spec (in the eval repo): `kagura-memory-eval:docs/superpowers/specs/2026-07-02-day2-placebo-kill-shot-design.md`. This realizes the **descriptive** half of prereg-v1 **H2** using the §3 τ procedure on the current corpus (provisional, **untagged**); the inferential kill-shot (N_probe=50, BCa CI, frozen τ) runs at Day-3 on the grown corpus.

## Result (live run on the GB10 pgx01 rig, qwen3-embedding:0.6b/1024)

`backend/tests/eval/results/placebo-2026-07-02.json`: provisional τ=0.5082, warm graph 23 edges, 3 seeds.

| arm | recovery@10 |
|---|---|
| real-warm | **0.40** |
| real-warm − density-matched random-edge placebo | **median 0.0** (all 3 seeds) |
| real-warm − shuffled-gold placebo | **0.2** |

**`directional_read = edge_spray`**: recovery is gold-specific (beats shuffled-gold) but **not edge-specific** — a degree-matched random rewiring recovers companions equally, i.e. a graph-density artifact on the 16-doc/23-edge corpus, not learned compounding. **Directional only** (`probe_count=5`, underpowered); the inferential confirmation is deferred to Day-3.

## Two fixes included

- **`fix(eval)`: stamp `ContextSearchConfig` + `ensure_kagura_memories_collection` before ingest.** The eval's raw-ORM `Context` bypasses `ContextService.create_context`, so ingest fell back to the legacy `text-embedding-3-small`/512 collection (`kagura_memories`) that doesn't exist on a `qwen3-embedding:0.6b`/1024 rig → Qdrant 404 on every doc. Mirrors `runner.py`'s existing provisioning. **This bug is latent in `replay_runner._run_mode` too** (never run e2e on this rig).
- **`chore(eval)`: local-OSS reranker default** (`self_hosted`/`qwen3-reranker-4b`) in both `runner.py` and `placebo_runner.py` eval provisioning — replaces an inert `voyage` default (never consulted; `use_rerank=False`) to keep the eval path all-local-OSS. No behavior change.

## Testing

- Pure suite `test_placebo.py`: **19 passed**; `ruff check` clean.
- `test_placebo_live` skips cleanly without `KAGURA_EVAL_LIVE=1`.
- `test_compounding.py`: **27 passed** (replay_runner untouched).
- Live run on pgx01 succeeded and produced the committed result JSON (real run only — numbers never fabricated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
