### PR TITLE
eval: Day-3 kagura_L corpus freeze — 300 docs, graded labels, τ_frozen=0.7192

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,8 @@ eval-compounding:
 
 .PHONY: eval-placebo
 eval-placebo:
+	@echo "Running live Day-2 placebo kill-shot (directional de-risk, needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/placebo-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.placebo_runner
 
 .PHONY: eval-reinforce

--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,10 @@ eval-compounding:
 	@echo "Writes backend/tests/eval/results/compounding-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.replay_runner
 
+.PHONY: eval-placebo
+eval-placebo:
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.placebo_runner
+
 .PHONY: eval-reinforce
 eval-reinforce:
 	@echo "Running live reinforce ON-vs-OFF rollout gate (Issue #1069, needs the stack: make up)..."

--- a/backend/tests/eval/fixtures/kagura_l.yaml
+++ b/backend/tests/eval/fixtures/kagura_l.yaml
@@ -1,0 +1,4630 @@
+meta:
+  version: 1
+  domain: Kagura Memory Cloud (dogfooded knowledge-base content, scaled)
+  notes: 'kagura_L (docs/02 §1.1): 300 documents (180 memory / 120 resource), 280 queries (240 heldout
+    / 40 public) across 6 buckets incl. 60 cross-source multi-gold probes; graded 0-3 labels. Frozen
+    snapshot — immutable; new versions get new files.'
+  content_sha256: ca7a717bcb745f873182ae3d328692bae3449b415ed51681ac904d35142e0997
+documents:
+- id: d_t01_c01_m1
+  source: memory
+  text: We spent an afternoon on the BM25 k1 and b settings after keyword-only searches kept surfacing
+    docs that repeated a term dozens of times. Raising k1 from 1.2 to 1.6 let term frequency keep contributing
+    longer before saturating, which helped long incident postmortems rank correctly. Dropping b from
+    0.75 to 0.6 reduced the penalty for longer documents, since our longest docs are also our most detailed
+    reference pages. We validated the change against fifty support tickets and saw keyword precision
+    improve without hurting recall on short queries.
+- id: d_t01_c01_m2
+  source: memory
+  text: After the k1/b retune, one engineer noticed short FAQ pages were now losing to longer documents
+    even when the short page was the better answer. We traced it to the lowered b value not penalizing
+    length enough for our shortest docs, so we added a minimum floor before the length penalty kicks
+    in. This keeps repeated-term contribution behaving well for long docs while stopping tiny pages
+    from being unfairly boosted just because they are brief. We wrote the floor value into the scoring
+    config alongside k1 and b.
+- id: d_t01_c01_r1
+  source: resource
+  text: Kagura's keyword scorer implements Okapi BM25 with two tunable settings, k1 and b, controlling
+    term frequency saturation and length normalization. k1 (default 1.2) governs how quickly repeated
+    occurrences of a query term stop adding score. b (default 0.75) scales how much a document's length
+    penalizes its score; setting b near 0 disables length normalization entirely. For Japanese input,
+    the scorer first runs a morphological analyzer that splits sentences into word units before any
+    of this scoring applies. Administrators can override both settings per workspace through the search
+    configuration API.
+- id: d_t01_c02_m1
+  source: memory
+  text: We swapped our embedding model for the vector half of search after noticing that near-duplicate
+    memories with different phrasing weren't clustering close together in cosine similarity. The new
+    model separates semantically distinct sentences much more cleanly, and cosine distance between paraphrased
+    notes dropped by nearly half in our sanity checks. Re-embedding the entire memory graph took about
+    six hours on the batch worker, so we scheduled it during a low-traffic window and kept the old vectors
+    readable until the new ones finished.
+- id: d_t01_c02_m2
+  source: memory
+  text: A user reported that semantic-only search felt worse after the embedding model swap, and it
+    turned out cosine similarity thresholds tuned for the old model were now too strict for the new
+    vector space. We had hardcoded a 0.72 cutoff for what counted as a close match, but the new model's
+    similarity distribution sits lower on average, so relevant memories were being filtered out before
+    scoring. Recalibrating the cutoff against the new model's distribution fixed the regression without
+    touching the fusion logic.
+- id: d_t01_c02_r1
+  source: resource
+  text: Dense retrieval in Kagura represents each memory and resource chunk as a fixed-length embedding
+    vector produced by the configured embedding model, then ranks candidates by cosine similarity to
+    the query vector. Vector similarity captures paraphrase and conceptual closeness that exact wording
+    matching misses, which is why semantic mode relies on it exclusively while hybrid mode blends it
+    with keyword scores. Because similarity distributions differ between embedding models, any threshold
+    tuned against one model's vector space should be re-validated whenever the embedding model changes.
+- id: d_t01_c03_m1
+  source: memory
+  text: ハイブリッド検索の重み付けを見直した。キーワードスコアとベクトル類似度を単純に足すと片方が支配的になり、 アルファ値を0.5から0.4に下げてベクトル側を強めたところ、言い換えを含む質問への回答精度が目に見えて改善した。
+- id: d_t01_c03_m2
+  source: memory
+  text: We debated whether to fuse BM25 and vector scores with a simple weighted sum or a rank-based
+    blend, and ended up going with the weighted sum because the alpha knob is easier for workspace admins
+    to reason about than rank-based blending. Setting alpha too close to 1 made hybrid mode behave almost
+    like pure keyword search, drowning out semantically relevant results that used different wording.
+    We settled on alpha 0.4 as the default after comparing precision across a mixed query set.
+- id: d_t01_c03_r1
+  source: resource
+  text: Hybrid search combines the keyword scorer and the vector scorer into a single ranked list using
+    a weighted linear fusion controlled by the alpha parameter. The final score for each candidate is
+    alpha times the normalized vector similarity plus (1 minus alpha) times the normalized keyword score,
+    so alpha near 1 favors keyword matches and alpha near 0 favors semantic similarity. The default
+    alpha of 0.5 balances both signals evenly; workspace administrators can adjust it through the search
+    configuration endpoint.
+- id: d_t01_c04_m1
+  source: memory
+  text: We added a cross-encoder reranker as a second pass after the initial hybrid retrieval because
+    the fused ordering still put some clearly better answers below mediocre ones. The reranker scores
+    each query-candidate pair jointly instead of comparing independent embeddings, which catches relevance
+    signals the first-stage fusion misses. Latency went up by roughly 80 milliseconds for the top candidates,
+    which the team judged acceptable given the noticeable jump in top-three accuracy on our internal
+    evaluation set.
+- id: d_t01_c04_m2
+  source: memory
+  text: After turning on the cross-encoder reranker, we noticed it sometimes reordered results in a
+    way that surprised users who expected an exact-wording match to stay first. We added a safeguard
+    so that when a candidate contains a verbatim phrase match, its score gets a small boost rather than
+    letting it be overridden purely by the joint relevance model. This compromise kept reranking's quality
+    gains for paraphrased queries while respecting users' expectation that literal matches surface near
+    the top.
+- id: d_t01_c04_r1
+  source: resource
+  text: Kagura's optional reranking stage applies a cross-encoder model to the top candidates returned
+    by hybrid fusion, jointly scoring each query-document pair rather than comparing precomputed vectors
+    independently. Because cross-encoder scoring is more computationally expensive than the initial
+    retrieval, it only runs over a limited candidate window rather than the full corpus. Reranking typically
+    improves ordering quality for queries that require reasoning about relevance beyond surface similarity,
+    at the cost of added latency.
+- id: d_t01_c05_m1
+  source: memory
+  text: 検索モードを用途別に使い分けることにした。固有名詞やエラーコードを探すときはキーワードモード、 言い換えや概念的な質問にはセマンティックモードが向いていると分かり、デフォルトはハイブリッドモードのままにして両方の利点を活かす設定にした。
+- id: d_t01_c05_m2
+  source: memory
+  text: サポートチームからハイブリッドモードでは固有のエラーコードがうまく見つからないという報告があり、 調査するとベクトル側のスコアが強すぎて完全一致の候補が埋もれていた。エラーコードを含む問い合わせには自動でキーワードモードに切り替える案を出した。
+- id: d_t01_c05_r1
+  source: resource
+  text: 'Kagura exposes three search modes selectable per request: keyword mode scores candidates using
+    only the BM25 scorer, semantic mode ranks by vector similarity alone, and hybrid mode fuses both
+    signals with the configured alpha weight. Keyword mode suits lookups for exact identifiers, error
+    codes, or proper nouns where wording is fixed, while semantic mode suits paraphrased or conceptual
+    questions where relevant text may share no words with the query. Hybrid mode, the default, is recommended
+    for general-purpose queries.'
+- id: d_t01_c06_m1
+  source: memory
+  text: We increased the fetch factor from 3 to 6 after noticing that the final hybrid results sometimes
+    missed a document that scored well on keyword but only entered the vector candidate list barely
+    below the cutoff. A higher fetch factor pulls in more candidates from each retriever before fusion,
+    so a document weak on one signal but strong on the other has a better chance of surviving both stages.
+    The tradeoff was a small latency increase, but recall for our multi-signal queries improved enough
+    to justify it.
+- id: d_t01_c06_m2
+  source: memory
+  text: Someone asked why doubling top_k didn't fix a missing-result complaint the way raising the fetch
+    factor did. It turns out top_k only controls how many final results are returned to the caller,
+    while the fetch factor controls how many candidates each underlying retriever contributes before
+    fusion and reranking trim the list down. Increasing top_k alone doesn't help if the missing document
+    never entered the candidate set in the first place, which is exactly what a low fetch factor causes.
+- id: d_t01_c06_r1
+  source: resource
+  text: The fetch factor setting controls how many candidates each underlying retriever (keyword and
+    vector) contributes to the fusion stage relative to the requested top_k. With the default fetch
+    factor of 4, a request for ten final results pulls forty candidates from each retriever before scores
+    are fused and truncated. Raising the fetch factor widens the candidate pool and improves recall
+    for documents that rank moderately on one signal but well on another, at the cost of additional
+    scoring work during fusion.
+- id: d_t01_c07_m1
+  source: memory
+  text: We noticed that when two candidates land on an identical fused score, the display order flipped
+    between requests, which confused users comparing results across sessions. Digging in, ties were
+    being broken by insertion order in the candidate list, which isn't stable once fetch factor or worker
+    parallelism changes iteration order. We added a deterministic tiebreaker using document recency
+    as a secondary sort key so equally scored results always land in the same order.
+- id: d_t01_c07_m2
+  source: memory
+  text: A workspace complained that the top five results were all near-copies of the same decision,
+    crowding out a distinct but slightly lower-scoring document. We introduced a lightweight diversity
+    pass that downranks additional candidates from the same source cluster once one has already been
+    placed near the top, so the final list better represents distinct subjects instead of five variations
+    on one note. Overall relevance held steady while perceived usefulness of the result list improved.
+- id: d_t01_c07_r1
+  source: resource
+  text: 'Ranking behavior after score fusion follows deterministic tie-breaking rules: when two candidates
+    receive an identical fused score, Kagura orders them by document recency and then by document id
+    to guarantee stable, reproducible ordering across repeated requests. An optional diversity pass
+    can also be enabled, which penalizes candidates that closely duplicate the subject of a higher-ranked
+    result already selected for the response, preventing the final list from being dominated by repetitive
+    content.'
+- id: d_t01_c08_m1
+  source: memory
+  text: 日本語のBM25検索で単語分割がうまくいかず、複合語がひとつのトークンとして扱われて部分一致が拾えない問題があった。 形態素解析器を導入して分かち書きしてからインデックスを作り直したところ、キーワード検索の再現率が大きく改善した。
+- id: d_t01_c08_m2
+  source: memory
+  text: We debugged a Japanese-language search complaint where a compound word query returned nothing
+    even though a document clearly contained the concept. It turned out our earlier tokenizer treated
+    the whole compound as one indivisible chunk, so a partial match on a shorter component never fired.
+    Switching to a morphological analyzer that splits Japanese text into proper word units before indexing
+    fixed the recall gap, and we re-indexed every Japanese document afterward.
+- id: d_t01_c08_r1
+  source: resource
+  text: 日本語のテキストには単語間にスペースがないため、BM25スコアラーは形態素解析器を使って文を単語単位に分割してからインデックスする。 この分かち書き処理により、複合語の一部だけを含む問い合わせでも該当する文書を正しく検索できるようになる。分割の精度は解析器の辞書に依存する。
+- id: d_t01_c09_m1
+  source: memory
+  text: キーワードスコアとベクトル類似度はスケールがまったく異なるため、そのまま足し合わせると片方だけが結果を支配してしまうことに気づいた。 両方の値をミニマックス正規化してから重み付けする形に直したところ、ハイブリッド検索の順位が期待通りに安定した。
+- id: d_t01_c09_r1
+  source: resource
+  text: BM25のスコアは上限のない実数値であるのに対し、ベクトル類似度は通常0から1の範囲に収まる。この二つを直接合算すると片方の信号が 結果を支配しやすいため、融合処理の前にそれぞれの値をミニマックス正規化し、同じ尺度に揃えてから重み付けする設計になっている。
+- id: d_t01_c09_r2
+  source: resource
+  text: Before hybrid fusion combines the two underlying score streams, each stream is independently
+    normalized to a common zero-to-one range using min-max normalization computed over the current candidate
+    set. This step prevents BM25's theoretically unbounded score range from dominating cosine similarity,
+    which is naturally bounded, ensuring the alpha weight actually reflects the intended balance between
+    signals rather than being skewed by differing raw scales.
+- id: d_t01_c10_m1
+  source: memory
+  text: We added a recency decay factor to the ranking formula after users kept complaining that an
+    outdated note from a year ago kept outranking a fresher correction on the same topic. The decay
+    multiplies the fused score by a small penalty that grows with document age, so two otherwise similar
+    candidates now favor the more recently updated one. We capped the penalty so genuinely authoritative
+    older reference docs don't get buried just for being old.
+- id: d_t01_c10_r1
+  source: resource
+  text: Query-time boosting lets callers apply multipliers to the fused ranking score based on metadata
+    such as document type, tag match, or recency. The recency decay boost reduces a candidate's final
+    score proportionally to its age relative to a configurable half-life, favoring fresher documents
+    when other signals are close. Boost multipliers are applied after fusion and before the final truncation
+    to top_k, so they can reorder but not bypass the established candidate pool.
+- id: d_t01_c10_r2
+  source: resource
+  text: 'Boost profiles can be attached per workspace to adjust ranking without changing the underlying
+    fusion weights: a tag boost multiplies scores for candidates matching specified tags, a type boost
+    favors memories over resources or vice versa, and a recency boost decays older documents relative
+    to a half-life setting, so it reduces a candidate''s final score proportionally as it ages. Multiple
+    boosts compose multiplicatively, and administrators are advised to keep combined boost effects modest.'
+- id: d_t02_c01_m1
+  source: memory
+  text: 'We watched the graph worker lay down its first edges last week: whenever two saved notes surface
+    together in one recall call, the background job drops a provisional link between them with a small
+    starting weight. A single co-occurrence isn''t enough to make the edge count, it stays dormant until
+    it has been reinforced across at least three separate sessions. Once that happens the edge crosses
+    into the active graph and explore can traverse it. Nobody hand-wires these connections; structure
+    grows out of what gets recalled side by side.'
+- id: d_t02_c01_m2
+  source: memory
+  text: 先週のデバッグ中、二つの過去メモが同じ検索結果に並んで出てきた回数を重ねたら、いつの間にか両者の間に細い関連線ができていた。最初の一回だけでは 何も起きず、複数回の共起があって初めて線が固定されることに気づいた。手動でつないだ覚えはなく、自然に育った印象を受けた。
+- id: d_t02_c01_r1
+  source: resource
+  text: 'The graph layer forms connections through pure co-activation: whenever two memory nodes are
+    returned inside the same recall response, a candidate edge is proposed between them with a low initial
+    weight. That candidate remains provisional, invisible to traversal, until it has been proposed again
+    in a separate recall call, typically after three independent co-occurrences within a rolling thirty-day
+    window. Only then does the edge graduate into the active graph. No manual linking API exists; every
+    connection mirrors how the team actually uses its stored knowledge.'
+- id: d_t02_c02_m1
+  source: memory
+  text: When we couldn't remember which note explained a decision, someone ran explore against the seed
+    node and let activation spread across two hops instead of a plain search. The tool started every
+    neighboring node at full strength and cut it roughly in half at each hop, so distant nodes barely
+    lit up while close ones stayed bright. That decay curve turned out to be the difference between
+    a useful subgraph and a noisy dump of everything tangentially related. We now reach for it whenever
+    a keyword search comes back empty.
+- id: d_t02_c02_m2
+  source: memory
+  text: Someone bumped the default hop count for explore from two to four during a demo, expecting richer
+    results, and instead got a subgraph so large it took longer to read than to just re-derive the answer.
+    Activation strength halves at every hop, so by hop four most included nodes carry almost no signal
+    and just add noise. We rolled the default back and now only raise hop depth manually for a handful
+    of deep architecture questions where the connecting nodes are genuinely sparse.
+- id: d_t02_c02_r1
+  source: resource
+  text: 探索機能は起点ノードから活性化を広げる方式で、隣接ノードへ移動するたびに強度がおよそ半分に減衰する。既定のホップ数は二段階までで、遠いノード ほど値が小さくなるため結果に含まれにくくなる。単純な検索では見つからない、緩やかにつながった記憶を洗い出す用途に向いている。
+- id: d_t02_c03_m1
+  source: memory
+  text: 'An edge we relied on for months quietly disappeared from the graph, and it took a while to
+    realize the cause: edge weight decays on a slow half-life if neither endpoint gets recalled together
+    again. Ours had gone almost a year without a fresh co-occurrence, so the weight had drifted below
+    the visibility floor and explore stopped surfacing it. Nothing was deleted outright, the link is
+    still there numerically, just too faint to traverse. A single new co-recall would have topped it
+    back up before it faded.'
+- id: d_t02_c03_m2
+  source: memory
+  text: For our compliance workspace, where the same two policies rarely get recalled together more
+    than twice a year, we lengthened the edge weight half-life so links wouldn't fade between reviews.
+    The default half-life suits fast-moving product contexts, but a weight that decays on the standard
+    schedule was too quick for our slow review cycle and kept collapsing to near zero before anyone
+    came back to the pair. After the change, edges from the annual audit cycle now survive the gap instead
+    of resetting every time someone finally revisits them.
+- id: d_t02_c03_r1
+  source: resource
+  text: エッジの重みは時間とともに緩やかに減衰する設計になっており、一定期間内に再び共起しなければ半減期に従って値が下がっていく。値が可視化の下限を 下回ると探索結果には表示されなくなるが、エッジ自体が削除されるわけではない。新たな共起が発生すれば重みは即座に回復し、再び辿れる状態に戻る。
+- id: d_t02_c04_m1
+  source: memory
+  text: 'After last night''s consolidation pass we noticed forty-some edges had vanished entirely rather
+    than just faded, and the sleep report confirmed it: the pruning step deletes any edge that has sat
+    below the minimum weight floor for longer than the grace period, freeing up storage instead of letting
+    dead links linger forever. It only touches edges already invisible to explore, so nothing that was
+    still traversable got removed. We were relieved the pass is reversible from the rollback log in
+    case the floor gets tuned wrong.'
+- id: d_t02_c04_r1
+  source: resource
+  text: During each maintenance pass, the graph pruning step scans for edges whose weight has remained
+    under the minimum floor for longer than the configured grace period and removes them outright, rather
+    than leaving faint, unreachable links to accumulate indefinitely. Pruning only ever touches edges
+    that decay has already made invisible to traversal, so no edge disappears abruptly without first
+    passing through the low-weight state. Every pruning pass is logged and reversible through the standard
+    rollback mechanism, so an overly aggressive floor setting can be corrected without losing data.
+- id: d_t02_c04_r2
+  source: resource
+  text: 'Two parameters control how aggressively the graph is pruned: the minimum weight floor, below
+    which an edge becomes invisible to traversal, and the grace period, which is how long an edge must
+    stay under that floor before removal. Lowering the floor keeps more faint associations around for
+    longer at the cost of graph size; shortening the grace period reclaims storage faster but risks
+    discarding links that might have been reinforced again. Most deployments leave both at their defaults
+    and only adjust them after reviewing several sleep reports for pruning volume.'
+- id: d_t02_c05_m1
+  source: memory
+  text: 検索結果に二つの無関係なメモがたまたま並んだが、埋め込み類似度が閾値に届かず、エッジは作られなかった。共起しただけでは足りず、内容がある程度 近くないと関連付けが成立しない仕組みだと分かり、グラフが意味のないノイズだらけにならない理由を理解できた。
+- id: d_t02_c05_m2
+  source: memory
+  text: We were worried the graph would turn into spaghetti once teams started running broad recall
+    queries that pull back loosely related notes, but it turns out co-occurrence alone isn't enough
+    to create a link. Two nodes only get an edge if their embeddings also clear a minimum cosine similarity
+    gate, so two documents that merely show up in the same result set without any real topical overlap
+    stay unconnected. That gate is why the graph has stayed navigable even as recall volume grew across
+    every workspace.
+- id: d_t02_c05_r1
+  source: resource
+  text: 'Co-occurrence in a recall result is necessary but not sufficient for edge formation: candidate
+    node pairs must also clear a minimum embedding similarity gate before any weight is assigned. This
+    dual requirement, recalled together, and topically close by cosine distance, keeps the graph from
+    accumulating spurious links whenever a broad query happens to surface unrelated memories side by
+    side. The similarity threshold is tunable per workspace, and raising it trades a sparser graph for
+    higher confidence that surviving edges reflect genuine topical relationships.'
+- id: d_t02_c06_m1
+  source: memory
+  text: We deliberately kept the graph-building work on its own lane, separate from the recall path
+    that answers a live query. Every recall call still triggers graph bookkeeping, but that update is
+    queued and processed afterward instead of holding up the response the user is waiting on. Early
+    on we tried updating edges synchronously inline and search latency crept up whenever the graph worker
+    was busy on a large cluster. Splitting the two lanes fixed the tail latency without changing anything
+    about how recall itself ranks results.
+- id: d_t02_c06_m2
+  source: memory
+  text: Our graph lane fell behind the recall lane by almost twenty minutes during a traffic spike last
+    week, so explore was returning a subgraph that didn't yet include memories from the most recent
+    queries. Recall itself was unaffected since it never depends on the graph being current, but anyone
+    chaining recall into explore in the same minute got a stale picture. We added a queue-depth alert
+    on the graph lane specifically so we catch that drift before it compounds during the next spike.
+- id: d_t02_c06_r1
+  source: resource
+  text: 'Kagura''s memory system runs two independent processing lanes: the recall lane, which serves
+    search requests synchronously and never depends on graph state, and the graph lane, which consumes
+    recall events asynchronously to update edge weights and node metadata. Because the lanes are decoupled,
+    a backlog in graph processing never adds latency to search, though it can cause explore results
+    to lag slightly behind the very latest recall activity. Operators can monitor the graph lane''s
+    queue depth independently of recall throughput to catch backlogs before they affect traversal freshness.'
+- id: d_t02_c07_m1
+  source: memory
+  text: 'The graph companion process crashed midway through a batch of overnight recalls, and we were
+    bracing for hours of manual repair, but recovery turned out to be automatic: on restart the companion
+    replayed the recall event log from its last checkpoint and rebuilt every edge that should have formed
+    during the outage. The only visible gap was about six minutes of edges that hadn''t been written
+    yet, all of which caught up within the first replay cycle. We added a startup alert to flag replays
+    rather than finding out later.'
+- id: d_t02_c07_m2
+  source: memory
+  text: グラフ用のコンパニオンプロセスが再起動した際、直近のチェックポイントからイベントログを再生してエッジを復元する仕組みだと初めて知った。チェッ クポイント間隔が長いほど再生に時間がかかることも分かり、負荷の高い時間帯は間隔を短めに設定する運用に変えた。
+- id: d_t02_c07_r1
+  source: resource
+  text: 'The graph companion persists periodic checkpoints of edge and node state alongside a rolling
+    recall event log. If the companion process terminates unexpectedly, restarting it triggers an automatic
+    recovery pass: the last checkpoint is loaded and the event log is replayed forward from that point,
+    reconstructing any edges that formed or updated during the outage. Recovery time scales with the
+    interval since the last checkpoint, so deployments with high recall volume benefit from shortening
+    the checkpoint interval to bound replay duration after a crash.'
+- id: d_t02_c08_m1
+  source: memory
+  text: We assumed recalling the same two notes together ten times in a row would make their edge ten
+    times stronger, but the reinforcement curve doesn't work that way. Each additional co-recall adds
+    a shrinking increment to the edge weight, so the first handful of repeats matter far more than the
+    fiftieth. After the first week, our most-used pair of onboarding docs had basically plateaued, and
+    further use barely nudged the weight at all. That saved us from worrying that heavily trafficked
+    pairs would drown out everything else in explore's ranking.
+- id: d_t02_c08_m2
+  source: memory
+  text: One of our long-standing edges had built up a strong weight from months of steady co-recall,
+    then sat untouched for a long stretch before being reinforced again, and the increment it got back
+    was smaller than what a fresh pair would have earned. Reinforcement isn't purely additive; the size
+    of the boost shrinks both with how strong the edge already is and with how long it's been since
+    the last co-recall. We now treat a big weight as something kept warm, not something earned once
+    and permanent.
+- id: d_t02_c08_r1
+  source: resource
+  text: 'Each time two nodes are co-recalled, the graph applies a reinforcement increment to their shared
+    edge rather than a fixed additive bump. The increment follows a diminishing curve: it shrinks as
+    the existing edge weight rises, so heavily used pairs plateau instead of growing without bound,
+    and it also shrinks with elapsed time since the last co-recall, so a dormant edge earns a smaller
+    boost than a recently active one would. This keeps weight distribution across the graph from being
+    dominated by a small number of frequently retrieved pairs.'
+- id: d_t02_c09_m1
+  source: memory
+  text: We ran explore on a heavily connected onboarding node and hit the breadth limit before we even
+    finished expanding the first hop, the tool only retained a maximum handful of top-scoring neighbors
+    per hop rather than returning everyone connected, even when far more edges existed. That surprised
+    us until we realized an uncapped expansion from a hub node could have returned hundreds of loosely
+    related nodes. Once we understood the limit only drops the weakest neighbors, we stopped worrying
+    that useful context was silently missing from the results.
+- id: d_t02_c09_r1
+  source: resource
+  text: 探索機能には二つの上限があり、たどるホップ数の最大値と、各ホップで保持する隣接ノード数の上限が設定されている。上限を超える候補は活性化強度 が低い順に切り捨てられるため、常に最も関連性の高いノードが結果に残る仕組みになっている。上限はワークスペースごとに調整可能である。
+- id: d_t02_c09_r2
+  source: resource
+  text: Both traversal limits in explore, maximum hop depth and maximum neighbors retained per hop,
+    are configurable per workspace rather than fixed globally. Raising the breadth limit surfaces more
+    tangential nodes at the cost of a larger, noisier response; raising the hop depth reaches further
+    across the graph but multiplies the number of low-activation nodes that must be filtered. Workspaces
+    with dense, highly interconnected memories typically lower both limits from their defaults, while
+    sparse workspaces can safely raise them without the response size growing out of control.
+- id: d_t02_c10_m1
+  source: memory
+  text: 二つのコンテキストを統合したとき、それぞれのグラフに存在していた同じノード同士のエッジが自動的に一本化され、重みは単純合算ではなく大きい方 を基準に調整されると知った。統合前に想定していたよりエッジ数が減り、統合後の探索結果がむしろ整理されて見やすくなった。
+- id: d_t02_c10_m2
+  source: memory
+  text: 'When we merged two long-running contexts ahead of a reorg, we expected the combined graph to
+    just be the union of both edge sets, but overlapping node pairs got reconciled instead of duplicated:
+    where both sides already had an edge between the same two nodes, the merge kept the stronger weight
+    rather than adding them together. That kept the merged graph from suddenly having inflated weights
+    on pairs that happened to exist in both source contexts, which would have skewed explore toward
+    the wrong neighbors right after the merge.'
+- id: d_t02_c10_r1
+  source: resource
+  text: Merging two contexts reconciles their memory graphs node by node rather than simply concatenating
+    edge lists. When both source graphs contain an edge between the same pair of nodes, the merge keeps
+    the higher of the two weights instead of summing them, preventing artificially inflated confidence
+    on pairs that happened to co-occur independently in each context. Nodes without a counterpart carry
+    their edges over unchanged. This reconciliation runs as part of the merge itself, not a separate
+    sleep pass, so the graph is consistent right after the merge completes.
+- id: d_t03_c01_m1
+  source: memory
+  text: We decided nightly sleep runs should fire at 3am UTC because traffic dashboards across every
+    customer workspace showed that hour as the quietest for live recall queries. Running the maintenance
+    pass then keeps latency impact on daytime users close to zero. We reviewed six weeks of query volume
+    before locking in the trigger time, and we revisit the window quarterly as customer time zones shift
+    the global traffic curve.
+- id: d_t03_c01_m2
+  source: memory
+  text: Last Tuesday the scheduled maintenance pass silently skipped for one workspace because their
+    admin had set a timezone override that pushed our fixed trigger time into their business hours,
+    so the scheduler's guard rail deferred the run entirely. We now cross-check per-workspace timezone
+    overrides before the nightly job fires and log a warning instead of skipping silently, so operators
+    notice a deferred run the same morning.
+- id: d_t03_c01_r1
+  source: resource
+  text: The nightly maintenance job run window is configured through a cron expression plus an optional
+    timezone field on the workspace settings page. By default every workspace inherits the platform-wide
+    trigger time, but operators can override the hour, the day-of-week mask, and the timezone independently.
+    Changes take effect on the next scheduling cycle, and a dry preview shows the next three planned
+    trigger timestamps before you save the override.
+- id: d_t03_c02_m1
+  source: memory
+  text: 夜間バッチの中で、埋め込みベクトルの類似度がしきい値を超えたメモリ同士を自動的に候補エッジとして拾い上げる仕組みを入れた。しきい値を上げすぎると関連の薄い組み合わせが増えたため、社内テストを経て現在の設定に落ち着いた。
+- id: d_t03_c02_m2
+  source: memory
+  text: After the first month we noticed the semantic edge discovery step was surfacing a lot of spurious
+    pairs between unrelated notes, so we tightened the cosine similarity threshold from 0.72 to 0.81
+    before a pair becomes a candidate. That single change cut the volume of low-quality candidates roughly
+    in half without missing the associations reviewers actually confirmed as useful in the following
+    weeks.
+- id: d_t03_c02_r1
+  source: resource
+  text: During the discovery phase of a maintenance pass, the engine compares embedding vectors across
+    recently touched memories and flags any pair whose cosine similarity clears the configured threshold
+    as a candidate association. Candidates do not become permanent edges automatically; each one is
+    queued for review in the next stage. Operators can inspect or adjust the similarity threshold from
+    the workspace search configuration panel.
+- id: d_t03_c03_m1
+  source: memory
+  text: We chose an LLM judge over a fixed similarity cutoff for candidate associations because a single
+    number cannot tell whether two memories are actually related in meaning or just share common phrasing.
+    The judge reads both memory texts, reasons about the relationship, and returns an accept or reject
+    decision together with a confidence score and a short justification, which also gives us an audit
+    trail when someone questions why an edge exists.
+- id: d_t03_c03_m2
+  source: memory
+  text: 先週の夜間処理で、判定を行うLLM判事が候補エッジの大半を低い確信度で却下する現象が起きた。プロンプトの指示が曖昧だったことが原因と判明し、判断基準の説明文を書き直したところ、翌晩の実行では妥当な採用率に戻った。
+- id: d_t03_c03_r1
+  source: resource
+  text: The judgment step sends every queued candidate association to a review prompt that asks the
+    model to decide accept or reject and to report a confidence score between zero and one. The response
+    schema requires a short rationale string alongside the decision so downstream reports can display
+    why an edge was kept or dropped. Only accepted candidates with confidence above the configured floor
+    become permanent graph edges.
+- id: d_t03_c04_m1
+  source: memory
+  text: We designed the maintenance summary so every run produces one report with counts for edges proposed,
+    edges accepted, edges rejected, and near-duplicate memories merged, plus the wall-clock duration
+    of the pass. Early versions only showed a single success or failure flag, which left operators guessing
+    why a run took longer or changed fewer edges than usual, so the breakdown was the most requested
+    addition from the pilot team.
+- id: d_t03_c04_m2
+  source: memory
+  text: A workspace owner asked us to add a language breakdown to the summary after a run so teams with
+    mixed Japanese and English memories could see how many candidates came from each language pool.
+    We added the split as an optional section rather than a default field, since most single-language
+    workspaces found the extra rows unnecessary clutter in the report view.
+- id: d_t03_c04_r1
+  source: resource
+  text: Each completed maintenance pass produces a structured summary document containing the run identifier,
+    start and end timestamps, total candidates discovered, accept and reject counts from the judgment
+    step, and the number of near-duplicate memories merged during consolidation. The summary is stored
+    alongside the run and can be retrieved individually or listed together with prior runs, using pagination
+    once the list grows long, for trend comparison across a workspace's history.
+- id: d_t03_c05_m1
+  source: memory
+  text: 今週の実行結果を先週分と比較したかったので、過去の夜間処理の履歴をさかのぼって一件ずつ細かく確認した。件数だけでなく判定理由や却下されたエッジの詳細も残っていたおかげで、なぜ今回はエッジ採用数が減ったのかをすぐにチームへ説明できて助かった。
+- id: d_t03_c05_m2
+  source: memory
+  text: Once a workspace had been running nightly for a few months, the history listing started taking
+    noticeably longer to load because every past run was returned in one response. We added pagination
+    with a default page size and a cursor parameter, and encouraged the dashboard team to fetch only
+    the most recent handful of runs unless someone is explicitly browsing further back in time.
+- id: d_t03_c05_r1
+  source: resource
+  text: 過去の夜間処理を確認するための一覧取得機能では、各実行のID、開始時刻、終了時刻、ステータスを新しい順に返す。期間やステータスで絞り込むフィルタも用意されており、特定の週だけを取り出して過去の傾向と比較することができる。
+- id: d_t03_c06_m1
+  source: memory
+  text: We built a way to undo an entire maintenance pass after a run in staging added a batch of edges
+    linking two customers' data that should never have been compared, thanks to a misconfigured shared
+    workspace. Being able to revert every change from that single run instead of hunting down each bad
+    edge by hand turned a multi-hour cleanup into a five-minute fix once we noticed the mistake.
+- id: d_t03_c06_m2
+  source: memory
+  text: During an incident review we discovered that reverting a run also undid several duplicate merges
+    that had been correct, because the recovery step treats every change from that run as a single unit
+    rather than distinguishing edge creation from consolidation. We now warn operators in the confirmation
+    prompt that this action restores merged memories to their separate originals, since a single undo
+    affects the bad batch as well as the good one.
+- id: d_t03_c06_r1
+  source: resource
+  text: Reverting a maintenance run restores the memory graph to the state it held immediately before
+    that run started, removing any edges it created and restoring any memories it had merged during
+    consolidation back to their separate originals. The action requires the run identifier and is logged
+    as its own event so the reversal itself appears in the workspace's activity trail for later auditing.
+- id: d_t03_c07_m1
+  source: memory
+  text: We added a step that folds near-duplicate memories together during the nightly pass because
+    teams kept saving the same decision twice with slightly different wording after a meeting, and notes
+    continued to accumulate until search results were getting cluttered with three or four almost identical
+    entries. Consolidation keeps one canonical memory and quietly links the others to it instead of
+    deleting anything outright, so history is preserved.
+- id: d_t03_c07_m2
+  source: memory
+  text: One consolidation run merged two customer support notes that only happened to share similar
+    phrasing about a billing question, even though they described different accounts, because the duplicate
+    similarity threshold was set too loosely for short notes. We raised the minimum length before a
+    pair is eligible for merging and added a stricter threshold specifically for short memories to prevent
+    that class of mistake.
+- id: d_t03_c07_r1
+  source: resource
+  text: The consolidation stage scans memories touched since the previous run for pairs whose content
+    overlaps enough to be considered near-duplicates rather than merely related, since almost any strong
+    overlap still gets a final check before merging. When a pair clears the duplicate threshold, the
+    newer memory is folded into the older one, both original texts remain retrievable through the surviving
+    memory's history, and any edges pointing to the folded memory are redirected automatically.
+- id: d_t03_c08_m1
+  source: memory
+  text: We introduced a lighter maintenance mode alongside the full pass so budget-conscious workspaces
+    could still get near-duplicate cleanup without paying for the more expensive semantic discovery
+    and judgment steps every night. Light mode runs consolidation only, while the deep mode still does
+    the complete cycle of discovery, judgment, and reporting. Customers pick a mode per workspace based
+    on how quickly their notes accumulate.
+- id: d_t03_c08_m2
+  source: memory
+  text: 新しいワークスペースを本番の夜間処理に入れる前に、まず変更を保存しない試験的な実行方式で一晩試した。実際にはエッジを作らず候補だけを記録できたので、いきなり本番で予期しない統合が起きる不安なく安心して切り替えられた。
+- id: d_t03_c08_r1
+  source: resource
+  text: 夜間メンテナンスには複数の実行方式が用意されている。軽量モードは重複メモリの統合のみを行い、通常モードは候補エッジ発見と判定まで含めた一連の処理を実行する。さらに変更を保存せず結果だけを確認できる試験的な方式も選択可能である。
+- id: d_t03_c09_m1
+  source: memory
+  text: A nightly pass on our largest workspace got stuck partway through the discovery step last month
+    and never produced a report, which paged the on-call engineer at four in the morning. The run had
+    no timeout, so it sat holding resources for hours instead of failing cleanly. We added a hard timeout
+    and an automatic retry with a smaller batch size for that class of oversized workspace.
+- id: d_t03_c09_r1
+  source: resource
+  text: When a maintenance run appears stuck or never completes, check the run status field first for
+    a hung or timed-out state before assuming a crash. Stuck runs are usually caused by an oversized
+    candidate set overwhelming the judgment step; reducing the batch size or splitting the workspace's
+    memories across two scheduled windows typically resolves it quickly. A timed-out run can be safely
+    retried once the cause is addressed.
+- id: d_t03_c09_r2
+  source: resource
+  text: Health monitoring for maintenance runs tracks run duration, queue depth, and judgment throughput,
+    and raises an alert if a run exceeds twice its typical duration for that workspace or if no heartbeat
+    has been recorded for several minutes. Alerts route to the on-call rotation with the run identifier
+    and current stage attached so responders can jump straight to the relevant logs without searching
+    first, even when the platform is under heavy load.
+- id: d_t03_c10_m1
+  source: memory
+  text: For workspaces with unusually large memory graphs we started throttling the maintenance pass
+    to a fixed batch size per cycle instead of processing everything in one pass, after a single oversized
+    run drove up compute cost far more than its workspace's subscription tier justified. Spreading the
+    same workload across several smaller batches keeps nightly cost predictable even as a workspace
+    keeps growing month over month, instead of letting one larger batch cover the entire graph and its
+    cost in a single night.
+- id: d_t03_c10_r1
+  source: resource
+  text: Batch size and concurrency limits for the maintenance pass can be tuned per workspace to balance
+    run duration against compute cost. Smaller batches finish each cycle faster and cost less per run
+    but may require several nights to fully process a very large graph, while larger batches cover more
+    memories per night at a higher per-run resource cost. Recommended defaults scale with the workspace's
+    total memory count.
+- id: d_t03_c10_r2
+  source: resource
+  text: 大規模なメモリグラフを持つワークスペース向けに、一回あたりの処理件数を制限するスロットリング設定が用意されている。件数を抑えるほど一晩あたりの計算コストは下がるが、全体の処理が完了するまでに複数晩かかる場合がある。推奨値はメモリ総数に応じて自動的に調整される。
+- id: d_t04_c01_m1
+  source: memory
+  text: We decided every new context defaults to private visibility unless a workspace admin explicitly
+    flips it to shared, because early on interns spun up test contexts that leaked draft product notes
+    into the general workspace feed. Now create_context always sets owner-only access at creation time,
+    and teams opt in to broader sharing only after reviewing what is inside. This one small default
+    change cut accidental oversharing incidents to zero, and nobody has complained about the extra confirmation
+    step when they do want to open a context up.
+- id: d_t04_c01_m2
+  source: memory
+  text: After onboarding three new hires in the same week, we noticed everyone was naming contexts things
+    like notes or temp, which made the workspace context list impossible to scan. We agreed on a naming
+    convention where every new context starts with the team abbreviation followed by a short topic,
+    like mkt-launch-plan or eng-onboarding. It is a small thing but it saved a lot of Slack messages
+    asking which context someone meant, and it made it much quicker to spot the right place to store
+    a memory.
+- id: d_t04_c01_r1
+  source: resource
+  text: The create_context tool provisions a new memory container scoped to a single subject or project.
+    Callers may pass a name, an optional description, and a visibility flag; when the flag is omitted
+    the platform assigns private visibility, meaning only the creator and workspace admins can query
+    it until explicitly shared. Context names should be short, lowercase, and hyphenated to remain sortable
+    in the workspace picker. Once created, a context receives a unique identifier that downstream remember
+    and recall calls must reference, anchoring later audit and quota reporting.
+- id: d_t04_c02_m1
+  source: memory
+  text: 先週、案件用のコンテキストを非公開から共有設定に切り替える前に、中身をもう一度確認する運用に決めた。過去に確認を怠って社外秘のメモが他チームに見えてしまったことがあり、切り替え前のレビューを必須にしたところ、同様の事故は今のところ一度も起きていない。
+- id: d_t04_c02_m2
+  source: memory
+  text: We had a scare last month when someone flipped a customer-support context from private to shared
+    without checking what was inside, and a few messages containing a client's billing details became
+    visible to the whole workspace. Since then, changing a context's visibility requires typing a short
+    confirmation reason, and the person doing it gets a summary of the most sensitive-looking notes
+    first. It slows down sharing by about thirty seconds but has stopped every accidental exposure since
+    we added it.
+- id: d_t04_c02_r1
+  source: resource
+  text: update_context の visibility パラメータには private か shared のいずれかを指定でき、変更できる権限はワークスペースの管理者とコンテキストの作成者に限られる。shared
+    に変更すると同じワークスペースの全メンバーが recall や remember を実行できるようになるため、切り替え前に内容の棚卸しを行うことが推奨される。
+- id: d_t04_c03_m1
+  source: memory
+  text: Before we kicked off the quarterly resource re-import for the support-docs context, we locked
+    it so no one could call remember against it mid-migration, since the importer rewrites large batches
+    of resource entries and stray writes were landing in half-updated clusters. Locking took one call,
+    the import finished in twenty minutes, and we unlocked the context right after verifying the new
+    resource counts matched the source system. We are making this maintenance step standard before any
+    bulk resource load from now on.
+- id: d_t04_c03_m2
+  source: memory
+  text: We had a rough afternoon when two teammates were adding notes to the same project context while
+    our Sleep consolidation job was rewriting its association graph in the background, and about a dozen
+    new memories ended up linked to associations that no longer existed once consolidation finished.
+    Nobody had realized the context should be locked during a consolidation run, so we now automatically
+    put a context into a locked, read-only state the moment its nightly job starts and release it once
+    the report is ready.
+- id: d_t04_c03_r1
+  source: resource
+  text: A context can be placed into a locked state through its configuration, which rejects incoming
+    remember calls and resource writes while still allowing recall to read existing memories. Locking
+    suits maintenance windows such as bulk resource imports, schema migrations, or an active Sleep consolidation
+    run, where concurrent writes could interleave with structural changes to the association graph.
+    Only a workspace admin or the context owner may lock or unlock a context, and the lock state is
+    visible to all members through get_context_info so collaborators know why writes are rejected.
+- id: d_t04_c04_m1
+  source: memory
+  text: We changed our onboarding so that inviting someone new to the workspace requires an existing
+    admin to approve the invite before it goes out, instead of any member being able to add outsiders
+    directly. This came up after a well-meaning teammate invited a vendor contact who only needed read
+    access to one context but ended up seeing the whole member list and every shared context by default.
+    The approval step adds maybe a day of delay but keeps membership growth intentional without touching
+    anyone's ability to recall.
+- id: d_t04_c04_m2
+  source: memory
+  text: 'When the contractor who helped us set up the support pipeline finished their engagement, we
+    forgot to remove them from the workspace for almost three weeks, which meant they could still recall
+    from every shared context during that window. We now treat offboarding as a same-day rule: removing
+    someone''s workspace membership revokes their access immediately, checked off the same list as badge
+    and laptop return.'
+- id: d_t04_c04_r1
+  source: resource
+  text: Workspace membership determines which users can see the workspace exists at all and, subject
+    to per-context sharing, which contexts they can query. Joining happens through an invite that a
+    current member sends and the invitee accepts, after which the new member appears in the workspace
+    member list with a default role. Removing a member immediately revokes their ability to call recall
+    or remember against any context in that workspace, though memories they previously authored remain
+    intact and attributed to their account.
+- id: d_t04_c05_m1
+  source: memory
+  text: ステークホルダー向けに閲覧専用のビューアーロールを新設した。これまでは編集者権限しかなく、進捗を確認したいだけの人にも remember の権限を渡してしまい、意図しない書き込みが増えていたためだ。ビューアーは
+    recall のみ可能で、記憶を追加したり削除したりはできない仕組みにした。
+- id: d_t04_c05_m2
+  source: memory
+  text: One of our editors accidentally deleted a shared planning context while cleaning up old test
+    data, and because editors had the same delete permission as admins at the time, there was no extra
+    confirmation step to catch the mistake. We split the role model so editors can create and update
+    memories but only workspace admins can delete a context, and admin actions now require a second
+    click with the context name typed out.
+- id: d_t04_c05_r1
+  source: resource
+  text: ワークスペースのロールは主に管理者、編集者、ビューアーの3種類に分かれる。管理者はメンバー招待やコンテキストの削除、ロール変更まで行える。編集者は remember によるメモリ追加とコンテキスト設定の更新が可能だが、削除権限は持たない。ビューアーは
+    recall による閲覧のみに限定される。
+- id: d_t04_c06_m1
+  source: memory
+  text: We locked down remember permission on the finance context to just the two people who reconcile
+    numbers each month, while leaving recall open to the whole workspace so anyone can still look up
+    past figures. Before this, well-meaning teammates would jot down half-checked numbers straight into
+    the context and other people would quote them as if they were verified. The narrower write access
+    has not slowed anyone down since looking things up is unaffected.
+- id: d_t04_c06_m2
+  source: memory
+  text: A new hire tried to save a note into the finance context on their first day and just got a generic
+    permission error with no explanation, which was confusing since they could recall from it fine moments
+    earlier. We improved the error to say plainly that write access to this particular context is restricted
+    to a smaller group and to name who to ask for it, which cut down the confused questions in the support
+    channel even though the restrictive rule itself never changed.
+- id: d_t04_c06_r1
+  source: resource
+  text: Per-context permission overrides let a workspace narrow recall or remember beyond what a member's
+    workspace role would otherwise allow. An override is attached to a specific context and a specific
+    action, so a context can, for example, permit recall to every workspace member while limiting remember
+    to a named subset of editors. When both a workspace role and a context override apply, the more
+    restrictive of the two determines whether a given recall or remember call succeeds, and the caller
+    receives a clear reason when it is denied.
+- id: d_t04_c07_m1
+  source: memory
+  text: During the project retro we needed to pull up decisions that were scattered between the engineering
+    context and the product context, and searching them one at a time meant flipping back and forth
+    and losing track of which result came from where. Once we passed both context ids into a single
+    recall call, the results came back merged and ranked together instead of as two separate lists,
+    which made writing the retro summary much faster. We are going to default retros to a combined search
+    across both contexts.
+- id: d_t04_c07_m2
+  source: memory
+  text: 先週、マーケティングと営業のコンテキストにまたがって同じキャンペーンの記憶を探す必要があった。ひとつずつ検索する代わりに、複数のコンテキストIDをまとめて指定して検索したところ、関連する記憶が一つのランキングにまとまって出てきて、比較がとても楽になった。
+- id: d_t04_c07_r1
+  source: resource
+  text: recall には scope パラメータがあり、複数のコンテキストIDを配列で渡すことで、それらをまたいだ横断検索を一度に実行できる。結果は単一の関連度スコアに統合されて返されるため、呼び出し側でコンテキストごとに結果を並べ替える必要はない。ただし呼び出したユーザーがアクセス権を持たないコンテキストは自動的に除外される。
+- id: d_t04_c08_m1
+  source: memory
+  text: After the reorg combined the mobile and web teams into one product group, we had two separate
+    contexts full of overlapping decisions about the same feature set, so we merged them into a single
+    context rather than leaving people guessing which one to check. The merge kept every memory's original
+    timestamp and author, and within a day the combined context felt like it had always been one place,
+    which was a relief compared to the confusion in the weeks right after the reorg was announced.
+- id: d_t04_c08_m2
+  source: memory
+  text: The first time we merged two contexts we did not expect how many near-duplicate memories would
+    end up sitting side by side, since both teams had independently written down almost the same launch-date
+    decision in their own words. Search results got cluttered with two or three versions of the same
+    fact ranked close together. Now before merging we run a quick duplicate check and consolidate obvious
+    repeats first, then merge, which leaves the graph edges cleanly remapped instead of dropped and
+    the resulting context much easier to trust.
+- id: d_t04_c08_r1
+  source: resource
+  text: The merge_contexts tool combines the memories, resources, and association graph of a source
+    context into a target context and then retires the source context id, redirecting any stored references
+    to it. Memories retain their original author and creation time after the merge, and existing edges
+    in the association graph are remapped rather than dropped. The operation does not automatically
+    deduplicate near-identical memories, so teams merging contexts with overlapping subject matter are
+    advised to review for repeats beforehand.
+- id: d_t04_c09_m1
+  source: memory
+  text: We noticed recall quality on our Japanese customer-support context was mediocre until we realized
+    the context was still using the workspace's default English-oriented embedding setting. Switching
+    that one context's language setting to Japanese noticeably improved how well paraphrased queries
+    matched existing memories, without touching any other context in the workspace. While we were in
+    there we also confirmed the retention window controlling automatic forgetting was still set to never
+    expire, since nobody had checked either setting since the context was created almost a year ago.
+- id: d_t04_c09_r1
+  source: resource
+  text: Each context exposes a settings panel independent of workspace-level defaults, covering the
+    embedding language hint, a retention window for automatic forgetting, and ranking weight adjustments
+    between recency and relevance. Changing a context's language hint re-embeds new memories using vocabulary
+    and tokenization tuned for that language, which improves semantic recall for content written primarily
+    in one language. These settings apply only to the context they are set on and never cascade to sibling
+    contexts in the same workspace.
+- id: d_t04_c09_r2
+  source: resource
+  text: コンテキストの設定パネルには保持期間という項目があり、指定した日数を過ぎた記憶を自動的に忘却させることができる。既定では無期限だが、一時的な案件用のコンテキストでは30日や90日を設定しておくと、案件終了後に手動で掃除しなくても記憶が自然に整理される。保持期間はコンテキストごとに独立しており、他のコンテキストには影響しない。
+- id: d_t04_c10_m1
+  source: memory
+  text: We hit our workspace's context quota right in the middle of a busy sprint, and the create_context
+    call just started failing with no memories lost but no way to start a new context either. The quick
+    fix was archiving four old contexts from a project we had wrapped up months earlier, which freed
+    up enough headroom immediately. Now someone checks the workspace usage dashboard at the start of
+    each quarter so we are never surprised by the limit again.
+- id: d_t04_c10_r1
+  source: resource
+  text: Every workspace is assigned a quota covering the total number of contexts, the combined memory
+    and resource document count, and total storage across attached files. Archived contexts still count
+    toward the context quota but their memories are excluded from the document count until they are
+    restored. When a workspace approaches its limit, new create_context and remember calls begin returning
+    a quota-warning header, and calls are only hard-blocked once the limit is fully reached.
+- id: d_t04_c10_r2
+  source: resource
+  text: ワークスペースのクォータに達すると、新しいコンテキストの作成やremember の呼び出しが拒否されるようになる。上限に達した場合は、不要になった古いコンテキストをアーカイブするか、上位プランにアップグレードしてクォータ自体を引き上げる必要がある。アーカイブされたコンテキストは記憶を保持したまま非表示になる。
+- id: d_t05_c01_m1
+  source: memory
+  text: We finally settled on always passing an explicit context_id when calling the remember tool from
+    the onboarding bot, because letting it default to the workspace root caused new hire notes to land
+    in the wrong context and get buried under unrelated tickets. The remember call now also sends a
+    tags array with team and project so recall filters work later. We noticed remember silently dedups
+    near-identical text within the same context, saving us from a flood of duplicate reminders, since
+    near-duplicate wording usually matches something already stored.
+- id: d_t05_c01_m2
+  source: memory
+  text: リマインダー用にrememberツールを呼ぶとき、tagsを省略すると自動タグ付けが働き、直近の会話文脈から推測したラベルが付与されることが分かった。ただし推測が外れると後で検索しづらくなるため、重要な議事録は必ずtagsを明示し、context_idも合わせて指定する運用に変えた。
+- id: d_t05_c01_r1
+  source: resource
+  text: The remember tool accepts a required text field plus optional tags, context_id, and importance
+    parameters, and returns a memory_id along with a dedup_of field when the new content closely matches
+    an existing entry in the same context. Text longer than roughly two thousand characters is automatically
+    chunked into linked memory_id segments before embedding. Callers should treat a populated dedup_of
+    field as confirmation that no new row was written, and reuse the referenced id instead of writing
+    a duplicate row.
+- id: d_t05_c02_m1
+  source: memory
+  text: After the search felt too broad during the support triage demo, we lowered the default top_k
+    for the recall tool from twenty to eight and raised the similarity_threshold slightly, which cut
+    noisy low-relevance hits without losing the ticket history results people actually wanted. We also
+    learned that passing a narrower context_id scope speeds up recall noticeably on the shared workspace,
+    since it skips ranking memories outside that scope entirely.
+- id: d_t05_c02_m2
+  source: memory
+  text: We debugged why recall kept surfacing an old deploy note above a fresher one and traced it to
+    the hybrid scoring blending BM25 and vector cosine unevenly when query terms were rare. Nudging
+    the lexical weight down in the blended score fixed the ordering for keyword-heavy queries without
+    hurting the paraphrase cases in our regression set, and it stopped dropping good hits for noisy
+    short queries too. Worth remembering that recall's ranking is not purely semantic, so exact wording
+    still matters for niche terms.
+- id: d_t05_c02_r1
+  source: resource
+  text: recallツールはqueryとcontext_id、任意のtop_kおよびsimilarity_thresholdを受け取り、BM25とベクトル類似度を組み合わせたハイブリッドスコアで結果を返す。各結果にはmemory_id、score、抜粋テキストが含まれ、similarity_thresholdを上げるほど関連度の低い記憶は除外される仕組みになっている。
+- id: d_t05_c03_m1
+  source: memory
+  text: During the incident review we used the explore tool to walk outward from the postmortem memory
+    and found three related deploy notes we had forgotten existed, connected through Hebbian edges that
+    strengthened every time someone recalled them together. Setting depth to two was enough to surface
+    the cluster without pulling in the whole workspace graph. It felt closer to browsing a mind map
+    than running a search query.
+- id: d_t05_c03_m2
+  source: memory
+  text: exploreツールでdepthパラメータを3まで上げてみたところ、関連が薄いメモまで芋づる式に出てきてしまい、逆に読みにくくなった。結局depth2、edge_typesを絞る設定に落ち着き、必要なノードだけがつながって見えるようになったので調査作業がかなり楽になった。
+- id: d_t05_c03_r1
+  source: resource
+  text: The explore tool starts from a given memory_id or query, such as a postmortem note, and walks
+    the Hebbian association graph outward, returning nodes grouped by depth up to a configurable limit.
+    Optional edge_types and min_weight parameters restrict traversal to strong links only, and a visited
+    node is never returned twice within one call. Edge weights increase whenever two memories are tied
+    together during recall, so callers may walk further simply by raising depth, though depth beyond
+    three typically returns diminishing relevance and a much larger payload.
+- id: d_t05_c04_m1
+  source: memory
+  text: We decided every deletion request from the privacy team gets handled through the forget tool
+    rather than direct database access, so there is always an audit trail of who removed what and when,
+    with every action marking a timestamp and an operator id. The support lead now runs forget with
+    the customer's context_id scoped explicitly, then double checks with recall that nothing sensitive
+    still surfaces. This became part of the offboarding checklist after last quarter's compliance review
+    flagged the gap.
+- id: d_t05_c04_m2
+  source: memory
+  text: Turns out forget only soft-deletes by default, marking the memory as tombstoned so it stops
+    showing up in recall and explore but still exists for the sleep consolidation job to reference during
+    grace period cleanup. We had assumed it was gone immediately and were confused when a teammate said
+    the row still appeared in an export. Passing hard true skips the tombstone and removes the row outright,
+    which we now reserve for genuine legal deletion requests rather than records merely removed from
+    everyday search.
+- id: d_t05_c04_r1
+  source: resource
+  text: forgetツールはmemory_idまたはcontext_idを指定して呼び出し、既定では論理削除としてタイムスタンプを付与するのみで、recallやexploreの結果からは除外される。hardパラメータをtrueにすると物理削除が行われ、猶予期間のロールバック手段も失われるため注意が必要である。
+- id: d_t05_c05_m1
+  source: memory
+  text: We started pinning the architecture decision memories with the reference tool right after the
+    big rewrite discussion, so anyone starting a new session gets them loaded automatically instead
+    of having to search for them every time. It turns out pinned entries get a small priority boost
+    inside recall too, not just in the startup load, which explains why that onboarding note kept outranking
+    newer content. We now review the pinned list monthly to keep it from growing stale.
+- id: d_t05_c05_m2
+  source: memory
+  text: 新しいセッションを開始するたびにload_pinnedを呼んでピン留め済みの重要な決定事項を読み込む運用にしたところ、毎回同じ経緯を説明する手間がかなり減った。ただしピンの数が増えすぎると読み込みが重くなるため、四半期ごとに棚卸しして古い項目を外すルールを決めた。
+- id: d_t05_c05_r1
+  source: resource
+  text: The reference tool pins an existing memory_id to a context so it is returned by load_pinned
+    at the start of every session, and accepts an optional pin_priority integer that also nudges the
+    entry's ranking within ordinary recall results. Unpinning is done by calling reference again with
+    pin set to false. There is a soft limit of fifty pinned entries per context, after which load_pinned
+    truncates by pin_priority.
+- id: d_t05_c06_m1
+  source: memory
+  text: 契約更新の期限をtime memoryとして登録し、due_atに日付を入れておくと、recall_upcomingで一週間前から自動的にリストに上がってくるようになった。以前は担当者の記憶頼みで更新漏れが何度かあったが、この仕組みにしてから見落としがなくなった。
+- id: d_t05_c06_m2
+  source: memory
+  text: We wired recall_upcoming into the Monday standup summary so every renewal and follow-up we had
+    stored as a time memory with a due_at field shows up automatically instead of relying on someone
+    remembering to check a spreadsheet. It also picks up recurring entries, which caught a quarterly
+    license renewal that had slipped through twice before. The window defaults to seven days out but
+    we widened it to fourteen for billing-related items.
+- id: d_t05_c06_r1
+  source: resource
+  text: A memory stored with a due_at timestamp and optional recurrence rule is treated as a time memory,
+    and the recall_upcoming tool returns any such entries whose due_at falls within a configurable lookahead
+    window, sorted soonest first. Recurring entries are expanded into their next single occurrence rather
+    than every future instance. Passing a context_id narrows the results, and entries without a due_at
+    are never included regardless of other filters, which is why a missed renewal is rarely caught unless
+    it was saved this way.
+- id: d_t05_c07_m1
+  source: memory
+  text: After the support bot kept citing an outdated pricing memory, we started calling the feedback
+    tool with a negative signal whenever an agent flagged a stale result, and a positive signal whenever
+    a recalled memory actually resolved the ticket. Within about two weeks the outdated pricing note
+    stopped surfacing near the top for common queries, which was the first time we saw the ranking visibly
+    self-correct from real usage rather than manual edits.
+- id: d_t05_c07_m2
+  source: memory
+  text: We learned that feedback does not just reorder a single search result, it actually nudges the
+    Hebbian edge weights tied to that memory, so a strong positive signal makes it more likely to surface
+    together with whatever else was recalled in the same session. That explained why upvoting one meeting
+    note also lifted a related note we never touched directly. It is closer to reinforcement than a
+    simple relevance flag.
+- id: d_t05_c07_r1
+  source: resource
+  text: feedbackツールはmemory_idと評価値を受け取り、正のフィードバックは該当メモリおよび関連するヘブ結合の重みを強化し、負のフィードバックは重みを弱めてrecallでの順位を下げる。評価は即時反映されるが、大きな重み変化はsleep処理時にまとめて整理される。
+- id: d_t05_c08_m1
+  source: memory
+  text: Our CI pipeline can't hold an MCP session open between build steps, so we swapped the nightly
+    summary job from calling the remember tool over MCP to hitting the REST endpoint directly with a
+    service API key. The payload shape ended up nearly identical, just wrapped in a plain JSON POST
+    instead of a tool call, and the response still includes the same memory_id and dedup_of fields we
+    already depended on downstream.
+- id: d_t05_c08_m2
+  source: memory
+  text: We kept hitting 401s from the new intern's script until we noticed the REST calls were missing
+    the Authorization Bearer header entirely and pointing at the unversioned base URL instead of the
+    v1 path. Once we standardized every internal script to send the API key as a bearer token against
+    the versioned base URL, the mystery 401 tickets stopped completely, and it became the first line
+    of our onboarding checklist for anyone touching the API directly, including whoever writes the next
+    nightly script instead of going through MCP again.
+- id: d_t05_c08_r1
+  source: resource
+  text: REST APIのベースURLはhttps://api.example.com/v1で統一されており、すべてのリクエストにAuthorizationヘッダーとしてBearerトークン形式のAPIキーを付与する必要がある。バージョンを省略した古いパスへのアクセスは非推奨として扱われ、将来的に410で拒否される予定である。
+- id: d_t05_c09_m1
+  source: memory
+  text: We hit a nasty bug where the client paginating through /v1/recall results kept looping forever
+    because it was comparing the raw next_cursor string instead of checking for a null value to detect
+    the last page. The response schema does include a has_more boolean specifically to avoid this, and
+    once the client switched to checking that field instead of guessing from cursor equality, the infinite
+    loop went away for good.
+- id: d_t05_c09_r1
+  source: resource
+  text: A recall request body accepts query, context_id, and top_k fields, and the response is a JSON
+    object containing a results array plus a next_cursor string and a has_more boolean for pagination.
+    Each entry in results carries memory_id, score, snippet, and source fields, where source distinguishes
+    memory from resource documents. Clients should treat a null next_cursor together with has_more false
+    as the definitive end-of-results signal rather than an empty results array. A well-behaved client
+    stops paging once has_more is false, avoiding a looping fetch of the same page it already saw.
+- id: d_t05_c09_r2
+  source: resource
+  text: recallのレスポンスに含まれるresults配列の各要素にはmemory_id、score、抜粋を表すsnippet、そしてsourceフィールドが含まれ、sourceの値によってmemoryかresourceかを区別できる。ページングにはnext_cursorとhas_moreを用い、has_moreがfalseになった時点で取得が完了したと判断する。
+- id: d_t05_c10_m1
+  source: memory
+  text: After the batch importer got throttled hard during the migration, we added exponential backoff
+    keyed off the 429 response's Retry-After header instead of a fixed delay, and error volume dropped
+    to almost nothing on the next run. We also started checking the error code field in the response
+    body rather than only the HTTP status, since a couple of validation failures were coming back as
+    400 with a code that told us exactly which field was malformed.
+- id: d_t05_c10_r1
+  source: resource
+  text: API error responses share a common JSON shape with a code, message, and optional field_errors
+    array, covering statuses such as 400 for validation failures, 401 for missing or invalid credentials,
+    404 for an unknown memory_id or context_id, and 500 for unexpected server faults. A 429 indicates
+    the caller exceeded its rate limit and always includes a Retry-After header. Clients should branch
+    on the code string rather than parsing the message text, which may change wording over time.
+- id: d_t05_c10_r2
+  source: resource
+  text: Every account is limited by a rolling per-minute request budget, and each response carries X-RateLimit-Limit,
+    X-RateLimit-Remaining, and X-RateLimit-Reset headers so callers can throttle proactively instead
+    of waiting to get throttled by a 429. Burst traffic beyond the limit is rejected with a 429 and
+    a Retry-After header set in seconds rather than a timestamp. The limit is enforced per API key,
+    so splitting traffic across multiple keys does not increase the effective total for a single workspace.
+- id: d_t06_c01_m1
+  source: memory
+  text: We decided to allowlist only three engineering channels for the Slack connector instead of enabling
+    workspace-wide ingestion, because pulling every channel would flood the context with sales chatter
+    and standup noise. The connector uses setup_connector with a channel filter, and we scoped the OAuth
+    token to read-only history and reactions. Reviewing the first week of ingestion, the allowlist kept
+    memory quality high while still capturing the design discussions we actually wanted to recall later.
+- id: d_t06_c01_m2
+  source: memory
+  text: Slackコネクタを有効化した際、ボットをチャンネルに招待し忘れると履歴が全く取り込まれないことに気づいた。招待後に setup_connectorを再実行すると過去メッセージも遡って取得できたが、招待前の反応やスレッド返信は失われたままだった。
+    今後は新しいチャンネルを追加するたびに招待手順をチェックリスト化することにした。
+- id: d_t06_c01_r1
+  source: resource
+  text: The Slack connector authenticates via OAuth and requires channels:history, channels:read, and
+    reactions:read scopes before setup_connector can begin ingestion. Administrators select an allowlist
+    of channels rather than the entire workspace, and the connector polls each channel on a configurable
+    cadence, batching new messages and thread replies into ingestion events. Bots must be invited to
+    a channel manually; ingestion only backfills history from the invitation point unless a wider history
+    scope is granted.
+- id: d_t06_c02_m1
+  source: memory
+  text: We added a Discord connector for the community server so support questions surface in memory
+    alongside our internal notes. Setup required inviting the bot with read message history permission
+    and scoping ingestion to a single guild id, then choosing which channels to include. We excluded
+    the memes and off-topic channels from day one, expecting they would add noise without contributing
+    useful long-term knowledge for the team.
+- id: d_t06_c02_m2
+  source: memory
+  text: After the Discord connector ran for a week, the community server's general-chat channel had
+    flooded the context with greetings and emoji reactions that drowned out the actual support answers
+    we cared about. We removed general-chat from the channel filter and left only the help-desk and
+    bug-reports channels enabled. The lesson was that community servers need a narrower channel filter
+    than internal Slack workspaces from the very start.
+- id: d_t06_c02_r1
+  source: resource
+  text: DiscordコネクタはギルドIDと対象チャンネルの一覧を指定して設定する。ボットには履歴読み取り権限が必要で、 招待後にサーバー内の既存メッセージを取り込む。チャンネルごとに取り込み頻度を調整でき、除外リストに追加した
+    チャンネルは同期対象から外れる仕組みになっている。
+- id: d_t06_c03_m1
+  source: memory
+  text: 個人のObsidianボールトを記憶コンテキストと同期する設定を有効にした。監視対象は特定のフォルダのみに絞り、 日々のジャーナルノートを除外することで、プロジェクト関連のノートだけが記憶として取り込まれるようにした。
+    フロントマターのタグがそのままコンテキストのタグとして扱われる点も確認できた。
+- id: d_t06_c03_m2
+  source: memory
+  text: Syncing the Obsidian vault taught us that wikilinks between notes do not automatically become
+    edges in the memory graph; only the frontmatter tags get carried over as context tags. We had assumed
+    linked notes would connect automatically, so early on several related design notes stayed isolated
+    from each other. Now we manually add a shared tag across linked notes so the sync process treats
+    them as one cluster.
+- id: d_t06_c03_r1
+  source: resource
+  text: Obsidian vault sync watches a configured folder for markdown file changes and mirrors edits
+    into the bound context within seconds. Frontmatter fields are parsed on ingestion; the tags array
+    maps directly to context tags, while other frontmatter keys are stored as note metadata. Wikilinks
+    and embeds are preserved as plain text references rather than graph edges, since resolving cross-note
+    links into memory edges is not yet supported.
+- id: d_t06_c04_m1
+  source: memory
+  text: We started attaching PDFs to the onboarding context using the file upload flow instead of pasting
+    summaries by hand, since init_file_upload followed by complete_file_upload gives us a sha256-checked
+    copy in storage that survives edits. Binding each upload to its owning context meant only teammates
+    with context access could fetch the download URL later. This turned out cheaper than re-ingesting
+    the same spec document every time someone asked for it.
+- id: d_t06_c04_r1
+  source: resource
+  text: 'File uploads use a two-step flow: init_file_upload registers the file and returns a presigned
+    target, and complete_file_upload finalizes storage once the bytes are written, verifying the sha256
+    hash supplied at initialization. Uploads can optionally be bound to an owning context so access
+    control follows the context''s membership rather than being public by default. Duplicate content
+    with a matching hash reuses the existing stored object instead of writing a second copy.'
+- id: d_t06_c04_r2
+  source: resource
+  text: Uploaded files are stored in R2-backed object storage behind the workspace's quota, and download
+    URLs returned by get_file_download_url expire after a short window to limit exposure of shared links.
+    Deleting a file through delete_file removes the storage object once no other upload references the
+    same content hash. Administrators can list all files bound to a context to audit what raw attachments
+    are backing a project's memories.
+- id: d_t06_c05_m1
+  source: memory
+  text: We turned on pre-compile summarization for chat-sourced ingestion so a long support thread gets
+    condensed into a short summary before it becomes a memory, rather than storing every back-and-forth
+    message verbatim. This cut the number of near-duplicate memories from a single conversation dramatically
+    and left the compiled summary carrying the actual resolution instead of the greeting and troubleshooting
+    back-and-forth that came before it.
+- id: d_t06_c05_m2
+  source: memory
+  text: チャット由来の取り込みでプリコンパイル要約を試したところ、雑談やあいさつがほとんど除去され、結論部分だけが 記憶として残ることが分かった。ただし要約が短すぎると誰が発言したかという文脈が失われる場合があり、
+    要約の長さを調整するパラメータを少し緩めることにした。
+- id: d_t06_c05_r1
+  source: resource
+  text: Before chat-sourced content is compiled into individual memories, the ingestion pipeline runs
+    a pre-compile summarization pass that condenses a thread into its key points and drops small talk,
+    greetings, and repeated confirmations. The summarized output, not the raw transcript, is what gets
+    passed to the compiler that produces overview and section memories. This keeps memory volume proportional
+    to information density rather than message count.
+- id: d_t06_c06_m1
+  source: memory
+  text: 外部コネクタ経由で取り込む内容に対してPIIスクラビングを有効にした。メールアドレスや電話番号らしき文字列は 取り込み前に自動的にマスクされ、記憶として保存される前に除去される。社内Slackだけでなく個人のObsidian
+    ボールトにも同じルールを適用することに決めた。
+- id: d_t06_c06_m2
+  source: memory
+  text: During a review we found that PII scrubbing caught email addresses and phone numbers reliably
+    but missed a customer's home address written across two lines of a Discord message. We reported
+    it and added a follow-up rule that scans multi-line blocks together instead of line by line before
+    redaction runs. The incident reminded us that scrubbing patterns tuned on single lines can miss
+    context split across messages.
+- id: d_t06_c06_r1
+  source: resource
+  text: PII scrubbing runs on connector-sourced content before it is compiled into memories, matching
+    patterns for emails, phone numbers, national id formats, and common address structures, then replacing
+    matches with typed placeholder tokens. The scrubbing pass operates on the full message or note text
+    rather than line by line, so patterns spanning line breaks are still caught. Administrators can
+    extend the pattern set per workspace for locale-specific identifiers.
+- id: d_t06_c07_m1
+  source: memory
+  text: We decided every memory produced from a connector must carry a source URI pointing back to the
+    original Slack permalink, Discord message link, or vault file path, instead of just a plain text
+    citation. This makes it possible to click through from a recalled memory straight to the original
+    conversation when someone wants more context than the summary gives. It cost a bit more storage
+    per memory but paid for itself within a week.
+- id: d_t06_c07_m2
+  source: memory
+  text: 'A source URI saved us real debugging time last week: a recalled memory about a pricing decision
+    looked wrong, and following its link back to the original Slack thread showed the number had been
+    corrected in a later reply that never got re-ingested. Without the permalink we would have had no
+    way to confirm which version was authoritative. Now we treat provenance links as required, not optional,
+    metadata.'
+- id: d_t06_c07_r1
+  source: resource
+  text: 取り込まれた記憶にはソースURIが付与され、元となったSlackの投稿やDiscordのメッセージ、ボールト内の ファイルパスへのリンクとして機能する。コネクタの種類ごとにURIの形式は異なり、パーマリンクが取得できない
+    場合はコネクタ名と内部IDを組み合わせた識別子が代わりに使われる。
+- id: d_t06_c08_m1
+  source: memory
+  text: We decided that when a source message is deleted, the connector should tombstone the derived
+    memory rather than hard-delete it, keeping a marker that the original content is gone while preserving
+    any edges other memories had formed with it. An edit event instead triggers a re-summarization of
+    the affected memory. This felt safer than silently purging records that other parts of the graph
+    might still reference.
+- id: d_t06_c08_m2
+  source: memory
+  text: A Discord message got deleted after a policy violation, but the memory it produced stayed fully
+    intact and searchable for two days before anyone noticed the mismatch. We traced the bug to a missing
+    delete webhook subscription on that particular channel's connector configuration. After fixing the
+    subscription, deletions now tombstone the memory within minutes, and we added an alert for connectors
+    missing lifecycle webhook coverage.
+- id: d_t06_c08_r1
+  source: resource
+  text: When a connector receives an edit or delete event from its source, the lifecycle handler either
+    re-summarizes the affected memory or marks it as tombstoned rather than purging it outright, so
+    existing graph edges are not silently broken. Tombstoned memories are excluded from normal recall
+    results but remain available for audit until a retention policy purges them. Each connector type
+    must subscribe to its platform's edit and delete webhooks for this to function.
+- id: d_t06_c09_m1
+  source: memory
+  text: 'We assigned trust tiers to ingested content based on its source: internal documentation sits
+    at the top tier, Slack and Obsidian notes from teammates sit in the middle, and anything pulled
+    from a public Discord server lands in the lowest tier by default. Lower-tier memories get a reduced
+    ranking weight during recall so an unverified community comment does not outrank a reviewed internal
+    decision on the same topic.'
+- id: d_t06_c09_m2
+  source: memory
+  text: 公開Discordサーバーから取り込んだ内容を最下位の信頼階層として扱い、共有コンテキストに反映する前に 一度隔離領域に置くようにした。誰かがレビューして問題ないと判断してから正式な記憶へ昇格させる運用に
+    変えたところ、誤情報がそのまま組織の共有知識に混ざる事故が減った。
+- id: d_t06_c09_r1
+  source: resource
+  text: Trust tiers classify ingested content by source reliability and adjust how strongly it influences
+    recall ranking and the Hebbian memory graph's edge strengthening. External or public-source content
+    can additionally be routed into a quarantine state, held out of shared contexts until a reviewer
+    promotes it, while internal sources compile directly. Administrators configure the default tier
+    per connector type and may override it per channel or folder.
+- id: d_t06_c10_m1
+  source: memory
+  text: After a weekend outage left the Slack connector paused for two days, we relied on its cursor-based
+    backfill to catch up automatically once the workspace came back online, rather than manually re-running
+    ingestion. The connector resumed from its last saved cursor and pulled only the missed messages
+    instead of reprocessing the whole channel history. It also skipped a handful of messages our on-call
+    had already pasted in manually, thanks to duplicate detection.
+- id: d_t06_c10_r1
+  source: resource
+  text: Each connector stores a cursor marking the last successfully ingested item, and after any downtime
+    it performs an incremental backfill starting from that cursor instead of a full re-scan of the source.
+    Backfill requests are chunked and rate-limited so a long gap does not overwhelm the source platform's
+    API. This mechanism applies uniformly across Slack, Discord, and vault-based connectors configured
+    for polling rather than webhook delivery.
+- id: d_t06_c10_r2
+  source: resource
+  text: Duplicate detection compares an incoming item's content hash against recently ingested items
+    from the same source before compiling it into a new memory, which prevents backfill re-runs or overlapping
+    polling windows from producing repeated entries. When a duplicate is found, the existing memory's
+    metadata is updated instead of creating a second record. This keeps memory counts accurate even
+    when a connector's cursor is reset manually during troubleshooting.
+- id: d_t07_c01_m1
+  source: memory
+  text: We decided to replace our scattered manual setup with a single docker compose stack covering
+    the API, Postgres, Qdrant, and Redis, so a new operator can get the whole memory backend running
+    with one command. Before this change, every self-hosted deploy took an afternoon of installing dependencies
+    by hand, and small differences between machines caused subtle bugs. Now the compose file is the
+    source of truth for versions and ports, onboarding a new self-hosted install takes under ten minutes,
+    and version-mismatch support requests have mostly disappeared.
+- id: d_t07_c01_m2
+  source: memory
+  text: Bringing the self-hosted stack up for the first time took longer than expected because the API
+    container kept crashing before Postgres had finished initializing. We added depends_on with health-based
+    conditions so the API waits for the database and vector store to report ready instead of just started.
+    Once we fixed the startup order, a clean install consistently reached a working state in under two
+    minutes. We also learned to always pull images before starting so an operator doesn't accidentally
+    run stale versions across services.
+- id: d_t07_c01_r1
+  source: resource
+  text: 'The self-hosted deployment ships as a single compose file defining four services: the API server,
+    a Postgres database, a Qdrant vector store, and a Redis instance used for caching and background
+    job queues. Each service has a named volume for persistent data, an internal network for service-to-service
+    traffic, and a small set of published ports for the API and admin endpoints. Operators start the
+    whole stack with one command and can scale the API service independently of the stateful dependencies.'
+- id: d_t07_c02_m1
+  source: memory
+  text: 自己ホスト環境でPostgresのマイグレーションを初めて実行したとき、既存データを含む テーブルへのカラム追加でロックが長時間続き、APIが応答不能になった。原因は本番相当の データ量でのテストを怠っていたことだった。以降はメンテナンスウィンドウ中にのみ破壊的な
+    変更を適用するルールを決めた。
+- id: d_t07_c02_m2
+  source: memory
+  text: We standardized on a single migration tool for the Postgres schema instead of letting each service
+    apply its own ad hoc SQL scripts on startup. Every schema change now lives as a numbered migration
+    file checked into the repository, and the compose stack runs pending migrations automatically before
+    the API container starts serving traffic. This removed a whole class of drift between self-hosted
+    installs that had been patched inconsistently over time, and rollbacks became a matter of running
+    one previous migration instead of restoring a whole database dump.
+- id: d_t07_c02_r1
+  source: resource
+  text: The Postgres service stores contexts, memories, and edges in a relational schema versioned through
+    numbered migration files. On startup the API container checks the current schema version against
+    the latest migration and applies any pending ones automatically before accepting requests. Operators
+    can also run migrations manually with a single command against a stopped or running database, and
+    a dry-run flag prints the SQL that would execute without applying it, useful before a scheduled
+    maintenance window.
+- id: d_t07_c03_m1
+  source: memory
+  text: Qdrantコレクションを初期化するスクリプトを実行し忘れたまま自己ホスト環境を起動して しまい、検索リクエストが軒並み失敗した。原因を調べると、コレクションが存在しない場合に API側が自動作成せずエラーを返す仕様だった。起動手順書に初期化ステップを明記して
+    再発を防いだ。
+- id: d_t07_c03_m2
+  source: memory
+  text: We chose cosine distance and a fixed embedding dimension when we set up the Qdrant collection
+    for self-hosted deployments, matching whatever embedding model an operator points the stack at.
+    Getting this wrong after data was already indexed meant deleting and rebuilding the entire collection
+    from scratch. We now validate the embedding endpoint's output size against the collection config
+    at startup and refuse to boot if they disagree, rather than silently storing vectors that would
+    never match at search time.
+- id: d_t07_c03_r1
+  source: resource
+  text: The Qdrant service persists vector embeddings in a single collection created by an initialization
+    script the first time the stack starts against an empty volume. The script reads the target embedding
+    dimension and distance metric from the stack's configuration and creates the collection accordingly
+    before the API begins indexing. Re-running the script against an already-initialized volume is a
+    no-op, and operators changing embedding models must drop and recreate the collection rather than
+    reuse the old vectors.
+- id: d_t07_c04_m1
+  source: memory
+  text: Background consolidation jobs started disappearing silently after we ran the self-hosted stack
+    for a few weeks under load, and we eventually traced it to Redis's default eviction policy reclaiming
+    queue keys once memory pressure got high. We switched the Redis service to a policy that never evicts
+    keys with no expiry and instead alerted on memory usage, since a dropped job is far worse for us
+    than Redis running out of headroom. No queued task has silently vanished since we changed the setting.
+- id: d_t07_c04_r1
+  source: resource
+  text: 'The Redis service in the self-hosted stack serves two roles: a short-lived cache for recall
+    results and the backing store for the background job queue that runs consolidation and Sleep passes.
+    Persistence is enabled with append-only file logging so queued jobs survive a container restart,
+    and the eviction policy defaults to rejecting writes rather than silently dropping keys once the
+    configured memory limit is reached, which operators can size according to expected queue depth.'
+- id: d_t07_c04_r2
+  source: resource
+  text: Redisサービスはリコールキャッシュとバックグラウンドジョブキューの両方を担う。 永続化はAOFを有効にしており、コンテナ再起動後もキュー内の未処理ジョブが失われない 設計になっている。メモリ上限に達した場合は新しい書き込みを拒否する設定を既定値と
+    している。
+- id: d_t07_c05_m1
+  source: memory
+  text: Every self-hosted operator used to copy environment variables from an old Slack thread, and
+    half the installs were missing a setting nobody remembered existed. We consolidated every configurable
+    value into one committed .env.example file with a short comment above each line, and the compose
+    stack now refuses to start if a required variable is unset rather than falling back to a silently
+    wrong default. New installs take the same file, fill in secrets, and rename it, cutting configuration
+    questions from new operators almost to zero.
+- id: d_t07_c05_m2
+  source: memory
+  text: 環境変数ファイルを誤ってリポジトリにコミットしてしまい、データベースのパスワードが 一時的に公開された。すぐにパスワードをローテーションし、以降は.envファイルを .gitignoreに追加した上で、シークレットは別の安全な保管場所から注入する運用に
+    変更した。
+- id: d_t07_c05_r1
+  source: resource
+  text: 'Configuration for the self-hosted stack is driven entirely by environment variables read at
+    container startup: database credentials, the API''s listen port, the embedding and reranker endpoint
+    URLs, and feature flags for optional connectors. A committed template file lists every recognized
+    variable with a short description and, where safe, a sensible default; secrets such as passwords
+    and API keys are left blank in the template and must be supplied per deployment rather than checked
+    into version control.'
+- id: d_t07_c06_m1
+  source: memory
+  text: We decided to run a local embedding endpoint inside the self-hosted stack instead of calling
+    an external provider for every recall and remember request, mainly to keep customer data from leaving
+    the deployment's own network. The tradeoff is that operators need a GPU or a reasonably fast CPU
+    to keep latency acceptable, so the compose file now exposes a config flag letting a deployment fall
+    back to a remote embedding provider if local hardware isn't available, without changing any application
+    code.
+- id: d_t07_c06_m2
+  source: memory
+  text: ローカル埋め込みエンドポイントを導入した際、GPUメモリ不足でモデルの読み込みに 失敗する事例が続いた。バッチサイズを小さくし、モデルの精度を下げることでメモリ 使用量を抑え、限られたGPUリソースでも安定して起動できるようになった。
+- id: d_t07_c06_r1
+  source: resource
+  text: The local embedding endpoint runs as its own container exposing a single HTTP route that accepts
+    a batch of text and returns fixed-length vectors. Configuration covers the model checkpoint to load,
+    the maximum batch size per request, and whether inference runs on GPU or CPU. Operators without
+    local hardware can instead point the same configuration at a remote embedding provider's URL, and
+    the rest of the stack is unaffected because it only depends on the endpoint's contract, not its
+    implementation.
+- id: d_t07_c07_m1
+  source: memory
+  text: We added a local reranker service to the self-hosted stack so candidate memories from the first-pass
+    hybrid search get reordered by a cross-encoder before reaching the API's response. Running the reranker
+    in-cluster instead of calling a hosted endpoint cut round-trip latency noticeably, since the candidate
+    list never leaves the deployment's own network. Search quality on ambiguous queries improved enough
+    in our internal testing that we now recommend every self-hosted operator enable the reranker rather
+    than treat it as optional.
+- id: d_t07_c07_m2
+  source: memory
+  text: The reranker container started getting killed under sustained load during a load test, and logs
+    showed it running out of memory whenever too many concurrent rerank requests queued up with large
+    candidate batches. We added a request queue in front of the reranker with a hard concurrency limit
+    so it processes one batch at a time per worker instead of accepting unlimited parallel calls, and
+    memory usage stayed flat afterward even at three times our expected production traffic.
+- id: d_t07_c07_r1
+  source: resource
+  text: The reranker service exposes a single endpoint that accepts a query alongside a list of candidate
+    passages and returns the same candidates reordered with a relevance score attached to each one.
+    It runs as a separate container from the embedding endpoint since the two models have different
+    memory footprints and are frequently upgraded on independent schedules. A concurrency limit and
+    a maximum candidate list length are both configurable to keep memory usage bounded under heavy self-hosted
+    traffic.
+- id: d_t07_c08_m1
+  source: memory
+  text: We added a healthcheck endpoint to every service in the self-hosted compose stack, not just
+    the API, after realizing the orchestrator had no way to tell a genuinely broken Postgres container
+    from one still finishing startup. Each service now exposes a lightweight status route the compose
+    file polls before marking a dependency ready, and containers that fail their check repeatedly get
+    restarted automatically instead of sitting silently unresponsive. Operators can also hit these same
+    routes from outside for their own monitoring.
+- id: d_t07_c08_m2
+  source: memory
+  text: ヘルスチェックを全サービスに導入した後、Qdrantの起動が遅い環境ではAPIコンテナが 何度も再起動を繰り返す問題が見つかった。ヘルスチェックの猶予期間を延ばし、起動直後の 再試行間隔を広げることで、遅い環境でも安定して起動できるようになった。
+- id: d_t07_c08_r1
+  source: resource
+  text: Every service in the self-hosted compose stack defines a healthcheck with a command, an interval,
+    a timeout, and a retry count, plus a start period during which failures are not counted against
+    the retry limit. The API's healthcheck queries its own readiness route, which in turn confirms connectivity
+    to Postgres, Qdrant, and Redis before reporting healthy. Operators can adjust the start period upward
+    for slower disks or constrained hardware where a dependency legitimately takes longer to become
+    ready.
+- id: d_t07_c09_m1
+  source: memory
+  text: 'Our last self-hosted stack upgrade went smoothly because we finally followed our own documented
+    order: pull the new images first, run any pending migrations against Postgres while the old API
+    containers are still serving traffic, then restart the API service last so it comes up already pointed
+    at the migrated schema. Skipping the migration-first step during an earlier upgrade had left us
+    with a brief window where new API code queried a schema it didn''t expect, which we don''t want
+    to repeat.'
+- id: d_t07_c09_r1
+  source: resource
+  text: 'Upgrading a self-hosted deployment follows a fixed order: pull the new image tags for every
+    service, apply any pending Postgres migrations while the previous version continues serving requests,
+    then restart services one at a time starting with stateful dependencies and finishing with the API.
+    Each step is idempotent, so a failed upgrade can be retried from wherever it stopped rather than
+    requiring a full rollback, and the previous image tags remain available locally in case a downgrade
+    is needed.'
+- id: d_t07_c09_r2
+  source: resource
+  text: 自己ホスト環境のアップグレードでは、新しいイメージを取得し、Postgresの マイグレーションを適用した後にAPIサービスを再起動する順序を守る。各手順は冪等な ため失敗しても途中から再実行でき、ロールバックが必要な場合は古いイメージタグを
+    使って以前の状態に戻せる。
+- id: d_t07_c10_m1
+  source: memory
+  text: We settled on a nightly backup job for the self-hosted stack that dumps Postgres with pg_dump,
+    snapshots the Qdrant collection, and saves the Redis RDB file, all three landing in the same timestamped
+    directory so a restore always uses a consistent set. Backing up Postgres alone used to leave us
+    with a database that referenced vectors no longer in Qdrant after a restore, since the two stores
+    had drifted apart in time. Bundling all three per run fixed that mismatch entirely.
+- id: d_t07_c10_m2
+  source: memory
+  text: 先月、バックアップからの復元を実際にテストした。Postgresのダンプ、Qdrantの スナップショット、Redisのバックアップファイルをまとめて復元したところ、想定より 時間がかかったが、データの整合性は保たれていた。復元手順書に所要時間の目安を
+    追記した。
+- id: d_t07_c10_r1
+  source: resource
+  text: 'The backup procedure for a self-hosted deployment captures three artifacts on a single schedule:
+    a pg_dump of the Postgres database, a snapshot request against the Qdrant collection, and a copy
+    of the Redis persistence file, written together into one timestamped directory. Restoring requires
+    stopping the stack, replacing each service''s volume contents with the matching artifact from the
+    same backup run, and starting the stack again; mixing artifacts from different backup runs risks
+    inconsistency between the relational and vector stores.'
+- id: d_t08_c01_m1
+  source: memory
+  text: 'We decided to move our internal coding agent off raw HTTP calls onto the packaged Python SDK
+    for Kagura Memory Cloud. The client gives us typed request and response models, connection pooling
+    across repeated remember and recall calls, and built-in retry logic so engineers stop hand-rolling
+    backoff. Rollout took one sprint: swap the wrapper module, keep the same environment variable for
+    the API key, and run the existing test suite unchanged. Everyone now imports kagura_memory.Client
+    instead of building requests by hand.'
+- id: d_t08_c01_m2
+  source: memory
+  text: 新しいコーディングエージェント向けにKaguraメモリのPython SDKを導入した。 pipでインストールし、APIキーを環境変数に設定してクライアントを初期化するだけで、 最初のrememberとrecallの呼び出しがすぐに動いた。手作業のHTTP実装より導入が簡単だった。
+- id: d_t08_c01_r1
+  source: resource
+  text: The Python SDK provides a quickstart for integrating Kagura Memory Cloud into any agent. Install
+    the package with pip, then construct a client with your API key, either passed directly or read
+    from an environment variable. The first call is typically a recall to check for existing context,
+    followed by a remember to persist new findings. The SDK ships typed dataclasses for every response
+    so editors can autocomplete fields, and connection pooling is enabled by default for repeated calls.
+- id: d_t08_c02_m1
+  source: memory
+  text: We added a session-start hook so the coding agent recalls recent decisions the moment a new
+    session begins, instead of starting cold. The hook fires before the first user turn, queries the
+    workspace for the last few days of notes, and injects a short summary into the system prompt. This
+    cut the number of times engineers had to re-explain earlier choices during a multi-day feature branch,
+    and it made the agent's first response noticeably more relevant to the task at hand.
+- id: d_t08_c02_m2
+  source: memory
+  text: 'After the session-start hook started pulling in too much history, we tightened its scope: cap
+    the recall to the last five memories, filter by the current repo''s tag, and skip anything older
+    than two weeks unless pinned. Without limits the injected summary pushed useful room out of the
+    context window and slowed the agent''s very first reply. The narrower hook now adds well under two
+    hundred tokens before the user even asks anything.'
+- id: d_t08_c02_r1
+  source: resource
+  text: The session-start hook runs automatically when a coding agent begins a new interactive or headless
+    session. It calls the recall API against the active workspace, ranks results by recency and relevance,
+    and prepends a condensed digest to the system prompt before the first turn. Configuration options
+    include a maximum memory count, an age cutoff, and an optional tag filter so teams can scope the
+    hook to a single project rather than the whole workspace.
+- id: d_t08_c03_m1
+  source: memory
+  text: We wired a session-summary hook that fires when the coding agent's task finishes, writing a
+    short remember call describing what changed and why. Before this, wrap-up notes only existed if
+    an engineer manually typed them, and most sessions ended with nothing saved. Now every completed
+    session leaves a one-paragraph trace, and the next agent picking up the branch starts with a record
+    of what was already tried instead of guessing from the diff alone.
+- id: d_t08_c03_m2
+  source: memory
+  text: セッション終了フックが原因で、エージェントが途中でクラッシュすると同じ要約が 二重に保存される不具合を見つけた。セッションIDで重複を判定するよう修正し、 再実行時に前回の未完了要約を上書きする仕組みを追加した。
+- id: d_t08_c03_r1
+  source: resource
+  text: The session-summary hook triggers when a coding agent session ends normally, on explicit close,
+    or on timeout. It gathers the turns since the last summary, condenses them into a short remember
+    entry tagged with the session id, and stores it before the process exits. Trigger conditions and
+    a debounce window are configurable so that rapid session restarts do not produce duplicate summaries
+    for the same underlying task.
+- id: d_t08_c04_m1
+  source: memory
+  text: 'We settled on a rule for our support agent: always call recall before drafting a reply, never
+    answer from the model''s own assumption first. Grounding every response in stored facts cut confidently
+    wrong answers about account history almost to zero in our internal testing. The tradeoff is one
+    extra round trip per turn, but the latency cost was small next to the drop in corrections our reviewers
+    had to make afterward.'
+- id: d_t08_c04_m2
+  source: memory
+  text: 根拠なしで応答する従来のエージェントと、応答前に必ずrecallを呼ぶ新しいエージェントを 比較するテストを行った。根拠ありのエージェントは事実誤りが大幅に減り、 レビュー担当者の修正作業も減った。追加のレイテンシは許容範囲内だった。
+- id: d_t08_c04_r1
+  source: resource
+  text: A memory-grounded agent pattern calls the recall endpoint before composing any answer that references
+    prior facts, then cites the returned memories in its reasoning instead of relying on the base model's
+    guess. Implementations typically insert the recall step as middleware around the model call so every
+    code path is covered, and log which memories were retrieved for later audit of why the agent answered
+    the way it did.
+- id: d_t08_c05_m1
+  source: memory
+  text: We now run the coding agent through headless automation inside our CI pipeline to auto-triage
+    failing builds. The pipeline invokes the CLI non-interactively, passing a prompt and reading structured
+    output, since interactive prompts have no use in a scripted job. It parses the suggested fix into
+    a comment on the pull request. No terminal, no human in the loop, and the whole triage step finishes
+    in under a minute per job.
+- id: d_t08_c05_m2
+  source: memory
+  text: CI上でヘッドレスモードのエージェントが応答せず固まる不具合を調査した。 原因は対話的な確認プロンプトが標準入力を待っていたことで、非対話フラグを 明示的に渡していなかったためだった。フラグを追加してからは固まらなくなった。
+- id: d_t08_c05_r1
+  source: resource
+  text: 'Headless automation runs the agent non-interactively for use in scripts and CI pipelines: pass
+    a prompt on the command line or via stdin, add the non-interactive flag, and read structured output
+    from stdout as JSON. Because no terminal is attached, any step that would normally prompt for confirmation
+    is either auto-approved by a permission profile or the call fails fast with a clear exit code instead
+    of hanging.'
+- id: d_t08_c06_m1
+  source: memory
+  text: 社内エージェントからのremember呼び出しがネットワーク遅延で頻繁にタイムアウトしていたため、 リトライ回数とタイムアウト秒数を見直した。デフォルトの設定では短すぎたので、 タイムアウトを伸ばし指数バックオフのリトライを有効にしたところ失敗がほぼなくなった。
+- id: d_t08_c06_r1
+  source: resource
+  text: 'The SDK retries transient failures automatically using exponential backoff: a failed call is
+    retried up to a configurable maximum, with the wait between attempts doubling each time and a small
+    random jitter added to avoid synchronized retries across many clients. Only errors classified as
+    retryable, such as connection resets and server-side timeouts, trigger a retry; validation errors
+    fail immediately without consuming a retry attempt.'
+- id: d_t08_c06_r2
+  source: resource
+  text: 'Timeout configuration in the SDK has two independent knobs: a connect timeout bounding how
+    long the client waits to establish a socket, and a read timeout bounding how long it waits for a
+    response body once the request is sent. Both default to a few seconds but can be overridden per
+    client or per call, which matters for slow operations like large batch remember requests that legitimately
+    take longer than a quick recall.'
+- id: d_t08_c07_m1
+  source: memory
+  text: 漏えいの疑いがあったため、SDK用の認証トークンをすべてローテーションした。 古いトークンを失効させ、新しいトークンを環境変数経由でデプロイし直す作業を行い、 影響範囲を確認するために監査ログも合わせて確認した。
+- id: d_t08_c07_r1
+  source: resource
+  text: 'The SDK accepts two kinds of auth tokens: a long-lived personal API key suited to server-side
+    scripts and CI, and a short-lived token issued through the OAuth device-flow login used by interactive
+    tools. Both are passed the same way to the client constructor, but the device-flow token expires
+    and must be refreshed, while the personal key remains valid until explicitly revoked from the account
+    settings.'
+- id: d_t08_c07_r2
+  source: resource
+  text: 認証トークンにはスコープと権限レベルが設定できる。読み取り専用トークンはrecallのみ許可し、 書き込み権限を持つトークンだけがrememberやforgetを実行できる。ワークスペース単位で
+    トークンを発行することで、他プロジェクトへの誤った書き込みを防げる。
+- id: d_t08_c08_m1
+  source: memory
+  text: We wired the kagura-memory MCP server into our coding agent's tool loop so remember, recall,
+    and explore show up as callable tools alongside the usual file and shell tools. The agent now decides
+    on its own when to check memory instead of us hardcoding a recall step, which handled cases we hadn't
+    anticipated, like recalling a naming convention halfway through writing a new module.
+- id: d_t08_c08_m2
+  source: memory
+  text: We trimmed the number of MCP tools exposed to the agent from the full kagura-memory set down
+    to five core ones, because a long tool list was pushing the agent to pick the wrong tool more often.
+    Recall, remember, explore, list_contexts, and feedback cover almost every real request; the rarer
+    admin-style tools are only loaded on demand for specific workflows.
+- id: d_t08_c08_r1
+  source: resource
+  text: Wiring a memory server into an agent's tool loop through MCP exposes each memory operation as
+    a discrete callable tool with a typed schema, letting the model choose when to recall or remember
+    rather than following a fixed script. Because tool count affects selection accuracy, integrators
+    are advised to expose a small, well-named core set and load specialized tools only for workflows
+    that need them.
+- id: d_t08_c09_m1
+  source: memory
+  text: We built a handoff pattern where one agent's remember calls become visible to a second agent
+    working the same shared context, so a research agent can hand a task to an implementation agent
+    without a manual summary step. The second agent just recalls the workspace and picks up exactly
+    where the first one left off, including any dead ends it already ruled out.
+- id: d_t08_c09_m2
+  source: memory
+  text: バグ潰しの日に、リサーチ担当エージェントと実装担当エージェントの間で共有コンテキスト経由の 引き継ぎをテストした。実装エージェントはrecallするだけで前段の調査結果を把握でき、 手動での要約作業なしにそのまま作業を始められた。
+- id: d_t08_c09_r1
+  source: resource
+  text: 'Multi-agent handoff through shared context lets one agent''s stored memories become visible
+    to a downstream agent as the interface between them: an upstream agent writes findings with remember,
+    and the downstream agent calls recall against the same context to resume the task. This avoids a
+    manual summary step between agents and keeps a full audit trail of what each participant learned
+    and decided along the way.'
+- id: d_t08_c10_m1
+  source: memory
+  text: A bulk migration script hammered remember with thousands of calls in a tight loop and started
+    getting 429 rate-limit responses back from the API. We added a queue that batches calls and backs
+    off when it sees a 429, which brought the whole migration to completion without dropping any records.
+    The fix was in the caller, not the SDK, since the SDK surfaces the rate limit as a normal exception
+    rather than silently swallowing it.
+- id: d_t08_c10_m2
+  source: memory
+  text: 'We mapped out the SDK''s exception hierarchy so our error handler stops treating every failure
+    the same way: a base error class splits into a retryable branch, covering timeouts and rate limits,
+    and a fatal branch, covering auth failures and validation errors. The agent''s wrapper now only
+    retries the first branch and surfaces the second branch straight to the user with the original message
+    intact.'
+- id: d_t08_c10_r1
+  source: resource
+  text: 'The SDK raises a distinct exception type for each failure category: connection and timeout
+    errors, rate-limit responses carrying a retry-after hint, authentication failures, and validation
+    errors for malformed requests. All of these inherit from a common base exception so callers can
+    catch broadly, but the specific subclasses let an integrator decide per category whether to retry,
+    back off, or surface the error to the end user immediately.'
+- id: d_t09_c01_m1
+  source: memory
+  text: We settled on a four-tier subscription ladder for Kagura Memory Cloud after beta feedback showed
+    customers found feature-toggle upsells confusing. Instead each tier now differs mainly by memory
+    capacity, seat count, and connector access, with advanced retrieval bundled into the higher levels.
+    Support response time and Sleep consolidation frequency also scale with the level a workspace is
+    on. We agreed to revisit these boundaries every two quarters based on churn and expansion data rather
+    than locking them permanently at launch.
+- id: d_t09_c01_m2
+  source: memory
+  text: During tier planning we debated whether to fold connector access into the lower paid level or
+    keep it exclusive to Team and above. We chose to keep Slack and CI connectors gated to Team because
+    early adopters running connectors were almost always multi-seat organizations. We also decided Enterprise
+    would be the only level offering self-hosting and custom retention policies, since those requests
+    came almost exclusively from regulated customers who also needed dedicated support contacts and
+    audit logging.
+- id: d_t09_c01_r1
+  source: resource
+  text: Kagura Memory Cloud offers four subscription tiers. Free includes a single workspace, limited
+    memory capacity, and no external connectors. Pro adds larger memory capacity, priority retrieval,
+    and email support. Team adds multi-seat workspaces, Slack and CI connector access, and shared context
+    permissions. Enterprise adds self-hosting options, custom data retention, dedicated support, and
+    audit logging. Each tier also sets a distinct daily API request allowance, described separately
+    in the usage limits reference. Tier changes take effect at the start of the next billing cycle unless
+    an immediate upgrade is requested.
+- id: d_t09_c02_m1
+  source: memory
+  text: We decided to enforce a daily API request cap per tier rather than a single account-wide ceiling,
+    so a burst on one integration would not starve other integrations from the same workspace. Free
+    accounts get a modest daily cap, Pro doubles it, and Team pools the cap across all seats. We chose
+    midnight UTC as the reset boundary for predictability, even though several customers operate in
+    other time zones and asked us to reconsider that choice.
+- id: d_t09_c02_m2
+  source: memory
+  text: 深夜0時にリセットされる仕組みだったが、日本のユーザーから体感時刻とずれて上限に達したという問い合わせが相次いだ。サポートチームで 調査した結果、表示上のタイムゾーンが原因と判明し、ダッシュボードにリセット時刻を明記する対応を行った。今後は利用者の設定に合わせた
+    表示も検討している。
+- id: d_t09_c02_r1
+  source: resource
+  text: The API enforces a daily request limit tied to the caller's subscription tier. Every response
+    includes rate-limit headers reporting the remaining request count and the timestamp when the daily
+    counter resets. When the daily cap is reached, subsequent calls return a 429 status until the reset
+    boundary passes. Team and Enterprise workspaces share one pooled counter across all seats rather
+    than per-user counters. Clients should back off using the reset header rather than polling repeatedly
+    after receiving a 429.
+- id: d_t09_c03_m1
+  source: memory
+  text: We chose a rolling seven-day window for the weekly usage quota instead of a fixed calendar week,
+    because a Monday reset was causing sudden capacity drops right before customers' own Monday planning
+    meetings. The rolling window smooths perceived limits and matches how customers described their
+    own usage patterns during interviews. Metering now recomputes the rolling total hourly rather than
+    once per day, which cost more compute but removed the confusing cliff at week boundaries.
+- id: d_t09_c03_m2
+  source: memory
+  text: A support ticket revealed customers assumed unused weekly quota would roll over into the next
+    week, similar to mobile data plans they were used to. We clarified in onboarding emails that Kagura's
+    weekly quota does not carry over and resets fully each cycle. We also learned that surfacing the
+    remaining quota in the dashboard, updated live, reduced these tickets significantly compared to
+    only showing it after a limit was hit.
+- id: d_t09_c03_r1
+  source: resource
+  text: Usage metering aggregates request counts per workspace using a rolling seven-day window rather
+    than a fixed calendar boundary, recalculated hourly by the metering pipeline. Each request increments
+    a counter tagged with workspace id, tier, and endpoint category. The pipeline flushes aggregated
+    counts to the billing database and to the dashboard cache so customers see near-real-time remaining
+    quota. Weekly quota values do not carry over between cycles; any unused allowance is discarded when
+    the rolling window advances.
+- id: d_t09_c04_m1
+  source: memory
+  text: We centralized entitlement checks into a single service that every API gateway route calls before
+    executing a request, rather than scattering tier checks across individual handlers. This let us
+    change what a tier includes without redeploying every service. The entitlement service caches each
+    workspace's plan and feature flags for a short interval to avoid hammering the billing database,
+    and it fails closed, denying access, if the cache and billing service are both unreachable. We also
+    agreed engineers should not treat missing plan data as a reason to grant default access.
+- id: d_t09_c04_m2
+  source: memory
+  text: アップグレード直後にも関わらず新機能が使えないという問い合わせが発生した。原因はエンタイトルメントキャッシュの無効化が反映される まで数分かかる仕様によるもので、支払い完了画面にキャッシュ反映まで待つ旨の案内を追加して対応した。同様の問い合わせは対応後に大きく
+    減少した。
+- id: d_t09_c04_r1
+  source: resource
+  text: The entitlement service exposes a lookup endpoint that returns the active plan, seat count,
+    and enabled feature flags for a given workspace. Feature flags map directly to tier boundaries described
+    on the pricing page, such as connector access or self-hosting eligibility. Results are cached for
+    a few minutes to reduce load, so plan changes may take a short time to propagate to every route.
+    Downstream services should treat a missing entitlement response as no access rather than assuming
+    default permissions.
+- id: d_t09_c05_m1
+  source: memory
+  text: We designed the upgrade flow to trigger an in-app prompt the moment a workspace approaches its
+    plan limit, rather than waiting for a hard block, so users could upgrade proactively without losing
+    momentum. The prompt links directly to a checkout session pre-filled with the recommended next tier
+    and its price. We deliberately avoided forcing a page reload after upgrade, instead polling entitlement
+    status so the new limits appear within seconds of payment confirmation.
+- id: d_t09_c05_m2
+  source: memory
+  text: We learned that customers upgrading mid-cycle expected the price difference to be prorated for
+    the remaining days, not charged as a fresh full month on top of what they already paid. After a
+    few confused billing questions we changed the checkout summary to show the prorated credit explicitly
+    before confirming the upgrade, which noticeably reduced refund requests tied to plan changes.
+- id: d_t09_c05_r1
+  source: resource
+  text: プラン画面から上位プランを選択すると決済画面に遷移し、現行プランの残り日数分の差額が自動的に日割り計算されます。決済完了後、 数秒以内に新しい利用上限が反映され、即座に追加のコネクタ機能などが利用可能になります。反映が遅れる場合は画面を更新してください。
+- id: d_t09_c06_m1
+  source: memory
+  text: We set a fourteen-day grace period after a downgrade request, before the workspace finishes
+    downgrading and the lower tier's limits take effect, so customers can export data or trim seats
+    exceeding the new plan. During the grace period the workspace keeps full access, but the dashboard
+    warns which over-limit seats or connectors will become read-only or removed once the period ends.
+    Seats that lose write access can regain it by trimming usage back under the limit. We never auto-delete
+    anything after the grace period, to avoid irreversible surprises.
+- id: d_t09_c06_m2
+  source: memory
+  text: チーム利用中のワークスペースがフリープランへダウングレードを申請した際、既存のシート数が新プランの上限を超えていたため、猶予期間 終了後は超過分のシートを凍結する仕様であることが判明した。事前に警告バナーで超過シート数を明示する改善を行った。
+- id: d_t09_c06_r1
+  source: resource
+  text: 'Downgrading a workspace schedules the new tier limits to take effect after a fourteen-day grace
+    period. If seat count, storage, or connector usage exceeds the target tier''s limits when the grace
+    period ends, the excess is frozen rather than deleted: over-limit seats lose write access and extra
+    connectors are disabled until usage falls back within bounds or the workspace upgrades again. Historical
+    memories and documents remain fully readable throughout this process.'
+- id: d_t09_c07_m1
+  source: memory
+  text: We decided Stripe owns all card storage, invoicing, and tax calculation, while our billing service
+    only stores the subscription id, tier, and current period dates returned by Stripe webhooks. This
+    boundary means we never touch raw card data and can rely on Stripe's compliance coverage. Our billing
+    service treats Stripe as the source of truth for subscription status and only updates entitlements
+    after a verified webhook event, never from client-side confirmation alone.
+- id: d_t09_c07_m2
+  source: memory
+  text: 決済完了直後にStripeからのWebhookが一時的に遅延し、ユーザーには請求が完了しているのにプラン変更が反映されない状態が数分 続いた。Webhookの再送を待つ間はダッシュボードに処理中である旨を表示するよう修正し、問い合わせ件数を減らした。
+- id: d_t09_c07_r1
+  source: resource
+  text: 'Payment processing is delegated entirely to Stripe: card details, invoices, and tax calculation
+    never pass through Kagura''s own infrastructure. The billing service subscribes to Stripe webhook
+    events for subscription creation, renewal, and cancellation, and updates the workspace''s tier only
+    after verifying the webhook signature. If a webhook is delayed, the dashboard shows a pending state
+    rather than assuming failure, and the entitlement update is retried automatically once the event
+    arrives.'
+- id: d_t09_c08_m1
+  source: memory
+  text: We chose to soft-throttle requests once a workspace exceeds its plan's daily allowance rather
+    than hard-blocking immediately, adding response latency and returning a warning header before eventually
+    returning 429s if usage stays far over the limit for multiple days. This gave customers a buffer
+    to notice and upgrade instead of an abrupt outage during a legitimate traffic spike. Enterprise
+    contracts can opt into a hard cap instead if predictable cost matters more to them than availability.
+- id: d_t09_c08_m2
+  source: memory
+  text: Several customer teams told us they preferred being billed a small overage fee instead of a
+    slowdown, especially during a product launch when request volume spikes unpredictably. Based on
+    that feedback we added an optional pay-as-you-go overage mode for the mid and upper tiers, billed
+    per extra thousand requests, while keeping the softer default behavior for customers who prefer
+    a predictable flat monthly cost.
+- id: d_t09_c08_r1
+  source: resource
+  text: 'When a workspace exceeds its included request allowance, the default behavior is graduated
+    throttling: added latency first, then rate limiting designed to return 429 responses if the overage
+    persists across multiple days. Workspaces with pay-as-you-go overage enabled are billed instead
+    for each additional block of requests beyond the plan limit, itemized on the next invoice. Teams
+    that prefer predictable costs can request a hard cap instead. Email and in-app notifications are
+    sent at fifty, eighty, and one hundred percent of the included allowance so teams can react before
+    charges accrue.'
+- id: d_t09_c09_m1
+  source: memory
+  text: フリープランの制約について議論し、ワークスペースは1シート、保存できるメモリ件数にも上限を設けることで合意した。無料利用者の 多くが個人開発者であるため、外部連携や長期保持機能を有料プラン限定にすることでアップグレード動機を作る狙いがある。
+- id: d_t09_c09_r1
+  source: resource
+  text: The Free plan includes one seat, one workspace, and a capped number of stored memories with
+    no connector access. Sleep consolidation runs on a reduced weekly schedule instead of nightly, and
+    retention for older raw events is shorter than paid tiers. Support is community-forum only, with
+    no guaranteed response time. These constraints are intended to let individuals evaluate core recall
+    and retrieval features before committing to a paid tier.
+- id: d_t09_c09_r2
+  source: resource
+  text: フリープランでは外部コネクタとの連携ができず、保存できるメモリ件数にも上限があります。スリープ整理処理は毎晩ではなく週次で 実行され、古いイベントデータの保持期間も有料プランより短く設定されています。組織全体での共有ワークスペースを利用するには
+    有料プランへのアップグレードが必要です。
+- id: d_t09_c10_m1
+  source: memory
+  text: We standardized on a monthly billing cycle anchored to the day a customer first subscribed,
+    rather than aligning everyone to the first of the calendar month, since anchor-date billing turned
+    out to simplify prorated charges for upgrades and downgrades mid-cycle. Invoices generate automatically
+    at the start of each new cycle and include both the flat tier fee and any metered overage charges
+    from the prior cycle, combined into a single line-itemized statement.
+- id: d_t09_c10_r1
+  source: resource
+  text: 請求サイクルは契約開始日を起点とした月次で運用されており、暦月の1日には統一されません。各サイクル開始時に自動生成される 請求書には、基本料金と前サイクル分の従量課金が明細として分けて記載されます。請求書はダッシュボードからいつでもPDF形式で
+    ダウンロード可能です。
+- id: d_t09_c10_r2
+  source: resource
+  text: Each invoice itemizes the flat subscription fee separately from any metered charges, such as
+    pay-as-you-go request overage or additional connector add-ons purchased during the prior cycle,
+    producing a line-itemized statement that has combined every charge for the billing period. Metered
+    line items reference the exact date range and quantity used, sourced from the same usage metering
+    pipeline that powers the dashboard's live quota display. Customers can download invoices as PDF
+    at any time from the billing settings page, and historical invoices remain available for at least
+    three years.
+- id: d_t10_c01_m1
+  source: memory
+  text: We discovered corrupted shards in the hybrid BM25 and vector index after nightly checksum verification
+    failed on three partitions. We decided to trigger a full reindex from the canonical document store
+    rather than attempt a partial patch, since the corruption pattern looked systemic and incremental
+    repair felt too risky to trust. The team scheduled the rebuild for the low-traffic window and paused
+    new writes to the affected workspace during the operation to avoid inconsistent reads.
+- id: d_t10_c01_m2
+  source: memory
+  text: After finishing the emergency reindex last week the team wrote down what we would do differently.
+    Running the full rebuild single-threaded took almost six hours and blocked search for that workspace
+    the whole time, so next time we want a rolling rebuild that keeps one shard serving stale results
+    while its replacement is built. We also learned the checksum job should run hourly instead of nightly
+    so corruption is caught before it spreads across partitions.
+- id: d_t10_c01_r1
+  source: resource
+  text: To rebuild the hybrid search index after detected corruption, take the affected workspace offline
+    for writes, export the canonical documents, and recreate both the BM25 inverted index and vector
+    embeddings from that export rather than patching individual shards. A rolling rebuild keeps at least
+    one healthy replica serving queries while the corrupted shard is regenerated, avoiding a full outage.
+    Checksum verification should run against every partition on a fixed schedule so corruption is caught
+    early, before it spreads across the index.
+- id: d_t10_c02_m1
+  source: memory
+  text: Ingestion for one customer workspace stalled for two hours yesterday and nobody noticed until
+    the backlog alert fired. We traced it to a worker that had wedged on a malformed event and stopped
+    pulling new items off the queue without crashing or logging an error. Restarting that worker process
+    cleared the backlog within minutes. We agreed to add a heartbeat check so a wedged worker gets killed
+    automatically instead of silently sitting idle.
+- id: d_t10_c02_m2
+  source: memory
+  text: 取り込みキューが詰まっていた件、原因は不正なイベントでワーカーが応答しなくなっていたことだった。ハートビートが無いとワーカーの停止に気づけないため、監視項目に生存確認を追加することをチームで決めた。バックログ通知が来る前に検知できるようにしたい。
+- id: d_t10_c02_r1
+  source: resource
+  text: The ingestion pipeline pulls events from a durable queue and distributes them to worker processes
+    for parsing and chunking before they reach the memory graph. When a worker hangs on a malformed
+    or oversized event without raising an exception, it stops consuming further items and the queue
+    depth grows, eventually tripping the backlog alert threshold. Operators should configure a heartbeat
+    timeout per worker so a stalled process is automatically restarted, which typically has the backlog
+    cleared again within minutes rather than left consuming nothing indefinitely.
+- id: d_t10_c03_m1
+  source: memory
+  text: Recall latency at the ninety-ninth percentile jumped from around two hundred milliseconds to
+    nearly four seconds during Tuesday's traffic spike. We spent most of the afternoon tracing spans
+    before finding the embedding service was queuing requests behind a connection pool that was far
+    too small for the concurrent load. Once we identified that bottleneck the fix was obvious, but the
+    tracing setup made it slower to find than it should have been.
+- id: d_t10_c03_m2
+  source: memory
+  text: Following up on the recall latency incident, we bumped the embedding service connection pool
+    size and added a dedicated timeout so slow calls fail fast instead of queuing behind healthy requests.
+    We also added a dashboard panel breaking down the recall pipeline by stage so the next time the
+    ninety-ninth percentile spikes we can see immediately whether the bottleneck is embedding, ranking,
+    or the database rather than guessing from traces alone.
+- id: d_t10_c03_r1
+  source: resource
+  text: The recall pipeline latency budget allocates roughly forty percent to the embedding service
+    call, thirty percent to hybrid ranking, and the remainder to fetching document bodies from storage.
+    Under normal load the ninety-ninth percentile should stay under three hundred milliseconds; sustained
+    spikes usually indicate the embedding service connection pool is undersized for concurrent traffic,
+    causing requests to queue rather than execute in parallel. A per-call timeout is recommended so
+    one slow embedding request cannot stall the whole pipeline.
+- id: d_t10_c04_m1
+  source: memory
+  text: 'Postmortem summary for last night''s incident: the Sleep consolidation run crashed halfway
+    through pruning weak associations in one workspace''s memory graph, leaving some edges partially
+    rewritten. We had no checkpoint to resume from, so the safest recovery path was rolling back the
+    entire run and restoring the graph from the pre-run snapshot rather than trying to reconcile the
+    half-applied changes by hand. We are treating checkpointing as the top follow-up action from this
+    incident.'
+- id: d_t10_c04_m2
+  source: memory
+  text: 夜間のSleep統合処理が途中でクラッシュし、記憶グラフの一部の関連が中途半端に書き換えられてしまった。チェックポイントが無かったため、実行前のスナップショットまで丸ごとロールバックする対応を取った。次回までにチェックポイント保存の仕組みを追加すると決めた。
+- id: d_t10_c04_r1
+  source: resource
+  text: If the Sleep consolidation process terminates unexpectedly before completing a pruning pass
+    over the memory graph, associations may be left in a partially rewritten state. Because consolidation
+    does not currently checkpoint progress mid-run, the recommended recovery procedure is a full rollback
+    to the snapshot captured immediately before the run started, rather than attempting to reconcile
+    individual edges. Operators should confirm the pre-run snapshot exists and is intact before starting
+    any consolidation job on a production workspace.
+- id: d_t10_c05_m1
+  source: memory
+  text: 障害対応のたびにログの形式がバラバラで原因特定に時間がかかっていたため、全サービスでJSON構造化ログに統一し、リクエストごとの相関IDを必ず付与することを決めた。これでインシデント調査の際にサービスをまたいで同じ相関IDでログを追跡できるようになる。
+- id: d_t10_c05_m2
+  source: memory
+  text: Since standardizing on structured JSON logging we noticed incident triage got noticeably faster,
+    mainly because every log line now carries a correlation id we can grep across every service involved
+    in a request. Before this change, tracing a single failed recall request through the ingestion,
+    ranking, and storage layers meant reading three different log formats and guessing at timestamps
+    to line events up, which routinely added twenty minutes to an already stressful incident. Now we
+    just filter the centralized log store by that one id instead.
+- id: d_t10_c05_r1
+  source: resource
+  text: Every log line emitted by the platform should be structured JSON containing at minimum a timestamp,
+    service name, severity, and correlation id that is propagated unchanged across every service a single
+    request touches. During incident triage, operators can filter the centralized log store by correlation
+    id to reconstruct the full path of a request through ingestion, ranking, and storage without cross-referencing
+    separate log formats. Severity levels follow standard conventions from debug through critical.
+- id: d_t10_c06_m1
+  source: memory
+  text: アラートの閾値が厳しすぎて夜間に誤報が頻発し、担当者が疲弊していたため、取り込み遅延アラートの閾値を緩め、五分継続した場合のみ通知する条件に変更した。これにより誤報が大幅に減り、本当に対応が必要な事象だけが通知されるようになった。
+- id: d_t10_c06_m2
+  source: memory
+  text: We added a new alert for ingestion lag after last month's backlog incident went unnoticed for
+    two hours because nothing was watching queue depth directly. The new rule does require a sustained
+    breach of five minutes before it fires, matching the threshold change we made to the existing noisy
+    alert so the two rules do not conflict. So far it has caught one real backlog before customers noticed,
+    which we count as a win for the added monitoring effort.
+- id: d_t10_c06_r1
+  source: resource
+  text: Core platform metrics monitored in production include ingestion queue depth, recall latency
+    percentiles, embedding service error rate, and Sleep consolidation run duration. Alert thresholds
+    should require a sustained breach, typically five minutes, before paging on-call, since brief spikes
+    are common and page-happy thresholds cause alert fatigue that leads operators to ignore real incidents.
+    Ingestion lag and recall latency are the two metrics most correlated with customer-visible incidents
+    and should page immediately once sustained.
+- id: d_t10_c07_m1
+  source: memory
+  text: A teammate accidentally ran a forget command against the wrong workspace and deleted roughly
+    two weeks of memories before anyone caught it. We restored the workspace from the previous night's
+    snapshot using the point-in-time restore procedure, which brought back everything except the few
+    hours of activity between the snapshot and the deletion. We agreed that destructive commands against
+    production workspaces need a confirmation step naming the workspace explicitly before they execute.
+- id: d_t10_c07_m2
+  source: memory
+  text: After restoring the workspace from snapshot we spent an hour verifying integrity before telling
+    the customer it was safe, checking that document counts matched the pre-incident total and spot
+    checking a sample of recent memories for correct content and timestamps. We found one edge case
+    where a memory created minutes before the deletion had been restored but its neural graph edges
+    had not yet been recomputed, so we reran the consolidation pass manually to fix it. The narrow window
+    of deleted activity itself could never be recovered.
+- id: d_t10_c07_r1
+  source: resource
+  text: Nightly snapshots of each workspace are retained for thirty days and support point-in-time restore
+    back to the start of any retained night. A restore replaces the current workspace state entirely,
+    so any activity between the snapshot and the restore request is lost unless separately recovered
+    from the event log. After a restore completes, operators should verify document counts against the
+    pre-restore total and confirm neural graph edges have been recomputed before marking the workspace
+    healthy again. A destructive restore command should never run without explicitly naming the target
+    workspace.
+- id: d_t10_c08_m1
+  source: memory
+  text: The Slack connector for one customer stopped syncing silently for four days because its OAuth
+    token had expired and nobody was watching for that failure mode. We had assumed the connector would
+    alert on auth failure the same way it alerts on rate limiting, but that path was never wired up,
+    so the sync just failed quietly every run. We are adding an explicit auth-failure alert and treating
+    this as a common misconfiguration to check first during future connector incidents.
+- id: d_t10_c08_m2
+  source: memory
+  text: コネクタのOAuthトークンが期限切れになっていたのに認証失敗の通知が無く、四日間気づかずに同期が失敗し続けていた。今後は認証エラー専用のアラートを追加し、トークンの自動更新が失敗した場合の設定ミスとして真っ先に疑う項目に加えることにした。
+- id: d_t10_c08_r1
+  source: resource
+  text: Connectors authenticate to external services using OAuth tokens that must be refreshed automatically
+    before expiry; the most common connector misconfiguration is a missing or misscoped refresh credential,
+    which causes the connector to fail silently on every sync attempt rather than raising a visible
+    auth error. Operators troubleshooting a connector that appears idle should check token expiry and
+    refresh scope before assuming the external service itself is unavailable, since silent auth failure
+    is far more common than an outage.
+- id: d_t10_c09_m1
+  source: memory
+  text: Writes across the whole cluster started failing around 3am because the primary storage volume
+    hit ninety-eight percent disk usage and the database refused new writes to protect itself. We freed
+    space quickly by force-running the retention cleanup job that normally runs weekly and removes expired
+    snapshot copies, which got us back under the safe threshold within twenty minutes. We are moving
+    that cleanup job to run daily so disk usage cannot climb this close to the limit again.
+- id: d_t10_c09_r1
+  source: resource
+  text: ストレージ容量は使用率が八十五パーセントを超えた時点で警告し、九十五パーセントで書き込みを制限する設計になっている。定期的なクリーンアップジョブが期限切れのスナップショットを削除して容量を確保するが、実行頻度が低いと使用率が急に閾値へ近づく場合がある。容量計画では想定される取り込み量からディスク使用の伸びを見積もることが推奨される。
+- id: d_t10_c09_r2
+  source: resource
+  text: The retention cleanup job removes snapshot copies and expired event log entries older than the
+    configured retention window, which defaults to thirty days but can be tightened for workspaces under
+    storage pressure. Running this job too infrequently allows disk usage to climb steadily until it
+    approaches the write-blocking threshold with little warning, since most storage growth comes from
+    retained snapshots rather than live documents. Operators managing storage-constrained clusters should
+    schedule the cleanup job daily rather than weekly, catching pressure quickly before it ever threatens
+    incoming writes.
+- id: d_t10_c10_m1
+  source: memory
+  text: We set up a formal on-call rotation after a paging alert went unacknowledged for ninety minutes
+    overnight because it only reached one person who happened to be asleep with their phone on silent.
+    The new rotation escalates to a second person automatically if the page is not acknowledged within
+    ten minutes, and we published a short runbook so whoever is on call that week does not need to remember
+    every troubleshooting step from memory. We call that second person the secondary responder in our
+    escalation notes.
+- id: d_t10_c10_r1
+  source: resource
+  text: The formal escalation policy for production alerts pages the primary on-call responder first;
+    if the page is not acknowledged within ten minutes it automatically escalates to a secondary responder
+    and then to the engineering lead after a further ten minutes. Every paging alert should link directly
+    to the relevant runbook section so the responder can begin triage immediately rather than searching
+    for context, and the on-call rotation schedule is reviewed monthly to keep coverage current across
+    time zones.
+- id: d_t10_c10_r2
+  source: resource
+  text: 本番アラートのオンコール対応では、一次担当者が十分以内に確認しない場合、自動的に二次担当者へエスカレーションされ、さらに十分後にエンジニアリングリードへ引き継がれる。各アラートには対応するランブックへのリンクを必ず添付し、担当者がすぐにトリアージを開始できるようにする。オンコールのローテーション表は毎月見直される。
+queries:
+- id: q_t01_x_01
+  bucket: cross-source
+  split: heldout
+  text: how do the keyword scorer's settings affect which documents rank highest
+  relevant:
+  - d_t01_c01_r1
+  - d_t01_c01_m1
+  - d_t01_c01_m2
+  graded:
+    d_t01_c01_r1: 3
+    d_t01_c01_m1: 2
+    d_t01_c01_m2: 2
+    d_t01_c08_m1: 1
+- id: q_t01_x_02
+  bucket: cross-source
+  split: heldout
+  text: what does adding an extra scoring stage change about result order
+  relevant:
+  - d_t01_c04_r1
+  - d_t01_c04_m1
+  - d_t01_c04_m2
+  graded:
+    d_t01_c04_r1: 3
+    d_t01_c04_m1: 2
+    d_t01_c04_m2: 2
+    d_t01_c07_m1: 1
+- id: q_t01_x_03
+  bucket: cross-source
+  split: heldout
+  text: when should someone pick keyword-only search over the blended default
+  relevant:
+  - d_t01_c05_r1
+  - d_t01_c05_m1
+  - d_t01_c05_m2
+  graded:
+    d_t01_c05_r1: 3
+    d_t01_c05_m1: 2
+    d_t01_c05_m2: 2
+    d_t01_c06_m2: 1
+- id: q_t01_x_04
+  bucket: cross-source
+  split: heldout
+  text: why do we grab more results from both retrievers before scoring them
+  relevant:
+  - d_t01_c06_r1
+  - d_t01_c06_m1
+  - d_t01_c06_m2
+  graded:
+    d_t01_c06_r1: 3
+    d_t01_c06_m1: 2
+    d_t01_c06_m2: 2
+    d_t01_c04_r1: 1
+- id: q_t01_x_05
+  bucket: cross-source
+  split: heldout
+  text: what decides the position of results that end up with the same total score
+  relevant:
+  - d_t01_c07_r1
+  - d_t01_c07_m1
+  - d_t01_c07_m2
+  graded:
+    d_t01_c07_r1: 3
+    d_t01_c07_m1: 2
+    d_t01_c07_m2: 2
+    d_t01_c05_m1: 1
+- id: q_t01_x_06
+  bucket: cross-source
+  split: heldout
+  text: why do the two scoring signals need a shared scale before merging
+  relevant:
+  - d_t01_c09_r2
+  - d_t01_c09_m1
+  - d_t01_c09_r1
+  graded:
+    d_t01_c09_r2: 3
+    d_t01_c09_m1: 2
+    d_t01_c09_r1: 2
+    d_t01_c03_m2: 1
+- id: q_t01_exact_01
+  bucket: retrieval-exact
+  split: heldout
+  text: why do you combine keyword scorer and the vector scorer
+  relevant:
+  - d_t01_c03_r1
+  graded:
+    d_t01_c03_r1: 3
+    d_t01_c09_r2: 1
+- id: q_t01_exact_02
+  bucket: retrieval-exact
+  split: public
+  text: explain how many candidates each underlying retriever provides
+  relevant:
+  - d_t01_c06_r1
+  graded:
+    d_t01_c06_r1: 3
+    d_t01_c10_r1: 1
+- id: q_t01_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: how does a morphological analyzer that splits Japanese text help
+  relevant:
+  - d_t01_c08_m2
+  graded:
+    d_t01_c08_m2: 3
+    d_t01_c01_r1: 1
+- id: q_t01_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: explain how it reduces a candidate's final score proportionally
+  relevant:
+  - d_t01_c10_r1
+  graded:
+    d_t01_c10_r1: 3
+    d_t01_c07_m1: 1
+- id: q_t01_sem_01
+  bucket: retrieval-semantic
+  split: public
+  text: why do very short answers sometimes rank below much longer documents
+  relevant:
+  - d_t01_c01_m2
+  graded:
+    d_t01_c01_m2: 3
+    d_t01_c09_r1: 1
+- id: q_t01_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: why did the team pick a straightforward score-combining method over an order-based approach
+  relevant:
+  - d_t01_c03_m2
+  graded:
+    d_t01_c03_m2: 3
+    d_t01_c06_r1: 1
+- id: q_t01_sem_03
+  bucket: retrieval-semantic
+  split: heldout
+  text: what is the tradeoff of adding an extra relevance-checking step that slows responses slightly
+  relevant:
+  - d_t01_c04_m1
+  graded:
+    d_t01_c04_m1: 3
+    d_t01_c02_m1: 1
+- id: q_t01_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: how does search avoid surfacing several duplicates of one saved note
+  relevant:
+  - d_t01_c07_m2
+  graded:
+    d_t01_c07_m2: 3
+    d_t01_c05_r1: 1
+- id: q_t01_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: why does an old note sometimes still beat a more current update in results
+  relevant:
+  - d_t01_c10_m1
+  graded:
+    d_t01_c10_m1: 3
+    d_t01_c06_m1: 1
+- id: q_t01_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: けんさくてんすうのわりあいをかえるとなぜけっかがかわるのか
+  relevant:
+  - d_t01_c03_m1
+  graded:
+    d_t01_c03_m1: 3
+    d_t01_c05_m2: 1
+- id: q_t01_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: とくべつなことばをさがすときはどのさがしかたがいいのか
+  relevant:
+  - d_t01_c05_m1
+  graded:
+    d_t01_c05_m1: 3
+    d_t01_c01_m2: 1
+- id: q_t01_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: ながいことばをくぎってさがせるようにするにはどうすればいいのか
+  relevant:
+  - d_t01_c08_m1
+  graded:
+    d_t01_c08_m1: 3
+    d_t01_c09_m1: 1
+- id: q_t01_hira_04
+  bucket: hiragana-only
+  split: heldout
+  text: てんすうのおおきさがちがうものをどうやってそろえるのか
+  relevant:
+  - d_t01_c09_r1
+  graded:
+    d_t01_c09_r1: 3
+    d_t01_c08_r1: 1
+- id: q_t01_res_01
+  bucket: resource-only
+  split: heldout
+  text: how does the system measure how near a question is to stored text
+  relevant:
+  - d_t01_c02_r1
+  graded:
+    d_t01_c02_r1: 3
+    d_t01_c03_r1: 1
+- id: q_t01_res_02
+  bucket: resource-only
+  split: heldout
+  text: what does the optional second scoring pass do to the initial candidate list
+  relevant:
+  - d_t01_c04_r1
+  graded:
+    d_t01_c04_r1: 3
+    d_t01_c07_r1: 1
+- id: q_t01_res_03
+  bucket: resource-only
+  split: public
+  text: what are the different ways to switch how a search interprets a query
+  relevant:
+  - d_t01_c05_r1
+  graded:
+    d_t01_c05_r1: 3
+    d_t01_c02_r1: 1
+- id: q_t01_res_04
+  bucket: resource-only
+  split: heldout
+  text: how are near-identical results and scoring ties handled overall
+  relevant:
+  - d_t01_c07_r1
+  graded:
+    d_t01_c07_r1: 3
+    d_t01_c04_r1: 1
+- id: q_t01_res_05
+  bucket: resource-only
+  split: heldout
+  text: why are two different scoring systems put on a matching numeric scale first
+  relevant:
+  - d_t01_c09_r2
+  graded:
+    d_t01_c09_r2: 3
+    d_t01_c10_r1: 1
+- id: q_t01_mem_01
+  bucket: memory-only
+  split: public
+  text: why did we increase how much repeated query words count toward relevance
+  relevant:
+  - d_t01_c01_m1
+  graded:
+    d_t01_c01_m1: 3
+    d_t01_c08_m2: 1
+- id: q_t01_mem_02
+  bucket: memory-only
+  split: heldout
+  text: why did a fixed similarity cutoff start filtering out good matches
+  relevant:
+  - d_t01_c02_m2
+  graded:
+    d_t01_c02_m2: 3
+    d_t01_c04_m2: 1
+- id: q_t01_mem_03
+  bucket: memory-only
+  split: heldout
+  text: why do exact support ticket codes get outranked in the default search
+  relevant:
+  - d_t01_c05_m2
+  graded:
+    d_t01_c05_m2: 3
+    d_t01_c01_m1: 1
+- id: q_t01_mem_04
+  bucket: memory-only
+  split: heldout
+  text: why did we pull more results from each retrieval method before merging
+  relevant:
+  - d_t01_c06_m1
+  graded:
+    d_t01_c06_m1: 3
+    d_t01_c10_r2: 1
+- id: q_t01_mem_05
+  bucket: memory-only
+  split: heldout
+  text: why did one scoring signal dominate before we rescaled both of them
+  relevant:
+  - d_t01_c09_m1
+  graded:
+    d_t01_c09_m1: 3
+    d_t01_c02_m2: 1
+- id: q_t02_x_01
+  bucket: cross-source
+  split: heldout
+  text: how do two separate memories end up linked just from being retrieved together
+  relevant:
+  - d_t02_c01_r1
+  - d_t02_c01_m1
+  - d_t02_c01_m2
+  graded:
+    d_t02_c01_r1: 3
+    d_t02_c01_m1: 2
+    d_t02_c01_m2: 2
+    d_t02_c08_r1: 1
+- id: q_t02_x_02
+  bucket: cross-source
+  split: heldout
+  text: why does exploring outward from a topic lose relevance the farther it goes
+  relevant:
+  - d_t02_c02_r1
+  - d_t02_c02_m1
+  - d_t02_c02_m2
+  graded:
+    d_t02_c02_r1: 3
+    d_t02_c02_m1: 2
+    d_t02_c02_m2: 2
+    d_t02_c09_r2: 1
+- id: q_t02_x_03
+  bucket: cross-source
+  split: heldout
+  text: what actually happens to a link that has been too weak for too long
+  relevant:
+  - d_t02_c04_r1
+  - d_t02_c04_m1
+  - d_t02_c04_r2
+  graded:
+    d_t02_c04_r1: 3
+    d_t02_c04_m1: 2
+    d_t02_c04_r2: 2
+    d_t02_c03_m1: 1
+- id: q_t02_x_04
+  bucket: cross-source
+  split: heldout
+  text: does maintaining the connection graph ever slow down an active search
+  relevant:
+  - d_t02_c06_r1
+  - d_t02_c06_m1
+  - d_t02_c06_m2
+  graded:
+    d_t02_c06_r1: 3
+    d_t02_c06_m1: 2
+    d_t02_c06_m2: 2
+    d_t02_c07_r1: 1
+- id: q_t02_x_05
+  bucket: cross-source
+  split: heldout
+  text: what happens to unfinished graph updates if the background process dies
+  relevant:
+  - d_t02_c07_r1
+  - d_t02_c07_m1
+  - d_t02_c07_m2
+  graded:
+    d_t02_c07_r1: 3
+    d_t02_c07_m1: 2
+    d_t02_c07_m2: 2
+    d_t02_c06_m2: 1
+- id: q_t02_x_06
+  bucket: cross-source
+  split: heldout
+  text: when two workspaces combine, does a shared link ever get double-counted
+  relevant:
+  - d_t02_c10_r1
+  - d_t02_c10_m1
+  - d_t02_c10_m2
+  graded:
+    d_t02_c10_r1: 3
+    d_t02_c10_m1: 2
+    d_t02_c10_m2: 2
+    d_t02_c04_r2: 1
+- id: q_t02_exact_01
+  bucket: retrieval-exact
+  split: heldout
+  text: what happens when notes surface together in one recall call
+  relevant:
+  - d_t02_c01_m1
+  graded:
+    d_t02_c01_m1: 3
+    d_t02_c05_r1: 1
+- id: q_t02_exact_02
+  bucket: retrieval-exact
+  split: public
+  text: edge weight that decays on a slow half-life
+  relevant:
+  - d_t02_c03_m1
+  graded:
+    d_t02_c03_m1: 3
+    d_t02_c08_m2: 1
+- id: q_t02_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: what has to clear a minimum cosine similarity gate
+  relevant:
+  - d_t02_c05_m2
+  graded:
+    d_t02_c05_m2: 3
+    d_t02_c01_r1: 1
+- id: q_t02_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: how is maximum neighbors retained per hop decided
+  relevant:
+  - d_t02_c09_r2
+  graded:
+    d_t02_c09_r2: 3
+    d_t02_c02_m2: 1
+- id: q_t02_sem_01
+  bucket: retrieval-semantic
+  split: heldout
+  text: how does the system automatically build associations between things looked up together
+  relevant:
+  - d_t02_c01_m1
+  graded:
+    d_t02_c01_m1: 3
+    d_t02_c06_m1: 1
+- id: q_t02_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: why do related results fade the further you branch from a starting point
+  relevant:
+  - d_t02_c02_m1
+  graded:
+    d_t02_c02_m1: 3
+    d_t02_c09_m1: 1
+- id: q_t02_sem_03
+  bucket: retrieval-semantic
+  split: public
+  text: does old unused structure ever get cleared out permanently instead of just staying forgotten
+  relevant:
+  - d_t02_c04_m1
+  graded:
+    d_t02_c04_m1: 3
+    d_t02_c03_m1: 1
+- id: q_t02_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: do heavily used connections keep gaining strength as fast as new ones
+  relevant:
+  - d_t02_c08_r1
+  graded:
+    d_t02_c08_r1: 3
+    d_t02_c01_m1: 1
+- id: q_t02_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: when two workspaces become one, could a relationship wrongly end up double-weighted
+  relevant:
+  - d_t02_c10_m2
+  graded:
+    d_t02_c10_m2: 3
+    d_t02_c04_r1: 1
+- id: q_t02_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: にていないものどうしがつながらないのはなぜですか
+  relevant:
+  - d_t02_c05_m1
+  graded:
+    d_t02_c05_m1: 3
+    d_t02_c01_r1: 1
+- id: q_t02_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: こわれたあとにきおくのつながりがもとにもどるしくみをしりたい
+  relevant:
+  - d_t02_c07_m2
+  graded:
+    d_t02_c07_m2: 3
+    d_t02_c06_m2: 1
+- id: q_t02_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: たどれるかずにはじょうげんがあるのかしりたい
+  relevant:
+  - d_t02_c09_r1
+  graded:
+    d_t02_c09_r1: 3
+    d_t02_c02_m2: 1
+- id: q_t02_hira_04
+  bucket: hiragana-only
+  split: heldout
+  text: ふたつをまとめたときおなじつながりがどうなるかしりたい
+  relevant:
+  - d_t02_c10_m1
+  graded:
+    d_t02_c10_m1: 3
+    d_t02_c08_m1: 1
+- id: q_t02_res_01
+  bucket: resource-only
+  split: heldout
+  text: how long can an unused connection go before it stops showing up in results
+  relevant:
+  - d_t02_c03_r1
+  graded:
+    d_t02_c03_r1: 3
+    d_t02_c01_m2: 1
+- id: q_t02_res_02
+  bucket: resource-only
+  split: heldout
+  text: which settings control how quickly faint connections disappear from the graph for good
+  relevant:
+  - d_t02_c04_r2
+  graded:
+    d_t02_c04_r2: 3
+    d_t02_c08_r1: 1
+- id: q_t02_res_03
+  bucket: resource-only
+  split: public
+  text: does search ever wait on the process that maintains the connection graph
+  relevant:
+  - d_t02_c06_r1
+  graded:
+    d_t02_c06_r1: 3
+    d_t02_c07_m1: 1
+- id: q_t02_res_04
+  bucket: resource-only
+  split: heldout
+  text: what limits keep an exploration from returning an overwhelming number of connected notes
+  relevant:
+  - d_t02_c09_r1
+  graded:
+    d_t02_c09_r1: 3
+    d_t02_c05_m2: 1
+- id: q_t02_res_05
+  bucket: resource-only
+  split: heldout
+  text: if the same relationship exists in two contexts being combined, which value survives
+  relevant:
+  - d_t02_c10_r1
+  graded:
+    d_t02_c10_r1: 3
+    d_t02_c09_m1: 1
+- id: q_t02_mem_01
+  bucket: memory-only
+  split: heldout
+  text: why did widening how far a lookup could branch make results take longer
+  relevant:
+  - d_t02_c02_m2
+  graded:
+    d_t02_c02_m2: 3
+    d_t02_c04_m1: 1
+- id: q_t02_mem_02
+  bucket: memory-only
+  split: heldout
+  text: are two things automatically connected just because a broad search returned both of them
+  relevant:
+  - d_t02_c05_m2
+  graded:
+    d_t02_c05_m2: 3
+    d_t02_c06_m1: 1
+- id: q_t02_mem_03
+  bucket: memory-only
+  split: heldout
+  text: did lag in updating the connection graph cause it to miss brand new items
+  relevant:
+  - d_t02_c06_m2
+  graded:
+    d_t02_c06_m2: 3
+    d_t02_c07_r1: 1
+- id: q_t02_mem_04
+  bucket: memory-only
+  split: public
+  text: what happened to connections that were supposed to form while the service was offline
+  relevant:
+  - d_t02_c07_m1
+  graded:
+    d_t02_c07_m1: 3
+    d_t02_c10_r1: 1
+- id: q_t02_mem_05
+  bucket: memory-only
+  split: heldout
+  text: does repeatedly pulling up the same memory pair grow their connection proportionally
+  relevant:
+  - d_t02_c08_m1
+  graded:
+    d_t02_c08_m1: 3
+    d_t02_c02_m1: 1
+- id: q_t03_x_01
+  bucket: cross-source
+  split: heldout
+  text: how is the overnight consolidation timing picked given worldwide client schedules
+  relevant:
+  - d_t03_c01_m1
+  - d_t03_c01_r1
+  - d_t03_c01_m2
+  graded:
+    d_t03_c01_m1: 3
+    d_t03_c01_r1: 2
+    d_t03_c01_m2: 2
+    d_t03_c10_r1: 1
+- id: q_t03_x_02
+  bucket: cross-source
+  split: heldout
+  text: how does the system automatically spot possibly related memories using embeddings
+  relevant:
+  - d_t03_c02_r1
+  - d_t03_c02_m2
+  graded:
+    d_t03_c02_r1: 3
+    d_t03_c02_m2: 2
+    d_t03_c07_r1: 1
+- id: q_t03_x_03
+  bucket: cross-source
+  split: heldout
+  text: what information does the maintenance run summary include after each pass
+  relevant:
+  - d_t03_c04_r1
+  - d_t03_c04_m1
+  graded:
+    d_t03_c04_r1: 3
+    d_t03_c04_m1: 2
+    d_t03_c06_r1: 1
+- id: q_t03_x_04
+  bucket: cross-source
+  split: heldout
+  text: is it possible to completely undo a bad overnight batch after the fact
+  relevant:
+  - d_t03_c06_r1
+  - d_t03_c06_m1
+  - d_t03_c06_m2
+  graded:
+    d_t03_c06_r1: 3
+    d_t03_c06_m1: 2
+    d_t03_c06_m2: 2
+    d_t03_c07_m1: 1
+- id: q_t03_x_05
+  bucket: cross-source
+  split: heldout
+  text: how are repeated notes that say almost the same thing combined into one
+  relevant:
+  - d_t03_c07_r1
+  - d_t03_c07_m1
+  graded:
+    d_t03_c07_r1: 3
+    d_t03_c07_m1: 2
+    d_t03_c08_m1: 1
+- id: q_t03_x_06
+  bucket: cross-source
+  split: heldout
+  text: what happens when an overnight batch never finishes and how is it caught
+  relevant:
+  - d_t03_c09_m1
+  - d_t03_c09_r1
+  - d_t03_c09_r2
+  graded:
+    d_t03_c09_m1: 3
+    d_t03_c09_r1: 2
+    d_t03_c09_r2: 2
+    d_t03_c10_m1: 1
+- id: q_t03_exact_01
+  bucket: retrieval-exact
+  split: public
+  text: how is the confidence score between zero and one calculated
+  relevant:
+  - d_t03_c03_r1
+  graded:
+    d_t03_c03_r1: 3
+    d_t03_c04_r1: 1
+- id: q_t03_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: why history uses pagination with a default page size
+  relevant:
+  - d_t03_c05_m2
+  graded:
+    d_t03_c05_m2: 3
+    d_t03_c09_r2: 1
+- id: q_t03_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: what determines how quickly their notes accumulate
+  relevant:
+  - d_t03_c08_m1
+  graded:
+    d_t03_c08_m1: 3
+    d_t03_c07_m1: 1
+- id: q_t03_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: how batch size and concurrency limits affect the maintenance pass
+  relevant:
+  - d_t03_c10_r1
+  graded:
+    d_t03_c10_r1: 3
+    d_t03_c09_r1: 1
+- id: q_t03_sem_01
+  bucket: retrieval-semantic
+  split: public
+  text: why use a reasoning model instead of a simple rule to decide connections
+  relevant:
+  - d_t03_c03_m1
+  graded:
+    d_t03_c03_m1: 3
+    d_t03_c02_r1: 1
+- id: q_t03_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: do groups with two note languages get separate counts for each
+  relevant:
+  - d_t03_c04_m2
+  graded:
+    d_t03_c04_m2: 3
+    d_t03_c02_m2: 1
+- id: q_t03_sem_03
+  bucket: retrieval-semantic
+  split: heldout
+  text: when an overnight fix is cancelled do previously joined notes come apart again too
+  relevant:
+  - d_t03_c06_m2
+  graded:
+    d_t03_c06_m2: 3
+    d_t03_c01_m2: 1
+- id: q_t03_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: why did two unrelated people's messages get folded into the same saved note
+  relevant:
+  - d_t03_c07_m2
+  graded:
+    d_t03_c07_m2: 3
+    d_t03_c06_m1: 1
+- id: q_t03_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: why is work for very big accounts done over multiple nights rather than one
+  relevant:
+  - d_t03_c10_m1
+  graded:
+    d_t03_c10_m1: 3
+    d_t03_c09_m1: 1
+- id: q_t03_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: にているきおくどうしをじどうでみつけだすほうほうは
+  relevant:
+  - d_t03_c02_m1
+  graded:
+    d_t03_c02_m1: 3
+    d_t03_c08_r1: 1
+- id: q_t03_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: はんていがこうほのほとんどをきゃっかしたりゆうは
+  relevant:
+  - d_t03_c03_m2
+  graded:
+    d_t03_c03_m2: 3
+    d_t03_c05_r1: 1
+- id: q_t03_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: せんしゅうとくらべるためにかこのきろくをみなおす
+  relevant:
+  - d_t03_c05_m1
+  graded:
+    d_t03_c05_m1: 3
+    d_t03_c10_r2: 1
+- id: q_t03_hira_04
+  bucket: hiragana-only
+  split: heldout
+  text: あたらしいばしょをほんばんにいれるまえにためしにひとばんうごかしてみること
+  relevant:
+  - d_t03_c08_m2
+  graded:
+    d_t03_c08_m2: 3
+    d_t03_c03_m2: 1
+- id: q_t03_res_01
+  bucket: resource-only
+  split: public
+  text: how can operators change the default trigger time for a workspace
+  relevant:
+  - d_t03_c01_r1
+  graded:
+    d_t03_c01_r1: 3
+    d_t03_c10_r1: 1
+- id: q_t03_res_02
+  bucket: resource-only
+  split: heldout
+  text: what makes a pair of memories become a possible link
+  relevant:
+  - d_t03_c02_r1
+  graded:
+    d_t03_c02_r1: 3
+    d_t03_c07_r1: 1
+- id: q_t03_res_03
+  bucket: resource-only
+  split: heldout
+  text: what fields appear in the record produced after each run
+  relevant:
+  - d_t03_c04_r1
+  graded:
+    d_t03_c04_r1: 3
+    d_t03_c05_r1: 1
+- id: q_t03_res_04
+  bucket: resource-only
+  split: heldout
+  text: what exactly gets restored when a maintenance action is reversed
+  relevant:
+  - d_t03_c06_r1
+  graded:
+    d_t03_c06_r1: 3
+    d_t03_c07_r1: 1
+- id: q_t03_res_05
+  bucket: resource-only
+  split: heldout
+  text: how does the system notice a run that is taking unusually long
+  relevant:
+  - d_t03_c09_r2
+  graded:
+    d_t03_c09_r2: 3
+    d_t03_c10_r1: 1
+- id: q_t03_mem_01
+  bucket: memory-only
+  split: public
+  text: why did the overnight job once miss a whole workspace
+  relevant:
+  - d_t03_c01_m2
+  graded:
+    d_t03_c01_m2: 3
+    d_t03_c09_m1: 1
+- id: q_t03_mem_02
+  bucket: memory-only
+  split: heldout
+  text: why was the matching threshold made stricter early on
+  relevant:
+  - d_t03_c02_m2
+  graded:
+    d_t03_c02_m2: 3
+    d_t03_c07_m2: 1
+- id: q_t03_mem_03
+  bucket: memory-only
+  split: heldout
+  text: why does the run list now load only a portion at a time
+  relevant:
+  - d_t03_c05_m2
+  graded:
+    d_t03_c05_m2: 3
+    d_t03_c04_m2: 1
+- id: q_t03_mem_04
+  bucket: memory-only
+  split: heldout
+  text: why might one decision get written down more than once
+  relevant:
+  - d_t03_c07_m1
+  graded:
+    d_t03_c07_m1: 3
+    d_t03_c01_m1: 1
+- id: q_t03_mem_05
+  bucket: memory-only
+  split: heldout
+  text: why did a run once hang without producing any output
+  relevant:
+  - d_t03_c09_m1
+  graded:
+    d_t03_c09_m1: 3
+    d_t03_c10_m1: 1
+- id: q_t04_x_01
+  bucket: cross-source
+  split: heldout
+  text: why are newly created contexts hidden from the rest of the workspace by default
+  relevant:
+  - d_t04_c01_m1
+  - d_t04_c01_r1
+  - d_t04_c01_m2
+  graded:
+    d_t04_c01_m1: 3
+    d_t04_c01_r1: 2
+    d_t04_c01_m2: 2
+- id: q_t04_x_02
+  bucket: cross-source
+  split: heldout
+  text: what decides which contexts a newly added workspace member can view
+  relevant:
+  - d_t04_c04_r1
+  - d_t04_c04_m1
+  - d_t04_c04_m2
+  graded:
+    d_t04_c04_r1: 3
+    d_t04_c04_m1: 2
+    d_t04_c04_m2: 2
+- id: q_t04_x_03
+  bucket: cross-source
+  split: heldout
+  text: can some teammates check notes in a context but not add new ones
+  relevant:
+  - d_t04_c06_r1
+  - d_t04_c06_m1
+  - d_t04_c06_m2
+  graded:
+    d_t04_c06_r1: 3
+    d_t04_c06_m1: 2
+    d_t04_c06_m2: 2
+- id: q_t04_x_04
+  bucket: cross-source
+  split: heldout
+  text: what happens to old memories when two overlapping contexts get combined into one
+  relevant:
+  - d_t04_c08_r1
+  - d_t04_c08_m1
+  - d_t04_c08_m2
+  graded:
+    d_t04_c08_r1: 3
+    d_t04_c08_m1: 2
+    d_t04_c08_m2: 2
+- id: q_t04_x_05
+  bucket: cross-source
+  split: heldout
+  text: how do teams keep writes from colliding while a context undergoes maintenance
+  relevant:
+  - d_t04_c03_r1
+  - d_t04_c03_m1
+  - d_t04_c03_m2
+  graded:
+    d_t04_c03_r1: 3
+    d_t04_c03_m1: 2
+    d_t04_c03_m2: 2
+- id: q_t04_x_06
+  bucket: cross-source
+  split: heldout
+  text: what options exist once a workspace runs out of room for new contexts
+  relevant:
+  - d_t04_c10_r1
+  - d_t04_c10_m1
+  - d_t04_c10_r2
+  graded:
+    d_t04_c10_r1: 3
+    d_t04_c10_m1: 2
+    d_t04_c10_r2: 2
+- id: q_t04_exact_01
+  bucket: retrieval-exact
+  split: public
+  text: retention window for automatic forgetting setting per context
+  relevant:
+  - d_t04_c09_r1
+  graded:
+    d_t04_c09_r1: 3
+    d_t04_c10_r1: 1
+- id: q_t04_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: removing a member revokes their ability to call recall instantly
+  relevant:
+  - d_t04_c04_r1
+  graded:
+    d_t04_c04_r1: 3
+    d_t04_c05_r1: 1
+- id: q_t04_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: when contexts merge are old graph edges remapped rather than dropped
+  relevant:
+  - d_t04_c08_r1
+  graded:
+    d_t04_c08_r1: 3
+    d_t04_c03_r1: 1
+- id: q_t04_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: the more restrictive of the two wins when rules conflict
+  relevant:
+  - d_t04_c06_r1
+  graded:
+    d_t04_c06_r1: 3
+    d_t04_c02_r1: 1
+- id: q_t04_sem_01
+  bucket: retrieval-semantic
+  split: public
+  text: do brand-new contexts stay hidden from teammates until someone decides to share them
+  relevant:
+  - d_t04_c01_m1
+  graded:
+    d_t04_c01_m1: 3
+    d_t04_c02_m2: 1
+- id: q_t04_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: why can't people add notes while a context is busy consolidating overnight
+  relevant:
+  - d_t04_c03_m2
+  graded:
+    d_t04_c03_m2: 3
+    d_t04_c08_m2: 1
+- id: q_t04_sem_03
+  bucket: retrieval-semantic
+  split: heldout
+  text: is there a safety check before opening a support context to everyone
+  relevant:
+  - d_t04_c02_m2
+  graded:
+    d_t04_c02_m2: 3
+    d_t04_c01_m1: 1
+- id: q_t04_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: how do you look up decisions spread across two different team logs at once
+  relevant:
+  - d_t04_c07_m1
+  graded:
+    d_t04_c07_m1: 3
+    d_t04_c08_r1: 1
+- id: q_t04_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: what do you do when your workspace can't hold any more projects
+  relevant:
+  - d_t04_c10_m1
+  graded:
+    d_t04_c10_m1: 3
+    d_t04_c09_r1: 1
+- id: q_t04_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: きょうゆうにきりかえるまえになかみをかくにんするのはなぜですか
+  relevant:
+  - d_t04_c02_m1
+  graded:
+    d_t04_c02_m1: 3
+    d_t04_c05_m1: 1
+- id: q_t04_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: へんしゅうしゃとえつらんしゃではできることがどうちがうのですか
+  relevant:
+  - d_t04_c05_r1
+  graded:
+    d_t04_c05_r1: 3
+    d_t04_c06_r1: 1
+- id: q_t04_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: ふたつのぶしょのきろくをいちどにさがすにはどうすればよいですか
+  relevant:
+  - d_t04_c07_m2
+  graded:
+    d_t04_c07_m2: 3
+    d_t04_c04_r1: 1
+- id: q_t04_hira_04
+  bucket: hiragana-only
+  split: heldout
+  text: じょうげんにたっしたらどうすればよいですか
+  relevant:
+  - d_t04_c10_r2
+  graded:
+    d_t04_c10_r2: 3
+    d_t04_c09_r1: 1
+- id: q_t04_res_01
+  bucket: resource-only
+  split: public
+  text: which workspace roles are allowed to freeze a context for upkeep
+  relevant:
+  - d_t04_c03_r1
+  graded:
+    d_t04_c03_r1: 3
+    d_t04_c08_r1: 1
+- id: q_t04_res_02
+  bucket: resource-only
+  split: heldout
+  text: who has permission to change a context from private to shared
+  relevant:
+  - d_t04_c02_r1
+  graded:
+    d_t04_c02_r1: 3
+    d_t04_c01_r1: 1
+- id: q_t04_res_03
+  bucket: resource-only
+  split: heldout
+  text: what actions can workspace admins perform that other roles cannot
+  relevant:
+  - d_t04_c05_r1
+  graded:
+    d_t04_c05_r1: 3
+    d_t04_c04_r1: 1
+- id: q_t04_res_04
+  bucket: resource-only
+  split: heldout
+  text: how does a single search request cover multiple contexts at once
+  relevant:
+  - d_t04_c07_r1
+  graded:
+    d_t04_c07_r1: 3
+    d_t04_c06_r1: 1
+- id: q_t04_res_05
+  bucket: resource-only
+  split: heldout
+  text: can old memories be automatically deleted after a set number of days
+  relevant:
+  - d_t04_c09_r2
+  graded:
+    d_t04_c09_r2: 3
+    d_t04_c10_r2: 1
+- id: q_t04_mem_01
+  bucket: memory-only
+  split: public
+  text: why did we combine two overlapping project contexts into one
+  relevant:
+  - d_t04_c08_m1
+  graded:
+    d_t04_c08_m1: 3
+    d_t04_c04_m1: 1
+- id: q_t04_mem_02
+  bucket: memory-only
+  split: heldout
+  text: what habit helps people pick the right context name faster
+  relevant:
+  - d_t04_c01_m2
+  graded:
+    d_t04_c01_m2: 3
+    d_t04_c09_m1: 1
+- id: q_t04_mem_03
+  bucket: memory-only
+  split: heldout
+  text: why can only a couple of people save notes here
+  relevant:
+  - d_t04_c06_m1
+  graded:
+    d_t04_c06_m1: 3
+    d_t04_c02_m2: 1
+- id: q_t04_mem_04
+  bucket: memory-only
+  split: heldout
+  text: why must an admin sign off before someone new joins the workspace
+  relevant:
+  - d_t04_c04_m1
+  graded:
+    d_t04_c04_m1: 3
+    d_t04_c05_m1: 1
+- id: q_t04_mem_05
+  bucket: memory-only
+  split: heldout
+  text: what did we do after running out of space for new contexts
+  relevant:
+  - d_t04_c10_m1
+  graded:
+    d_t04_c10_m1: 3
+    d_t04_c03_m1: 1
+- id: q_t05_x_01
+  bucket: cross-source
+  split: heldout
+  text: how do remember calls avoid keeping the same note as a duplicate
+  relevant:
+  - d_t05_c01_r1
+  - d_t05_c01_m1
+  - d_t05_c01_m2
+  graded:
+    d_t05_c01_r1: 3
+    d_t05_c01_m1: 2
+    d_t05_c01_m2: 2
+    d_t05_c04_r1: 1
+- id: q_t05_x_02
+  bucket: cross-source
+  split: heldout
+  text: why would narrowing the relevance cutoff change which hits appear first
+  relevant:
+  - d_t05_c02_m1
+  - d_t05_c02_m2
+  - d_t05_c02_r1
+  graded:
+    d_t05_c02_m1: 3
+    d_t05_c02_m2: 2
+    d_t05_c02_r1: 2
+    d_t05_c09_r1: 1
+- id: q_t05_x_03
+  bucket: cross-source
+  split: heldout
+  text: difference between marking something removed and erasing it for good
+  relevant:
+  - d_t05_c04_m2
+  - d_t05_c04_m1
+  - d_t05_c04_r1
+  graded:
+    d_t05_c04_m2: 3
+    d_t05_c04_m1: 2
+    d_t05_c04_r1: 2
+    d_t05_c10_r1: 1
+- id: q_t05_x_04
+  bucket: cross-source
+  split: heldout
+  text: how do saved important notes appear automatically the moment work begins
+  relevant:
+  - d_t05_c05_r1
+  - d_t05_c05_m1
+  - d_t05_c05_m2
+  graded:
+    d_t05_c05_r1: 3
+    d_t05_c05_m1: 2
+    d_t05_c05_m2: 2
+    d_t05_c06_r1: 1
+- id: q_t05_x_05
+  bucket: cross-source
+  split: heldout
+  text: how do stored deadlines end up on an automatic reminder list
+  relevant:
+  - d_t05_c06_r1
+  - d_t05_c06_m1
+  - d_t05_c06_m2
+  graded:
+    d_t05_c06_r1: 3
+    d_t05_c06_m1: 2
+    d_t05_c06_m2: 2
+    d_t05_c02_m1: 1
+- id: q_t05_x_06
+  bucket: cross-source
+  split: heldout
+  text: what should a client do after getting throttled with a wait time
+  relevant:
+  - d_t05_c10_m1
+  - d_t05_c10_r1
+  - d_t05_c10_r2
+  graded:
+    d_t05_c10_m1: 3
+    d_t05_c10_r1: 2
+    d_t05_c10_r2: 2
+    d_t05_c08_m2: 1
+- id: q_t05_exact_01
+  bucket: retrieval-exact
+  split: public
+  text: how explore found three related deploy notes after the incident
+  relevant:
+  - d_t05_c03_m1
+  graded:
+    d_t05_c03_m1: 3
+    d_t05_c07_m2: 1
+- id: q_t05_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: explain how feedback nudges the Hebbian edge weights tied to memories
+  relevant:
+  - d_t05_c07_m2
+  graded:
+    d_t05_c07_m2: 3
+    d_t05_c03_m1: 1
+- id: q_t05_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: why was the request missing the Authorization Bearer header entirely
+  relevant:
+  - d_t05_c08_m2
+  graded:
+    d_t05_c08_m2: 3
+    d_t05_c10_r1: 1
+- id: q_t05_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: does null next_cursor together with has_more false mean done
+  relevant:
+  - d_t05_c09_r1
+  graded:
+    d_t05_c09_r1: 3
+    d_t05_c10_r1: 1
+- id: q_t05_sem_01
+  bucket: retrieval-semantic
+  split: public
+  text: why could an older record outrank a more recent better match
+  relevant:
+  - d_t05_c02_m2
+  graded:
+    d_t05_c02_m2: 3
+    d_t05_c09_m1: 1
+- id: q_t05_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: is there a way to browse related notes branching out from one item
+  relevant:
+  - d_t05_c03_r1
+  graded:
+    d_t05_c03_r1: 3
+    d_t05_c05_r1: 1
+- id: q_t05_sem_03
+  bucket: retrieval-semantic
+  split: heldout
+  text: what lets frequently needed information load in without a manual lookup
+  relevant:
+  - d_t05_c05_r1
+  graded:
+    d_t05_c05_r1: 3
+    d_t05_c06_r1: 1
+- id: q_t05_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: how does search ranking correct itself once agents flag bad ticket answers
+  relevant:
+  - d_t05_c07_m1
+  graded:
+    d_t05_c07_m1: 3
+    d_t05_c02_m2: 1
+- id: q_t05_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: how can an app know it is about to be throttled before getting blocked
+  relevant:
+  - d_t05_c10_r2
+  graded:
+    d_t05_c10_r2: 3
+    d_t05_c08_r1: 1
+- id: q_t05_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: たぐをつけずにおぼえさせるとじどうでらべるがつくのはどうしてですか
+  relevant:
+  - d_t05_c01_m2
+  graded:
+    d_t05_c01_m2: 3
+- id: q_t05_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: わすれさせてもすぐにはきえないばあいがあるのはなぜですか
+  relevant:
+  - d_t05_c04_r1
+  graded:
+    d_t05_c04_r1: 3
+- id: q_t05_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: きげんがちかづくとじどうでおしえてくれるしくみはなにですか
+  relevant:
+  - d_t05_c06_m1
+  graded:
+    d_t05_c06_m1: 3
+- id: q_t05_hira_04
+  bucket: hiragana-only
+  split: heldout
+  text: よいひょうかをつけるとかんれんするきおくがつよくなるのはなぜですか
+  relevant:
+  - d_t05_c07_r1
+  graded:
+    d_t05_c07_r1: 3
+- id: q_t05_res_01
+  bucket: resource-only
+  split: public
+  text: what fields come back when a new entry matches an old one
+  relevant:
+  - d_t05_c01_r1
+  graded:
+    d_t05_c01_r1: 3
+    d_t05_c04_m2: 1
+- id: q_t05_res_02
+  bucket: resource-only
+  split: heldout
+  text: how far can you branch before the connections stop being meaningful
+  relevant:
+  - d_t05_c03_r1
+  graded:
+    d_t05_c03_r1: 3
+    d_t05_c07_m2: 1
+- id: q_t05_res_03
+  bucket: resource-only
+  split: heldout
+  text: what happens once too many items are kept loaded every session
+  relevant:
+  - d_t05_c05_r1
+  graded:
+    d_t05_c05_r1: 3
+    d_t05_c06_r1: 1
+- id: q_t05_res_04
+  bucket: resource-only
+  split: heldout
+  text: which field lets you tell a saved note apart from a reference document
+  relevant:
+  - d_t05_c09_r1
+  graded:
+    d_t05_c09_r1: 3
+    d_t05_c02_r1: 1
+- id: q_t05_res_05
+  bucket: resource-only
+  split: heldout
+  text: how can code tell exactly which input field caused a rejection
+  relevant:
+  - d_t05_c10_r1
+  graded:
+    d_t05_c10_r1: 3
+    d_t05_c08_m2: 1
+- id: q_t05_mem_01
+  bucket: memory-only
+  split: public
+  text: why did a record marked as deleted still appear somewhere later
+  relevant:
+  - d_t05_c04_m2
+  graded:
+    d_t05_c04_m2: 3
+    d_t05_c10_r1: 1
+- id: q_t05_mem_02
+  bucket: memory-only
+  split: heldout
+  text: how did a repeating renewal get missed before automation caught it
+  relevant:
+  - d_t05_c06_m2
+  graded:
+    d_t05_c06_m2: 3
+    d_t05_c05_m1: 1
+- id: q_t05_mem_03
+  bucket: memory-only
+  split: heldout
+  text: why did the nightly job switch from an MCP call to a direct http request
+  relevant:
+  - d_t05_c08_m1
+  graded:
+    d_t05_c08_m1: 3
+    d_t05_c01_m1: 1
+- id: q_t05_mem_04
+  bucket: memory-only
+  split: heldout
+  text: what caused a client to keep looping through the same page of results
+  relevant:
+  - d_t05_c09_m1
+  graded:
+    d_t05_c09_m1: 3
+    d_t05_c02_m1: 1
+- id: q_t05_mem_05
+  bucket: memory-only
+  split: heldout
+  text: why did lowering the result count reduce noisy irrelevant hits
+  relevant:
+  - d_t05_c02_m1
+  graded:
+    d_t05_c02_m1: 3
+    d_t05_c09_m1: 1
+- id: q_t06_x_01
+  bucket: cross-source
+  split: heldout
+  text: why does the slack integration only cover a handful of approved channels
+  relevant:
+  - d_t06_c01_r1
+  - d_t06_c01_m1
+  graded:
+    d_t06_c01_r1: 3
+    d_t06_c01_m1: 2
+    d_t06_c02_m1: 1
+- id: q_t06_x_02
+  bucket: cross-source
+  split: heldout
+  text: how are obsidian note tags reflected once the vault syncs into a workspace
+  relevant:
+  - d_t06_c03_r1
+  - d_t06_c03_m1
+  graded:
+    d_t06_c03_r1: 3
+    d_t06_c03_m1: 2
+    d_t06_c07_m1: 1
+- id: q_t06_x_03
+  bucket: cross-source
+  split: heldout
+  text: what happens when you upload the same pdf twice through the attachment flow
+  relevant:
+  - d_t06_c04_r1
+  - d_t06_c04_m1
+  graded:
+    d_t06_c04_r1: 3
+    d_t06_c04_m1: 2
+    d_t06_c10_r2: 1
+- id: q_t06_x_04
+  bucket: cross-source
+  split: heldout
+  text: does the scrubbing process catch personal details written across more than one line
+  relevant:
+  - d_t06_c06_r1
+  - d_t06_c06_m2
+  graded:
+    d_t06_c06_r1: 3
+    d_t06_c06_m2: 2
+    d_t06_c09_r1: 1
+- id: q_t06_x_05
+  bucket: cross-source
+  split: heldout
+  text: why does a deleted message stay visible in memory after removal at the source
+  relevant:
+  - d_t06_c08_r1
+  - d_t06_c08_m2
+  graded:
+    d_t06_c08_r1: 3
+    d_t06_c08_m2: 2
+    d_t06_c07_m2: 1
+- id: q_t06_x_06
+  bucket: cross-source
+  split: heldout
+  text: how does content from an open discord channel get weighted differently than internal notes
+  relevant:
+  - d_t06_c09_r1
+  - d_t06_c09_m1
+  graded:
+    d_t06_c09_r1: 3
+    d_t06_c09_m1: 2
+    d_t06_c06_r1: 1
+- id: q_t06_exact_01
+  bucket: retrieval-exact
+  split: public
+  text: notes on the discord connector for the community server setup
+  relevant:
+  - d_t06_c02_m1
+  graded:
+    d_t06_c02_m1: 3
+    d_t06_c01_m1: 1
+- id: q_t06_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: how the system runs a pre-compile summarization pass
+  relevant:
+  - d_t06_c05_r1
+  graded:
+    d_t06_c05_r1: 3
+    d_t06_c06_r1: 1
+- id: q_t06_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: why does every memory produced from a connector need this
+  relevant:
+  - d_t06_c07_m1
+  graded:
+    d_t06_c07_m1: 3
+    d_t06_c08_r1: 1
+- id: q_t06_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: how the connector pulled only the missed messages instead
+  relevant:
+  - d_t06_c10_m1
+  graded:
+    d_t06_c10_m1: 3
+    d_t06_c04_r1: 1
+- id: q_t06_sem_01
+  bucket: retrieval-semantic
+  split: heldout
+  text: does modifying a personal note collection show up on its own without re-uploading anything
+  relevant:
+  - d_t06_c03_r1
+  graded:
+    d_t06_c03_r1: 3
+    d_t06_c03_m2: 1
+- id: q_t06_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: how long does a link to a shared document stay valid once issued
+  relevant:
+  - d_t06_c04_r2
+  graded:
+    d_t06_c04_r2: 3
+    d_t06_c04_m1: 1
+- id: q_t06_sem_03
+  bucket: retrieval-semantic
+  split: public
+  text: why do we boil long help conversations down before they get saved permanently
+  relevant:
+  - d_t06_c05_m1
+  graded:
+    d_t06_c05_m1: 3
+    d_t06_c05_r1: 1
+- id: q_t06_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: what happens to information pulled from a note that later gets taken down upstream
+  relevant:
+  - d_t06_c08_m1
+  graded:
+    d_t06_c08_m1: 3
+    d_t06_c08_r1: 1
+- id: q_t06_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: how does syncing resume smoothly after being offline without redoing everything
+  relevant:
+  - d_t06_c10_r1
+  graded:
+    d_t06_c10_r1: 3
+    d_t06_c10_m1: 1
+- id: q_t06_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: こじんのめもをきおくにとりこむしくみについてしりたい
+  relevant:
+  - d_t06_c03_m1
+  graded:
+    d_t06_c03_m1: 3
+    d_t06_c01_m2: 1
+- id: q_t06_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: きおくがもとのばしょとどうつながっているのかしりたい
+  relevant:
+  - d_t06_c07_r1
+  graded:
+    d_t06_c07_r1: 3
+    d_t06_c07_m1: 1
+- id: q_t06_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: そとからきたじょうほうをすぐにしんじてよいかどうかについて
+  relevant:
+  - d_t06_c09_m2
+  graded:
+    d_t06_c09_m2: 3
+    d_t06_c06_m1: 1
+- id: q_t06_res_01
+  bucket: resource-only
+  split: heldout
+  text: how are repeated items caught when a connector re-syncs the same window twice
+  relevant:
+  - d_t06_c10_r2
+  graded:
+    d_t06_c10_r2: 3
+    d_t06_c04_r1: 1
+- id: q_t06_res_02
+  bucket: resource-only
+  split: heldout
+  text: what access permission is needed before message history can be pulled from a workspace
+  relevant:
+  - d_t06_c01_r1
+  graded:
+    d_t06_c01_r1: 3
+    d_t06_c02_m1: 1
+- id: q_t06_res_03
+  bucket: resource-only
+  split: heldout
+  text: does a removed source item get erased from memory right away or held back
+  relevant:
+  - d_t06_c08_r1
+  graded:
+    d_t06_c08_r1: 3
+    d_t06_c06_m2: 1
+- id: q_t06_res_04
+  bucket: resource-only
+  split: public
+  text: how do trust tiers change the way outside content gets ranked during search
+  relevant:
+  - d_t06_c09_r1
+  graded:
+    d_t06_c09_r1: 3
+    d_t06_c06_r1: 1
+- id: q_t06_mem_01
+  bucket: memory-only
+  split: heldout
+  text: 新しいチャンネルでボットの招待を忘れた場合に何が起きるか
+  relevant:
+  - d_t06_c01_m2
+  graded:
+    d_t06_c01_m2: 3
+    d_t06_c02_m2: 1
+- id: q_t06_mem_02
+  bucket: memory-only
+  split: heldout
+  text: catching an outdated number by tracing a memory back to its origin
+  relevant:
+  - d_t06_c07_m2
+  graded:
+    d_t06_c07_m2: 3
+    d_t06_c08_m2: 1
+- id: q_t06_mem_03
+  bucket: memory-only
+  split: heldout
+  text: 外部から取り込む情報の個人情報保護はどのように設定されているか
+  relevant:
+  - d_t06_c06_m1
+  graded:
+    d_t06_c06_m1: 3
+    d_t06_c09_m2: 1
+- id: q_t06_mem_04
+  bucket: memory-only
+  split: heldout
+  text: why did project notes stay disconnected before we grouped them under one label
+  relevant:
+  - d_t06_c03_m2
+  graded:
+    d_t06_c03_m2: 3
+    d_t06_c07_m1: 1
+- id: q_t06_mem_05
+  bucket: memory-only
+  split: public
+  text: why do public discord messages carry less influence than internal decisions in search
+  relevant:
+  - d_t06_c09_m1
+  graded:
+    d_t06_c09_m1: 3
+    d_t06_c06_m1: 1
+- id: q_t07_x_01
+  bucket: cross-source
+  split: heldout
+  text: bringing up all self-hosted services together using a single instruction
+  relevant:
+  - d_t07_c01_r1
+  - d_t07_c01_m1
+  graded:
+    d_t07_c01_r1: 3
+    d_t07_c01_m1: 2
+    d_t07_c09_r1: 1
+- id: q_t07_x_02
+  bucket: cross-source
+  split: heldout
+  text: why did we standardize on one numbered approach for changing the database schema
+  relevant:
+  - d_t07_c02_r1
+  - d_t07_c02_m2
+  graded:
+    d_t07_c02_r1: 3
+    d_t07_c02_m2: 2
+    d_t07_c03_r1: 1
+- id: q_t07_x_03
+  bucket: cross-source
+  split: heldout
+  text: keeping the vector store's settings in sync with the embedding model
+  relevant:
+  - d_t07_c03_r1
+  - d_t07_c03_m2
+  graded:
+    d_t07_c03_r1: 3
+    d_t07_c03_m2: 2
+    d_t07_c06_r1: 1
+- id: q_t07_x_04
+  bucket: cross-source
+  split: heldout
+  text: avoiding silent loss of queued background tasks under heavy load
+  relevant:
+  - d_t07_c04_r1
+  - d_t07_c04_m1
+  graded:
+    d_t07_c04_r1: 3
+    d_t07_c04_m1: 2
+    d_t07_c07_m2: 1
+- id: q_t07_x_05
+  bucket: cross-source
+  split: heldout
+  text: reordering search results locally to reduce extra network delay
+  relevant:
+  - d_t07_c07_r1
+  - d_t07_c07_m1
+  graded:
+    d_t07_c07_r1: 3
+    d_t07_c07_m1: 2
+    d_t07_c06_m1: 1
+- id: q_t07_x_06
+  bucket: cross-source
+  split: heldout
+  text: keeping database and vector store backups aligned for a trustworthy recovery
+  relevant:
+  - d_t07_c10_r1
+  - d_t07_c10_m1
+  graded:
+    d_t07_c10_r1: 3
+    d_t07_c10_m1: 2
+    d_t07_c02_r1: 1
+- id: q_t07_exact_01
+  bucket: retrieval-exact
+  split: heldout
+  text: why can operators start the whole stack with one command
+  relevant:
+  - d_t07_c01_r1
+  graded:
+    d_t07_c01_r1: 3
+    d_t07_c08_r1: 1
+- id: q_t07_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: explain the background job queue that runs consolidation and sleep
+  relevant:
+  - d_t07_c04_r1
+  graded:
+    d_t07_c04_r1: 3
+    d_t07_c06_r1: 1
+- id: q_t07_exact_03
+  bucket: retrieval-exact
+  split: public
+  text: explain why the embedding service runs as its own container
+  relevant:
+  - d_t07_c06_r1
+  graded:
+    d_t07_c06_r1: 3
+    d_t07_c07_r1: 1
+- id: q_t07_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: why do we restart services one at a time during upgrades
+  relevant:
+  - d_t07_c09_r1
+  graded:
+    d_t07_c09_r1: 3
+    d_t07_c01_m1: 1
+- id: q_t07_sem_01
+  bucket: retrieval-semantic
+  split: heldout
+  text: how did we fix services starting before their dependencies were fully up
+  relevant:
+  - d_t07_c01_m2
+  graded:
+    d_t07_c01_m2: 3
+    d_t07_c08_m1: 1
+- id: q_t07_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: why does it decline to launch when vector sizes don't agree
+  relevant:
+  - d_t07_c03_m2
+  graded:
+    d_t07_c03_m2: 3
+    d_t07_c06_m1: 1
+- id: q_t07_sem_03
+  bucket: retrieval-semantic
+  split: public
+  text: where can operators find every setting to fill in before deploying
+  relevant:
+  - d_t07_c05_r1
+  graded:
+    d_t07_c05_r1: 3
+    d_t07_c01_r1: 1
+- id: q_t07_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: how did we stop a reordering service from crashing under heavy simultaneous traffic
+  relevant:
+  - d_t07_c07_m2
+  graded:
+    d_t07_c07_m2: 3
+    d_t07_c04_m1: 1
+- id: q_t07_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: how does the stack decide a dependency is finally ready to use
+  relevant:
+  - d_t07_c08_r1
+  graded:
+    d_t07_c08_r1: 3
+    d_t07_c01_m2: 1
+- id: q_t07_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: なぜぱすわーどをすぐにこうかんすることにしたのですか
+  relevant:
+  - d_t07_c05_m2
+  graded:
+    d_t07_c05_m2: 3
+    d_t07_c07_m2: 1
+- id: q_t07_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: なぜじーぴーゆーのめもりがたりずにもでるがうまくうごかなかったのですか
+  relevant:
+  - d_t07_c06_m2
+  graded:
+    d_t07_c06_m2: 3
+    d_t07_c03_m2: 1
+- id: q_t07_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: なぜふくげんにおもったよりじかんがかかったのですか
+  relevant:
+  - d_t07_c10_m2
+  graded:
+    d_t07_c10_m2: 3
+    d_t07_c04_m1: 1
+- id: q_t07_res_01
+  bucket: resource-only
+  split: heldout
+  text: what happens automatically before the api starts accepting new requests
+  relevant:
+  - d_t07_c02_r1
+  graded:
+    d_t07_c02_r1: 3
+    d_t07_c03_r1: 1
+- id: q_t07_res_02
+  bucket: resource-only
+  split: public
+  text: what two things does this service take in before sending results back
+  relevant:
+  - d_t07_c07_r1
+  graded:
+    d_t07_c07_r1: 3
+    d_t07_c06_r1: 1
+- id: q_t07_res_03
+  bucket: resource-only
+  split: heldout
+  text: which three files get grouped into the nightly capture
+  relevant:
+  - d_t07_c10_r1
+  graded:
+    d_t07_c10_r1: 3
+    d_t07_c04_r1: 1
+- id: q_t07_res_04
+  bucket: resource-only
+  split: heldout
+  text: can each part of the stack be resized without touching the rest
+  relevant:
+  - d_t07_c01_r1
+  graded:
+    d_t07_c01_r1: 3
+    d_t07_c09_r1: 1
+- id: q_t07_mem_01
+  bucket: memory-only
+  split: heldout
+  text: why did we stop each service from running its own separate startup sql commands
+  relevant:
+  - d_t07_c02_m2
+  graded:
+    d_t07_c02_m2: 3
+    d_t07_c05_m1: 1
+- id: q_t07_mem_02
+  bucket: memory-only
+  split: heldout
+  text: why were queued jobs vanishing without any error under heavy load
+  relevant:
+  - d_t07_c04_m1
+  graded:
+    d_t07_c04_m1: 3
+    d_t07_c07_m2: 1
+- id: q_t07_mem_03
+  bucket: memory-only
+  split: public
+  text: why do we now require every setting to be explicitly set before startup
+  relevant:
+  - d_t07_c05_m1
+  graded:
+    d_t07_c05_m1: 3
+    d_t07_c01_m1: 1
+- id: q_t07_mem_04
+  bucket: memory-only
+  split: heldout
+  text: why do we reorder results using our own hardware instead of an external service
+  relevant:
+  - d_t07_c07_m1
+  graded:
+    d_t07_c07_m1: 3
+    d_t07_c06_m1: 1
+- id: q_t07_mem_05
+  bucket: memory-only
+  split: heldout
+  text: what order do we follow so upgrades avoid interrupting live traffic
+  relevant:
+  - d_t07_c09_m1
+  graded:
+    d_t07_c09_m1: 3
+    d_t07_c10_m1: 1
+- id: q_t08_x_01
+  bucket: cross-source
+  split: heldout
+  text: how our engineering team began using the memory sdk
+  relevant:
+  - d_t08_c01_r1
+  - d_t08_c01_m1
+  graded:
+    d_t08_c01_r1: 3
+    d_t08_c01_m1: 2
+    d_t08_c08_m1: 1
+- id: q_t08_x_02
+  bucket: cross-source
+  split: heldout
+  text: loading history automatically before an agent's first reply
+  relevant:
+  - d_t08_c02_r1
+  - d_t08_c02_m1
+  graded:
+    d_t08_c02_r1: 3
+    d_t08_c02_m1: 2
+    d_t08_c03_r1: 1
+- id: q_t08_x_03
+  bucket: cross-source
+  split: heldout
+  text: making sure an assistant checks recorded history before answering
+  relevant:
+  - d_t08_c04_r1
+  - d_t08_c04_m1
+  graded:
+    d_t08_c04_r1: 3
+    d_t08_c04_m1: 2
+    d_t08_c09_r1: 1
+- id: q_t08_x_04
+  bucket: cross-source
+  split: heldout
+  text: how the system copes with slow calls without failing outright
+  relevant:
+  - d_t08_c06_r1
+  - d_t08_c06_m1
+  graded:
+    d_t08_c06_r1: 3
+    d_t08_c06_m1: 2
+    d_t08_c10_r1: 1
+- id: q_t08_x_05
+  bucket: cross-source
+  split: heldout
+  text: exposing memory operations as callable functions an agent can use
+  relevant:
+  - d_t08_c08_r1
+  - d_t08_c08_m1
+  graded:
+    d_t08_c08_r1: 3
+    d_t08_c08_m1: 2
+    d_t08_c04_m1: 1
+- id: q_t08_x_06
+  bucket: cross-source
+  split: heldout
+  text: keeping a big import job running smoothly when the server pushes back
+  relevant:
+  - d_t08_c10_r1
+  - d_t08_c10_m1
+  graded:
+    d_t08_c10_r1: 3
+    d_t08_c10_m1: 2
+    d_t08_c06_r1: 1
+- id: q_t08_exact_01
+  bucket: retrieval-exact
+  split: heldout
+  text: what happens when a coding agent begins a new session
+  relevant:
+  - d_t08_c02_r1
+  graded:
+    d_t08_c02_r1: 3
+    d_t08_c03_r1: 1
+- id: q_t08_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: how to pass a prompt on the command line for automation
+  relevant:
+  - d_t08_c05_r1
+  graded:
+    d_t08_c05_r1: 3
+    d_t08_c10_r1: 1
+- id: q_t08_exact_03
+  bucket: retrieval-exact
+  split: public
+  text: is authentication handled the same way to the client
+  relevant:
+  - d_t08_c07_r1
+  graded:
+    d_t08_c07_r1: 3
+    d_t08_c01_r1: 1
+- id: q_t08_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: how do remember calls become visible to a second agent
+  relevant:
+  - d_t08_c09_m1
+  graded:
+    d_t08_c09_m1: 3
+    d_t08_c04_m1: 1
+- id: q_t08_sem_01
+  bucket: retrieval-semantic
+  split: heldout
+  text: is anything written down right after an agent stops working on something
+  relevant:
+  - d_t08_c03_m1
+  graded:
+    d_t08_c03_m1: 3
+    d_t08_c02_r1: 1
+- id: q_t08_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: why might a bot check information first rather than assume a response
+  relevant:
+  - d_t08_c04_r1
+  graded:
+    d_t08_c04_r1: 3
+    d_t08_c09_r1: 1
+- id: q_t08_sem_03
+  bucket: retrieval-semantic
+  split: public
+  text: does the sdk try again on its own after a network hiccup
+  relevant:
+  - d_t08_c06_r1
+  graded:
+    d_t08_c06_r1: 3
+    d_t08_c10_r1: 1
+- id: q_t08_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: why did we reduce how many callable functions the model has access to
+  relevant:
+  - d_t08_c08_m2
+  graded:
+    d_t08_c08_m2: 3
+    d_t08_c04_r1: 1
+- id: q_t08_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: how does the system decide which failures are worth trying again
+  relevant:
+  - d_t08_c10_m2
+  graded:
+    d_t08_c10_m2: 3
+    d_t08_c06_r1: 1
+- id: q_t08_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: とちゅうでとまったときになぜようやくがにどほぞんされるのですか
+  relevant:
+  - d_t08_c03_m2
+  graded:
+    d_t08_c03_m2: 3
+    d_t08_c09_m2: 1
+- id: q_t08_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: なぜかいせんがおそいときにまちじかんとさいしどすうをふやしたのですか
+  relevant:
+  - d_t08_c06_m1
+  graded:
+    d_t08_c06_m1: 3
+    d_t08_c07_m1: 1
+- id: q_t08_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: なぜろうえいのうたがいでにんしょうじょうほうをすべてつくりなおしたのですか
+  relevant:
+  - d_t08_c07_m1
+  graded:
+    d_t08_c07_m1: 3
+    d_t08_c06_m1: 1
+- id: q_t08_res_01
+  bucket: resource-only
+  split: public
+  text: what's the recommended first step after installing the client library
+  relevant:
+  - d_t08_c01_r1
+  graded:
+    d_t08_c01_r1: 3
+    d_t08_c08_r1: 1
+- id: q_t08_res_02
+  bucket: resource-only
+  split: heldout
+  text: what configuration settings control how much history gets pulled in at session start
+  relevant:
+  - d_t08_c02_r1
+  graded:
+    d_t08_c02_r1: 3
+    d_t08_c03_r1: 1
+- id: q_t08_res_03
+  bucket: resource-only
+  split: heldout
+  text: how are individual memory operations exposed for a model to call
+  relevant:
+  - d_t08_c08_r1
+  graded:
+    d_t08_c08_r1: 3
+    d_t08_c04_r1: 1
+- id: q_t08_res_04
+  bucket: resource-only
+  split: heldout
+  text: what categories of errors does the client distinguish between
+  relevant:
+  - d_t08_c10_r1
+  graded:
+    d_t08_c10_r1: 3
+    d_t08_c06_r1: 1
+- id: q_t08_mem_01
+  bucket: memory-only
+  split: heldout
+  text: why we limited how far back the startup recall can reach into notes
+  relevant:
+  - d_t08_c02_m2
+  graded:
+    d_t08_c02_m2: 3
+    d_t08_c05_m1: 1
+- id: q_t08_mem_02
+  bucket: memory-only
+  split: public
+  text: what standard did we set for checking answers before replying to customers
+  relevant:
+  - d_t08_c04_m1
+  graded:
+    d_t08_c04_m1: 3
+    d_t08_c09_m1: 1
+- id: q_t08_mem_03
+  bucket: memory-only
+  split: heldout
+  text: how are broken jobs flagged and fixed with nobody watching the terminal
+  relevant:
+  - d_t08_c05_m1
+  graded:
+    d_t08_c05_m1: 3
+    d_t08_c02_m2: 1
+- id: q_t08_mem_04
+  bucket: memory-only
+  split: heldout
+  text: how one agent passes an unfinished task to another without a summary
+  relevant:
+  - d_t08_c09_m1
+  graded:
+    d_t08_c09_m1: 3
+    d_t08_c04_m1: 1
+- id: q_t08_mem_05
+  bucket: memory-only
+  split: heldout
+  text: what fixed the flood of rate-limit errors during the large import
+  relevant:
+  - d_t08_c10_m1
+  graded:
+    d_t08_c10_m1: 3
+    d_t08_c06_m1: 1
+- id: q_t09_x_01
+  bucket: cross-source
+  split: heldout
+  text: how are kagura's paid subscription tiers differentiated from each other
+  relevant:
+  - d_t09_c01_m1
+  - d_t09_c01_r1
+  - d_t09_c01_m2
+  graded:
+    d_t09_c01_m1: 3
+    d_t09_c01_r1: 2
+    d_t09_c01_m2: 2
+    d_t09_c09_r1: 1
+- id: q_t09_x_02
+  bucket: cross-source
+  split: heldout
+  text: will extra weekly allowance still be usable in a later week
+  relevant:
+  - d_t09_c03_m2
+  - d_t09_c03_r1
+  graded:
+    d_t09_c03_m2: 3
+    d_t09_c03_r1: 2
+    d_t09_c02_r1: 1
+- id: q_t09_x_03
+  bucket: cross-source
+  split: heldout
+  text: what happens automatically when someone upgrades their plan mid cycle
+  relevant:
+  - d_t09_c05_m1
+  - d_t09_c05_r1
+  - d_t09_c05_m2
+  graded:
+    d_t09_c05_m1: 3
+    d_t09_c05_r1: 2
+    d_t09_c05_m2: 2
+    d_t09_c06_r1: 1
+- id: q_t09_x_04
+  bucket: cross-source
+  split: heldout
+  text: which company actually handles card charges and invoices behind the scenes
+  relevant:
+  - d_t09_c07_m1
+  - d_t09_c07_r1
+  graded:
+    d_t09_c07_m1: 3
+    d_t09_c07_r1: 2
+    d_t09_c10_r2: 1
+- id: q_t09_x_05
+  bucket: cross-source
+  split: heldout
+  text: what occurs when a team's usage goes well beyond its plan limit
+  relevant:
+  - d_t09_c08_m1
+  - d_t09_c08_r1
+  - d_t09_c08_m2
+  graded:
+    d_t09_c08_m1: 3
+    d_t09_c08_r1: 2
+    d_t09_c08_m2: 2
+    d_t09_c03_r1: 1
+- id: q_t09_x_06
+  bucket: cross-source
+  split: heldout
+  text: what restrictions apply to workspaces that never pay for a plan
+  relevant:
+  - d_t09_c09_m1
+  - d_t09_c09_r1
+  - d_t09_c09_r2
+  graded:
+    d_t09_c09_m1: 3
+    d_t09_c09_r1: 2
+    d_t09_c09_r2: 2
+    d_t09_c01_r1: 1
+- id: q_t09_exact_01
+  bucket: retrieval-exact
+  split: public
+  text: why would calls return a 429 status suddenly
+  relevant:
+  - d_t09_c02_r1
+  graded:
+    d_t09_c02_r1: 3
+    d_t09_c08_r1: 1
+- id: q_t09_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: how should the api treat a missing entitlement response
+  relevant:
+  - d_t09_c04_r1
+  graded:
+    d_t09_c04_r1: 3
+    d_t09_c01_r1: 1
+- id: q_t09_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: after downgrade why would over-limit seats lose write access
+  relevant:
+  - d_t09_c06_r1
+  graded:
+    d_t09_c06_r1: 3
+    d_t09_c05_m1: 1
+- id: q_t09_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: are overage charges combined into a single line-itemized statement
+  relevant:
+  - d_t09_c10_m1
+  graded:
+    d_t09_c10_m1: 3
+    d_t09_c08_m1: 1
+- id: q_t09_sem_01
+  bucket: retrieval-semantic
+  split: public
+  text: why did kagura simplify how its paid plans differ from each other
+  relevant:
+  - d_t09_c01_m1
+  graded:
+    d_t09_c01_m1: 3
+    d_t09_c09_r1: 1
+- id: q_t09_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: do people expect leftover capacity to transfer forward like a phone data plan
+  relevant:
+  - d_t09_c03_m2
+  graded:
+    d_t09_c03_m2: 3
+    d_t09_c08_m2: 1
+- id: q_t09_sem_03
+  bucket: retrieval-semantic
+  split: heldout
+  text: who actually keeps hold of customer payment details behind the scenes
+  relevant:
+  - d_t09_c07_m1
+  graded:
+    d_t09_c07_m1: 3
+    d_t09_c10_r2: 1
+- id: q_t09_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: how are teams warned before they start getting extra charges for high usage
+  relevant:
+  - d_t09_c08_r1
+  graded:
+    d_t09_c08_r1: 3
+    d_t09_c02_m1: 1
+- id: q_t09_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: what should someone expect if they stick with the zero cost option long term
+  relevant:
+  - d_t09_c09_r1
+  graded:
+    d_t09_c09_r1: 3
+    d_t09_c05_m1: 1
+- id: q_t09_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: じょうげんにたっするじかんがまいにちちがうのはなぜですか
+  relevant:
+  - d_t09_c02_m2
+  graded:
+    d_t09_c02_m2: 3
+    d_t09_c08_r1: 1
+- id: q_t09_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: しはらいがおわってもすぐにはんえいされないのはなぜですか
+  relevant:
+  - d_t09_c07_m2
+  graded:
+    d_t09_c07_m2: 3
+    d_t09_c05_r1: 1
+- id: q_t09_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: むりょうのままがいぶとのれんけいはつかえますか
+  relevant:
+  - d_t09_c09_r2
+  graded:
+    d_t09_c09_r2: 3
+    d_t09_c01_r1: 1
+- id: q_t09_res_01
+  bucket: resource-only
+  split: public
+  text: what does each subscription level actually include for customers
+  relevant:
+  - d_t09_c01_r1
+  graded:
+    d_t09_c01_r1: 3
+    d_t09_c04_r1: 1
+- id: q_t09_res_02
+  bucket: resource-only
+  split: heldout
+  text: how does the system decide if a workspace can access a feature
+  relevant:
+  - d_t09_c04_r1
+  graded:
+    d_t09_c04_r1: 3
+    d_t09_c01_m1: 1
+- id: q_t09_res_03
+  bucket: resource-only
+  split: heldout
+  text: what happens to extra seats after downgrading takes effect
+  relevant:
+  - d_t09_c06_r1
+  graded:
+    d_t09_c06_r1: 3
+    d_t09_c05_m2: 1
+- id: q_t09_res_04
+  bucket: resource-only
+  split: heldout
+  text: what limitations come with the plan that costs nothing
+  relevant:
+  - d_t09_c09_r1
+  graded:
+    d_t09_c09_r1: 3
+    d_t09_c01_m2: 1
+- id: q_t09_mem_01
+  bucket: memory-only
+  split: heldout
+  text: why are connector integrations limited to larger team plans
+  relevant:
+  - d_t09_c01_m2
+  graded:
+    d_t09_c01_m2: 3
+    d_t09_c09_r1: 1
+- id: q_t09_mem_02
+  bucket: memory-only
+  split: public
+  text: why was a rolling window chosen over a fixed weekly reset
+  relevant:
+  - d_t09_c03_m1
+  graded:
+    d_t09_c03_m1: 3
+    d_t09_c02_m1: 1
+- id: q_t09_mem_03
+  bucket: memory-only
+  split: heldout
+  text: should the cost change be spread out during a mid cycle upgrade
+  relevant:
+  - d_t09_c05_m2
+  graded:
+    d_t09_c05_m2: 3
+    d_t09_c06_m1: 1
+- id: q_t09_mem_04
+  bucket: memory-only
+  split: heldout
+  text: do customers prefer paying overage fees rather than getting rate limited
+  relevant:
+  - d_t09_c08_m2
+  graded:
+    d_t09_c08_m2: 3
+    d_t09_c02_r1: 1
+- id: q_t09_mem_05
+  bucket: memory-only
+  split: heldout
+  text: why is the monthly invoice date tied to when someone first signed up
+  relevant:
+  - d_t09_c10_m1
+  graded:
+    d_t09_c10_m1: 3
+    d_t09_c07_m1: 1
+- id: q_t10_x_01
+  bucket: cross-source
+  split: heldout
+  text: what happened when the hybrid index got corrupted and how was it rebuilt
+  relevant:
+  - d_t10_c01_r1
+  - d_t10_c01_m1
+  - d_t10_c01_m2
+  graded:
+    d_t10_c01_r1: 3
+    d_t10_c01_m1: 2
+    d_t10_c01_m2: 2
+    d_t10_c09_m1: 1
+- id: q_t10_x_02
+  bucket: cross-source
+  split: heldout
+  text: why did new data stop flowing into the workspace and how was it fixed
+  relevant:
+  - d_t10_c02_m1
+  - d_t10_c02_r1
+  - d_t10_c02_m2
+  graded:
+    d_t10_c02_m1: 3
+    d_t10_c02_r1: 2
+    d_t10_c02_m2: 2
+    d_t10_c06_m2: 1
+- id: q_t10_x_03
+  bucket: cross-source
+  split: heldout
+  text: what caused search responses to slow down dramatically and how was it fixed
+  relevant:
+  - d_t10_c03_r1
+  - d_t10_c03_m1
+  - d_t10_c03_m2
+  graded:
+    d_t10_c03_r1: 3
+    d_t10_c03_m1: 2
+    d_t10_c03_m2: 2
+    d_t10_c05_m2: 1
+- id: q_t10_x_04
+  bucket: cross-source
+  split: heldout
+  text: what went wrong during the overnight consolidation job and how did the team recover
+  relevant:
+  - d_t10_c04_m1
+  - d_t10_c04_r1
+  - d_t10_c04_m2
+  graded:
+    d_t10_c04_m1: 3
+    d_t10_c04_r1: 2
+    d_t10_c04_m2: 2
+    d_t10_c07_m2: 1
+- id: q_t10_x_05
+  bucket: cross-source
+  split: heldout
+  text: how did the team bring back memories after they were mistakenly deleted
+  relevant:
+  - d_t10_c07_r1
+  - d_t10_c07_m1
+  - d_t10_c07_m2
+  graded:
+    d_t10_c07_r1: 3
+    d_t10_c07_m1: 2
+    d_t10_c07_m2: 2
+    d_t10_c01_m2: 1
+- id: q_t10_x_06
+  bucket: cross-source
+  split: heldout
+  text: why did a third party sync stop working without any visible error
+  relevant:
+  - d_t10_c08_r1
+  - d_t10_c08_m1
+  - d_t10_c08_m2
+  graded:
+    d_t10_c08_r1: 3
+    d_t10_c08_m1: 2
+    d_t10_c08_m2: 2
+    d_t10_c02_r1: 1
+- id: q_t10_exact_01
+  bucket: retrieval-exact
+  split: public
+  text: operators filter the centralized log store during triage
+  relevant:
+  - d_t10_c05_r1
+  graded:
+    d_t10_c05_r1: 3
+    d_t10_c04_m1: 1
+- id: q_t10_exact_02
+  bucket: retrieval-exact
+  split: heldout
+  text: why should alerts require a sustained breach before paging
+  relevant:
+  - d_t10_c06_r1
+  graded:
+    d_t10_c06_r1: 3
+    d_t10_c02_m1: 1
+- id: q_t10_exact_03
+  bucket: retrieval-exact
+  split: heldout
+  text: what removes data older than the configured retention window
+  relevant:
+  - d_t10_c09_r2
+  graded:
+    d_t10_c09_r2: 3
+    d_t10_c01_m2: 1
+- id: q_t10_exact_04
+  bucket: retrieval-exact
+  split: heldout
+  text: what happens when a page escalates to a secondary responder
+  relevant:
+  - d_t10_c10_r1
+  graded:
+    d_t10_c10_r1: 3
+    d_t10_c06_m2: 1
+- id: q_t10_sem_01
+  bucket: retrieval-semantic
+  split: heldout
+  text: what changed after a slow maintenance operation locked users out for a workday
+  relevant:
+  - d_t10_c01_m2
+  graded:
+    d_t10_c01_m2: 3
+    d_t10_c09_r2: 1
+- id: q_t10_sem_02
+  bucket: retrieval-semantic
+  split: heldout
+  text: where does the time go during a slow document lookup request
+  relevant:
+  - d_t10_c03_r1
+  graded:
+    d_t10_c03_r1: 3
+    d_t10_c05_m2: 1
+- id: q_t10_sem_03
+  bucket: retrieval-semantic
+  split: public
+  text: how can we track one user request across several backend services when debugging
+  relevant:
+  - d_t10_c05_r1
+  graded:
+    d_t10_c05_r1: 3
+    d_t10_c03_m1: 1
+- id: q_t10_sem_04
+  bucket: retrieval-semantic
+  split: heldout
+  text: how did the team confirm nothing was lost after bringing data back
+  relevant:
+  - d_t10_c07_m2
+  graded:
+    d_t10_c07_m2: 3
+    d_t10_c04_r1: 1
+- id: q_t10_sem_05
+  bucket: retrieval-semantic
+  split: heldout
+  text: why did writes fail overnight and how was storage room reclaimed quickly
+  relevant:
+  - d_t10_c09_m1
+  graded:
+    d_t10_c09_m1: 3
+    d_t10_c01_r1: 1
+- id: q_t10_hira_01
+  bucket: hiragana-only
+  split: heldout
+  text: とりこみしょりがとまったりゆうとどうやってきづいたか
+  relevant:
+  - d_t10_c02_m2
+  graded:
+    d_t10_c02_m2: 3
+    d_t10_c06_m1: 1
+- id: q_t10_hira_02
+  bucket: hiragana-only
+  split: heldout
+  text: やかんのしょりがとちゅうでとまったときにどうやってふっきゅうしたか
+  relevant:
+  - d_t10_c04_m2
+  graded:
+    d_t10_c04_m2: 3
+    d_t10_c07_m1: 1
+- id: q_t10_hira_03
+  bucket: hiragana-only
+  split: heldout
+  text: がいぶれんけいがきづかれずにしっぱいしつづけたげんいんはなにか
+  relevant:
+  - d_t10_c08_m2
+  graded:
+    d_t10_c08_m2: 3
+    d_t10_c02_r1: 1
+- id: q_t10_res_01
+  bucket: resource-only
+  split: public
+  text: how does the ingestion system pass events along to workers
+  relevant:
+  - d_t10_c02_r1
+  graded:
+    d_t10_c02_r1: 3
+    d_t10_c06_r1: 1
+- id: q_t10_res_02
+  bucket: resource-only
+  split: heldout
+  text: what is the recovery process when consolidation stops before finishing
+  relevant:
+  - d_t10_c04_r1
+  graded:
+    d_t10_c04_r1: 3
+    d_t10_c07_r1: 1
+- id: q_t10_res_03
+  bucket: resource-only
+  split: heldout
+  text: what usually makes a connector stop authenticating without a visible error
+  relevant:
+  - d_t10_c08_r1
+  graded:
+    d_t10_c08_r1: 3
+    d_t10_c10_r1: 1
+- id: q_t10_res_04
+  bucket: resource-only
+  split: heldout
+  text: how does the escalation chain work if nobody responds to a page
+  relevant:
+  - d_t10_c10_r1
+  graded:
+    d_t10_c10_r1: 3
+    d_t10_c06_r1: 1
+- id: q_t10_mem_01
+  bucket: memory-only
+  split: public
+  text: how did the team first discover the search index was corrupted
+  relevant:
+  - d_t10_c01_m1
+  graded:
+    d_t10_c01_m1: 3
+    d_t10_c09_m1: 1
+- id: q_t10_mem_02
+  bucket: memory-only
+  split: heldout
+  text: what changes did we make after last week's slow recall investigation
+  relevant:
+  - d_t10_c03_m2
+  graded:
+    d_t10_c03_m2: 3
+    d_t10_c05_m2: 1
+- id: q_t10_mem_03
+  bucket: memory-only
+  split: heldout
+  text: why did we set up a separate notification for delayed data intake
+  relevant:
+  - d_t10_c06_m2
+  graded:
+    d_t10_c06_m2: 3
+    d_t10_c02_m1: 1
+- id: q_t10_mem_04
+  bucket: memory-only
+  split: heldout
+  text: what happened when someone ran a destructive command on the incorrect workspace
+  relevant:
+  - d_t10_c07_m1
+  graded:
+    d_t10_c07_m1: 3
+    d_t10_c04_m1: 1
+- id: q_t10_mem_05
+  bucket: memory-only
+  split: heldout
+  text: why did we create a formal escalation rotation for after-hours alerts
+  relevant:
+  - d_t10_c10_m1
+  graded:
+    d_t10_c10_m1: 3
+    d_t10_c08_m1: 1

