### PR TITLE
refactor(api): reuse audit helper + dedup member-credential SELECT

### DIFF
--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.api_keys import APIKeyManager
 from auth.dependencies import APIKeyOrSessionUser, SessionUser
 from auth.programmatic_workspace_auth import (
+    audit_programmatic_workspace_action,
     authorize_workspace_management,
     is_api_key_principal,
     is_oauth_principal,
@@ -138,7 +139,7 @@ async def _owner_provisioned_mint(
     # KeyError/500), so read caller_id via .get() only after it passes (Copilot
     # review, PR #1171). session_required_role is unused for the API-key
     # principal but must be supplied.
-    await authorize_workspace_management(
+    principal = await authorize_workspace_management(
         user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
     )
     caller_id = user.get("user_id")
@@ -182,23 +183,22 @@ async def _owner_provisioned_mint(
         new_key.visibility_expires_at = None
         new_key.plaintext_encrypted = None
 
-        from models.auth import AuditLog
-
-        db.add(
-            AuditLog(
-                user_email=user.get("email") or f"{caller_id}@api",
-                user_id=caller_id,
-                action="member_api_key_provisioned",
-                resource=f"api_key:{new_key.id}",
-                user_metadata={
-                    "workspace_id": str(workspace_id),
-                    "target": user_id,
-                    "key_prefix": new_key.key_prefix,  # the MINTED key
-                    "actor_key_prefix": user.get("api_key_prefix"),  # the ACTING owner key
-                    "expires_days": data.expires_days,
-                    "via": "api_key",
-                },
-            )
+        # Audit via the shared helper (#1164) — it records the ACTING owner key
+        # under metadata["key_prefix"] and hardcodes via/workspace_id/target; we
+        # override the resource to point at the minted key and carry the minted
+        # prefix under a distinct key so the actor prefix is not clobbered.
+        await audit_programmatic_workspace_action(
+            db,
+            principal,
+            user,
+            workspace_id,
+            action="member_api_key_provisioned",
+            target=user_id,
+            resource=f"api_key:{new_key.id}",
+            metadata={
+                "minted_key_prefix": new_key.key_prefix,  # the MINTED key
+                "expires_days": data.expires_days,
+            },
         )
         await db.commit()
 
@@ -253,10 +253,15 @@ async def get_member_credentials(
             message="OAuth bearer tokens cannot view member credentials. Use a workspace-owner API key."
         )
     programmatic = is_api_key_principal(user)
+    caller_role: str | None = None
     if programmatic:
-        await authorize_workspace_management(
+        # authorize_workspace_management already fetched the caller's owner
+        # WorkspaceMember row; reuse its role so the view-permission check below
+        # does not re-SELECT the same row (max code-review, PR #1171).
+        principal = await authorize_workspace_management(
             user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
         )
+        caller_role = principal.member.role
 
     service = MemberCredentialsService(db)
 
@@ -265,6 +270,7 @@ async def get_member_credentials(
             workspace_id=workspace_id,
             user_id=user_id,
             requester_id=user["user_id"],
+            requester_role=caller_role,
         )
 
         # Issue #1165: metadata-only for programmatic principals — never leak
@@ -765,9 +771,10 @@ async def delete_api_key_by_id(
     # caller (Copilot review, PR #1171).
     caller_id = user.get("user_id")
     programmatic = is_api_key_principal(user)
+    principal = None
     if programmatic:
         # Owner gate on the path workspace (+ #963 confinement).
-        await authorize_workspace_management(
+        principal = await authorize_workspace_management(
             user, workspace_id, db, session_required_role=WorkspaceRole.OWNER
         )
         if user_id != caller_id:
@@ -840,24 +847,27 @@ async def delete_api_key_by_id(
     # the revoked_at update commit atomically in one transaction. Session
     # self-delete keeps the existing hard-delete semantics (#252, #626).
     soft_revoke = programmatic
-    from models.auth import AuditLog
 
     if soft_revoke:
-        db.add(
-            AuditLog(
-                user_email=user.get("email") or f"{caller_id}@api",
-                user_id=caller_id,
-                action="member_api_key_revoked",
-                resource=f"api_key:{key_id}",
-                user_metadata={
-                    "workspace_id": str(workspace_id),
-                    "target": user_id,
-                    "key_prefix": api_key.key_prefix,  # the REVOKED key
-                    "actor_key_prefix": user.get("api_key_prefix"),  # the ACTING owner key
-                    "self_revoke": user_id == caller_id,
-                    "via": "api_key",
-                },
-            )
+        # soft_revoke == programmatic, so authorize_workspace_management above
+        # returned a (non-None) api_key principal.
+        assert principal is not None
+        # Audit via the shared helper (#1164): it records the ACTING owner key
+        # under metadata["key_prefix"]; the revoked key's prefix is carried under
+        # a distinct key so the actor prefix is not clobbered. resource points at
+        # the revoked key, not the workspace.
+        await audit_programmatic_workspace_action(
+            db,
+            principal,
+            user,
+            workspace_id,
+            action="member_api_key_revoked",
+            target=user_id,
+            resource=f"api_key:{key_id}",
+            metadata={
+                "revoked_key_prefix": api_key.key_prefix,  # the REVOKED key
+                "self_revoke": user_id == caller_id,
+            },
         )
         api_key.revoked_at = utcnow()
         await db.commit()
@@ -874,6 +884,8 @@ async def delete_api_key_by_id(
 
     # Issue #626: audit log entry for public-bound key revocation.
     if bound_ctx_id is not None:
+        from models.auth import AuditLog
+
         db.add(
             AuditLog(
                 user_email=user.get("email") or f"{user_id}@api",

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -181,8 +181,8 @@ async def audit_programmatic_workspace_action(
     ``resource`` defaults to ``workspace:{workspace_id}`` (the member/invitation
     surface, whose resource IS the workspace). The member-credential surface
     (#1165) passes ``resource=f"api_key:{id}"`` so the row points at the specific
-    minted/revoked key. The ACTING key prefix is always recorded under
-    ``metadata["key_prefix"]``; a caller that also wants to record the
+    minted/revoked key. When the acting API key prefix is present, it is recorded
+    under ``metadata["key_prefix"]``; callers that also want to record the
     minted/revoked key prefix must pass it via ``metadata`` under a DISTINCT key
     (e.g. ``minted_key_prefix`` / ``revoked_key_prefix``) so it is not clobbered.
 

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -166,6 +166,7 @@ async def audit_programmatic_workspace_action(
     *,
     action: str,
     target: str,
+    resource: str | None = None,
     metadata: dict | None = None,
 ) -> None:
     """Write an AuditLog row for a PROGRAMMATIC workspace-management mutation.
@@ -176,6 +177,14 @@ async def audit_programmatic_workspace_action(
     the actor, workspace, action, and target. Session actions are intentionally
     NOT audited here — this call is a no-op for session principals so the web-UI
     path keeps its existing (unaudited) behavior unchanged.
+
+    ``resource`` defaults to ``workspace:{workspace_id}`` (the member/invitation
+    surface, whose resource IS the workspace). The member-credential surface
+    (#1165) passes ``resource=f"api_key:{id}"`` so the row points at the specific
+    minted/revoked key. The ACTING key prefix is always recorded under
+    ``metadata["key_prefix"]``; a caller that also wants to record the
+    minted/revoked key prefix must pass it via ``metadata`` under a DISTINCT key
+    (e.g. ``minted_key_prefix`` / ``revoked_key_prefix``) so it is not clobbered.
 
     The row is added to the session but NOT committed — the caller commits it
     atomically with the mutation it is auditing.
@@ -218,7 +227,7 @@ async def audit_programmatic_workspace_action(
             user_email=user.get("email") or f"{actor_id}@api",
             user_id=actor_id,
             action=action,
-            resource=f"workspace:{workspace_id}",
+            resource=resource if resource is not None else f"workspace:{workspace_id}",
             user_metadata=audit_metadata,
         )
     )

--- a/backend/src/services/member_credentials_service.py
+++ b/backend/src/services/member_credentials_service.py
@@ -134,7 +134,11 @@ class MemberCredentialsService:
         return count
 
     async def get_or_create_credentials(
-        self, workspace_id: UUID, user_id: str, requester_id: str
+        self,
+        workspace_id: UUID,
+        user_id: str,
+        requester_id: str,
+        requester_role: str | None = None,
     ) -> dict[str, Any]:
         """Get or create default API keys for a member (Lazy initialization).
 
@@ -144,6 +148,11 @@ class MemberCredentialsService:
             workspace_id: Workspace ID
             user_id: Target user ID
             requester_id: Requesting user ID (for permission check)
+            requester_role: The requester's already-known workspace role, when a
+                caller has resolved it (e.g. the programmatic owner-key GET path,
+                where ``authorize_workspace_management`` already fetched the
+                caller's membership). Threaded into ``_check_can_view`` to skip a
+                duplicate ``WorkspaceMember`` SELECT. ``None`` → look it up.
 
         Returns:
             {
@@ -166,7 +175,9 @@ class MemberCredentialsService:
             AuthorizationError: If requester doesn't have permission (403)
         """
         # Permission check: Can view credentials?
-        await self._check_can_view(requester_id, workspace_id, user_id)
+        await self._check_can_view(
+            requester_id, workspace_id, user_id, requester_role=requester_role
+        )
 
         # Get ALL api keys for user + workspace.
         # Issue #626: public-bound keys have ``workspace_id=NULL`` (mutually
@@ -253,7 +264,11 @@ class MemberCredentialsService:
         return False
 
     async def _check_can_view(
-        self, requester_id: str, workspace_id: UUID, target_user_id: str
+        self,
+        requester_id: str,
+        workspace_id: UUID,
+        target_user_id: str,
+        requester_role: str | None = None,
     ) -> None:
         """Check if requester can view target user's credentials page.
 
@@ -265,6 +280,11 @@ class MemberCredentialsService:
             requester_id: Requesting user ID
             workspace_id: Workspace ID
             target_user_id: Target user ID
+            requester_role: The requester's already-known workspace role. When
+                supplied (non-self path), it is trusted instead of re-querying
+                ``WorkspaceMember`` — the programmatic owner-key GET path already
+                resolved it via ``authorize_workspace_management``. ``None`` →
+                look it up.
 
         Raises:
             AuthorizationError: If not allowed (403)
@@ -273,8 +293,10 @@ class MemberCredentialsService:
         if requester_id == target_user_id:
             return
 
-        # Check if requester is workspace owner/admin
-        requester_role = await self.get_workspace_role(requester_id, workspace_id)
+        # Check if requester is workspace owner/admin. Reuse a caller-provided
+        # role to avoid a duplicate SELECT; otherwise look it up.
+        if requester_role is None:
+            requester_role = await self.get_workspace_role(requester_id, workspace_id)
 
         if requester_role not in ["owner", "admin"]:
             raise AuthorizationError("Insufficient permissions")

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -135,7 +135,15 @@ class TestOwnerProvisionedMint:
         ]
         assert len(audit_rows) == 1
         assert audit_rows[0].action == "member_api_key_provisioned"
-        assert audit_rows[0].user_metadata["target"] == "target-user"
+        assert audit_rows[0].resource == "api_key:42"
+        meta = audit_rows[0].user_metadata
+        assert meta["target"] == "target-user"
+        assert meta["via"] == "api_key"
+        # #1171 cleanup: routed through the shared helper — the MINTED key prefix
+        # lands under the distinct ``minted_key_prefix`` key (the helper reserves
+        # ``key_prefix`` for the ACTING owner key).
+        assert meta["minted_key_prefix"] == "kagura_abc"
+        assert meta["expires_days"] == 30
 
     def test_self_mint_forbidden(self, client, owner_gate, monkeypatch):
         # target == caller → anti self-replication 403
@@ -255,6 +263,14 @@ class TestOwnerProvisionedRevoke:
         ]
         assert len(audit_rows) == 1
         assert audit_rows[0].action == "member_api_key_revoked"
+        assert audit_rows[0].resource == "api_key:42"
+        meta = audit_rows[0].user_metadata
+        assert meta["target"] == "target-user"
+        assert meta["via"] == "api_key"
+        # #1171 cleanup: routed through the shared helper — the REVOKED key prefix
+        # lands under the distinct ``revoked_key_prefix`` key.
+        assert meta["revoked_key_prefix"] == "kagura_abc"
+        assert meta["self_revoke"] is False
 
     def test_cross_member_global_key_revoke_404(self, client, owner_gate, monkeypatch):
         # #1171 max-review: a global key (workspace_id NULL, bound_context_id NULL)

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -173,6 +173,37 @@ class TestAuditProgrammaticAction:
         row = db.add.call_args[0][0]
         assert row.user_metadata["key_prefix"] == "kagura_abc123"
 
+    async def test_default_resource_is_workspace(self):
+        # #1164 member/invitation surface: resource defaults to the workspace.
+        db = MagicMock()
+        principal = AuthorizedPrincipal(kind="api_key", member=MagicMock())
+        await audit_programmatic_workspace_action(
+            db, principal, _api_key_user(), _WS, action="x", target="m1"
+        )
+        assert db.add.call_args[0][0].resource == f"workspace:{_WS}"
+
+    async def test_resource_override_and_distinct_prefix_key(self):
+        # #1165 member-credential surface: resource points at the key, the ACTING
+        # key prefix stays under key_prefix, and a caller-supplied minted prefix
+        # rides under its own distinct metadata key (not clobbered).
+        db = MagicMock()
+        principal = AuthorizedPrincipal(kind="api_key", member=MagicMock())
+        user = {**_api_key_user(), "api_key_prefix": "kagura_actor"}
+        await audit_programmatic_workspace_action(
+            db,
+            principal,
+            user,
+            _WS,
+            action="member_api_key_provisioned",
+            target="m1",
+            resource="api_key:42",
+            metadata={"minted_key_prefix": "kagura_minted"},
+        )
+        row = db.add.call_args[0][0]
+        assert row.resource == "api_key:42"
+        assert row.user_metadata["key_prefix"] == "kagura_actor"
+        assert row.user_metadata["minted_key_prefix"] == "kagura_minted"
+
     async def test_omits_key_prefix_when_absent(self):
         db = MagicMock()
         principal = AuthorizedPrincipal(kind="api_key", member=MagicMock())

--- a/backend/tests/services/test_member_credentials_service.py
+++ b/backend/tests/services/test_member_credentials_service.py
@@ -95,6 +95,29 @@ class TestCheckCanView:
         assert exc_info.value.message == "Insufficient permissions"
         assert exc_info.value.reason is None
 
+    @pytest.mark.asyncio
+    async def test_threaded_role_skips_lookup(self, service, workspace_id):
+        """A caller-supplied requester_role is trusted and skips the duplicate
+        WorkspaceMember SELECT — the programmatic owner-key GET path already
+        resolved the role via authorize_workspace_management (#1171 cleanup)."""
+        service.get_workspace_role = AsyncMock(return_value=None)
+        await service._check_can_view(
+            "owner_user", workspace_id, "target_user", requester_role="owner"
+        )
+        service.get_workspace_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_threaded_role_still_enforces_deny(self, service, workspace_id):
+        """A threaded non-owner/admin role is still denied without a lookup —
+        trusting the role must not bypass the owner/admin gate."""
+        service.get_workspace_role = AsyncMock(return_value="owner")  # would allow if queried
+        with pytest.raises(AuthorizationError) as exc_info:
+            await service._check_can_view(
+                "member_user", workspace_id, "target_user", requester_role="member"
+            )
+        assert exc_info.value.status_code == 403
+        service.get_workspace_role.assert_not_awaited()
+
 
 class TestSerializeApiKeyLastUsed:
     """Issue #943 — the API Keys table surfaces a 'Last used' column, so the


### PR DESCRIPTION
## Summary

Two deferred, non-blocking cleanups from the max code-review of [#1171](https://github.com/kagura-ai/memory-cloud/pull/1171) (#1165), both in `backend/src/api/routes/member_credentials.py`. The PR merged without them; this lands them as pure tech-debt with no behavior change.

### 1. Reuse the shared audit helper for the two inline `AuditLog` constructions

`_owner_provisioned_mint` (mint) and `delete_api_key_by_id`'s soft-revoke branch each hand-built an `AuditLog` row. They now route through `audit_programmatic_workspace_action` (`auth/programmatic_workspace_auth.py`), matching the 5 sibling #1164 call sites in `workspaces.py` / `invitations.py`.

The helper reserved `metadata["key_prefix"]` for the **actor** key and hardcoded `resource=f"workspace:{workspace_id}"`, whereas these sites need `resource=f"api_key:{id}"` and record the **minted/revoked** key prefix. So:
- the helper gains an optional `resource=` kwarg (defaults to `workspace:{id}`, unchanged for siblings);
- the minted/revoked prefix is passed via `metadata` under a distinct key (`minted_key_prefix` / `revoked_key_prefix`) so it does not clobber the actor `key_prefix`.

**Audit-shape note:** `key_prefix` now consistently means the **acting** key (as on the sibling surfaces); the minted/revoked key moves to its own field. No code or frontend consumes these metadata keys (verified by grep).

### 2. Collapse the duplicate `WorkspaceMember` SELECT on the programmatic GET path

`authorize_workspace_management` already fetches and returns the caller's `AuthorizedPrincipal.member`, but `get_member_credentials` discarded it and `get_or_create_credentials → _check_can_view` re-fetched the same row via `get_workspace_role(caller, ws)`. The caller's role is now threaded through `get_or_create_credentials(requester_role=...)` into `_check_can_view`, which trusts it instead of re-querying. Session path unchanged (role stays `None` → falls back to the lookup).

## Testing

- `ruff check` — clean
- `pyright` — 0 errors on the three changed source files
- Affected suites — **99 passed**: `test_programmatic_workspace_auth`, `test_member_credentials_owner_key`, `test_member_credentials_service`, `test_programmatic_member_access`, `test_workspace`, `test_invitation_service_coverage`, `test_workspace_plan_tiers`
- Added regression tests: helper `resource=` override + distinct-prefix-key, and `_check_can_view` threaded-role skips the lookup (and still enforces deny)

🤖 Generated with [Claude Code](https://claude.com/claude-code)