--- a/backend/tests/eval/freeze_tau.py
+++ b/backend/tests/eval/freeze_tau.py
@@ -1,0 +1,225 @@
+"""Day-3 corpus-freeze τ computation (prereg-v1 §3) — live, run ONCE per freeze.
+
+Computes the FROZEN τ for the inferential H2 kill-shot: the median cosine over
+the **held-out** cross-topic gold pairs of the frozen corpus, measured with the
+rig's real embedder. Procedure (prereg-v1 §3, stamped into Appendix A):
+
+    1. ingest the frozen corpus into a throwaway workspace (production write path)
+    2. fetch the stored vectors for every corpus doc
+    3. enumerate gold pairs from HELD-OUT multi-gold probes only (``split ==
+       "heldout"``), keep the cross-topic ones (differing ``Document.source`` —
+       the same definition the Day-2 directional probe used)
+    4. τ := median pairwise cosine over that population
+    5. teardown (corpus data is ephemeral; only the JSON survives)
+
+Also records the counts Appendix A stamps (N_heldout, N_probe, doc/query counts),
+the corpus ``content_sha256`` from its meta, the Sudachi version, and the
+embedder identity — one self-contained freeze artifact. Real run only; numbers
+are never fabricated. Heavy imports are function-local (module import is CI-safe).
+
+Usage (inside the stack's api container):
+    KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.freeze_tau \
+        --corpus tests/eval/fixtures/kagura_l.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from tests.eval.placebo import median_cross_topic_gold_pair_cosine
+from tests.eval.runner import _ingest_corpus, _sudachi_version, _teardown
+from tests.eval.tools.corpus import Corpus, load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+
+def heldout_cross_topic_gold_pairs(corpus: Corpus) -> set[frozenset[str]]:
+    """Gold pairs from held-out multi-gold probes, cross-topic only.
+
+    A probe is a query with >= 2 gold docs (same selection as
+    ``build_replay_plan``) restricted to ``split == "heldout"``; a pair is
+    cross-topic when its two docs have different ``Document.source``. Pure —
+    unit-testable without the stack.
+    """
+    by_id = corpus.docs_by_id
+    pairs: set[frozenset[str]] = set()
+    for q in corpus.queries:
+        if q.split != "heldout" or len(q.relevant) < 2:
+            continue
+        gold = list(q.relevant)
+        for i in range(len(gold)):
+            for j in range(i + 1, len(gold)):
+                a, b = gold[i], gold[j]
+                da, db = by_id.get(a), by_id.get(b)
+                if da is None or db is None or da.source == db.source:
+                    continue
+                pairs.add(frozenset((a, b)))
+    return pairs
+
+
+async def run_freeze_tau(corpus_path: str, write: bool = True) -> dict[str, Any]:
+    """Ingest the frozen corpus, measure τ per prereg-v1 §3, tear down."""
+    from utils.datetime import utcnow
+
+    corpus = load_corpus(Path(corpus_path))
+    run_date = utcnow().strftime("%Y-%m-%d")
+
+    n_heldout = sum(1 for q in corpus.queries if q.split == "heldout")
+    n_public = sum(1 for q in corpus.queries if q.split == "public")
+    heldout_probes = [q for q in corpus.queries if q.split == "heldout" and len(q.relevant) >= 2]
+    # Valid H2 probes = held-out multi-gold whose gold set spans both sources
+    # (the cross-topic population the compounding gate acts on).
+    by_id = corpus.docs_by_id
+    n_probe = sum(
+        1
+        for q in heldout_probes
+        if {by_id[d].source for d in q.relevant if d in by_id} == {"memory", "resource"}
+    )
+    gold_pairs = heldout_cross_topic_gold_pairs(corpus)
+
+    measurement = await _measure_tau(corpus, gold_pairs)
+
+    results: dict[str, Any] = {
+        "run_date": run_date,
+        "experiment": "day3-corpus-freeze",
+        "corpus_path": corpus_path,
+        "corpus_version": corpus.meta.get("version"),
+        "content_sha256": corpus.meta.get("content_sha256"),
+        "sudachi_version": _sudachi_version(),
+        "doc_count": len(corpus.documents),
+        "query_count": len(corpus.queries),
+        "n_heldout": n_heldout,
+        "n_public": n_public,
+        "n_probe": n_probe,
+        "heldout_cross_topic_gold_pair_count": len(gold_pairs),
+        "tau_method": "median_heldout_cross_topic_gold_pair_cosine (prereg-v1 §3)",
+        **measurement,
+        "design_note": (
+            "Frozen τ for the inferential H2 kill-shot, computed ONCE at Day-3 "
+            "corpus-freeze from the held-out cross-topic gold-pair cosine "
+            "distribution — before any inferential result. Stamped into "
+            "prereg-v1 Appendix A and tagged prereg-v1-frozen."
+        ),
+    }
+
+    if write:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        stem = Path(corpus_path).stem
+        out = _RESULTS_DIR / f"freeze-{stem}-{run_date}.json"
+        out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"freeze-tau: wrote {out}")
+    return results
+
+
+async def _measure_tau(corpus: Corpus, gold_pairs: set[frozenset[str]]) -> dict[str, Any]:
+    """Provision, ingest, fetch vectors, compute τ, tear down (always)."""
+    from auth.workspace_roles import WorkspaceRole
+    from config.constants import EMBEDDING_MODEL_REGISTRY
+    from config.settings import get_settings
+    from db.base import get_db
+    from db.qdrant import ensure_kagura_memories_collection, get_collection_name, get_qdrant_client
+    from models.auth import Context, Workspace, WorkspaceMember
+    from models.config import ContextSearchConfig
+    from neural.utils import cosine_similarity
+    from services.memory_service import MemoryService
+    from tasks.neural_calibration import _load_measure_script
+
+    async for db in get_db():
+        owner = f"eval_{uuid4().hex[:8]}"
+        ws = Workspace(
+            id=uuid4(),
+            name=f"eval-ws-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=10_000_000,
+            weekly_api_limit=50_000_000,
+        )
+        ctx = Context(
+            id=uuid4(),
+            workspace_id=ws.id,
+            name=f"eval-ctx-{uuid4().hex[:8]}",
+            created_by=owner,
+            is_private=False,
+        )
+        db.add(ws)
+        await db.flush()
+        db.add(ctx)
+        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        # Same provisioning as runner.py/placebo_runner.py: stamp the per-context
+        # embedding config so ingest routes to the rig's real collection.
+        settings = get_settings()
+        emb_model = settings.embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        db.add(
+            ContextSearchConfig(
+                context_id=ctx.id,
+                semantic_weight=0.6,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="self_hosted",
+                reranker_model="qwen3-reranker-4b",
+                embedding_model=emb_model,
+                embedding_dimensions=emb_dims,
+            )
+        )
+        await db.flush()
+        await db.commit()
+
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await ensure_kagura_memories_collection(
+                emb_dims, get_collection_name(emb_model, emb_dims)
+            )
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+
+            script = _load_measure_script()
+            model_name, dims, collection = await script.resolve_embedding_model(db, ctx.id)
+            qdrant = get_qdrant_client()
+            vecs_by_mem = await script.fetch_vectors(qdrant, collection, [UUID(m) for m in id_map])
+            doc_vec = {id_map[m]: v for m, v in vecs_by_mem.items() if m in id_map}
+            source_by_doc = {d.id: d.source for d in corpus.documents}
+
+            tau = median_cross_topic_gold_pair_cosine(
+                doc_vec, gold_pairs, source_by_doc, cosine_fn=cosine_similarity
+            )
+            pair_cosines = sorted(
+                round(cosine_similarity(doc_vec[a], doc_vec[b]), 4)
+                for pr in gold_pairs
+                if len(pr) == 2
+                for a, b in [tuple(pr)]
+                if a in doc_vec and b in doc_vec
+            )
+            return {
+                "embedding_model": model_name,
+                "embedding_dimensions": dims,
+                "vectors_fetched": len(doc_vec),
+                "tau_frozen": round(tau, 4) if tau is not None else None,
+                "pair_cosine_min": pair_cosines[0] if pair_cosines else None,
+                "pair_cosine_max": pair_cosines[-1] if pair_cosines else None,
+            }
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+
+    raise RuntimeError("database session unavailable — is the stack up?")
+
+
+def _main() -> int:
+    import asyncio
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--corpus", required=True, help="corpus YAML path (the frozen fixture)")
+    ap.add_argument("--no-write", action="store_true", help="print only, skip the JSON artifact")
+    args = ap.parse_args()
+
+    results = asyncio.run(run_freeze_tau(args.corpus, write=not args.no_write))
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/metrics.py
+++ b/backend/tests/eval/metrics.py
@@ -67,16 +67,43 @@ def mean_precision_at_k(
     return sum(precision_at_k(r, rel, k) for r, rel in rankings) / len(rankings)
 
 
-def ndcg_at_k(ranked: Sequence[str], relevant: set[str], k: int) -> float:
-    """Normalized discounted cumulative gain @k under binary relevance.
+def ndcg_at_k(
+    ranked: Sequence[str],
+    relevant: set[str],
+    k: int,
+    *,
+    gains: dict[str, int] | None = None,
+) -> float:
+    """Normalized discounted cumulative gain @k, binary or graded relevance.
 
-    DCG@k discounts each relevant hit by ``1/log2(rank+1)``; the ideal DCG
-    places relevant docs in the top ``min(k, len(relevant))`` positions, so a
-    ranking that fills the top-``k`` with relevant docs scores 1.0 even when
-    the gold set is larger than ``k``. Returns 0.0 for ``k <= 0`` or an empty
-    gold set (a corpus-construction problem, not a metric error).
+    Binary path (default, ``gains=None``): DCG@k discounts each relevant hit by
+    ``1/log2(rank+1)``; the ideal DCG places relevant docs in the top
+    ``min(k, len(relevant))`` positions, so a ranking that fills the top-``k``
+    with relevant docs scores 1.0 even when the gold set is larger than ``k``.
+    Returns 0.0 for ``k <= 0`` or an empty gold set (a corpus-construction
+    problem, not a metric error).
+
+    Graded path (docs/02 §1.2 item 5, ``gains`` is a doc_id -> 0-3 grade map):
+    DCG@k = sum over ``ranked[:k]`` of ``(2**gain - 1) / log2(pos + 1)`` with
+    1-based ``pos`` (gain 0 for a ranked doc absent from ``gains``); IDCG@k is
+    the same formula applied to the top-``k`` gains sorted descending over
+    *all* graded docs (not only the retrieved ones). ``relevant`` is ignored in
+    this path — ``gains`` is the sole relevance signal. Returns 0.0 when
+    ``IDCG == 0`` (e.g. no positive grades) rather than dividing by zero.
     """
-    if k <= 0 or not relevant:
+    if k <= 0:
+        return 0.0
+    if gains is not None:
+        dcg = sum(
+            (2 ** gains.get(doc_id, 0) - 1) / math.log2(idx + 1)
+            for idx, doc_id in enumerate(ranked[:k], start=1)
+        )
+        top_gains = sorted(gains.values(), reverse=True)[:k]
+        idcg = sum(
+            (2**gain - 1) / math.log2(idx + 1) for idx, gain in enumerate(top_gains, start=1)
+        )
+        return dcg / idcg if idcg else 0.0
+    if not relevant:
         return 0.0
     dcg = sum(
         1.0 / math.log2(idx + 1)

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -1,0 +1,77 @@
+"""Pure logic for the Day-2 placebo kill-shot (directional de-risk).
+
+Infrastructure-free and deterministic — runs in normal CI (test_placebo.py).
+The live cold→warm→placebo orchestration lives in tests.eval.placebo_runner.
+
+Realizes the descriptive half of prereg-v1 H2: three arms (real-warm,
+density-matched random-edge placebo, shuffled-gold placebo) scored on companion
+recovery, compared by paired point estimates with DESCRIPTIVE bootstrap
+intervals. No inferential claim, no gated CI — that is the Day-3 confirmatory
+run at the single committed τ.
+"""
+
+from __future__ import annotations
+
+import random
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from statistics import median
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class Edge:
+    """One neural-memory edge, reduced to what the null model needs. The
+    non-endpoint attributes travel with the edge through a rewire (only src/dst
+    change), so the placebo differs from real-warm in exactly which endpoints
+    are connected — density, degree sequence and attribute multisets are held."""
+
+    src: str
+    dst: str
+    weight: float
+    origin: str
+    confidence: float
+    edge_type: str
+
+
+def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int = 10) -> list[Edge]:
+    """Maslov-Sneppen directed double-edge-swap null graph.
+
+    Repeatedly picks two edges (s1->d1),(s2->d2) and swaps their destinations to
+    (s1->d2),(s2->d1) — preserving every node's out-degree (src) and in-degree
+    (dst), the edge count, and each edge's own weight/origin/confidence/edge_type
+    (hence the exact attribute multisets). Rejects any swap that would create a
+    self-loop or a parallel edge. Attempts ``swap_factor * len(edges)`` accepted
+    swaps for mixing. Raises if fewer than two edges (nothing to swap).
+    """
+    if len(edges) < 2:
+        raise ValueError(f"need >= 2 edges to rewire, got {len(edges)}")
+
+    rng = random.Random(seed)
+    current = list(edges)
+    present = {(e.src, e.dst) for e in current}
+    target = swap_factor * len(current)
+    done = 0
+    attempts = 0
+    max_attempts = target * 20
+    while done < target and attempts < max_attempts:
+        attempts += 1
+        i = rng.randrange(len(current))
+        j = rng.randrange(len(current))
+        if i == j:
+            continue
+        e1, e2 = current[i], current[j]
+        new1 = (e1.src, e2.dst)
+        new2 = (e2.src, e1.dst)
+        if new1[0] == new1[1] or new2[0] == new2[1]:
+            continue  # self-loop
+        if new1 == new2 or new1 in present or new2 in present:
+            continue  # parallel edge
+        present.discard((e1.src, e1.dst))
+        present.discard((e2.src, e2.dst))
+        present.add(new1)
+        present.add(new2)
+        current[i] = replace(e1, dst=e2.dst)
+        current[j] = replace(e2, dst=e1.dst)
+        done += 1
+    return current

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -171,7 +171,12 @@ def median_cross_topic_gold_pair_cosine(
     """
     cosines: list[float] = []
     for pair in gold_pairs:
+        if len(pair) != 2:
+            continue  # a gold "pair" that collapsed to <2 distinct docs (e.g. seed==companion) is not a pair
         a, b = tuple(pair)
+        # Same-source pairs are not cross-topic. If exactly one doc is missing
+        # from source_by_doc, .get() yields None vs a real source → treated as
+        # cross-topic (included); both missing → None==None → skipped.
         if source_by_doc.get(a) == source_by_doc.get(b):
             continue
         if a not in doc_vec or b not in doc_vec:

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -75,3 +75,43 @@ def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int =
         current[j] = replace(e2, dst=e1.dst)
         done += 1
     return current
+
+
+def _derangement(n: int, rng: random.Random) -> list[int]:
+    """A permutation of range(n) with no fixed point (n >= 2)."""
+    while True:
+        perm = list(range(n))
+        rng.shuffle(perm)
+        if all(perm[i] != i for i in range(n)):
+            return perm
+
+
+def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
+    """Permute which companion set each probe seed is scored against.
+
+    Preserves each probe's companion-set SIZE. Probes are grouped by companion
+    count; groups of >= 2 are deranged among themselves (no probe keeps its own
+    gold). A singleton size-class draws its companions from the global gold-doc
+    pool (all probes' seeds + companions) excluding the probe's own docs, so it
+    is still "not own gold". Deterministic under ``seed``.
+    """
+    rng = random.Random(seed)
+    groups: dict[int, list[int]] = defaultdict(list)
+    for idx, p in enumerate(probes):
+        groups[len(p.companion_docs)].append(idx)
+
+    all_gold = sorted({d for p in probes for d in p.companion_docs} | {p.seed_doc for p in probes})
+
+    result: dict[str, tuple[str, ...]] = {}
+    for size, idxs in groups.items():
+        if len(idxs) >= 2:
+            originals = [probes[i].companion_docs for i in idxs]
+            perm = _derangement(len(idxs), rng)
+            for pos, i in enumerate(idxs):
+                result[probes[i].query_id] = originals[perm[pos]]
+        else:
+            i = idxs[0]
+            own = set(probes[i].companion_docs) | {probes[i].seed_doc}
+            pool = [d for d in all_gold if d not in own]
+            result[probes[i].query_id] = tuple(rng.sample(pool, size))
+    return result

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -126,7 +126,7 @@ def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
 
 def paired_delta_bootstrap(
     per_probe_a: list[float], per_probe_b: list[float], *, seed: int, resamples: int = 10_000
-) -> dict[str, float]:
+) -> dict[str, float | int]:
     """Paired (a - b) point estimate + DESCRIPTIVE percentile bootstrap interval.
 
     Point estimate is the paired mean of the per-probe differences. The interval

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 
 import random
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from statistics import median
-from typing import Callable
 
 from tests.eval.compounding import recall_at_k
 from tests.eval.metrics import mrr_at_k
@@ -145,7 +145,7 @@ def paired_delta_bootstrap(
     if n == 0:
         raise ValueError("paired inputs are empty — nothing to bootstrap")
 
-    diffs = [a - b for a, b in zip(per_probe_a, per_probe_b)]
+    diffs = [a - b for a, b in zip(per_probe_a, per_probe_b, strict=True)]
     point = sum(diffs) / n
 
     rng = random.Random(seed)

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -18,6 +18,9 @@ from dataclasses import dataclass, replace
 from statistics import median
 from typing import Callable
 
+from tests.eval.compounding import recall_at_k
+from tests.eval.metrics import mrr_at_k
+
 
 @dataclass(frozen=True)
 class Edge:
@@ -185,3 +188,23 @@ def median_cross_topic_gold_pair_cosine(
     if not cosines:
         return None
     return median(cosines)
+
+
+def recovery_from_rankings(
+    rankings: list[tuple[str, list[str]]],
+    gold_map: dict[str, tuple[str, ...]],
+    *,
+    at: tuple[int, ...] = (5, 10),
+    mrr_at: int = 10,
+) -> dict:
+    """Score explore() rankings against a gold assignment (one scorer for all
+    three arms). ``rankings`` is [(query_id, ranked_docs)] in probe order;
+    ``gold_map`` maps query_id -> gold companion docs. Returns mean recovery@k,
+    mrr@k, and the per-probe recovery@10 list (paired-bootstrap input)."""
+    pairs = [(ranked, set(gold_map[qid])) for qid, ranked in rankings]
+    result: dict = {"n": len(pairs)}
+    for k in at:
+        result[f"recovery@{k}"] = round(sum(recall_at_k(r, g, k) for r, g in pairs) / len(pairs), 4)
+    result[f"mrr@{mrr_at}"] = round(mrr_at_k(pairs, mrr_at), 4)
+    result["per_probe@10"] = [round(recall_at_k(r, g, 10), 4) for r, g in pairs]
+    return result

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -122,3 +122,34 @@ def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
                 )
             result[probes[i].query_id] = tuple(rng.sample(pool, size))
     return result
+
+
+def paired_delta_bootstrap(
+    per_probe_a: list[float], per_probe_b: list[float], *, seed: int, resamples: int = 10_000
+) -> dict[str, float]:
+    """Paired (a - b) point estimate + DESCRIPTIVE percentile bootstrap interval.
+
+    Point estimate is the paired mean of the per-probe differences. The interval
+    is the 2.5/97.5 percentile of the resampled paired means — a shape aid, NOT
+    an inferential CI (percentile method, not BCa; the gated inferential test is
+    Day-3). Deterministic under ``seed``. Raises on length mismatch or empty.
+    """
+    if len(per_probe_a) != len(per_probe_b):
+        raise ValueError(
+            f"paired inputs differ in length: {len(per_probe_a)} vs {len(per_probe_b)}"
+        )
+    n = len(per_probe_a)
+    if n == 0:
+        raise ValueError("paired inputs are empty — nothing to bootstrap")
+
+    diffs = [a - b for a, b in zip(per_probe_a, per_probe_b)]
+    point = sum(diffs) / n
+
+    rng = random.Random(seed)
+    means: list[float] = []
+    for _ in range(resamples):
+        means.append(sum(diffs[rng.randrange(n)] for _ in range(n)) / n)
+    means.sort()
+    lo = means[int(0.025 * resamples)]
+    hi = means[int(0.975 * resamples)]
+    return {"delta": round(point, 4), "lo": round(lo, 4), "hi": round(hi, 4), "n": n}

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -153,3 +153,30 @@ def paired_delta_bootstrap(
     lo = means[int(0.025 * resamples)]
     hi = means[int(0.975 * resamples)]
     return {"delta": round(point, 4), "lo": round(lo, 4), "hi": round(hi, 4), "n": n}
+
+
+def median_cross_topic_gold_pair_cosine(
+    doc_vec: dict[str, list[float]],
+    gold_pairs: set[frozenset[str]],
+    source_by_doc: dict[str, str],
+    *,
+    cosine_fn: Callable[[list[float], list[float]], float],
+) -> float | None:
+    """Provisional τ = median cosine over CROSS-TOPIC gold pairs (prereg §3).
+
+    A gold pair is cross-topic when its two docs have different ``Document.source``
+    values. Pairs missing a vector are skipped. ``cosine_fn`` is injected so this
+    stays infra-free; the live caller passes ``neural.utils.cosine_similarity``.
+    Returns ``None`` when no cross-topic gold pair has both vectors.
+    """
+    cosines: list[float] = []
+    for pair in gold_pairs:
+        a, b = tuple(pair)
+        if source_by_doc.get(a) == source_by_doc.get(b):
+            continue
+        if a not in doc_vec or b not in doc_vec:
+            continue
+        cosines.append(cosine_fn(doc_vec[a], doc_vec[b]))
+    if not cosines:
+        return None
+    return median(cosines)

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -113,5 +113,12 @@ def permute_gold(probes, *, seed: int) -> dict[str, tuple[str, ...]]:
             i = idxs[0]
             own = set(probes[i].companion_docs) | {probes[i].seed_doc}
             pool = [d for d in all_gold if d not in own]
+            if len(pool) < size:
+                raise ValueError(
+                    f"cannot build a size-{size} foreign gold set for probe "
+                    f"{probes[i].query_id!r}: only {len(pool)} non-own gold docs "
+                    f"available — corpus too small for a size-preserving "
+                    f"shuffled-gold placebo for this probe"
+                )
             result[probes[i].query_id] = tuple(rng.sample(pool, size))
     return result

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -102,8 +102,12 @@ async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> d
     """Provision an isolated workspace, build the warm graph once, run every
     seed's placebo arms off it, tear down."""
     from auth.workspace_roles import WorkspaceRole
+    from config.constants import EMBEDDING_MODEL_REGISTRY
+    from config.settings import get_settings
     from db.base import get_db
+    from db.qdrant import ensure_kagura_memories_collection, get_collection_name
     from models.auth import Context, Workspace, WorkspaceMember
+    from models.config import ContextSearchConfig
     from services.memory_service import MemoryService
 
     async for db in get_db():
@@ -128,12 +132,36 @@ async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> d
         await db.flush()
         db.add(ctx)
         db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        # The raw ORM Context bypasses ContextService.create_context, which stamps
+        # the per-context embedding config and ensures the model-specific Qdrant
+        # collection. Without an explicit ContextSearchConfig the lazy create_or_get
+        # defaults to text-embedding-3-small/512 and ingest routes to a collection
+        # that does not exist on a qwen3-embedding:0.6b/1024 rig — stamp it exactly
+        # like the production create path (mirrors runner.py's eval provisioning).
+        settings = get_settings()
+        emb_model = settings.embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        db.add(
+            ContextSearchConfig(
+                context_id=ctx.id,
+                semantic_weight=0.6,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2-lite",
+                embedding_model=emb_model,
+                embedding_dimensions=emb_dims,
+            )
+        )
         await db.flush()
         await db.commit()
 
         svc = MemoryService(db)
         id_map: dict[str, str] = {}
         try:
+            await ensure_kagura_memories_collection(
+                emb_dims, get_collection_name(emb_model, emb_dims)
+            )
             await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
             return await _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
         finally:

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -1,0 +1,474 @@
+"""Live Day-2 placebo kill-shot orchestration (directional de-risk).
+
+Builds ONE warm graph at a provisional τ (prereg-v1 §3 procedure on the current
+corpus), then measures companion recovery@10 for three arms off it:
+
+    real-warm            — true warm graph, true gold
+    shuffled-gold        — same rankings, size-preserving permuted gold
+    random-edge placebo  — degree-preserving rewired graph, true gold
+
+Reports paired point-estimate deltas with DESCRIPTIVE bootstrap intervals. This
+is NOT the inferential kill-shot (no gated CI, no accept/reject, τ untagged) —
+that runs at Day-3 on the grown corpus at the single committed τ.
+
+Writes results/placebo-<YYYY-MM-DD>.json from a REAL run only. Heavy imports are
+function-local (same convention as replay_runner) so importing this module is
+cheap and CI-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from tests.eval.compounding import MODE_EXCLUDE_PROBES, build_replay_plan
+from tests.eval.placebo import (
+    Edge,
+    degree_preserving_rewire,
+    median_cross_topic_gold_pair_cosine,
+    paired_delta_bootstrap,
+    permute_gold,
+    recovery_from_rankings,
+)
+from tests.eval.replay_runner import (
+    _EXPLORE_DEPTH,
+    _EXPLORE_MIN_WEIGHT,
+    _REPLAY_ROUNDS,
+    _gold_pairs_from_plan,
+    _replay,
+    _restore_env,
+    _run_sleep,
+)
+from tests.eval.runner import _ingest_corpus, _sudachi_version, _teardown
+from tests.eval.tools.corpus import load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+_DELTA_COMPOUND = 0.10  # directional keep/pivot threshold (prereg δ_compound)
+
+
+async def run_placebo_eval(
+    write: bool = True,
+    run_date: str | None = None,
+    seeds: tuple[int, ...] = (1, 2, 3),
+    rounds: int = _REPLAY_ROUNDS,
+    mode: str = MODE_EXCLUDE_PROBES,
+) -> dict[str, Any]:
+    from utils.datetime import utcnow
+
+    corpus = load_corpus()
+    run_date = run_date or utcnow().strftime("%Y-%m-%d")
+    plan = build_replay_plan(corpus, mode=mode, rounds=rounds)
+
+    block = await _run_placebo_mode(corpus, plan, seeds)
+
+    probe_count = len(plan.probes)
+    results: dict[str, Any] = {
+        "run_date": run_date,
+        "experiment": "day2-placebo",
+        "issue": None,
+        "sudachi_version": _sudachi_version(),
+        "corpus_version": corpus.meta.get("version"),
+        "doc_count": len(corpus.documents),
+        "query_count": len(corpus.queries),
+        "probe_count": probe_count,
+        "probe_underpowered": probe_count < 50,
+        "rounds": rounds,
+        "explore_depth": _EXPLORE_DEPTH,
+        "explore_min_weight": _EXPLORE_MIN_WEIGHT,
+        "seeds": list(seeds),
+        "design_note": (
+            "Descriptive/directional de-risk (week1-derisk Day 2). Provisional τ "
+            "(prereg §3 procedure on the CURRENT corpus), untagged. Percentile "
+            "bootstrap intervals are shape aids, NOT gated CIs; no accept/reject. "
+            "The inferential H2 kill-shot runs at Day-3 (prereg-v1-frozen)."
+        ),
+        **block,
+    }
+    if probe_count < 50:
+        print(
+            f"eval-placebo: WARNING probe_count={probe_count} << 50 — directional read only, underpowered"
+        )
+
+    if write:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out = _RESULTS_DIR / f"placebo-{run_date}.json"
+        out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"eval-placebo: wrote {out}")
+    return results
+
+
+async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> dict[str, Any]:
+    """Provision an isolated workspace, build the warm graph once, run every
+    seed's placebo arms off it, tear down."""
+    from auth.workspace_roles import WorkspaceRole
+    from db.base import get_db
+    from models.auth import Context, Workspace, WorkspaceMember
+    from services.memory_service import MemoryService
+
+    async for db in get_db():
+        owner = f"eval_{uuid4().hex[:8]}"
+        ws = Workspace(
+            id=uuid4(),
+            name=f"eval-ws-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=10_000_000,
+            weekly_api_limit=50_000_000,
+        )
+        ctx = Context(
+            id=uuid4(),
+            workspace_id=ws.id,
+            name=f"eval-ctx-{uuid4().hex[:8]}",
+            created_by=owner,
+            is_private=False,
+            sleep_mode="edges_only",
+        )
+        db.add(ws)
+        await db.flush()
+        db.add(ctx)
+        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        await db.flush()
+        await db.commit()
+
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+            return await _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+
+    raise RuntimeError("database session unavailable — is the stack up?")
+
+
+async def _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds) -> dict[str, Any]:
+    seed_mem_by_doc = {doc_id: mem_id for mem_id, doc_id in id_map.items()}
+    true_gold = {p.query_id: p.companion_docs for p in plan.probes}
+
+    # --- warm build (once, seed-independent): provisional τ -> replay -> sleep ---
+    tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
+    sleep_info: dict[str, Any]
+    try:
+        await _replay(svc, corpus, plan, owner, ctx, ws)
+        sleep_info = await _run_sleep(db, owner, ctx, ws)
+        real_rankings, seeds_in_graph = await _explore_rankings(
+            svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+        )
+        real_warm = recovery_from_rankings(real_rankings, true_gold)
+        snapshot = await _snapshot_edges(db, ctx.id)
+
+        per_seed = []
+        for s in seeds:
+            per_seed.append(
+                await _placebo_arms_for_seed(
+                    svc,
+                    db,
+                    plan,
+                    id_map,
+                    seed_mem_by_doc,
+                    owner,
+                    ctx,
+                    ws,
+                    real_rankings,
+                    real_warm,
+                    true_gold,
+                    snapshot,
+                    s,
+                )
+            )
+    finally:
+        if tau_info.get("seeded"):
+            await _delete_provisional_tau(db, tau_info["model"], tau_info["dimensions"])
+
+    d_rand = sorted(
+        b["deltas"]["random_edge"]["delta"] for b in per_seed if b["deltas"].get("random_edge")
+    )
+    d_shuf = sorted(b["deltas"]["shuffled_gold"]["delta"] for b in per_seed)
+    across = {
+        "delta_random_edge": _min_med_max(d_rand),
+        "delta_shuffled_gold": _min_med_max(d_shuf),
+    }
+    return {
+        "tau": tau_info,
+        "seeds_in_graph": seeds_in_graph,
+        "sleep": sleep_info,
+        "real_warm": real_warm,
+        "edge_count": len(snapshot),
+        "per_seed": per_seed,
+        "across_seeds": across,
+        "directional_read": _directional_read(real_warm, across),
+    }
+
+
+async def _placebo_arms_for_seed(
+    svc,
+    db,
+    plan,
+    id_map,
+    seed_mem_by_doc,
+    owner,
+    ctx,
+    ws,
+    real_rankings,
+    real_warm,
+    true_gold,
+    snapshot,
+    seed,
+) -> dict[str, Any]:
+    # shuffled-gold: same real-warm rankings, permuted gold
+    shuffled_map = permute_gold(plan.probes, seed=seed)
+    shuffled = recovery_from_rankings(real_rankings, shuffled_map)
+
+    # random-edge: degree-preserving rewire of the snapshot, re-explore, restore
+    if len(snapshot) < 2:
+        random_edge: dict[str, Any] = {"n": 0, "reason": "graph_too_sparse_to_rewire"}
+        rewire_swaps = 0
+    else:
+        placebo_edges = [
+            Edge(
+                str(r["src_id"]),
+                str(r["dst_id"]),
+                r["weight"],
+                r["origin"],
+                r["confidence"],
+                r["edge_type"],
+            )
+            for r in snapshot
+        ]
+        rewired = degree_preserving_rewire(placebo_edges, seed=seed)
+        rewire_swaps = len(rewired)
+        template = {"user_id": owner, "workspace_id": ws.id, "context_id": ctx.id}
+        rewired_rows = [
+            {
+                "src_id": UUID(e.src),
+                "dst_id": UUID(e.dst),
+                "weight": e.weight,
+                "confidence": e.confidence,
+                "origin": e.origin,
+                "edge_type": e.edge_type,
+                **template,
+            }
+            for e in rewired
+        ]
+        await _replace_edges(db, ctx.id, rewired_rows)
+        re_rankings, _ = await _explore_rankings(
+            svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+        )
+        random_edge = recovery_from_rankings(re_rankings, true_gold)
+        await _replace_edges(db, ctx.id, snapshot)  # restore for the next seed
+
+    deltas: dict[str, Any] = {
+        "shuffled_gold": paired_delta_bootstrap(
+            real_warm["per_probe@10"], shuffled["per_probe@10"], seed=seed
+        ),
+        "random_edge": (
+            paired_delta_bootstrap(
+                real_warm["per_probe@10"], random_edge["per_probe@10"], seed=seed
+            )
+            if random_edge.get("n")
+            else None
+        ),
+    }
+    return {
+        "seed": seed,
+        "arms": {"real_warm": real_warm, "shuffled_gold": shuffled, "random_edge": random_edge},
+        "deltas": deltas,
+        "gold_permutation": {k: list(v) for k, v in shuffled_map.items()},
+        "edge_snapshot": {"count": len(snapshot), "rewire_swaps_done": rewire_swaps},
+    }
+
+
+async def _explore_rankings(svc, probes, seed_mem_by_doc, id_map, owner, ctx, ws):
+    """Explore from each probe seed; return [(query_id, ranked_docs)] in probe
+    order + a seeds-in-graph count. Mirrors replay_runner._measure_graph_lane's
+    explore loop but returns the raw rankings so all arms can re-score them."""
+    from models.schemas import ExploreRequest
+
+    out: list[tuple[str, list[str]]] = []
+    seeds_in_graph = 0
+    for probe in probes:
+        resp = await svc.explore(
+            request=ExploreRequest(
+                memory_id=UUID(seed_mem_by_doc[probe.seed_doc]),
+                depth=_EXPLORE_DEPTH,
+                min_weight=_EXPLORE_MIN_WEIGHT,
+            ),
+            user_id=owner,
+            current_context_id=ctx.id,
+            current_workspace_id=ws.id,
+        )
+        if resp.metadata.get("reason") != "seed_not_in_graph":
+            seeds_in_graph += 1
+        related = sorted(resp.related_memories, key=lambda m: m.activation, reverse=True)
+        out.append((probe.query_id, [id_map.get(str(m.memory_id), "?") for m in related]))
+    return out, seeds_in_graph
+
+
+async def _snapshot_edges(db, ctx_id) -> list[dict[str, Any]]:
+    from sqlalchemy import select
+
+    from models.memory import NeuralMemoryEdge
+
+    rows = (
+        (await db.execute(select(NeuralMemoryEdge).where(NeuralMemoryEdge.context_id == ctx_id)))
+        .scalars()
+        .all()
+    )
+    return [
+        {
+            "src_id": r.src_id,
+            "dst_id": r.dst_id,
+            "weight": r.weight,
+            "confidence": r.confidence,
+            "origin": r.origin,
+            "edge_type": r.edge_type,
+            "user_id": r.user_id,
+            "workspace_id": r.workspace_id,
+            "context_id": r.context_id,
+        }
+        for r in rows
+    ]
+
+
+async def _replace_edges(db, ctx_id, rows: list[dict[str, Any]]) -> None:
+    from sqlalchemy import delete as sa_delete
+
+    from models.memory import NeuralMemoryEdge
+
+    await db.execute(sa_delete(NeuralMemoryEdge).where(NeuralMemoryEdge.context_id == ctx_id))
+    for r in rows:
+        db.add(
+            NeuralMemoryEdge(**r)
+        )  # fresh autoincrement id; created_at/last_updated default now()
+    await db.commit()
+
+
+async def _seed_provisional_tau(db, corpus, plan, id_map, ctx) -> dict[str, Any]:
+    """Compute provisional τ (median cross-topic gold-pair cosine) and seed a
+    transient model-global edge_gate calibration row so resolve_edge_threshold
+    returns max(τ, floor). Mirrors replay_runner._seed_edge_calibration but
+    substitutes τ for the non-gold percentile: compute_percentiles([τ]*N) makes
+    every stored percentile τ, so percentile(95) == τ."""
+    from datetime import timedelta
+
+    from db.qdrant import get_qdrant_client
+    from models.neural import CALIBRATION_KIND_EDGE_GATE
+    from neural.calibration import resolve_edge_threshold
+    from neural.config import NeuralMemoryConfig
+    from neural.utils import cosine_similarity
+    from tasks.neural_calibration import _load_measure_script, _upsert_calibration
+    from utils.datetime import utcnow
+
+    script = _load_measure_script()
+    model_name, dims, collection = await script.resolve_embedding_model(db, ctx.id)
+    qdrant = get_qdrant_client()
+    vecs_by_mem = await script.fetch_vectors(qdrant, collection, [UUID(m) for m in id_map])
+    doc_vec = {id_map[m]: v for m, v in vecs_by_mem.items() if m in id_map}
+    source_by_doc = {d.id: d.source for d in corpus.documents}
+    gold_pairs = _gold_pairs_from_plan(plan)
+
+    tau = median_cross_topic_gold_pair_cosine(
+        doc_vec, gold_pairs, source_by_doc, cosine_fn=cosine_similarity
+    )
+    cross_topic_count = sum(
+        1 for pr in gold_pairs if len(pr) == 2 and len({source_by_doc.get(d) for d in pr}) == 2
+    )
+    if tau is None:
+        return {
+            "seeded": False,
+            "reason": "no_cross_topic_gold_pair",
+            "model": model_name,
+            "dimensions": dims,
+            "tau_provisional": None,
+            "cross_topic_gold_pair_count": cross_topic_count,
+        }
+
+    percentiles = script.compute_percentiles([tau] * 128)
+    config = await NeuralMemoryConfig.from_db(db)
+    now = utcnow()
+    await _upsert_calibration(
+        db,
+        model_name,
+        dims,
+        None,
+        kind=CALIBRATION_KIND_EDGE_GATE,
+        percentiles=percentiles,
+        observations=cross_topic_count,
+        now=now,
+        valid_until=now + timedelta(days=config.calibration_ttl_days),
+    )
+    await db.commit()
+
+    result: dict[str, Any] = {
+        "seeded": True,
+        "model": model_name,
+        "dimensions": dims,
+        "tau_provisional": round(tau, 4),
+        "tau_method": "median_cross_topic_gold_pair_cosine",
+        "cross_topic_gold_pair_count": cross_topic_count,
+        "floor": config.min_similarity_for_edge_floor,
+        "resolved_edge_threshold": None,
+    }
+    try:
+        resolved = await resolve_edge_threshold(
+            db=db, config=config, model_name=model_name, dimensions=dims
+        )
+        result["resolved_edge_threshold"] = round(resolved, 4)
+    except Exception:  # noqa: BLE001 — diagnostic only; row stays cleanable
+        pass
+    return result
+
+
+async def _delete_provisional_tau(db, model_name, dimensions) -> None:
+    from sqlalchemy import delete as sa_delete
+
+    from models.neural import CALIBRATION_KIND_EDGE_GATE, EmbeddingCalibration
+
+    await db.execute(
+        sa_delete(EmbeddingCalibration).where(
+            EmbeddingCalibration.model_name == model_name,
+            EmbeddingCalibration.dimensions == dimensions,
+            EmbeddingCalibration.context_id.is_(None),
+            EmbeddingCalibration.kind == CALIBRATION_KIND_EDGE_GATE,
+        )
+    )
+    await db.commit()
+
+
+def _min_med_max(values: list[float]) -> dict[str, float | None]:
+    from statistics import median
+
+    if not values:
+        return {"min": None, "median": None, "max": None}
+    return {
+        "min": round(min(values), 4),
+        "median": round(median(values), 4),
+        "max": round(max(values), 4),
+    }
+
+
+def _directional_read(real_warm: dict[str, Any], across: dict[str, Any]) -> str:
+    med_rand = across["delta_random_edge"]["median"]
+    med_shuf = across["delta_shuffled_gold"]["median"]
+    if med_rand is None:
+        return "inconclusive"
+    if med_rand >= _DELTA_COMPOUND and med_shuf is not None and med_shuf >= _DELTA_COMPOUND:
+        return "alive"
+    if med_rand <= 0.0:
+        return "edge_spray"
+    return "inconclusive"
+
+
+def _main() -> int:
+    import asyncio
+
+    results = asyncio.run(run_placebo_eval())
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -19,7 +19,6 @@ cheap and CI-safe.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -39,7 +38,6 @@ from tests.eval.replay_runner import (
     _REPLAY_ROUNDS,
     _gold_pairs_from_plan,
     _replay,
-    _restore_env,
     _run_sleep,
 )
 from tests.eval.runner import _ingest_corpus, _sudachi_version, _teardown
@@ -254,11 +252,13 @@ async def _placebo_arms_for_seed(
             for e in rewired
         ]
         await _replace_edges(db, ctx.id, rewired_rows)
-        re_rankings, _ = await _explore_rankings(
-            svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
-        )
-        random_edge = recovery_from_rankings(re_rankings, true_gold)
-        await _replace_edges(db, ctx.id, snapshot)  # restore for the next seed
+        try:
+            re_rankings, _ = await _explore_rankings(
+                svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+            )
+            random_edge = recovery_from_rankings(re_rankings, true_gold)
+        finally:
+            await _replace_edges(db, ctx.id, snapshot)  # always restore the true warm graph
 
     deltas: dict[str, Any] = {
         "shuffled_gold": paired_delta_bootstrap(

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -147,9 +147,10 @@ async def _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
     true_gold = {p.query_id: p.companion_docs for p in plan.probes}
 
     # --- warm build (once, seed-independent): provisional τ -> replay -> sleep ---
-    tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
+    tau_info: dict[str, Any] = {"seeded": False}
     sleep_info: dict[str, Any]
     try:
+        tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
         await _replay(svc, corpus, plan, owner, ctx, ws)
         sleep_info = await _run_sleep(db, owner, ctx, ws)
         real_rankings, seeds_in_graph = await _explore_rankings(

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -147,8 +147,8 @@ async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> d
                 semantic_weight=0.6,
                 fetch_factor=3,
                 use_rerank=False,
-                reranker_provider="voyage",
-                reranker_model="rerank-2-lite",
+                reranker_provider="self_hosted",
+                reranker_model="qwen3-reranker-4b",
                 embedding_model=emb_model,
                 embedding_dimensions=emb_dims,
             )

--- a/backend/tests/eval/results/freeze-kagura_l-2026-07-02.json
+++ b/backend/tests/eval/results/freeze-kagura_l-2026-07-02.json
@@ -1,0 +1,22 @@
+{
+  "run_date": "2026-07-02",
+  "experiment": "day3-corpus-freeze",
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "corpus_version": 1,
+  "content_sha256": "ca7a717bcb745f873182ae3d328692bae3449b415ed51681ac904d35142e0997",
+  "sudachi_version": "20260428",
+  "doc_count": 300,
+  "query_count": 280,
+  "n_heldout": 240,
+  "n_public": 40,
+  "n_probe": 60,
+  "heldout_cross_topic_gold_pair_count": 97,
+  "tau_method": "median_heldout_cross_topic_gold_pair_cosine (prereg-v1 §3)",
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "vectors_fetched": 300,
+  "tau_frozen": 0.7192,
+  "pair_cosine_min": 0.4869,
+  "pair_cosine_max": 0.9068,
+  "design_note": "Frozen τ for the inferential H2 kill-shot, computed ONCE at Day-3 corpus-freeze from the held-out cross-topic gold-pair cosine distribution — before any inferential result. Stamped into prereg-v1 Appendix A and tagged prereg-v1-frozen."
+}

--- a/backend/tests/eval/results/placebo-2026-07-02.json
+++ b/backend/tests/eval/results/placebo-2026-07-02.json
@@ -1,0 +1,349 @@
+{
+  "run_date": "2026-07-02",
+  "experiment": "day2-placebo",
+  "issue": null,
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "doc_count": 16,
+  "query_count": 30,
+  "probe_count": 5,
+  "probe_underpowered": true,
+  "rounds": 8,
+  "explore_depth": 2,
+  "explore_min_weight": 0.05,
+  "seeds": [
+    1,
+    2,
+    3
+  ],
+  "design_note": "Descriptive/directional de-risk (week1-derisk Day 2). Provisional τ (prereg §3 procedure on the CURRENT corpus), untagged. Percentile bootstrap intervals are shape aids, NOT gated CIs; no accept/reject. The inferential H2 kill-shot runs at Day-3 (prereg-v1-frozen).",
+  "tau": {
+    "seeded": true,
+    "model": "qwen3-embedding:0.6b",
+    "dimensions": 1024,
+    "tau_provisional": 0.5082,
+    "tau_method": "median_cross_topic_gold_pair_cosine",
+    "cross_topic_gold_pair_count": 5,
+    "floor": 0.3,
+    "resolved_edge_threshold": 0.5082
+  },
+  "seeds_in_graph": 4,
+  "sleep": {
+    "ok": true,
+    "status": "completed",
+    "edge_discovery": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 0,
+      "memories_processed": 16,
+      "details": {
+        "sampled": 16,
+        "candidates": 3,
+        "filtered": 1,
+        "edges_created": 1,
+        "llm_accepted": 0,
+        "llm_rejected": 0,
+        "llm_call_failures": 0,
+        "auto_accepted": 1,
+        "edge_type_dist": {},
+        "avg_confidence": 0.0,
+        "median_confidence": 0.0,
+        "p25_confidence": 0.0,
+        "p75_confidence": 0.0,
+        "confidence_n": 0,
+        "confidence_imputed": 0,
+        "confidence_histogram": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "avg_confidence_rejected": 0.0,
+        "median_confidence_rejected": 0.0,
+        "p25_confidence_rejected": 0.0,
+        "p75_confidence_rejected": 0.0,
+        "confidence_n_rejected": 0,
+        "confidence_imputed_rejected": 0,
+        "confidence_histogram_rejected": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "llm_model": "gpt-5-nano",
+        "prompt_revision": "v3"
+      },
+      "llm_breakdown": [],
+      "embedding_calls": 16,
+      "embedding_tokens": 0
+    }
+  },
+  "real_warm": {
+    "n": 5,
+    "recovery@5": 0.4,
+    "recovery@10": 0.4,
+    "mrr@10": 0.2667,
+    "per_probe@10": [
+      1.0,
+      1.0,
+      0.0,
+      0.0,
+      0.0
+    ]
+  },
+  "edge_count": 23,
+  "per_seed": [
+    {
+      "seed": 1,
+      "arms": {
+        "real_warm": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.2667,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "shuffled_gold": {
+          "n": 5,
+          "recovery@5": 0.2,
+          "recovery@10": 0.2,
+          "mrr@10": 0.05,
+          "per_probe@10": [
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "random_edge": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.24,
+          "per_probe@10": [
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0
+          ]
+        }
+      },
+      "deltas": {
+        "shuffled_gold": {
+          "delta": 0.2,
+          "lo": 0.0,
+          "hi": 0.6,
+          "n": 5
+        },
+        "random_edge": {
+          "delta": 0.0,
+          "lo": -0.6,
+          "hi": 0.6,
+          "n": 5
+        }
+      },
+      "gold_permutation": {
+        "q_cross_01": [
+          "doc_res_apikey"
+        ],
+        "q_cross_02": [
+          "doc_res_chunking"
+        ],
+        "q_cross_03": [
+          "doc_mem_context"
+        ],
+        "q_cross_04": [
+          "doc_mem_hybrid"
+        ],
+        "q_cross_05": [
+          "doc_mem_context"
+        ]
+      },
+      "edge_snapshot": {
+        "count": 23,
+        "rewire_swaps_done": 23
+      }
+    },
+    {
+      "seed": 2,
+      "arms": {
+        "real_warm": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.2667,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "shuffled_gold": {
+          "n": 5,
+          "recovery@5": 0.2,
+          "recovery@10": 0.2,
+          "mrr@10": 0.1,
+          "per_probe@10": [
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "random_edge": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.3,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        }
+      },
+      "deltas": {
+        "shuffled_gold": {
+          "delta": 0.2,
+          "lo": 0.0,
+          "hi": 0.6,
+          "n": 5
+        },
+        "random_edge": {
+          "delta": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n": 5
+        }
+      },
+      "gold_permutation": {
+        "q_cross_01": [
+          "doc_res_chunking"
+        ],
+        "q_cross_02": [
+          "doc_mem_hybrid"
+        ],
+        "q_cross_03": [
+          "doc_mem_context"
+        ],
+        "q_cross_04": [
+          "doc_res_apikey"
+        ],
+        "q_cross_05": [
+          "doc_mem_context"
+        ]
+      },
+      "edge_snapshot": {
+        "count": 23,
+        "rewire_swaps_done": 23
+      }
+    },
+    {
+      "seed": 3,
+      "arms": {
+        "real_warm": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.2667,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "shuffled_gold": {
+          "n": 5,
+          "recovery@5": 0.2,
+          "recovery@10": 0.2,
+          "mrr@10": 0.1,
+          "per_probe@10": [
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        },
+        "random_edge": {
+          "n": 5,
+          "recovery@5": 0.4,
+          "recovery@10": 0.4,
+          "mrr@10": 0.1,
+          "per_probe@10": [
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0
+          ]
+        }
+      },
+      "deltas": {
+        "shuffled_gold": {
+          "delta": 0.2,
+          "lo": 0.0,
+          "hi": 0.6,
+          "n": 5
+        },
+        "random_edge": {
+          "delta": 0.0,
+          "lo": 0.0,
+          "hi": 0.0,
+          "n": 5
+        }
+      },
+      "gold_permutation": {
+        "q_cross_01": [
+          "doc_mem_context"
+        ],
+        "q_cross_02": [
+          "doc_mem_hybrid"
+        ],
+        "q_cross_03": [
+          "doc_mem_context"
+        ],
+        "q_cross_04": [
+          "doc_res_apikey"
+        ],
+        "q_cross_05": [
+          "doc_res_chunking"
+        ]
+      },
+      "edge_snapshot": {
+        "count": 23,
+        "rewire_swaps_done": 23
+      }
+    }
+  ],
+  "across_seeds": {
+    "delta_random_edge": {
+      "min": 0.0,
+      "median": 0.0,
+      "max": 0.0
+    },
+    "delta_shuffled_gold": {
+      "min": 0.2,
+      "median": 0.2,
+      "max": 0.2
+    }
+  },
+  "directional_read": "edge_spray"
+}

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -308,17 +308,19 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
         settings = get_settings()
         emb_model = settings.embedding_model
         emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
-        # Mirror ContextService.create_context's defaults (not just the
-        # embedding fields) so an eval context behaves like a production one if
-        # any reranking / weighting default is ever consulted.
+        # Stamp the full ContextSearchConfig (not just the embedding fields) so
+        # an eval context behaves like a created one if any reranking / weighting
+        # default is ever consulted. Reranker fields target the local self_hosted
+        # rig (qwen3-reranker), keeping the eval path all-local-OSS; inert here
+        # since use_rerank=False.
         db.add(
             ContextSearchConfig(
                 context_id=ctx.id,
                 semantic_weight=0.6,
                 fetch_factor=3,
                 use_rerank=False,
-                reranker_provider="voyage",
-                reranker_model="rerank-2-lite",
+                reranker_provider="self_hosted",
+                reranker_model="qwen3-reranker-4b",
                 embedding_model=emb_model,
                 embedding_dimensions=emb_dims,
             )

--- a/backend/tests/eval/test_corpus_schema.py
+++ b/backend/tests/eval/test_corpus_schema.py
@@ -14,6 +14,10 @@ README.md.
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 from tests.eval.tools.corpus import _VALID_SOURCES, BUCKETS, load_corpus
 
 MIN_QUERIES = 30
@@ -80,3 +84,85 @@ def test_source_scoped_buckets_are_consistent():
             assert sources == {expected}, (
                 f"{bucket} query {q.id} has sources {sources}; expected {{{expected!r}}}"
             )
+
+
+# --- split / graded schema extension (kagura_L prep, prereg-v1 H3) ---------
+
+
+def _write_corpus(tmp_path: Path, queries_yaml: str) -> Path:
+    """Write a minimal 2-doc corpus YAML with the given ``queries:`` body."""
+    content = f"""
+meta:
+  version: 1
+documents:
+  - id: doc_a
+    source: memory
+    text: "alpha"
+  - id: doc_b
+    source: memory
+    text: "beta"
+queries:
+{queries_yaml}
+"""
+    p = tmp_path / "corpus.yaml"
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+def test_golden_corpus_has_no_split_or_graded_by_default():
+    """The frozen starter corpus is a legacy corpus: split/graded are unset."""
+    corpus = load_corpus()
+    for q in corpus.queries:
+        assert q.split is None
+        assert q.graded is None
+
+
+def test_split_and_graded_round_trip(tmp_path: Path):
+    p = _write_corpus(
+        tmp_path,
+        """\
+  - id: q1
+    bucket: retrieval-exact
+    text: "find alpha"
+    relevant: [doc_a]
+    split: heldout
+    graded:
+      doc_a: 3
+      doc_b: 1
+""",
+    )
+    corpus = load_corpus(p)
+    q = corpus.queries[0]
+    assert q.split == "heldout"
+    assert q.graded == {"doc_a": 3, "doc_b": 1}
+
+
+def test_bad_split_value_raises(tmp_path: Path):
+    p = _write_corpus(
+        tmp_path,
+        """\
+  - id: q1
+    bucket: retrieval-exact
+    text: "find alpha"
+    relevant: [doc_a]
+    split: bogus
+""",
+    )
+    with pytest.raises(ValueError, match="q1"):
+        load_corpus(p)
+
+
+def test_bad_grade_value_raises(tmp_path: Path):
+    p = _write_corpus(
+        tmp_path,
+        """\
+  - id: q1
+    bucket: retrieval-exact
+    text: "find alpha"
+    relevant: [doc_a]
+    graded:
+      doc_a: 5
+""",
+    )
+    with pytest.raises(ValueError, match="q1"):
+        load_corpus(p)

--- a/backend/tests/eval/test_freeze_tau.py
+++ b/backend/tests/eval/test_freeze_tau.py
@@ -1,0 +1,48 @@
+"""Deterministic tests for the Day-3 freeze-τ pure layer.
+
+The live τ measurement (ingest + vector fetch on the rig) is driven manually
+via ``python -m tests.eval.freeze_tau`` at corpus-freeze time; only the pure
+pair-enumeration logic is unit-tested here.
+"""
+
+from __future__ import annotations
+
+from tests.eval.freeze_tau import heldout_cross_topic_gold_pairs
+from tests.eval.tools.corpus import Corpus, Document, Query
+
+
+def _corpus(queries: list[Query]) -> Corpus:
+    docs = (
+        Document(id="m1", source="memory", text="m1 text"),
+        Document(id="m2", source="memory", text="m2 text"),
+        Document(id="r1", source="resource", text="r1 text"),
+        Document(id="r2", source="resource", text="r2 text"),
+    )
+    return Corpus(meta={}, documents=docs, queries=tuple(queries))
+
+
+def _q(qid: str, relevant: tuple[str, ...], split: str | None) -> Query:
+    return Query(id=qid, bucket="cross-source", text=qid, relevant=relevant, split=split)
+
+
+def test_pairs_come_only_from_heldout_multigold_and_cross_source():
+    corpus = _corpus(
+        [
+            _q("q1", ("m1", "r1"), "heldout"),  # cross-topic pair -> included
+            _q("q2", ("m1", "m2"), "heldout"),  # same-source pair -> excluded
+            _q("q3", ("m2", "r2"), "public"),  # public -> excluded entirely
+            _q("q4", ("r2",), "heldout"),  # single-gold -> not a probe
+            _q("q5", ("m2", "r1", "r2"), "heldout"),  # mixed: m2-r1, m2-r2 in; r1-r2 out
+        ]
+    )
+    pairs = heldout_cross_topic_gold_pairs(corpus)
+    assert pairs == {
+        frozenset(("m1", "r1")),
+        frozenset(("m2", "r1")),
+        frozenset(("m2", "r2")),
+    }
+
+
+def test_no_heldout_probes_yields_empty_set():
+    corpus = _corpus([_q("q1", ("m1", "r1"), "public"), _q("q2", ("m1",), "heldout")])
+    assert heldout_cross_topic_gold_pairs(corpus) == set()

--- a/backend/tests/eval/test_kagura_l_corpus.py
+++ b/backend/tests/eval/test_kagura_l_corpus.py
@@ -1,0 +1,94 @@
+"""kagura_L corpus gates (Day-3, docs/02 §1.1-1.2) — fail-loud regression tests.
+
+The frozen kagura_L fixture must keep passing every gate that justified its
+freeze: schema/count shape, graded-label consistency, split discipline,
+probe validity, ZERO leakage flags (all three rules live at 300 docs), and
+stratification coverage (≥3 difficulty regimes, ≥20% hard — the docs/02 §1.2
+item-4 proportion gate). golden_corpus.yaml keeps its own, untouched tests.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+from tests.eval.tools.corpus import load_corpus
+from tests.eval.tools.leakage_check import run_leakage_check
+from tests.eval.tools.stratify import stratify_corpus
+
+_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "kagura_l.yaml"
+
+
+@pytest.fixture(scope="module")
+def corpus():
+    return load_corpus(_FIXTURE)
+
+
+def test_shape_and_counts(corpus):
+    assert len(corpus.documents) == 300
+    src = Counter(d.source for d in corpus.documents)
+    assert src == {"memory": 180, "resource": 120}
+    assert len(corpus.queries) == 280
+    split = Counter(q.split for q in corpus.queries)
+    assert split == {"heldout": 240, "public": 40}
+    buckets = Counter(q.bucket for q in corpus.queries)
+    assert buckets == {
+        "cross-source": 60,
+        "retrieval-exact": 40,
+        "retrieval-semantic": 50,
+        "hiragana-only": 35,
+        "resource-only": 45,
+        "memory-only": 50,
+    }
+    assert corpus.meta.get("content_sha256"), "frozen corpus must carry its content hash"
+
+
+def test_labels_and_references(corpus):
+    docset = {d.id for d in corpus.documents}
+    for q in corpus.queries:
+        assert q.relevant, q.id
+        assert set(q.relevant) <= docset, q.id
+        assert q.graded is not None, q.id
+        assert set(q.graded) <= docset, q.id
+        # binary gold SoT == graded >= 2; primary gold is grade 3.
+        assert set(q.relevant) == {d for d, g in q.graded.items() if g >= 2}, q.id
+        assert q.graded[q.relevant[0]] == 3, q.id
+
+
+def test_probe_population(corpus):
+    """>= 50 valid held-out cross-source multi-gold probes (N_probe floor)."""
+    by_id = corpus.docs_by_id
+    valid = [
+        q
+        for q in corpus.queries
+        if q.bucket == "cross-source"
+        and q.split == "heldout"
+        and len(q.relevant) >= 2
+        and {by_id[d].source for d in q.relevant} == {"memory", "resource"}
+    ]
+    assert len(valid) >= 50, f"only {len(valid)} valid probes"
+
+
+def test_split_discipline(corpus):
+    for q in corpus.queries:
+        assert q.split in ("public", "heldout"), q.id
+        if q.bucket in ("cross-source", "hiragana-only"):
+            assert q.split == "heldout", q.id
+
+
+def test_leakage_gate_zero_flags(corpus):
+    """All three leakage rules live (300 docs >= MIN_DOCS_FOR_RARE_TERM) — zero flags."""
+    flags = run_leakage_check(corpus)
+    detail = [str(f) for f in flags]
+    assert not flags, "leakage flags:\n" + "\n".join(detail)
+
+
+def test_stratification_spans_regimes_with_hard_proportion(corpus):
+    """docs/02 §1.2 item 4: all three bm25 difficulty labels, >= 20% hard."""
+    strata = stratify_corpus(corpus)
+    dist = Counter(s.bm25_rank_label for s in strata)
+    assert set(dist) == {"easy", "medium", "hard"}, dist
+    hard_share = dist["hard"] / len(strata)
+    assert hard_share >= 0.20, f"hard share {hard_share:.2%} < 20%: {dist}"

--- a/backend/tests/eval/test_metrics.py
+++ b/backend/tests/eval/test_metrics.py
@@ -108,6 +108,41 @@ class TestNDCG:
         assert mean_ndcg_at_k([], 5) == 0.0
 
 
+class TestGradedNDCG:
+    """Graded-relevance overload of ``ndcg_at_k`` (docs/02 §1.2 item 5).
+
+    ``gains=None`` (the default) must stay byte-identical to the pre-existing
+    binary metric; passing ``gains`` switches to the ``2^rel - 1`` DCG formula.
+    """
+
+    def test_gains_none_matches_binary_behavior(self):
+        # Same hand case as TestNDCG.test_single_relevant_at_position_two, called
+        # both without the kwarg and with it explicitly None — must agree exactly
+        # with the binary result.
+        expected = 1.0 / math.log2(3)
+        assert ndcg_at_k(["x", "a", "y"], {"a"}, 5) == expected
+        assert ndcg_at_k(["x", "a", "y"], {"a"}, 5, gains=None) == expected
+
+    def test_graded_hand_case(self):
+        # ranked=[a,b,c], gains={a:3,b:1,d:2} (d not retrieved), k=3.
+        # DCG = (2^3-1)/log2(2) + (2^1-1)/log2(3) + 0/log2(4)
+        #     = 7/1 + 1/1.58496...  = 7 + 0.630929... = 7.630929...
+        # IDCG = top-3 gains sorted desc = [3, 2, 1]
+        #      = (2^3-1)/log2(2) + (2^2-1)/log2(3) + (2^1-1)/log2(4)
+        #      = 7 + 3/1.58496... + 1/2 = 7 + 1.892789... + 0.5 = 9.392789...
+        # nDCG = 7.630929.../9.392789... = 0.812424...
+        dcg = 7.0 + 1.0 / math.log2(3)
+        idcg = 7.0 + 3.0 / math.log2(3) + 1.0 / math.log2(4)
+        expected = dcg / idcg
+        result = ndcg_at_k(["a", "b", "c"], {"a", "b"}, 3, gains={"a": 3, "b": 1, "d": 2})
+        assert result == pytest.approx(expected)
+        assert result == pytest.approx(0.8125, abs=1e-3)
+
+    def test_idcg_zero_is_zero_not_error(self):
+        assert ndcg_at_k(["a", "b"], {"a", "b"}, 2, gains={}) == 0.0
+        assert ndcg_at_k(["a", "b"], {"a", "b"}, 2, gains={"a": 0, "b": 0}) == 0.0
+
+
 class TestArmOrder:
     def test_graph_writing_neural_arm_runs_last(self):
         # Load-bearing measurement-validity invariant (#967): with

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -14,8 +14,13 @@ import pytest
 from tests.eval.placebo import Edge, degree_preserving_rewire
 
 
-def _edges(pairs, *, weight=0.5, origin="hebbian", edge_type="neural_association"):
-    return [Edge(s, d, weight, origin, confidence=1.0, edge_type=edge_type) for s, d in pairs]
+def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
+    # Distinct weight per edge so a test can verify the non-dst attribute
+    # bundle travels with its OWN edge through a rewire (only dst changes).
+    return [
+        Edge(s, d, 0.1 * (i + 1), origin, confidence=1.0, edge_type=edge_type)
+        for i, (s, d) in enumerate(pairs)
+    ]
 
 
 def _src_deg(edges):
@@ -33,8 +38,11 @@ def test_rewire_preserves_degree_count_and_attribute_multisets():
     assert len(out) == len(edges)
     assert _src_deg(out) == _src_deg(edges)
     assert _dst_deg(out) == _dst_deg(edges)
-    assert Counter((e.weight, e.origin, e.confidence, e.edge_type) for e in out) == Counter(
-        (e.weight, e.origin, e.confidence, e.edge_type) for e in edges
+    # Non-dst attributes travel with their own edge (only dst changes): the
+    # (src, weight, origin, confidence, edge_type) bundle multiset is invariant.
+    # Distinct per-edge weights make this discriminating, not tautological.
+    assert Counter((e.src, e.weight, e.origin, e.confidence, e.edge_type) for e in out) == Counter(
+        (e.src, e.weight, e.origin, e.confidence, e.edge_type) for e in edges
     )
 
 
@@ -61,3 +69,12 @@ def test_rewire_is_deterministic_under_seed():
 def test_rewire_raises_below_two_edges():
     with pytest.raises(ValueError):
         degree_preserving_rewire(_edges([("a", "b")]), seed=1)
+
+
+def test_rewire_returns_pure_star_unchanged():
+    """A pure out-star has exactly one graph with its degree sequence, so a
+    degree-preserving rewire correctly returns it unchanged — this is correct
+    behavior (a unique realization), not a failure to mix."""
+    star = _edges([("h", x) for x in "abcdef"])
+    out = degree_preserving_rewire(star, seed=1)
+    assert {(e.src, e.dst) for e in out} == {(e.src, e.dst) for e in star}

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -149,7 +149,9 @@ def test_bootstrap_point_estimate_is_the_paired_mean():
     a = [1.0, 0.8, 0.6, 0.4]
     b = [0.0, 0.2, 0.1, 0.0]
     out = paired_delta_bootstrap(a, b, seed=1, resamples=2000)
-    assert out["delta"] == pytest.approx(sum(x - y for x, y in zip(a, b)) / len(a), abs=1e-9)
+    assert out["delta"] == pytest.approx(
+        sum(x - y for x, y in zip(a, b, strict=True)) / len(a), abs=1e-9
+    )
     assert out["n"] == 4
     assert out["lo"] <= out["delta"] <= out["hi"]
     assert out["lo"] < out["hi"]  # non-degenerate data -> real interval width (not a stub)
@@ -183,8 +185,11 @@ def test_bootstrap_raises_on_length_mismatch_or_empty():
 
 def test_median_cross_topic_ignores_same_source_pairs():
     doc_vec = {"a": [1.0], "b": [2.0], "c": [3.0]}
+
     # cosine_fn returns the product of the single components (a stand-in metric)
-    cos = lambda u, v: u[0] * v[0]
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory", "b": "resource", "c": "memory"}
     gold_pairs = {frozenset(("a", "b")), frozenset(("a", "c")), frozenset(("b", "c"))}
     # cross-topic pairs: a-b (1*2=2), b-c (2*3=6); a-c is same-source -> skipped
@@ -194,7 +199,10 @@ def test_median_cross_topic_ignores_same_source_pairs():
 
 def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
     doc_vec = {"a": [1.0], "b": [2.0]}
-    cos = lambda u, v: u[0] * v[0]
+
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory", "b": "memory"}
     gold_pairs = {frozenset(("a", "b"))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
@@ -202,7 +210,10 @@ def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
 
 def test_median_cross_topic_skips_pair_missing_a_vector():
     doc_vec = {"a": [1.0]}  # b has no vector -> the only gold pair is skipped
-    cos = lambda u, v: u[0] * v[0]
+
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory", "b": "resource"}
     gold_pairs = {frozenset(("a", "b"))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
@@ -211,7 +222,10 @@ def test_median_cross_topic_skips_pair_missing_a_vector():
 def test_median_cross_topic_skips_degenerate_single_element_pair():
     # A gold "pair" that collapsed to one doc (seed == companion) must be skipped, not crash.
     doc_vec = {"a": [1.0]}
-    cos = lambda u, v: u[0] * v[0]
+
+    def cos(u, v):
+        return u[0] * v[0]
+
     source = {"a": "memory"}
     gold_pairs = {frozenset(("a",))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -197,3 +197,20 @@ def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
     source = {"a": "memory", "b": "memory"}
     gold_pairs = {frozenset(("a", "b"))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
+
+
+def test_median_cross_topic_skips_pair_missing_a_vector():
+    doc_vec = {"a": [1.0]}  # b has no vector -> the only gold pair is skipped
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory", "b": "resource"}
+    gold_pairs = {frozenset(("a", "b"))}
+    assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
+
+
+def test_median_cross_topic_skips_degenerate_single_element_pair():
+    # A gold "pair" that collapsed to one doc (seed == companion) must be skipped, not crash.
+    doc_vec = {"a": [1.0]}
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory"}
+    gold_pairs = {frozenset(("a",))}
+    assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -1,0 +1,63 @@
+"""Deterministic tests for the Day-2 placebo kill-shot pure layer.
+
+Everything here is infrastructure-free (no DB/Qdrant) and runs in normal CI.
+The live orchestration is exercised by test_placebo_live.py (gated behind
+KAGURA_EVAL_LIVE=1).
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from tests.eval.placebo import Edge, degree_preserving_rewire
+
+
+def _edges(pairs, *, weight=0.5, origin="hebbian", edge_type="neural_association"):
+    return [Edge(s, d, weight, origin, confidence=1.0, edge_type=edge_type) for s, d in pairs]
+
+
+def _src_deg(edges):
+    return Counter(e.src for e in edges)
+
+
+def _dst_deg(edges):
+    return Counter(e.dst for e in edges)
+
+
+def test_rewire_preserves_degree_count_and_attribute_multisets():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out = degree_preserving_rewire(edges, seed=7)
+
+    assert len(out) == len(edges)
+    assert _src_deg(out) == _src_deg(edges)
+    assert _dst_deg(out) == _dst_deg(edges)
+    assert Counter((e.weight, e.origin, e.confidence, e.edge_type) for e in out) == Counter(
+        (e.weight, e.origin, e.confidence, e.edge_type) for e in edges
+    )
+
+
+def test_rewire_has_no_self_loops_or_parallel_edges():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out = degree_preserving_rewire(edges, seed=3)
+
+    assert all(e.src != e.dst for e in out)
+    assert len({(e.src, e.dst) for e in out}) == len(out)
+
+
+def test_rewire_actually_moves_endpoints():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out = degree_preserving_rewire(edges, seed=1)
+
+    assert {(e.src, e.dst) for e in out} != {(e.src, e.dst) for e in edges}
+
+
+def test_rewire_is_deterministic_under_seed():
+    edges = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    assert degree_preserving_rewire(edges, seed=42) == degree_preserving_rewire(edges, seed=42)
+
+
+def test_rewire_raises_below_two_edges():
+    with pytest.raises(ValueError):
+        degree_preserving_rewire(_edges([("a", "b")]), seed=1)

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -12,7 +12,7 @@ from collections import Counter
 import pytest
 
 from tests.eval.compounding import ProbeSpec
-from tests.eval.placebo import Edge, degree_preserving_rewire, permute_gold
+from tests.eval.placebo import Edge, degree_preserving_rewire, paired_delta_bootstrap, permute_gold
 
 
 def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
@@ -136,3 +136,27 @@ def test_permute_gold_raises_when_singleton_pool_too_small():
     )
     with pytest.raises(ValueError, match="corpus too small"):
         permute_gold(probes, seed=1)
+
+
+def test_bootstrap_point_estimate_is_the_paired_mean():
+    a = [1.0, 0.8, 0.6, 0.4]
+    b = [0.0, 0.2, 0.1, 0.0]
+    out = paired_delta_bootstrap(a, b, seed=1, resamples=2000)
+    assert out["delta"] == pytest.approx(sum(x - y for x, y in zip(a, b)) / len(a), abs=1e-9)
+    assert out["n"] == 4
+    assert out["lo"] <= out["delta"] <= out["hi"]
+
+
+def test_bootstrap_is_deterministic_under_seed():
+    a = [0.9, 0.7, 0.5, 0.3, 0.6]
+    b = [0.1, 0.0, 0.2, 0.1, 0.0]
+    assert paired_delta_bootstrap(a, b, seed=11, resamples=1500) == paired_delta_bootstrap(
+        a, b, seed=11, resamples=1500
+    )
+
+
+def test_bootstrap_raises_on_length_mismatch_or_empty():
+    with pytest.raises(ValueError):
+        paired_delta_bootstrap([0.1, 0.2], [0.1], seed=1)
+    with pytest.raises(ValueError):
+        paired_delta_bootstrap([], [], seed=1)

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -11,7 +11,8 @@ from collections import Counter
 
 import pytest
 
-from tests.eval.placebo import Edge, degree_preserving_rewire
+from tests.eval.compounding import ProbeSpec
+from tests.eval.placebo import Edge, degree_preserving_rewire, permute_gold
 
 
 def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
@@ -78,3 +79,49 @@ def test_rewire_returns_pure_star_unchanged():
     star = _edges([("h", x) for x in "abcdef"])
     out = degree_preserving_rewire(star, seed=1)
     assert {(e.src, e.dst) for e in out} == {(e.src, e.dst) for e in star}
+
+
+def _probe(qid, seed_doc, companions):
+    return ProbeSpec(
+        query_id=qid,
+        text=qid,
+        bucket="cross-source",
+        seed_doc=seed_doc,
+        companion_docs=tuple(companions),
+    )
+
+
+def test_permute_gold_preserves_sizes_and_is_a_derangement_within_a_group():
+    probes = (
+        _probe("q1", "s1", ["c1a", "c1b"]),
+        _probe("q2", "s2", ["c2a", "c2b"]),
+        _probe("q3", "s3", ["c3a", "c3b"]),
+    )
+    out = permute_gold(probes, seed=5)
+
+    for p in probes:
+        assert len(out[p.query_id]) == len(p.companion_docs)  # size preserved
+        assert set(out[p.query_id]) != set(p.companion_docs)  # not own gold
+
+
+def test_permute_gold_is_deterministic_under_seed():
+    probes = (
+        _probe("q1", "s1", ["c1a", "c1b"]),
+        _probe("q2", "s2", ["c2a", "c2b"]),
+        _probe("q3", "s3", ["c3a", "c3b"]),
+    )
+    assert permute_gold(probes, seed=9) == permute_gold(probes, seed=9)
+
+
+def test_permute_gold_singleton_size_class_draws_excluding_own():
+    # q3 has a unique companion count (1) -> singleton class -> pool-draw path.
+    probes = (
+        _probe("q1", "s1", ["c1a", "c1b"]),
+        _probe("q2", "s2", ["c2a", "c2b"]),
+        _probe("q3", "s3", ["c3a"]),
+    )
+    out = permute_gold(probes, seed=2)
+
+    assert len(out["q3"]) == 1
+    assert "c3a" not in out["q3"]
+    assert "s3" not in out["q3"]

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -145,6 +145,7 @@ def test_bootstrap_point_estimate_is_the_paired_mean():
     assert out["delta"] == pytest.approx(sum(x - y for x, y in zip(a, b)) / len(a), abs=1e-9)
     assert out["n"] == 4
     assert out["lo"] <= out["delta"] <= out["hi"]
+    assert out["lo"] < out["hi"]  # non-degenerate data -> real interval width (not a stub)
 
 
 def test_bootstrap_is_deterministic_under_seed():
@@ -153,6 +154,17 @@ def test_bootstrap_is_deterministic_under_seed():
     assert paired_delta_bootstrap(a, b, seed=11, resamples=1500) == paired_delta_bootstrap(
         a, b, seed=11, resamples=1500
     )
+
+
+def test_bootstrap_interval_reacts_to_seed():
+    # Different seeds must produce different resampled intervals — guards against
+    # a degenerate implementation that ignores the resampling loop.
+    a = [0.9, 0.7, 0.5, 0.3, 0.6]
+    b = [0.1, 0.0, 0.2, 0.1, 0.0]
+    out1 = paired_delta_bootstrap(a, b, seed=1, resamples=2000)
+    out2 = paired_delta_bootstrap(a, b, seed=2, resamples=2000)
+    assert out1["delta"] == out2["delta"]  # point estimate is seed-independent
+    assert (out1["lo"], out1["hi"]) != (out2["lo"], out2["hi"])  # interval is seed-driven
 
 
 def test_bootstrap_raises_on_length_mismatch_or_empty():

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -18,6 +18,7 @@ from tests.eval.placebo import (
     median_cross_topic_gold_pair_cosine,
     paired_delta_bootstrap,
     permute_gold,
+    recovery_from_rankings,
 )
 
 
@@ -214,3 +215,15 @@ def test_median_cross_topic_skips_degenerate_single_element_pair():
     source = {"a": "memory"}
     gold_pairs = {frozenset(("a",))}
     assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None
+
+
+def test_recovery_from_rankings_scores_against_the_gold_map():
+    # probe q1: gold {b, c}; ranked [b, x, c] -> recovery@10 = 2/2 = 1.0
+    # probe q2: gold {d};    ranked [x, y]    -> recovery@10 = 0/1 = 0.0
+    rankings = [("q1", ["b", "x", "c"]), ("q2", ["x", "y"])]
+    gold_map = {"q1": ("b", "c"), "q2": ("d",)}
+    out = recovery_from_rankings(rankings, gold_map)
+
+    assert out["n"] == 2
+    assert out["recovery@10"] == pytest.approx((1.0 + 0.0) / 2)
+    assert out["per_probe@10"] == [pytest.approx(1.0), pytest.approx(0.0)]

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -12,7 +12,13 @@ from collections import Counter
 import pytest
 
 from tests.eval.compounding import ProbeSpec
-from tests.eval.placebo import Edge, degree_preserving_rewire, paired_delta_bootstrap, permute_gold
+from tests.eval.placebo import (
+    Edge,
+    degree_preserving_rewire,
+    median_cross_topic_gold_pair_cosine,
+    paired_delta_bootstrap,
+    permute_gold,
+)
 
 
 def _edges(pairs, *, origin="hebbian", edge_type="neural_association"):
@@ -172,3 +178,22 @@ def test_bootstrap_raises_on_length_mismatch_or_empty():
         paired_delta_bootstrap([0.1, 0.2], [0.1], seed=1)
     with pytest.raises(ValueError):
         paired_delta_bootstrap([], [], seed=1)
+
+
+def test_median_cross_topic_ignores_same_source_pairs():
+    doc_vec = {"a": [1.0], "b": [2.0], "c": [3.0]}
+    # cosine_fn returns the product of the single components (a stand-in metric)
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory", "b": "resource", "c": "memory"}
+    gold_pairs = {frozenset(("a", "b")), frozenset(("a", "c")), frozenset(("b", "c"))}
+    # cross-topic pairs: a-b (1*2=2), b-c (2*3=6); a-c is same-source -> skipped
+    out = median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos)
+    assert out == pytest.approx((2.0 + 6.0) / 2)
+
+
+def test_median_cross_topic_returns_none_when_no_cross_topic_pair():
+    doc_vec = {"a": [1.0], "b": [2.0]}
+    cos = lambda u, v: u[0] * v[0]
+    source = {"a": "memory", "b": "memory"}
+    gold_pairs = {frozenset(("a", "b"))}
+    assert median_cross_topic_gold_pair_cosine(doc_vec, gold_pairs, source, cosine_fn=cos) is None

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -125,3 +125,14 @@ def test_permute_gold_singleton_size_class_draws_excluding_own():
     assert len(out["q3"]) == 1
     assert "c3a" not in out["q3"]
     assert "s3" not in out["q3"]
+
+
+def test_permute_gold_raises_when_singleton_pool_too_small():
+    # q2's size-3 singleton class cannot be satisfied: after excluding q2's own
+    # 3 companions + seed, only {s1, c1a} (2 < 3) remain in the foreign pool.
+    probes = (
+        _probe("q1", "s1", ["c1a"]),
+        _probe("q2", "s2", ["c2a", "c2b", "c2c"]),
+    )
+    with pytest.raises(ValueError, match="corpus too small"):
+        permute_gold(probes, seed=1)

--- a/backend/tests/eval/test_placebo_live.py
+++ b/backend/tests/eval/test_placebo_live.py
@@ -1,0 +1,34 @@
+"""Live-stack Day-2 placebo kill-shot driver (directional de-risk).
+
+Needs the full stack (Postgres + Qdrant + Redis + embedding provider + Sudachi),
+so it is skip-guarded behind KAGURA_EVAL_LIVE=1 exactly like the compounding
+live test (the ``make eval-placebo`` target sets it).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("KAGURA_EVAL_LIVE") != "1",
+    reason="live placebo eval requires the full stack; set KAGURA_EVAL_LIVE=1 (make eval-placebo)",
+)
+
+
+@pytest.mark.asyncio
+async def test_placebo_live():
+    from tests.eval.placebo_runner import run_placebo_eval
+
+    results = await run_placebo_eval(seeds=(1, 2))
+
+    assert results["experiment"] == "day2-placebo"
+    assert results["real_warm"]["n"] > 0
+    assert len(results["per_seed"]) == 2
+    for block in results["per_seed"]:
+        assert block["arms"]["shuffled_gold"]["n"] > 0
+        # random_edge is n==0 only when the graph is too sparse to rewire
+        assert "random_edge" in block["arms"]
+    assert "tau" in results
+    assert results["directional_read"] in {"alive", "edge_spray", "inconclusive"}

--- a/backend/tests/eval/tools/corpus.py
+++ b/backend/tests/eval/tools/corpus.py
@@ -21,6 +21,13 @@ SOURCE_MEMORY = "memory"
 SOURCE_RESOURCE = "resource"
 _VALID_SOURCES = {SOURCE_MEMORY, SOURCE_RESOURCE}
 
+# Contamination-split values a query's optional ``split`` field may take
+# (prereg-v1 H3). See ``Query.split``.
+_VALID_SPLITS = {"public", "heldout"}
+# Graded relevance is 0-3 inclusive (docs/02 §1.2 item 5). See ``Query.graded``.
+_MIN_GRADE = 0
+_MAX_GRADE = 3
+
 # The six difficulty/coverage buckets every query must belong to.
 BUCKETS = (
     "retrieval-exact",
@@ -57,6 +64,12 @@ class Query:
     # a zero-adoption memory — reinforce must not bury it). None for the static
     # golden corpus, which is not stratified by adoption.
     population: str | None = None
+    # Contamination split (prereg-v1 H3): "public" queries may be published;
+    # "heldout" queries drive every headline claim. None for legacy corpora.
+    split: str | None = None
+    # Graded relevance 0-3 (docs/02 §1.2 item 5): doc_id -> grade. relevant stays
+    # the binary gold SoT (== docs graded >= 2); grade-1 docs are nDCG-only shading.
+    graded: dict[str, int] | None = None
 
 
 @dataclass(frozen=True)
@@ -92,17 +105,38 @@ def load_corpus(path: Path | None = None) -> Corpus:
             f"golden corpus has document(s) with unknown source(s) {bad_sources}; "
             f"valid sources are {sorted(_VALID_SOURCES)}"
         )
-    queries = tuple(
-        Query(
-            id=q["id"],
-            bucket=q["bucket"],
-            text=q["text"],
-            relevant=tuple(q.get("relevant", [])),
-            population=q.get("population"),
+    queries = []
+    for q in raw.get("queries", []):
+        split = q.get("split")
+        if split is not None and split not in _VALID_SPLITS:
+            raise ValueError(
+                f"query {q['id']!r} has invalid split {split!r}; "
+                f"valid splits are {sorted(_VALID_SPLITS)}"
+            )
+        graded = q.get("graded")
+        if graded is not None:
+            bad_grades = {
+                doc_id: grade
+                for doc_id, grade in graded.items()
+                if not isinstance(grade, int) or not (_MIN_GRADE <= grade <= _MAX_GRADE)
+            }
+            if bad_grades:
+                raise ValueError(
+                    f"query {q['id']!r} has invalid grade(s) {bad_grades}; "
+                    f"grades must be int in [{_MIN_GRADE}, {_MAX_GRADE}]"
+                )
+        queries.append(
+            Query(
+                id=q["id"],
+                bucket=q["bucket"],
+                text=q["text"],
+                relevant=tuple(q.get("relevant", [])),
+                population=q.get("population"),
+                split=split,
+                graded=graded,
+            )
         )
-        for q in raw.get("queries", [])
-    )
-    return Corpus(meta=raw.get("meta", {}), documents=documents, queries=queries)
+    return Corpus(meta=raw.get("meta", {}), documents=documents, queries=tuple(queries))
 
 
 @lru_cache(maxsize=4096)


### PR DESCRIPTION
> Built on #1172 (Day-2 placebo harness, already merged) — this PR adds the 5 Day-3 commits on top.

## What

**Day-3 corpus-freeze** (week1-derisk Day 3, eval-repo prereg-v1 Appendix A): scales the eval corpus to paper-grade size and freezes the corpus-dependent constants — before any inferential result.

- **`fixtures/kagura_l.yaml`** — the scaled frozen corpus (docs/02 §1.1 `kagura_L` row): **300 documents** (180 memory / 120 resource, 76 Japanese) and **280 queries** (240 held-out + 40 public) across the six buckets, including **60 valid cross-source multi-gold probes** with **graded 0–3 labels** (`relevant` stays the binary gold SoT = grades ≥ 2). Authored in 10 leakage-aware theme batches; the docs/02 §1.2 build loop drove `leakage_check` to **zero flags with all three rules live** (Rule 3 activates at 300 docs; 12 rare-term query rewrites — Jaccard/3-gram were clean on first assembly). `meta.content_sha256` stamps the canonical content hash.
- **`test_kagura_l_corpus.py`** — fail-loud regression gates: shape/counts, graded↔relevant consistency, probe population (≥50), split discipline, leakage zero-flags, stratification ≥3 difficulty regimes with **≥20% hard** (docs/02 §1.2 item 4 proportion gate).
- **Schema** — `Query.split` (`public|heldout`, prereg H3 contamination split) + `Query.graded` (0–3), parsed/validated in `tools/corpus.py`; golden corpus untouched (loads with both None).
- **Metrics** — `ndcg_at_k(..., gains=)` graded overload with `(2^rel − 1)` gains (docs/02 §1.2 item 5); binary path byte-identical; P@k/MRR stay binary.
- **`freeze_tau.py`** — one-shot live freeze measurement (prereg-v1 §3): ingest the frozen corpus into a throwaway workspace, fetch stored vectors, **τ := median cosine over held-out cross-topic gold pairs**, teardown; emits a self-contained freeze artifact.

## Freeze result (live run on the GB10 pgx01 rig)

`results/freeze-kagura_l-2026-07-02.json`: **τ_frozen = 0.7192** (median over **97** held-out cross-topic gold-pair cosines, range 0.4869–0.9068; `qwen3-embedding:0.6b`/1024, 300/300 vectors). **N_heldout = 240**, N_public = 40, **N_probe = 60**, sudachi = 20260428, content hash `ca7a717b…`.

These values are stamped into the eval repo's prereg-v1 **Appendix A** and tagged **`prereg-v1-frozen`** (pushed) — still before any inferential result: the Day-2 kill-shot was descriptive-only, and the Day-3 inferential H2 run was skipped per its pre-declared condition (Day-2 read = `edge_spray`).

## Testing

- Whole eval suite: **124 passed** (live tests skip without `KAGURA_EVAL_LIVE=1`); `ruff check` clean.
- Schema + metrics landed TDD (RED→GREEN evidence in the task reports); binary nDCG verified byte-identical.
- Live freeze run succeeded on pgx01 (2 transient embedding failures auto-retried by the existing ingest retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
