### PR TITLE
eval: Day-4 static factorial — H0 pass, H1 replicated null (hybrid ≤ semantic at P@5), σ_d stamped

### DIFF
--- a/backend/tests/eval/day4_analysis.py
+++ b/backend/tests/eval/day4_analysis.py
@@ -193,6 +193,82 @@ def _rr10(run: dict[str, Any], arm: str, split: str) -> list[float]:
     return [rec["rr@10"] for rec in run["arms"][arm]["per_query"] if rec["split"] == split]
 
 
+def _p5_by_query_id(run: dict[str, Any], arm: str, split: str) -> dict[str, float]:
+    """Per-query P@5 for ``arm`` filtered to ``split``, keyed by ``query_id``.
+
+    Dict insertion order mirrors ``arm``'s own filtered ``per_query`` record
+    order (Python dicts preserve insertion order), so a caller can recover a
+    deterministic value ordering straight from any one arm's dict via
+    ``_join_by_query_id``.
+    """
+    return {
+        rec["query_id"]: rec["p@5"]
+        for rec in run["arms"][arm]["per_query"]
+        if rec["split"] == split
+    }
+
+
+def _join_by_query_id(
+    by_arm: dict[str, dict[str, float]], reference_arm: str, *, label: str, split: str
+) -> dict[str, list[float]]:
+    """Query_id-keyed join of ``by_arm``'s ``{query_id: value}`` dicts.
+
+    A Task-3 review flag: pairing arm-vs-arm ``split``-filtered values by list
+    POSITION is only correct when every arm's filtered records name the exact
+    same query_ids in the exact same order. ``_assert_aligned`` guarantees the
+    FULL (unfiltered) per_query query_id sequence matches across arms, but not
+    that ``split`` labels for a given query_id agree between arms — a per-arm
+    split divergence would silently misalign the heldout-filtered values that
+    positional zip/dict-comprehension pairing assumed were aligned.
+
+    Fatal (``SystemExit``), naming the FIRST query_id (in ``reference_arm``'s
+    own order, or — if ``reference_arm``'s key set is otherwise a subset of
+    another arm's — in that other arm's own order) present in one arm's key
+    set but missing from another's, if any arm's key set differs from
+    ``reference_arm``'s.
+
+    Returns ``{arm: values}`` with every arm's values reordered to
+    ``reference_arm``'s own query_id order — one deterministic shared
+    ordering, derived from real query identities rather than list position.
+    """
+    reference_ids = list(by_arm[reference_arm])
+    reference_set = set(reference_ids)
+    for arm, values in by_arm.items():
+        if arm == reference_arm:
+            continue
+        arm_set = set(values)
+        if arm_set == reference_set:
+            continue
+        for query_id in reference_ids:
+            if query_id not in arm_set:
+                _fatal(
+                    f"run {label!r}: split={split!r} query_id {query_id!r} present in "
+                    f"{reference_arm!r} but missing from {arm!r} — heldout-filtered "
+                    "arms must name the exact same query_ids for query_id-keyed pairing"
+                )
+        for query_id in values:
+            if query_id not in reference_set:
+                _fatal(
+                    f"run {label!r}: split={split!r} query_id {query_id!r} present in "
+                    f"{arm!r} but missing from {reference_arm!r} — heldout-filtered "
+                    "arms must name the exact same query_ids for query_id-keyed pairing"
+                )
+    return {arm: [values[query_id] for query_id in reference_ids] for arm, values in by_arm.items()}
+
+
+def _h1_verdict(mean_: float, ci_low: float, h0_reject: bool) -> dict[str, bool]:
+    """H1's ``pass``/``pass_gated``/``tested`` flags from their 3 inputs.
+
+    Split out as a small pure function (no bootstrap/omnibus computation
+    inside) so the pass/gated-by-H0 interaction — in particular the
+    ``pass=True, tested=False`` combination, which requires an H0 non-reject
+    alongside a decisive H1 contrast and is otherwise awkward to construct
+    naturally — can be unit-tested directly.
+    """
+    h1_pass = ci_low > 0 and mean_ >= DELTA_HYBRID
+    return {"pass": h1_pass, "pass_gated": h1_pass and h0_reject, "tested": h0_reject}
+
+
 def _analyze_group(
     embedding_model: str, group: list[dict[str, Any]], inferential_run_label: str
 ) -> dict[str, Any]:
@@ -208,32 +284,53 @@ def _analyze_group(
     inferential = _resolve_inferential(embedding_model, group, inferential_run_label)
     _assert_aligned(inferential)
 
-    heldout_p5 = {arm: _p5(inferential, arm, "heldout") for arm in GATED_ARMS}
+    # Query_id-keyed (not positional) per-arm heldout values — see
+    # ``_join_by_query_id`` for why positional pairing across independently
+    # split-filtered arms is unsafe.
+    heldout_by_query = {arm: _p5_by_query_id(inferential, arm, "heldout") for arm in GATED_ARMS}
     public_p5 = {arm: _p5(inferential, arm, "public") for arm in GATED_ARMS}
+    heldout_p5 = _join_by_query_id(
+        heldout_by_query, GATED_ARMS[0], label=inferential["label"], split="heldout"
+    )
     n_heldout = len(heldout_p5[GATED_ARMS[0]])
     n_public = len(public_p5[GATED_ARMS[0]])
 
-    # 1. H0 omnibus (gate).
+    # 1. H0 omnibus (gate). All 4 arms' heldout value lists share one ordering
+    # (GATED_ARMS[0]'s query_id order, via the join above) — the permutation
+    # test permutes within-index, so this alignment is load-bearing.
     h0_raw = permutation_omnibus(heldout_p5, n_permutations=N_RESAMPLES, seed=SEED)
     h0_reject = h0_raw["p_value"] < ALPHA
     h0 = {"stat": h0_raw["stat"], "p_value": h0_raw["p_value"], "reject": h0_reject}
 
-    # 2. H1 (computed always; interpretation gated by H0).
+    # 2. H1 (computed always; interpretation gated by H0). Paired query_id-
+    # keyed against the hybrid arm's own filtered order (not GATED_ARMS[0]'s),
+    # per the H1 contrast's own reference arm.
     keyword_mean = mean(heldout_p5["keyword"])
     semantic_mean = mean(heldout_p5["semantic"])
     best_single = "semantic" if semantic_mean > keyword_mean else "keyword"
-    h1_diffs = [h - b for h, b in zip(heldout_p5["hybrid"], heldout_p5[best_single], strict=True)]
+    hybrid_vs_best_single = _join_by_query_id(
+        {"hybrid": heldout_by_query["hybrid"], best_single: heldout_by_query[best_single]},
+        "hybrid",
+        label=inferential["label"],
+        split="heldout",
+    )
+    h1_diffs = [
+        h - b
+        for h, b in zip(
+            hybrid_vs_best_single["hybrid"], hybrid_vs_best_single[best_single], strict=True
+        )
+    ]
     h1_ci = paired_bca_ci(h1_diffs, n_resamples=N_RESAMPLES, alpha=ALPHA, seed=SEED)
-    h1_pass = h1_ci["ci_low"] > 0 and h1_ci["mean"] >= DELTA_HYBRID
+    h1_verdict = _h1_verdict(h1_ci["mean"], h1_ci["ci_low"], h0_reject)
     h1 = {
         "best_single": best_single,
         "mean": h1_ci["mean"],
         "ci_low": h1_ci["ci_low"],
         "ci_high": h1_ci["ci_high"],
-        "pass": h1_pass,
-        "pass_gated": h1_pass and h0_reject,
+        "pass": h1_verdict["pass"],
+        "pass_gated": h1_verdict["pass_gated"],
         "gated_by_h0": True,
-        "tested": h0_reject,
+        "tested": h1_verdict["tested"],
     }
 
     # 3. H3 (supporting) — production-arm public/heldout leak gap.

--- a/backend/tests/eval/day4_analysis.py
+++ b/backend/tests/eval/day4_analysis.py
@@ -1,0 +1,378 @@
+"""Day-4 pre-declared confirmatory analysis — H0/H1/H3 verdicts (prereg-v1).
+
+Turns N per-embedder retrieval-eval result JSONs (produced by
+``tests.eval.runner``, each carrying top-level ``embedding_model``, ``label``,
+and ``arms.<arm>.per_query`` — a list of ``{"query_id", "bucket", "split",
+"p@5", "rr@10"}`` in corpus order) into the PRE-DECLARED hypothesis verdicts
+for the Day-4 static factorial (2 embedders x 4 arms x 3 re-runs on the frozen
+``kagura_L`` corpus). All statistics are imported from ``tests.eval.stats``
+(Task 1) — this module does not reimplement any of them.
+
+Pre-declared (prereg-v1 + Day-4 mini-annex, D1-D3; see ``_DESIGN_NOTES``):
+
+- Gated family: exactly the four #967 arms — keyword, semantic, hybrid,
+  hybrid_neural. The Sleep static arm is DROPPED (D1): ``recall()`` never
+  reads graph edges (Issue #120), so a "hybrid_neural + Sleep" arm scored on
+  the recall surface would be definitionally identical to hybrid_neural.
+- Primary metric: held-out per-query P@5. Secondary: RR@10 (MRR, reported
+  only, never gated).
+- H0 (gate): within-query permutation omnibus over the 4 gated arms,
+  10,000 permutations, seed 20260703, reject at p < 0.05.
+- H1 (contrast; ALWAYS computed and reported, but only licensed to be
+  interpreted as a real effect when H0 rejects — ``"gated_by_h0": true``):
+  hybrid - best_single(keyword, semantic) — best_single is whichever of the
+  two has the higher held-out mean P@5 (ties go to keyword), paired BCa
+  bootstrap, 10,000 resamples, seed 20260703. Pass = CI lower bound > 0 AND
+  point estimate >= delta_hybrid (0.05); ``pass_gated`` additionally requires
+  H0 to have rejected.
+- H3 (supporting): production arm (hybrid_neural) public - heldout mean-P@5
+  gap, unpaired percentile bootstrap, 10,000 resamples, seed 20260703. Within
+  the leak tolerance when the gap <= delta_leak (0.05). ``None`` when the
+  corpus carries no public queries (nothing to compute a gap against).
+- sigma_d / achieved_power: sample SD of the H1 per-query paired diffs and
+  the closed-form two-sided normal-approximation power at delta_hybrid, for
+  the prereg's Appendix A power re-estimation stamp.
+- Re-runs: each embedder gets (nominally) 3 identical-invocation runs; ONE is
+  pre-declared the inferential run (used for every inferential statistic
+  above — see ``_resolve_inferential``); every run (including non-inferential
+  ones) contributes to the descriptive ``arm_means_across_runs`` (min/median/
+  max of held-out mean P@5 per arm).
+
+Pure stdlib + ``tests.eval.stats`` only — no app/src imports — so this CLI
+runs locally without the backend stack (DB, Qdrant, LiteLLM, ...).
+
+Usage:
+    PYTHONPATH=src:. python -m tests.eval.day4_analysis \\
+        --results results/day4-qwen3-embedding-0.6b-run0-2026-07-05.json ... \\
+        --inferential-run day4-qwen3-embedding-0.6b-run0 \\
+        [--out results/day4-analysis-2026-07-05.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from itertools import zip_longest
+from pathlib import Path
+from statistics import mean, median
+from typing import Any, NoReturn
+
+from tests.eval.stats import (
+    achieved_power,
+    paired_bca_ci,
+    permutation_omnibus,
+    sigma_d,
+    unpaired_percentile_ci_diff,
+)
+
+#: The four pre-registered arms (#967); order is fixed — it drives the H0
+#: omnibus dict key order and the H1 best_single tie-break (keyword first).
+GATED_ARMS: tuple[str, ...] = ("keyword", "semantic", "hybrid", "hybrid_neural")
+#: Shared seed for every resampling procedure below — one seed for the whole
+#: confirmatory analysis, per the prereg (byte-reproducible across machines).
+SEED = 20260703
+N_RESAMPLES = 10_000
+ALPHA = 0.05
+#: H1 pass threshold: hybrid must beat best_single by at least this much.
+DELTA_HYBRID = 0.05
+#: H3 leak tolerance: the public - heldout mean-P@5 gap must not exceed this.
+DELTA_LEAK = 0.05
+#: The arm mirrored to production; H3's subject.
+PRODUCTION_ARM = "hybrid_neural"
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+_DESIGN_NOTES: tuple[str, ...] = (
+    "D1: sleep static arm dropped — recall() never reads graph edges (Issue #120); "
+    "gated family = the prereg's exact 4 arms.",
+    "D2: qwen3-embedding:0.6b = inferential/primary; qwen3-embedding:4b = replication "
+    "(descriptive).",
+    "D3: permutation omnibus + paired BCa (10k, seed 20260703); run 0 inferential; "
+    "3 re-runs min/median/max.",
+)
+
+
+def _fatal(message: str) -> NoReturn:
+    """Fail loud with a prefixed, actionable message (never a bare traceback)."""
+    raise SystemExit(f"day4_analysis: {message}")
+
+
+def _load_run(path: Path) -> dict[str, Any]:
+    """Load and structurally validate one result JSON.
+
+    Fatal (``SystemExit``) if the file cannot be parsed, lacks
+    ``embedding_model``/``label``, or any gated arm is missing its
+    ``per_query`` list — every downstream statistic assumes this shape.
+    """
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        _fatal(f"{path}: cannot read/parse as JSON ({exc})")
+
+    embedding_model = data.get("embedding_model")
+    label = data.get("label")
+    if not embedding_model:
+        _fatal(f"{path}: missing 'embedding_model'")
+    if not label:
+        _fatal(f"{path}: missing 'label'")
+
+    arms = data.get("arms") or {}
+    for arm in GATED_ARMS:
+        arm_block = arms.get(arm)
+        if not isinstance(arm_block, dict) or "per_query" not in arm_block:
+            _fatal(
+                f"{path}: gated arm {arm!r} is missing 'per_query' (label={label!r}) — "
+                f"every gated arm must carry per-query records"
+            )
+
+    return {"path": str(path), "embedding_model": embedding_model, "label": label, "arms": arms}
+
+
+def _resolve_inferential(
+    embedding_model: str, group: list[dict[str, Any]], inferential_run: str
+) -> dict[str, Any]:
+    """Pick the one inferential run for ``embedding_model``'s group.
+
+    The run whose ``label`` equals ``--inferential-run`` is the inferential
+    run for its own embedding_model group, when present; every OTHER group
+    (embedding_model doesn't match) falls back to the run whose label ends
+    with ``-run0``. Either resolution must yield EXACTLY one candidate — 0 or
+    >1 is a fatal, named ambiguity (never silently guessed).
+    """
+    exact = [r for r in group if r["label"] == inferential_run]
+    if len(exact) == 1:
+        return exact[0]
+    if len(exact) > 1:
+        _fatal(
+            f"embedding_model {embedding_model!r}: {len(exact)} runs share the label "
+            f"{inferential_run!r} — ambiguous inferential-run resolution"
+        )
+
+    run0 = [r for r in group if r["label"].endswith("-run0")]
+    if len(run0) == 1:
+        return run0[0]
+    _fatal(
+        f"embedding_model {embedding_model!r}: could not resolve an inferential run "
+        f"(no run labeled {inferential_run!r}, and {len(run0)} run(s) end with '-run0'; "
+        "need exactly 1 candidate)"
+    )
+
+
+def _assert_aligned(run: dict[str, Any]) -> None:
+    """Assert the 4 gated arms' per_query lists share one query_id sequence.
+
+    Runs BEFORE any statistic is computed on the inferential run (a Task-1
+    review flag): paired/omnibus statistics silently misattribute results if
+    the arms are not aligned query-for-query. Fatal, naming the FIRST
+    mismatching arm/index, otherwise.
+    """
+    label = run["label"]
+    reference_arm = GATED_ARMS[0]
+    reference_ids = [rec["query_id"] for rec in run["arms"][reference_arm]["per_query"]]
+    for arm in GATED_ARMS[1:]:
+        ids = [rec["query_id"] for rec in run["arms"][arm]["per_query"]]
+        if ids == reference_ids:
+            continue
+        for i, (expected, actual) in enumerate(zip_longest(reference_ids, ids)):
+            if expected != actual:
+                _fatal(
+                    f"run {label!r}: per_query query_id mismatch between "
+                    f"{reference_arm!r} and {arm!r} at index {i}: {expected!r} != {actual!r}"
+                )
+
+
+def _p5(run: dict[str, Any], arm: str, split: str) -> list[float]:
+    """Per-query P@5 values for ``arm``, filtered to ``split``, in order."""
+    return [rec["p@5"] for rec in run["arms"][arm]["per_query"] if rec["split"] == split]
+
+
+def _rr10(run: dict[str, Any], arm: str, split: str) -> list[float]:
+    """Per-query RR@10 values for ``arm``, filtered to ``split``, in order."""
+    return [rec["rr@10"] for rec in run["arms"][arm]["per_query"] if rec["split"] == split]
+
+
+def _analyze_group(
+    embedding_model: str, group: list[dict[str, Any]], inferential_run_label: str
+) -> dict[str, Any]:
+    """The full H0/H1/H3 + power + cross-run verdict block for one embedder."""
+    if len(group) != 3:
+        print(
+            f"day4_analysis: WARNING embedding_model {embedding_model!r} has "
+            f"{len(group)} run(s) (expected 3)",
+            file=sys.stderr,
+        )
+
+    run_labels = sorted(r["label"] for r in group)
+    inferential = _resolve_inferential(embedding_model, group, inferential_run_label)
+    _assert_aligned(inferential)
+
+    heldout_p5 = {arm: _p5(inferential, arm, "heldout") for arm in GATED_ARMS}
+    public_p5 = {arm: _p5(inferential, arm, "public") for arm in GATED_ARMS}
+    n_heldout = len(heldout_p5[GATED_ARMS[0]])
+    n_public = len(public_p5[GATED_ARMS[0]])
+
+    # 1. H0 omnibus (gate).
+    h0_raw = permutation_omnibus(heldout_p5, n_permutations=N_RESAMPLES, seed=SEED)
+    h0_reject = h0_raw["p_value"] < ALPHA
+    h0 = {"stat": h0_raw["stat"], "p_value": h0_raw["p_value"], "reject": h0_reject}
+
+    # 2. H1 (computed always; interpretation gated by H0).
+    keyword_mean = mean(heldout_p5["keyword"])
+    semantic_mean = mean(heldout_p5["semantic"])
+    best_single = "semantic" if semantic_mean > keyword_mean else "keyword"
+    h1_diffs = [h - b for h, b in zip(heldout_p5["hybrid"], heldout_p5[best_single], strict=True)]
+    h1_ci = paired_bca_ci(h1_diffs, n_resamples=N_RESAMPLES, alpha=ALPHA, seed=SEED)
+    h1_pass = h1_ci["ci_low"] > 0 and h1_ci["mean"] >= DELTA_HYBRID
+    h1 = {
+        "best_single": best_single,
+        "mean": h1_ci["mean"],
+        "ci_low": h1_ci["ci_low"],
+        "ci_high": h1_ci["ci_high"],
+        "pass": h1_pass,
+        "pass_gated": h1_pass and h0_reject,
+        "gated_by_h0": True,
+        "tested": h0_reject,
+    }
+
+    # 3. H3 (supporting) — production-arm public/heldout leak gap.
+    if n_public == 0:
+        print(
+            f"day4_analysis: h3 skipped for embedding_model {embedding_model!r} — "
+            "inferential run has 0 public queries",
+            file=sys.stderr,
+        )
+        h3: dict[str, Any] | None = None
+    else:
+        h3_ci = unpaired_percentile_ci_diff(
+            public_p5[PRODUCTION_ARM],
+            heldout_p5[PRODUCTION_ARM],
+            n_resamples=N_RESAMPLES,
+            alpha=ALPHA,
+            seed=SEED,
+        )
+        h3 = {
+            "gap_mean": h3_ci["mean"],
+            "ci_low": h3_ci["ci_low"],
+            "ci_high": h3_ci["ci_high"],
+            "within_delta_leak": h3_ci["mean"] <= DELTA_LEAK,
+        }
+
+    # 4. sigma_d + achieved power, from the H1 per-query paired diffs.
+    sd = sigma_d(h1_diffs)
+    power = achieved_power(DELTA_HYBRID, sd, len(h1_diffs), alpha=ALPHA)
+
+    # 5. Across runs (all runs of the group): held-out mean P@5 per arm.
+    arm_means_across_runs: dict[str, dict[str, float]] = {}
+    for arm in GATED_ARMS:
+        means = [mean(_p5(r, arm, "heldout")) for r in group]
+        arm_means_across_runs[arm] = {"min": min(means), "median": median(means), "max": max(means)}
+
+    # 6. MRR secondary (inferential run, held-out, report only).
+    mrr_secondary = {arm: mean(_rr10(inferential, arm, "heldout")) for arm in GATED_ARMS}
+
+    return {
+        "run_labels": run_labels,
+        "inferential_run": inferential["label"],
+        "n_heldout": n_heldout,
+        "n_public": n_public,
+        "h0": h0,
+        "h1": h1,
+        "h3": h3,
+        "sigma_d": sd,
+        "achieved_power": {"delta": DELTA_HYBRID, "n": len(h1_diffs), "power": power},
+        "arm_means_across_runs": arm_means_across_runs,
+        "mrr_secondary": mrr_secondary,
+    }
+
+
+def _round_floats(obj: Any, ndigits: int = 4) -> Any:
+    """Recursively round every float in a JSON-shaped structure to ``ndigits``.
+
+    ``bool`` is an ``int`` subclass but never a ``float``, so the
+    ``isinstance(obj, float)`` check never conflates a boolean flag (e.g.
+    ``reject``, ``pass``) with a numeric value.
+    """
+    if isinstance(obj, float):
+        return round(obj, ndigits)
+    if isinstance(obj, dict):
+        return {k: _round_floats(v, ndigits) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_round_floats(v, ndigits) for v in obj]
+    return obj
+
+
+def analyze(paths: list[Path], inferential_run: str) -> dict[str, Any]:
+    """Turn N result JSONs into the pre-declared H0/H1/H3 verdicts.
+
+    Groups the inputs by ``embedding_model``; every group is analyzed
+    independently, using ONLY its resolved inferential run for inference (see
+    ``_resolve_inferential``). Fatal (``SystemExit``) on any structural
+    defect: a missing ``per_query``, a missing ``embedding_model``/``label``,
+    an unaligned per-query query_id sequence, or an ambiguous inferential-run
+    resolution. A group with != 3 runs is a WARNING (stderr) only — the
+    analysis must still work when re-run counts change (e.g. mid-flight,
+    before all re-runs exist).
+    """
+    runs = [_load_run(Path(p)) for p in paths]
+
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for run in runs:
+        groups.setdefault(run["embedding_model"], []).append(run)
+
+    per_embedder = {
+        embedding_model: _analyze_group(embedding_model, group, inferential_run)
+        for embedding_model, group in groups.items()
+    }
+
+    result: dict[str, Any] = {
+        "run_date": datetime.now(UTC).strftime("%Y-%m-%d"),
+        "experiment": "day4-static-factorial",
+        "seed": SEED,
+        "n_resamples": N_RESAMPLES,
+        "alpha": ALPHA,
+        "delta_hybrid": DELTA_HYBRID,
+        "delta_leak": DELTA_LEAK,
+        "gated_arms": list(GATED_ARMS),
+        "per_embedder": per_embedder,
+        "design_notes": list(_DESIGN_NOTES),
+    }
+    return _round_floats(result)
+
+
+def _main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--results",
+        nargs="+",
+        required=True,
+        type=Path,
+        help="result JSON path(s) to analyze (2 embedders x 3 re-runs, typically 6 files)",
+    )
+    ap.add_argument(
+        "--inferential-run",
+        dest="inferential_run",
+        required=True,
+        help="label of the pre-declared inferential run, e.g. day4-qwen3-embedding-0.6b-run0",
+    )
+    ap.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="output path (default: results/day4-analysis-<run_date>.json)",
+    )
+    args = ap.parse_args()
+
+    result = analyze(args.results, args.inferential_run)
+
+    out_path = args.out or (_RESULTS_DIR / f"day4-analysis-{result['run_date']}.json")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"day4_analysis: wrote {out_path}", file=sys.stderr)
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/results/day4-analysis-2026-07-03.json
+++ b/backend/tests/eval/results/day4-analysis-2026-07-03.json
@@ -1,0 +1,152 @@
+{
+  "run_date": "2026-07-03",
+  "experiment": "day4-static-factorial",
+  "seed": 20260703,
+  "n_resamples": 10000,
+  "alpha": 0.05,
+  "delta_hybrid": 0.05,
+  "delta_leak": 0.05,
+  "gated_arms": [
+    "keyword",
+    "semantic",
+    "hybrid",
+    "hybrid_neural"
+  ],
+  "per_embedder": {
+    "qwen3-embedding:0.6b": {
+      "run_labels": [
+        "day4-qwen3-embedding-0.6b-run0",
+        "day4-qwen3-embedding-0.6b-run1",
+        "day4-qwen3-embedding-0.6b-run2"
+      ],
+      "inferential_run": "day4-qwen3-embedding-0.6b-run0",
+      "n_heldout": 240,
+      "n_public": 40,
+      "h0": {
+        "stat": 0.0025,
+        "p_value": 0.0001,
+        "reject": true
+      },
+      "h1": {
+        "best_single": "semantic",
+        "mean": -0.0133,
+        "ci_low": -0.0267,
+        "ci_high": 0.0008,
+        "pass": false,
+        "pass_gated": false,
+        "gated_by_h0": true,
+        "tested": true
+      },
+      "h3": {
+        "gap_mean": 0.0033,
+        "ci_low": -0.025,
+        "ci_high": 0.0292,
+        "within_delta_leak": true
+      },
+      "sigma_d": 0.109,
+      "achieved_power": {
+        "delta": 0.05,
+        "n": 240,
+        "power": 1.0
+      },
+      "arm_means_across_runs": {
+        "keyword": {
+          "min": 0.1158,
+          "median": 0.1175,
+          "max": 0.1175
+        },
+        "semantic": {
+          "min": 0.18,
+          "median": 0.18,
+          "max": 0.18
+        },
+        "hybrid": {
+          "min": 0.1658,
+          "median": 0.1658,
+          "max": 0.1667
+        },
+        "hybrid_neural": {
+          "min": 0.1717,
+          "median": 0.1717,
+          "max": 0.1725
+        }
+      },
+      "mrr_secondary": {
+        "keyword": 0.3911,
+        "semantic": 0.5441,
+        "hybrid": 0.5298,
+        "hybrid_neural": 0.5321
+      }
+    },
+    "qwen3-embedding:4b": {
+      "run_labels": [
+        "day4-qwen3-embedding-4b-run0",
+        "day4-qwen3-embedding-4b-run1",
+        "day4-qwen3-embedding-4b-run2"
+      ],
+      "inferential_run": "day4-qwen3-embedding-4b-run0",
+      "n_heldout": 240,
+      "n_public": 40,
+      "h0": {
+        "stat": 0.0035,
+        "p_value": 0.0001,
+        "reject": true
+      },
+      "h1": {
+        "best_single": "semantic",
+        "mean": -0.0175,
+        "ci_low": -0.0317,
+        "ci_high": -0.0017,
+        "pass": false,
+        "pass_gated": false,
+        "gated_by_h0": true,
+        "tested": true
+      },
+      "h3": {
+        "gap_mean": -0.0125,
+        "ci_low": -0.0408,
+        "ci_high": 0.0125,
+        "within_delta_leak": true
+      },
+      "sigma_d": 0.1194,
+      "achieved_power": {
+        "delta": 0.05,
+        "n": 240,
+        "power": 1.0
+      },
+      "arm_means_across_runs": {
+        "keyword": {
+          "min": 0.1183,
+          "median": 0.1192,
+          "max": 0.1192
+        },
+        "semantic": {
+          "min": 0.1925,
+          "median": 0.1925,
+          "max": 0.1925
+        },
+        "hybrid": {
+          "min": 0.175,
+          "median": 0.175,
+          "max": 0.1758
+        },
+        "hybrid_neural": {
+          "min": 0.1875,
+          "median": 0.1883,
+          "max": 0.1883
+        }
+      },
+      "mrr_secondary": {
+        "keyword": 0.3952,
+        "semantic": 0.6123,
+        "hybrid": 0.5734,
+        "hybrid_neural": 0.5801
+      }
+    }
+  },
+  "design_notes": [
+    "D1: sleep static arm dropped — recall() never reads graph edges (Issue #120); gated family = the prereg's exact 4 arms.",
+    "D2: qwen3-embedding:0.6b = inferential/primary; qwen3-embedding:4b = replication (descriptive).",
+    "D3: permutation omnibus + paired BCa (10k, seed 20260703); run 0 inferential; 3 re-runs min/median/max."
+  ]
+}

--- a/backend/tests/eval/results/day4-qwen3-embedding-0.6b-run0-2026-07-03.json
+++ b/backend/tests/eval/results/day4-qwen3-embedding-0.6b-run0-2026-07-03.json
@@ -1,0 +1,8253 @@
+{
+  "run_date": "2026-07-03",
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 280,
+  "doc_count": 300,
+  "recall_k": 10,
+  "production_arm": "hybrid_neural",
+  "overall": {
+    "n": 280,
+    "p@5": 0.1721,
+    "p@10": 0.1004,
+    "mrr@10": 0.5487,
+    "ndcg@5": 0.5515,
+    "ndcg@10": 0.586
+  },
+  "per_bucket": {
+    "retrieval-exact": {
+      "n": 40,
+      "p@5": 0.2,
+      "p@10": 0.1,
+      "mrr@10": 0.8917,
+      "ndcg@5": 0.9196,
+      "ndcg@10": 0.9196
+    },
+    "retrieval-semantic": {
+      "n": 50,
+      "p@5": 0.1,
+      "p@10": 0.064,
+      "mrr@10": 0.3022,
+      "ndcg@5": 0.336,
+      "ndcg@10": 0.3822
+    },
+    "hiragana-only": {
+      "n": 35,
+      "p@5": 0.0971,
+      "p@10": 0.0571,
+      "mrr@10": 0.3795,
+      "ndcg@5": 0.399,
+      "ndcg@10": 0.4238
+    },
+    "cross-source": {
+      "n": 60,
+      "p@5": 0.3,
+      "p@10": 0.1833,
+      "mrr@10": 0.644,
+      "ndcg@5": 0.5414,
+      "ndcg@10": 0.5946
+    },
+    "resource-only": {
+      "n": 45,
+      "p@5": 0.1422,
+      "p@10": 0.0756,
+      "mrr@10": 0.4695,
+      "ndcg@5": 0.5237,
+      "ndcg@10": 0.5383
+    },
+    "memory-only": {
+      "n": 50,
+      "p@5": 0.148,
+      "p@10": 0.09,
+      "mrr@10": 0.5962,
+      "ndcg@5": 0.616,
+      "ndcg@10": 0.6693
+    }
+  },
+  "source_recall@10": {
+    "resource": 0.4296,
+    "memory": 0.5704
+  },
+  "arms": {
+    "keyword": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.115,
+        "p@10": 0.0696,
+        "mrr@10": 0.3986,
+        "ndcg@5": 0.3927,
+        "ndcg@10": 0.4195
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9042,
+          "ndcg@5": 0.9289,
+          "ndcg@10": 0.9289
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.032,
+          "p@10": 0.018,
+          "mrr@10": 0.0882,
+          "ndcg@5": 0.1042,
+          "ndcg@10": 0.1105
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0857,
+          "p@10": 0.0514,
+          "mrr@10": 0.3248,
+          "ndcg@5": 0.3414,
+          "ndcg@10": 0.3696
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.1667,
+          "p@10": 0.1217,
+          "mrr@10": 0.4112,
+          "ndcg@5": 0.3019,
+          "ndcg@10": 0.3668
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.0844,
+          "p@10": 0.0489,
+          "mrr@10": 0.3321,
+          "ndcg@5": 0.3477,
+          "ndcg@10": 0.3696
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.116,
+          "p@10": 0.066,
+          "mrr@10": 0.4009,
+          "ndcg@5": 0.4375,
+          "ndcg@10": 0.464
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.3629,
+        "memory": 0.6371
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1158,
+          "p@10": 0.0717,
+          "mrr@10": 0.3911,
+          "ndcg@5": 0.3802,
+          "ndcg@10": 0.4102
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.11,
+          "p@10": 0.0575,
+          "mrr@10": 0.4432,
+          "ndcg@5": 0.4678,
+          "ndcg@10": 0.4753
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1786,
+        "p@10": 0.1025,
+        "mrr@10": 0.5696,
+        "ndcg@5": 0.572,
+        "ndcg@10": 0.6069
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.0925,
+          "mrr@10": 0.6823,
+          "ndcg@5": 0.7344,
+          "ndcg@10": 0.7427
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.144,
+          "p@10": 0.082,
+          "mrr@10": 0.5419,
+          "ndcg@5": 0.5764,
+          "ndcg@10": 0.6093
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0457,
+          "p@10": 0.0343,
+          "mrr@10": 0.145,
+          "ndcg@5": 0.1558,
+          "ndcg@10": 0.1915
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3233,
+          "p@10": 0.1867,
+          "mrr@10": 0.6983,
+          "ndcg@5": 0.5994,
+          "ndcg@10": 0.6406
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1333,
+          "p@10": 0.0844,
+          "mrr@10": 0.5754,
+          "ndcg@5": 0.5797,
+          "ndcg@10": 0.6388
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.172,
+          "p@10": 0.094,
+          "mrr@10": 0.6449,
+          "ndcg@5": 0.6894,
+          "ndcg@10": 0.7174
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.5696,
+        "memory": 0.4304
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.18,
+          "p@10": 0.1033,
+          "mrr@10": 0.5441,
+          "ndcg@5": 0.5437,
+          "ndcg@10": 0.5774
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.17,
+          "p@10": 0.0975,
+          "mrr@10": 0.7224,
+          "ndcg@5": 0.742,
+          "ndcg@10": 0.784
+        }
+      }
+    },
+    "hybrid": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1679,
+        "p@10": 0.1025,
+        "mrr@10": 0.5476,
+        "ndcg@5": 0.5407,
+        "ndcg@10": 0.5887
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.19,
+          "p@10": 0.095,
+          "mrr@10": 0.8417,
+          "ndcg@5": 0.8696,
+          "ndcg@10": 0.8696
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.1,
+          "p@10": 0.078,
+          "mrr@10": 0.3117,
+          "ndcg@5": 0.3296,
+          "ndcg@10": 0.4195
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0743,
+          "p@10": 0.0514,
+          "mrr@10": 0.3208,
+          "ndcg@5": 0.3198,
+          "ndcg@10": 0.3654
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3,
+          "p@10": 0.1817,
+          "mrr@10": 0.6574,
+          "ndcg@5": 0.5491,
+          "ndcg@10": 0.599
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1289,
+          "p@10": 0.0778,
+          "mrr@10": 0.4653,
+          "ndcg@5": 0.4974,
+          "ndcg@10": 0.5383
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.16,
+          "p@10": 0.096,
+          "mrr@10": 0.6495,
+          "ndcg@5": 0.6723,
+          "ndcg@10": 0.7225
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4782,
+        "memory": 0.5218
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1667,
+          "p@10": 0.1038,
+          "mrr@10": 0.5298,
+          "ndcg@5": 0.514,
+          "ndcg@10": 0.5659
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.095,
+          "mrr@10": 0.6544,
+          "ndcg@5": 0.7009,
+          "ndcg@10": 0.7254
+        }
+      }
+    },
+    "hybrid_neural": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1721,
+        "p@10": 0.1004,
+        "mrr@10": 0.5487,
+        "ndcg@5": 0.5515,
+        "ndcg@10": 0.586
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.8917,
+          "ndcg@5": 0.9196,
+          "ndcg@10": 0.9196
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.1,
+          "p@10": 0.064,
+          "mrr@10": 0.3022,
+          "ndcg@5": 0.336,
+          "ndcg@10": 0.3822
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0971,
+          "p@10": 0.0571,
+          "mrr@10": 0.3795,
+          "ndcg@5": 0.399,
+          "ndcg@10": 0.4238
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3,
+          "p@10": 0.1833,
+          "mrr@10": 0.644,
+          "ndcg@5": 0.5414,
+          "ndcg@10": 0.5946
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1422,
+          "p@10": 0.0756,
+          "mrr@10": 0.4695,
+          "ndcg@5": 0.5237,
+          "ndcg@10": 0.5383
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.148,
+          "p@10": 0.09,
+          "mrr@10": 0.5962,
+          "ndcg@5": 0.616,
+          "ndcg@10": 0.6693
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4296,
+        "memory": 0.5704
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1717,
+          "p@10": 0.1021,
+          "mrr@10": 0.5321,
+          "ndcg@5": 0.5263,
+          "ndcg@10": 0.5654
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.09,
+          "mrr@10": 0.6485,
+          "ndcg@5": 0.7022,
+          "ndcg@10": 0.7101
+        }
+      }
+    }
+  },
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "label": "day4-qwen3-embedding-0.6b-run0"
+}

--- a/backend/tests/eval/results/day4-qwen3-embedding-0.6b-run1-2026-07-03.json
+++ b/backend/tests/eval/results/day4-qwen3-embedding-0.6b-run1-2026-07-03.json
@@ -1,0 +1,8253 @@
+{
+  "run_date": "2026-07-03",
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 280,
+  "doc_count": 300,
+  "recall_k": 10,
+  "production_arm": "hybrid_neural",
+  "overall": {
+    "n": 280,
+    "p@5": 0.1729,
+    "p@10": 0.1004,
+    "mrr@10": 0.5474,
+    "ndcg@5": 0.5523,
+    "ndcg@10": 0.5856
+  },
+  "per_bucket": {
+    "retrieval-exact": {
+      "n": 40,
+      "p@5": 0.2,
+      "p@10": 0.1,
+      "mrr@10": 0.8917,
+      "ndcg@5": 0.9196,
+      "ndcg@10": 0.9196
+    },
+    "retrieval-semantic": {
+      "n": 50,
+      "p@5": 0.104,
+      "p@10": 0.064,
+      "mrr@10": 0.3024,
+      "ndcg@5": 0.3438,
+      "ndcg@10": 0.3823
+    },
+    "hiragana-only": {
+      "n": 35,
+      "p@5": 0.0971,
+      "p@10": 0.0571,
+      "mrr@10": 0.3795,
+      "ndcg@5": 0.399,
+      "ndcg@10": 0.4238
+    },
+    "cross-source": {
+      "n": 60,
+      "p@5": 0.3,
+      "p@10": 0.1833,
+      "mrr@10": 0.6365,
+      "ndcg@5": 0.5381,
+      "ndcg@10": 0.5914
+    },
+    "resource-only": {
+      "n": 45,
+      "p@5": 0.1422,
+      "p@10": 0.0756,
+      "mrr@10": 0.4693,
+      "ndcg@5": 0.5237,
+      "ndcg@10": 0.5381
+    },
+    "memory-only": {
+      "n": 50,
+      "p@5": 0.148,
+      "p@10": 0.09,
+      "mrr@10": 0.5978,
+      "ndcg@5": 0.6173,
+      "ndcg@10": 0.6705
+    }
+  },
+  "source_recall@10": {
+    "resource": 0.4296,
+    "memory": 0.5704
+  },
+  "arms": {
+    "keyword": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1164,
+        "p@10": 0.0696,
+        "mrr@10": 0.3969,
+        "ndcg@5": 0.3927,
+        "ndcg@10": 0.4181
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9042,
+          "ndcg@5": 0.9289,
+          "ndcg@10": 0.9289
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.032,
+          "p@10": 0.018,
+          "mrr@10": 0.0875,
+          "ndcg@5": 0.1033,
+          "ndcg@10": 0.11
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0857,
+          "p@10": 0.0514,
+          "mrr@10": 0.3105,
+          "ndcg@5": 0.3308,
+          "ndcg@10": 0.359
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.1733,
+          "p@10": 0.1217,
+          "mrr@10": 0.4124,
+          "ndcg@5": 0.3089,
+          "ndcg@10": 0.3673
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.0844,
+          "p@10": 0.0489,
+          "mrr@10": 0.3321,
+          "ndcg@5": 0.3477,
+          "ndcg@10": 0.3696
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.116,
+          "p@10": 0.066,
+          "mrr@10": 0.4006,
+          "ndcg@5": 0.4375,
+          "ndcg@10": 0.4636
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.3632,
+        "memory": 0.6368
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1175,
+          "p@10": 0.0717,
+          "mrr@10": 0.3892,
+          "ndcg@5": 0.3802,
+          "ndcg@10": 0.4086
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.11,
+          "p@10": 0.0575,
+          "mrr@10": 0.4432,
+          "ndcg@5": 0.4678,
+          "ndcg@10": 0.4753
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1786,
+        "p@10": 0.1025,
+        "mrr@10": 0.5696,
+        "ndcg@5": 0.572,
+        "ndcg@10": 0.6069
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.0925,
+          "mrr@10": 0.6823,
+          "ndcg@5": 0.7344,
+          "ndcg@10": 0.7427
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.144,
+          "p@10": 0.082,
+          "mrr@10": 0.5419,
+          "ndcg@5": 0.5764,
+          "ndcg@10": 0.6093
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0457,
+          "p@10": 0.0343,
+          "mrr@10": 0.145,
+          "ndcg@5": 0.1558,
+          "ndcg@10": 0.1915
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3233,
+          "p@10": 0.1867,
+          "mrr@10": 0.6983,
+          "ndcg@5": 0.5994,
+          "ndcg@10": 0.6406
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1333,
+          "p@10": 0.0844,
+          "mrr@10": 0.5754,
+          "ndcg@5": 0.5797,
+          "ndcg@10": 0.6388
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.172,
+          "p@10": 0.094,
+          "mrr@10": 0.6449,
+          "ndcg@5": 0.6894,
+          "ndcg@10": 0.7174
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.5696,
+        "memory": 0.4304
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.18,
+          "p@10": 0.1033,
+          "mrr@10": 0.5441,
+          "ndcg@5": 0.5437,
+          "ndcg@10": 0.5774
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.17,
+          "p@10": 0.0975,
+          "mrr@10": 0.7224,
+          "ndcg@5": 0.742,
+          "ndcg@10": 0.784
+        }
+      }
+    },
+    "hybrid": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1671,
+        "p@10": 0.1032,
+        "mrr@10": 0.5471,
+        "ndcg@5": 0.5391,
+        "ndcg@10": 0.5897
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.19,
+          "p@10": 0.095,
+          "mrr@10": 0.8417,
+          "ndcg@5": 0.8696,
+          "ndcg@10": 0.8696
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.096,
+          "p@10": 0.08,
+          "mrr@10": 0.3128,
+          "ndcg@5": 0.3222,
+          "ndcg@10": 0.4242
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0743,
+          "p@10": 0.0514,
+          "mrr@10": 0.3208,
+          "ndcg@5": 0.3198,
+          "ndcg@10": 0.3654
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3,
+          "p@10": 0.1833,
+          "mrr@10": 0.6509,
+          "ndcg@5": 0.5453,
+          "ndcg@10": 0.5975
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1289,
+          "p@10": 0.0778,
+          "mrr@10": 0.4658,
+          "ndcg@5": 0.4974,
+          "ndcg@10": 0.5388
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.16,
+          "p@10": 0.096,
+          "mrr@10": 0.6525,
+          "ndcg@5": 0.6749,
+          "ndcg@10": 0.7248
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4782,
+        "memory": 0.5218
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1658,
+          "p@10": 0.1042,
+          "mrr@10": 0.5287,
+          "ndcg@5": 0.5121,
+          "ndcg@10": 0.5658
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0975,
+          "mrr@10": 0.6575,
+          "ndcg@5": 0.7009,
+          "ndcg@10": 0.7333
+        }
+      }
+    },
+    "hybrid_neural": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1729,
+        "p@10": 0.1004,
+        "mrr@10": 0.5474,
+        "ndcg@5": 0.5523,
+        "ndcg@10": 0.5856
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.8917,
+          "ndcg@5": 0.9196,
+          "ndcg@10": 0.9196
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.104,
+          "p@10": 0.064,
+          "mrr@10": 0.3024,
+          "ndcg@5": 0.3438,
+          "ndcg@10": 0.3823
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0971,
+          "p@10": 0.0571,
+          "mrr@10": 0.3795,
+          "ndcg@5": 0.399,
+          "ndcg@10": 0.4238
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3,
+          "p@10": 0.1833,
+          "mrr@10": 0.6365,
+          "ndcg@5": 0.5381,
+          "ndcg@10": 0.5914
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1422,
+          "p@10": 0.0756,
+          "mrr@10": 0.4693,
+          "ndcg@5": 0.5237,
+          "ndcg@10": 0.5381
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.148,
+          "p@10": 0.09,
+          "mrr@10": 0.5978,
+          "ndcg@5": 0.6173,
+          "ndcg@10": 0.6705
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4296,
+        "memory": 0.5704
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1725,
+          "p@10": 0.1021,
+          "mrr@10": 0.5309,
+          "ndcg@5": 0.5277,
+          "ndcg@10": 0.5651
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.09,
+          "mrr@10": 0.6465,
+          "ndcg@5": 0.7005,
+          "ndcg@10": 0.7084
+        }
+      }
+    }
+  },
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "label": "day4-qwen3-embedding-0.6b-run1"
+}

--- a/backend/tests/eval/results/day4-qwen3-embedding-0.6b-run2-2026-07-03.json
+++ b/backend/tests/eval/results/day4-qwen3-embedding-0.6b-run2-2026-07-03.json
@@ -1,0 +1,8253 @@
+{
+  "run_date": "2026-07-03",
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 280,
+  "doc_count": 300,
+  "recall_k": 10,
+  "production_arm": "hybrid_neural",
+  "overall": {
+    "n": 280,
+    "p@5": 0.1721,
+    "p@10": 0.1004,
+    "mrr@10": 0.5491,
+    "ndcg@5": 0.5516,
+    "ndcg@10": 0.5861
+  },
+  "per_bucket": {
+    "retrieval-exact": {
+      "n": 40,
+      "p@5": 0.2,
+      "p@10": 0.1,
+      "mrr@10": 0.8917,
+      "ndcg@5": 0.9196,
+      "ndcg@10": 0.9196
+    },
+    "retrieval-semantic": {
+      "n": 50,
+      "p@5": 0.1,
+      "p@10": 0.064,
+      "mrr@10": 0.3021,
+      "ndcg@5": 0.336,
+      "ndcg@10": 0.3821
+    },
+    "hiragana-only": {
+      "n": 35,
+      "p@5": 0.0971,
+      "p@10": 0.0571,
+      "mrr@10": 0.3795,
+      "ndcg@5": 0.399,
+      "ndcg@10": 0.4238
+    },
+    "cross-source": {
+      "n": 60,
+      "p@5": 0.3,
+      "p@10": 0.1833,
+      "mrr@10": 0.6449,
+      "ndcg@5": 0.541,
+      "ndcg@10": 0.5942
+    },
+    "resource-only": {
+      "n": 45,
+      "p@5": 0.1422,
+      "p@10": 0.0756,
+      "mrr@10": 0.4693,
+      "ndcg@5": 0.5237,
+      "ndcg@10": 0.5381
+    },
+    "memory-only": {
+      "n": 50,
+      "p@5": 0.148,
+      "p@10": 0.09,
+      "mrr@10": 0.5978,
+      "ndcg@5": 0.6173,
+      "ndcg@10": 0.6705
+    }
+  },
+  "source_recall@10": {
+    "resource": 0.4293,
+    "memory": 0.5707
+  },
+  "arms": {
+    "keyword": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1164,
+        "p@10": 0.0704,
+        "mrr@10": 0.3961,
+        "ndcg@5": 0.3924,
+        "ndcg@10": 0.4198
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9042,
+          "ndcg@5": 0.9289,
+          "ndcg@10": 0.9289
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.032,
+          "p@10": 0.02,
+          "mrr@10": 0.0895,
+          "ndcg@5": 0.1033,
+          "ndcg@10": 0.1158
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0857,
+          "p@10": 0.0514,
+          "mrr@10": 0.3105,
+          "ndcg@5": 0.3308,
+          "ndcg@10": 0.359
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.1733,
+          "p@10": 0.1217,
+          "mrr@10": 0.4068,
+          "ndcg@5": 0.3085,
+          "ndcg@10": 0.3668
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.0844,
+          "p@10": 0.0511,
+          "mrr@10": 0.3343,
+          "ndcg@5": 0.3477,
+          "ndcg@10": 0.376
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.116,
+          "p@10": 0.066,
+          "mrr@10": 0.3989,
+          "ndcg@5": 0.4361,
+          "ndcg@10": 0.4622
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.3636,
+        "memory": 0.6364
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1175,
+          "p@10": 0.0721,
+          "mrr@10": 0.3878,
+          "ndcg@5": 0.3798,
+          "ndcg@10": 0.4094
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.11,
+          "p@10": 0.06,
+          "mrr@10": 0.4457,
+          "ndcg@5": 0.4678,
+          "ndcg@10": 0.4825
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1786,
+        "p@10": 0.1025,
+        "mrr@10": 0.5696,
+        "ndcg@5": 0.572,
+        "ndcg@10": 0.6069
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.0925,
+          "mrr@10": 0.6823,
+          "ndcg@5": 0.7344,
+          "ndcg@10": 0.7427
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.144,
+          "p@10": 0.082,
+          "mrr@10": 0.5419,
+          "ndcg@5": 0.5764,
+          "ndcg@10": 0.6093
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0457,
+          "p@10": 0.0343,
+          "mrr@10": 0.145,
+          "ndcg@5": 0.1558,
+          "ndcg@10": 0.1915
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3233,
+          "p@10": 0.1867,
+          "mrr@10": 0.6983,
+          "ndcg@5": 0.5994,
+          "ndcg@10": 0.6406
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1333,
+          "p@10": 0.0844,
+          "mrr@10": 0.5754,
+          "ndcg@5": 0.5797,
+          "ndcg@10": 0.6388
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.172,
+          "p@10": 0.094,
+          "mrr@10": 0.6449,
+          "ndcg@5": 0.6894,
+          "ndcg@10": 0.7174
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.5696,
+        "memory": 0.4304
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.18,
+          "p@10": 0.1033,
+          "mrr@10": 0.5441,
+          "ndcg@5": 0.5437,
+          "ndcg@10": 0.5774
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.17,
+          "p@10": 0.0975,
+          "mrr@10": 0.7224,
+          "ndcg@5": 0.742,
+          "ndcg@10": 0.784
+        }
+      }
+    },
+    "hybrid": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1671,
+        "p@10": 0.1029,
+        "mrr@10": 0.5486,
+        "ndcg@5": 0.5397,
+        "ndcg@10": 0.5894
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.19,
+          "p@10": 0.095,
+          "mrr@10": 0.8417,
+          "ndcg@5": 0.8696,
+          "ndcg@10": 0.8696
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.096,
+          "p@10": 0.078,
+          "mrr@10": 0.3109,
+          "ndcg@5": 0.3222,
+          "ndcg@10": 0.4184
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0743,
+          "p@10": 0.0514,
+          "mrr@10": 0.3208,
+          "ndcg@5": 0.3198,
+          "ndcg@10": 0.3654
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3,
+          "p@10": 0.1833,
+          "mrr@10": 0.6592,
+          "ndcg@5": 0.5482,
+          "ndcg@10": 0.6005
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1289,
+          "p@10": 0.0778,
+          "mrr@10": 0.4658,
+          "ndcg@5": 0.4974,
+          "ndcg@10": 0.5388
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.16,
+          "p@10": 0.096,
+          "mrr@10": 0.6529,
+          "ndcg@5": 0.6749,
+          "ndcg@10": 0.7251
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4779,
+        "memory": 0.5221
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1658,
+          "p@10": 0.1042,
+          "mrr@10": 0.531,
+          "ndcg@5": 0.5128,
+          "ndcg@10": 0.5668
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.095,
+          "mrr@10": 0.654,
+          "ndcg@5": 0.7009,
+          "ndcg@10": 0.725
+        }
+      }
+    },
+    "hybrid_neural": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1721,
+        "p@10": 0.1004,
+        "mrr@10": 0.5491,
+        "ndcg@5": 0.5516,
+        "ndcg@10": 0.5861
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.8917,
+          "ndcg@5": 0.9196,
+          "ndcg@10": 0.9196
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.1,
+          "p@10": 0.064,
+          "mrr@10": 0.3021,
+          "ndcg@5": 0.336,
+          "ndcg@10": 0.3821
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0971,
+          "p@10": 0.0571,
+          "mrr@10": 0.3795,
+          "ndcg@5": 0.399,
+          "ndcg@10": 0.4238
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3,
+          "p@10": 0.1833,
+          "mrr@10": 0.6449,
+          "ndcg@5": 0.541,
+          "ndcg@10": 0.5942
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1422,
+          "p@10": 0.0756,
+          "mrr@10": 0.4693,
+          "ndcg@5": 0.5237,
+          "ndcg@10": 0.5381
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.148,
+          "p@10": 0.09,
+          "mrr@10": 0.5978,
+          "ndcg@5": 0.6173,
+          "ndcg@10": 0.6705
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4293,
+        "memory": 0.5707
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1717,
+          "p@10": 0.1021,
+          "mrr@10": 0.5329,
+          "ndcg@5": 0.5268,
+          "ndcg@10": 0.5658
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.09,
+          "mrr@10": 0.6465,
+          "ndcg@5": 0.7005,
+          "ndcg@10": 0.7084
+        }
+      }
+    }
+  },
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "label": "day4-qwen3-embedding-0.6b-run2"
+}

--- a/backend/tests/eval/results/day4-qwen3-embedding-4b-run0-2026-07-03.json
+++ b/backend/tests/eval/results/day4-qwen3-embedding-4b-run0-2026-07-03.json
@@ -1,0 +1,8253 @@
+{
+  "run_date": "2026-07-03",
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 280,
+  "doc_count": 300,
+  "recall_k": 10,
+  "production_arm": "hybrid_neural",
+  "overall": {
+    "n": 280,
+    "p@5": 0.1857,
+    "p@10": 0.1068,
+    "mrr@10": 0.595,
+    "ndcg@5": 0.5996,
+    "ndcg@10": 0.6325
+  },
+  "per_bucket": {
+    "retrieval-exact": {
+      "n": 40,
+      "p@5": 0.2,
+      "p@10": 0.1,
+      "mrr@10": 0.9125,
+      "ndcg@5": 0.9348,
+      "ndcg@10": 0.9348
+    },
+    "retrieval-semantic": {
+      "n": 50,
+      "p@5": 0.12,
+      "p@10": 0.076,
+      "mrr@10": 0.3507,
+      "ndcg@5": 0.3969,
+      "ndcg@10": 0.4484
+    },
+    "hiragana-only": {
+      "n": 35,
+      "p@5": 0.12,
+      "p@10": 0.0657,
+      "mrr@10": 0.4726,
+      "ndcg@5": 0.4987,
+      "ndcg@10": 0.5179
+    },
+    "cross-source": {
+      "n": 60,
+      "p@5": 0.32,
+      "p@10": 0.1933,
+      "mrr@10": 0.6824,
+      "ndcg@5": 0.5741,
+      "ndcg@10": 0.627
+    },
+    "resource-only": {
+      "n": 45,
+      "p@5": 0.1289,
+      "p@10": 0.0756,
+      "mrr@10": 0.4826,
+      "ndcg@5": 0.5138,
+      "ndcg@10": 0.5474
+    },
+    "memory-only": {
+      "n": 50,
+      "p@5": 0.176,
+      "p@10": 0.096,
+      "mrr@10": 0.6673,
+      "ndcg@5": 0.7126,
+      "ndcg@10": 0.7381
+    }
+  },
+  "source_recall@10": {
+    "resource": 0.4286,
+    "memory": 0.5714
+  },
+  "arms": {
+    "keyword": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1171,
+        "p@10": 0.07,
+        "mrr@10": 0.4027,
+        "ndcg@5": 0.3982,
+        "ndcg@10": 0.424
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9167,
+          "ndcg@5": 0.9381,
+          "ndcg@10": 0.9381
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.032,
+          "p@10": 0.02,
+          "mrr@10": 0.0907,
+          "ndcg@5": 0.1042,
+          "ndcg@10": 0.1169
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0857,
+          "p@10": 0.0514,
+          "mrr@10": 0.3319,
+          "ndcg@5": 0.3471,
+          "ndcg@10": 0.3753
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.1733,
+          "p@10": 0.12,
+          "mrr@10": 0.4121,
+          "ndcg@5": 0.3105,
+          "ndcg@10": 0.3666
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.0844,
+          "p@10": 0.0511,
+          "mrr@10": 0.3343,
+          "ndcg@5": 0.3477,
+          "ndcg@10": 0.376
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.12,
+          "p@10": 0.066,
+          "mrr@10": 0.4035,
+          "ndcg@5": 0.4466,
+          "ndcg@10": 0.4662
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.364,
+        "memory": 0.636
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1183,
+          "p@10": 0.0717,
+          "mrr@10": 0.3952,
+          "ndcg@5": 0.3863,
+          "ndcg@10": 0.414
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.11,
+          "p@10": 0.06,
+          "mrr@10": 0.4478,
+          "ndcg@5": 0.4695,
+          "ndcg@10": 0.4842
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1907,
+        "p@10": 0.1064,
+        "mrr@10": 0.6257,
+        "ndcg@5": 0.6249,
+        "ndcg@10": 0.6486
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.0925,
+          "mrr@10": 0.6823,
+          "ndcg@5": 0.7346,
+          "ndcg@10": 0.7429
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.16,
+          "p@10": 0.084,
+          "mrr@10": 0.6053,
+          "ndcg@5": 0.6506,
+          "ndcg@10": 0.6632
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0571,
+          "p@10": 0.0371,
+          "mrr@10": 0.1849,
+          "ndcg@5": 0.2023,
+          "ndcg@10": 0.2287
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3367,
+          "p@10": 0.2033,
+          "mrr@10": 0.7917,
+          "ndcg@5": 0.6452,
+          "ndcg@10": 0.7007
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1511,
+          "p@10": 0.0822,
+          "mrr@10": 0.5917,
+          "ndcg@5": 0.6247,
+          "ndcg@10": 0.648
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.184,
+          "p@10": 0.094,
+          "mrr@10": 0.7407,
+          "ndcg@5": 0.7831,
+          "ndcg@10": 0.7903
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.5389,
+        "memory": 0.4611
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1925,
+          "p@10": 0.1083,
+          "mrr@10": 0.6123,
+          "ndcg@5": 0.6042,
+          "ndcg@10": 0.6289
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.095,
+          "mrr@10": 0.7057,
+          "ndcg@5": 0.7493,
+          "ndcg@10": 0.7665
+        }
+      }
+    },
+    "hybrid": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.175,
+        "p@10": 0.1082,
+        "mrr@10": 0.5908,
+        "ndcg@5": 0.5792,
+        "ndcg@10": 0.6297
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.19,
+          "p@10": 0.095,
+          "mrr@10": 0.8625,
+          "ndcg@5": 0.8848,
+          "ndcg@10": 0.8848
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.112,
+          "p@10": 0.084,
+          "mrr@10": 0.3714,
+          "ndcg@5": 0.3928,
+          "ndcg@10": 0.4804
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0914,
+          "p@10": 0.0514,
+          "mrr@10": 0.4083,
+          "ndcg@5": 0.4143,
+          "ndcg@10": 0.4335
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3133,
+          "p@10": 0.2,
+          "mrr@10": 0.6997,
+          "ndcg@5": 0.5789,
+          "ndcg@10": 0.6474
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1244,
+          "p@10": 0.0822,
+          "mrr@10": 0.506,
+          "ndcg@5": 0.5173,
+          "ndcg@10": 0.5797
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.164,
+          "p@10": 0.096,
+          "mrr@10": 0.666,
+          "ndcg@5": 0.6925,
+          "ndcg@10": 0.7361
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4793,
+        "memory": 0.5207
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.175,
+          "p@10": 0.11,
+          "mrr@10": 0.5734,
+          "ndcg@5": 0.5539,
+          "ndcg@10": 0.6077
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0975,
+          "mrr@10": 0.6947,
+          "ndcg@5": 0.7307,
+          "ndcg@10": 0.7615
+        }
+      }
+    },
+    "hybrid_neural": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1857,
+        "p@10": 0.1068,
+        "mrr@10": 0.595,
+        "ndcg@5": 0.5996,
+        "ndcg@10": 0.6325
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9125,
+          "ndcg@5": 0.9348,
+          "ndcg@10": 0.9348
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.12,
+          "p@10": 0.076,
+          "mrr@10": 0.3507,
+          "ndcg@5": 0.3969,
+          "ndcg@10": 0.4484
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.12,
+          "p@10": 0.0657,
+          "mrr@10": 0.4726,
+          "ndcg@5": 0.4987,
+          "ndcg@10": 0.5179
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.32,
+          "p@10": 0.1933,
+          "mrr@10": 0.6824,
+          "ndcg@5": 0.5741,
+          "ndcg@10": 0.627
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1289,
+          "p@10": 0.0756,
+          "mrr@10": 0.4826,
+          "ndcg@5": 0.5138,
+          "ndcg@10": 0.5474
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.176,
+          "p@10": 0.096,
+          "mrr@10": 0.6673,
+          "ndcg@5": 0.7126,
+          "ndcg@10": 0.7381
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4286,
+        "memory": 0.5714
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1875,
+          "p@10": 0.1092,
+          "mrr@10": 0.5801,
+          "ndcg@5": 0.5782,
+          "ndcg@10": 0.6141
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0925,
+          "mrr@10": 0.6847,
+          "ndcg@5": 0.7279,
+          "ndcg@10": 0.7429
+        }
+      }
+    }
+  },
+  "embedding_model": "qwen3-embedding:4b",
+  "embedding_dimensions": 2560,
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "label": "day4-qwen3-embedding-4b-run0"
+}

--- a/backend/tests/eval/results/day4-qwen3-embedding-4b-run1-2026-07-03.json
+++ b/backend/tests/eval/results/day4-qwen3-embedding-4b-run1-2026-07-03.json
@@ -1,0 +1,8253 @@
+{
+  "run_date": "2026-07-03",
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 280,
+  "doc_count": 300,
+  "recall_k": 10,
+  "production_arm": "hybrid_neural",
+  "overall": {
+    "n": 280,
+    "p@5": 0.1864,
+    "p@10": 0.1068,
+    "mrr@10": 0.5951,
+    "ndcg@5": 0.6002,
+    "ndcg@10": 0.6327
+  },
+  "per_bucket": {
+    "retrieval-exact": {
+      "n": 40,
+      "p@5": 0.2,
+      "p@10": 0.1,
+      "mrr@10": 0.9125,
+      "ndcg@5": 0.9348,
+      "ndcg@10": 0.9348
+    },
+    "retrieval-semantic": {
+      "n": 50,
+      "p@5": 0.12,
+      "p@10": 0.076,
+      "mrr@10": 0.3512,
+      "ndcg@5": 0.3969,
+      "ndcg@10": 0.4489
+    },
+    "hiragana-only": {
+      "n": 35,
+      "p@5": 0.12,
+      "p@10": 0.0657,
+      "mrr@10": 0.4726,
+      "ndcg@5": 0.4987,
+      "ndcg@10": 0.5179
+    },
+    "cross-source": {
+      "n": 60,
+      "p@5": 0.3233,
+      "p@10": 0.1933,
+      "mrr@10": 0.6821,
+      "ndcg@5": 0.5771,
+      "ndcg@10": 0.6273
+    },
+    "resource-only": {
+      "n": 45,
+      "p@5": 0.1289,
+      "p@10": 0.0756,
+      "mrr@10": 0.4826,
+      "ndcg@5": 0.5138,
+      "ndcg@10": 0.5474
+    },
+    "memory-only": {
+      "n": 50,
+      "p@5": 0.176,
+      "p@10": 0.096,
+      "mrr@10": 0.6676,
+      "ndcg@5": 0.7126,
+      "ndcg@10": 0.7384
+    }
+  },
+  "source_recall@10": {
+    "resource": 0.4279,
+    "memory": 0.5721
+  },
+  "arms": {
+    "keyword": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1179,
+        "p@10": 0.0704,
+        "mrr@10": 0.4006,
+        "ndcg@5": 0.3971,
+        "ndcg@10": 0.4228
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9042,
+          "ndcg@5": 0.9289,
+          "ndcg@10": 0.9289
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.032,
+          "p@10": 0.02,
+          "mrr@10": 0.0907,
+          "ndcg@5": 0.1042,
+          "ndcg@10": 0.1169
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0857,
+          "p@10": 0.0514,
+          "mrr@10": 0.3271,
+          "ndcg@5": 0.3434,
+          "ndcg@10": 0.3716
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.1767,
+          "p@10": 0.1217,
+          "mrr@10": 0.4132,
+          "ndcg@5": 0.3136,
+          "ndcg@10": 0.3691
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.0844,
+          "p@10": 0.0511,
+          "mrr@10": 0.3343,
+          "ndcg@5": 0.3477,
+          "ndcg@10": 0.376
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.12,
+          "p@10": 0.066,
+          "mrr@10": 0.4035,
+          "ndcg@5": 0.4466,
+          "ndcg@10": 0.4662
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.3643,
+        "memory": 0.6357
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1192,
+          "p@10": 0.0721,
+          "mrr@10": 0.3927,
+          "ndcg@5": 0.385,
+          "ndcg@10": 0.4125
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.11,
+          "p@10": 0.06,
+          "mrr@10": 0.4478,
+          "ndcg@5": 0.4695,
+          "ndcg@10": 0.4842
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1907,
+        "p@10": 0.1064,
+        "mrr@10": 0.6257,
+        "ndcg@5": 0.6249,
+        "ndcg@10": 0.6486
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.0925,
+          "mrr@10": 0.6823,
+          "ndcg@5": 0.7346,
+          "ndcg@10": 0.7429
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.16,
+          "p@10": 0.084,
+          "mrr@10": 0.6053,
+          "ndcg@5": 0.6506,
+          "ndcg@10": 0.6632
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0571,
+          "p@10": 0.0371,
+          "mrr@10": 0.1849,
+          "ndcg@5": 0.2023,
+          "ndcg@10": 0.2287
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3367,
+          "p@10": 0.2033,
+          "mrr@10": 0.7917,
+          "ndcg@5": 0.6452,
+          "ndcg@10": 0.7007
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1511,
+          "p@10": 0.0822,
+          "mrr@10": 0.5917,
+          "ndcg@5": 0.6247,
+          "ndcg@10": 0.648
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.184,
+          "p@10": 0.094,
+          "mrr@10": 0.7407,
+          "ndcg@5": 0.7831,
+          "ndcg@10": 0.7903
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.5389,
+        "memory": 0.4611
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1925,
+          "p@10": 0.1083,
+          "mrr@10": 0.6123,
+          "ndcg@5": 0.6042,
+          "ndcg@10": 0.6289
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.095,
+          "mrr@10": 0.7057,
+          "ndcg@5": 0.7493,
+          "ndcg@10": 0.7665
+        }
+      }
+    },
+    "hybrid": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.175,
+        "p@10": 0.1079,
+        "mrr@10": 0.5906,
+        "ndcg@5": 0.5792,
+        "ndcg@10": 0.6295
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.19,
+          "p@10": 0.095,
+          "mrr@10": 0.8625,
+          "ndcg@5": 0.8848,
+          "ndcg@10": 0.8848
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.112,
+          "p@10": 0.084,
+          "mrr@10": 0.3718,
+          "ndcg@5": 0.3928,
+          "ndcg@10": 0.4807
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0914,
+          "p@10": 0.0514,
+          "mrr@10": 0.4083,
+          "ndcg@5": 0.4143,
+          "ndcg@10": 0.4335
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3133,
+          "p@10": 0.1983,
+          "mrr@10": 0.698,
+          "ndcg@5": 0.5789,
+          "ndcg@10": 0.6453
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1244,
+          "p@10": 0.0822,
+          "mrr@10": 0.5063,
+          "ndcg@5": 0.5173,
+          "ndcg@10": 0.5801
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.164,
+          "p@10": 0.096,
+          "mrr@10": 0.6664,
+          "ndcg@5": 0.6925,
+          "ndcg@10": 0.7365
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4796,
+        "memory": 0.5204
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.175,
+          "p@10": 0.1096,
+          "mrr@10": 0.5732,
+          "ndcg@5": 0.5539,
+          "ndcg@10": 0.6074
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0975,
+          "mrr@10": 0.6947,
+          "ndcg@5": 0.7307,
+          "ndcg@10": 0.7615
+        }
+      }
+    },
+    "hybrid_neural": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1864,
+        "p@10": 0.1068,
+        "mrr@10": 0.5951,
+        "ndcg@5": 0.6002,
+        "ndcg@10": 0.6327
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9125,
+          "ndcg@5": 0.9348,
+          "ndcg@10": 0.9348
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.12,
+          "p@10": 0.076,
+          "mrr@10": 0.3512,
+          "ndcg@5": 0.3969,
+          "ndcg@10": 0.4489
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.12,
+          "p@10": 0.0657,
+          "mrr@10": 0.4726,
+          "ndcg@5": 0.4987,
+          "ndcg@10": 0.5179
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3233,
+          "p@10": 0.1933,
+          "mrr@10": 0.6821,
+          "ndcg@5": 0.5771,
+          "ndcg@10": 0.6273
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1289,
+          "p@10": 0.0756,
+          "mrr@10": 0.4826,
+          "ndcg@5": 0.5138,
+          "ndcg@10": 0.5474
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.176,
+          "p@10": 0.096,
+          "mrr@10": 0.6676,
+          "ndcg@5": 0.7126,
+          "ndcg@10": 0.7384
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4279,
+        "memory": 0.5721
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1883,
+          "p@10": 0.1092,
+          "mrr@10": 0.5801,
+          "ndcg@5": 0.579,
+          "ndcg@10": 0.6143
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0925,
+          "mrr@10": 0.6847,
+          "ndcg@5": 0.7279,
+          "ndcg@10": 0.7429
+        }
+      }
+    }
+  },
+  "embedding_model": "qwen3-embedding:4b",
+  "embedding_dimensions": 2560,
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "label": "day4-qwen3-embedding-4b-run1"
+}

--- a/backend/tests/eval/results/day4-qwen3-embedding-4b-run2-2026-07-03.json
+++ b/backend/tests/eval/results/day4-qwen3-embedding-4b-run2-2026-07-03.json
@@ -1,0 +1,8253 @@
+{
+  "run_date": "2026-07-03",
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 280,
+  "doc_count": 300,
+  "recall_k": 10,
+  "production_arm": "hybrid_neural",
+  "overall": {
+    "n": 280,
+    "p@5": 0.1864,
+    "p@10": 0.1068,
+    "mrr@10": 0.5954,
+    "ndcg@5": 0.6005,
+    "ndcg@10": 0.633
+  },
+  "per_bucket": {
+    "retrieval-exact": {
+      "n": 40,
+      "p@5": 0.2,
+      "p@10": 0.1,
+      "mrr@10": 0.9125,
+      "ndcg@5": 0.9348,
+      "ndcg@10": 0.9348
+    },
+    "retrieval-semantic": {
+      "n": 50,
+      "p@5": 0.12,
+      "p@10": 0.076,
+      "mrr@10": 0.3512,
+      "ndcg@5": 0.3969,
+      "ndcg@10": 0.4489
+    },
+    "hiragana-only": {
+      "n": 35,
+      "p@5": 0.12,
+      "p@10": 0.0657,
+      "mrr@10": 0.475,
+      "ndcg@5": 0.5007,
+      "ndcg@10": 0.5199
+    },
+    "cross-source": {
+      "n": 60,
+      "p@5": 0.3233,
+      "p@10": 0.1933,
+      "mrr@10": 0.6821,
+      "ndcg@5": 0.5771,
+      "ndcg@10": 0.6274
+    },
+    "resource-only": {
+      "n": 45,
+      "p@5": 0.1289,
+      "p@10": 0.0756,
+      "mrr@10": 0.4826,
+      "ndcg@5": 0.5138,
+      "ndcg@10": 0.5474
+    },
+    "memory-only": {
+      "n": 50,
+      "p@5": 0.176,
+      "p@10": 0.096,
+      "mrr@10": 0.6676,
+      "ndcg@5": 0.7126,
+      "ndcg@10": 0.7384
+    }
+  },
+  "source_recall@10": {
+    "resource": 0.4282,
+    "memory": 0.5718
+  },
+  "arms": {
+    "keyword": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1179,
+        "p@10": 0.0704,
+        "mrr@10": 0.3982,
+        "ndcg@5": 0.396,
+        "ndcg@10": 0.4217
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9042,
+          "ndcg@5": 0.9289,
+          "ndcg@10": 0.9289
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.032,
+          "p@10": 0.02,
+          "mrr@10": 0.0907,
+          "ndcg@5": 0.1042,
+          "ndcg@10": 0.1169
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0857,
+          "p@10": 0.0514,
+          "mrr@10": 0.3248,
+          "ndcg@5": 0.3414,
+          "ndcg@10": 0.3696
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.1767,
+          "p@10": 0.1217,
+          "mrr@10": 0.4049,
+          "ndcg@5": 0.3107,
+          "ndcg@10": 0.3663
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.0844,
+          "p@10": 0.0511,
+          "mrr@10": 0.3343,
+          "ndcg@5": 0.3477,
+          "ndcg@10": 0.376
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.12,
+          "p@10": 0.066,
+          "mrr@10": 0.4019,
+          "ndcg@5": 0.4452,
+          "ndcg@10": 0.4648
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.3632,
+        "memory": 0.6368
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1192,
+          "p@10": 0.0721,
+          "mrr@10": 0.39,
+          "ndcg@5": 0.3837,
+          "ndcg@10": 0.4113
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.11,
+          "p@10": 0.06,
+          "mrr@10": 0.4478,
+          "ndcg@5": 0.4695,
+          "ndcg@10": 0.4842
+        }
+      }
+    },
+    "semantic": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1907,
+        "p@10": 0.1064,
+        "mrr@10": 0.6257,
+        "ndcg@5": 0.6249,
+        "ndcg@10": 0.6486
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.0925,
+          "mrr@10": 0.6823,
+          "ndcg@5": 0.7346,
+          "ndcg@10": 0.7429
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.16,
+          "p@10": 0.084,
+          "mrr@10": 0.6053,
+          "ndcg@5": 0.6506,
+          "ndcg@10": 0.6632
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0571,
+          "p@10": 0.0371,
+          "mrr@10": 0.1849,
+          "ndcg@5": 0.2023,
+          "ndcg@10": 0.2287
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3367,
+          "p@10": 0.2033,
+          "mrr@10": 0.7917,
+          "ndcg@5": 0.6452,
+          "ndcg@10": 0.7007
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1511,
+          "p@10": 0.0822,
+          "mrr@10": 0.5917,
+          "ndcg@5": 0.6247,
+          "ndcg@10": 0.648
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.184,
+          "p@10": 0.094,
+          "mrr@10": 0.7407,
+          "ndcg@5": 0.7831,
+          "ndcg@10": 0.7903
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.5389,
+        "memory": 0.4611
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1925,
+          "p@10": 0.1083,
+          "mrr@10": 0.6123,
+          "ndcg@5": 0.6042,
+          "ndcg@10": 0.6289
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.18,
+          "p@10": 0.095,
+          "mrr@10": 0.7057,
+          "ndcg@5": 0.7493,
+          "ndcg@10": 0.7665
+        }
+      }
+    },
+    "hybrid": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1757,
+        "p@10": 0.1071,
+        "mrr@10": 0.5901,
+        "ndcg@5": 0.58,
+        "ndcg@10": 0.6278
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.19,
+          "p@10": 0.095,
+          "mrr@10": 0.8625,
+          "ndcg@5": 0.8848,
+          "ndcg@10": 0.8848
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.112,
+          "p@10": 0.082,
+          "mrr@10": 0.3696,
+          "ndcg@5": 0.3928,
+          "ndcg@10": 0.4747
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.0914,
+          "p@10": 0.0514,
+          "mrr@10": 0.4083,
+          "ndcg@5": 0.4143,
+          "ndcg@10": 0.4335
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3167,
+          "p@10": 0.1983,
+          "mrr@10": 0.698,
+          "ndcg@5": 0.5828,
+          "ndcg@10": 0.6463
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1244,
+          "p@10": 0.08,
+          "mrr@10": 0.5041,
+          "ndcg@5": 0.5173,
+          "ndcg@10": 0.5736
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.164,
+          "p@10": 0.096,
+          "mrr@10": 0.6678,
+          "ndcg@5": 0.6925,
+          "ndcg@10": 0.7379
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4789,
+        "memory": 0.5211
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1758,
+          "p@10": 0.1088,
+          "mrr@10": 0.5726,
+          "ndcg@5": 0.5549,
+          "ndcg@10": 0.6055
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0975,
+          "mrr@10": 0.6947,
+          "ndcg@5": 0.7307,
+          "ndcg@10": 0.7615
+        }
+      }
+    },
+    "hybrid_neural": {
+      "overall": {
+        "n": 280,
+        "p@5": 0.1864,
+        "p@10": 0.1068,
+        "mrr@10": 0.5954,
+        "ndcg@5": 0.6005,
+        "ndcg@10": 0.633
+      },
+      "per_bucket": {
+        "retrieval-exact": {
+          "n": 40,
+          "p@5": 0.2,
+          "p@10": 0.1,
+          "mrr@10": 0.9125,
+          "ndcg@5": 0.9348,
+          "ndcg@10": 0.9348
+        },
+        "retrieval-semantic": {
+          "n": 50,
+          "p@5": 0.12,
+          "p@10": 0.076,
+          "mrr@10": 0.3512,
+          "ndcg@5": 0.3969,
+          "ndcg@10": 0.4489
+        },
+        "hiragana-only": {
+          "n": 35,
+          "p@5": 0.12,
+          "p@10": 0.0657,
+          "mrr@10": 0.475,
+          "ndcg@5": 0.5007,
+          "ndcg@10": 0.5199
+        },
+        "cross-source": {
+          "n": 60,
+          "p@5": 0.3233,
+          "p@10": 0.1933,
+          "mrr@10": 0.6821,
+          "ndcg@5": 0.5771,
+          "ndcg@10": 0.6274
+        },
+        "resource-only": {
+          "n": 45,
+          "p@5": 0.1289,
+          "p@10": 0.0756,
+          "mrr@10": 0.4826,
+          "ndcg@5": 0.5138,
+          "ndcg@10": 0.5474
+        },
+        "memory-only": {
+          "n": 50,
+          "p@5": 0.176,
+          "p@10": 0.096,
+          "mrr@10": 0.6676,
+          "ndcg@5": 0.7126,
+          "ndcg@10": 0.7384
+        }
+      },
+      "source_recall@10": {
+        "resource": 0.4282,
+        "memory": 0.5718
+      },
+      "per_query": [
+        {
+          "query_id": "q_t01_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t01_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t01_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t01_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t01_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t01_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t01_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t01_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_03",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t02_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t02_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t02_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t02_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t02_mem_04",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t02_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t03_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t03_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t03_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t03_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t03_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t03_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t04_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t04_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t04_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t04_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t04_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t04_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t04_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t04_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t04_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t05_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_hira_04",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t05_res_05",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t05_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t05_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t06_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t06_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t06_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t06_res_04",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t06_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t06_mem_05",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t07_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t07_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t07_res_01",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_02",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t07_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t07_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t07_mem_03",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t07_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t08_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t08_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t08_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.25
+        },
+        {
+          "query_id": "q_t08_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t08_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1
+        },
+        {
+          "query_id": "q_t08_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t08_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t08_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t08_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t08_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t09_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t09_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t09_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.0,
+          "rr@10": 0.1111
+        },
+        {
+          "query_id": "q_t09_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_01",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t09_mem_02",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.2
+        },
+        {
+          "query_id": "q_t09_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t09_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_01",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_02",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_x_03",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.4,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_04",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_x_05",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_x_06",
+          "bucket": "cross-source",
+          "split": "heldout",
+          "p@5": 0.6,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_01",
+          "bucket": "retrieval-exact",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_02",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_exact_03",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_exact_04",
+          "bucket": "retrieval-exact",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_sem_01",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.0
+        },
+        {
+          "query_id": "q_t10_sem_02",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1429
+        },
+        {
+          "query_id": "q_t10_sem_03",
+          "bucket": "retrieval-semantic",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.3333
+        },
+        {
+          "query_id": "q_t10_sem_04",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.125
+        },
+        {
+          "query_id": "q_t10_sem_05",
+          "bucket": "retrieval-semantic",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_01",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_hira_02",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.0,
+          "rr@10": 0.1667
+        },
+        {
+          "query_id": "q_t10_hira_03",
+          "bucket": "hiragana-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_01",
+          "bucket": "resource-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_02",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_03",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_res_04",
+          "bucket": "resource-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_01",
+          "bucket": "memory-only",
+          "split": "public",
+          "p@5": 0.2,
+          "rr@10": 0.5
+        },
+        {
+          "query_id": "q_t10_mem_02",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_03",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_04",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        },
+        {
+          "query_id": "q_t10_mem_05",
+          "bucket": "memory-only",
+          "split": "heldout",
+          "p@5": 0.2,
+          "rr@10": 1.0
+        }
+      ],
+      "by_split": {
+        "heldout": {
+          "n": 240,
+          "p@5": 0.1883,
+          "p@10": 0.1092,
+          "mrr@10": 0.5805,
+          "ndcg@5": 0.5793,
+          "ndcg@10": 0.6146
+        },
+        "public": {
+          "n": 40,
+          "p@5": 0.175,
+          "p@10": 0.0925,
+          "mrr@10": 0.6847,
+          "ndcg@5": 0.7279,
+          "ndcg@10": 0.7429
+        }
+      }
+    }
+  },
+  "embedding_model": "qwen3-embedding:4b",
+  "embedding_dimensions": 2560,
+  "corpus_path": "tests/eval/fixtures/kagura_l.yaml",
+  "label": "day4-qwen3-embedding-4b-run2"
+}

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -10,8 +10,10 @@ Produces ``results/<YYYY-MM-DD>.json`` from a REAL run only — never fabricated
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from uuid import UUID, uuid4
@@ -20,6 +22,8 @@ from tests.eval.metrics import (
     mean_ndcg_at_k,
     mean_precision_at_k,
     mrr_at_k,
+    precision_at_k,
+    reciprocal_rank_at_k,
     source_recall_share,
 )
 from tests.eval.tools.corpus import BUCKETS, Corpus, load_corpus
@@ -250,17 +254,47 @@ async def _await_all_indexed(
     )
 
 
-async def run_retrieval_eval(write: bool = True, run_date: str | None = None) -> dict[str, Any]:
+async def run_retrieval_eval(
+    write: bool = True,
+    run_date: str | None = None,
+    *,
+    corpus_path: str | None = None,
+    embedding_model: str | None = None,
+    label: str | None = None,
+) -> dict[str, Any]:
     """Ingest the corpus, run every query, compute metrics, write results JSON.
 
     Args:
-        write: when True, persist results/<run_date>.json.
+        write: when True, persist results/<filename> (see ``_results_filename``).
         run_date: YYYY-MM-DD label for the results file; defaults to today (UTC).
+        corpus_path: path to an alternate corpus YAML (e.g. the frozen kagura_L
+            fixture, ``tests/eval/fixtures/kagura_l.yaml``); None loads the
+            golden corpus — the unchanged default.
+        embedding_model: override for the per-context embedding config; must be
+            a key of ``EMBEDDING_MODEL_REGISTRY``. Overrides BOTH the
+            ``ContextSearchConfig`` stamp and the Qdrant collection ensured for
+            ingest. None keeps the current settings-derived stamp byte-identical
+            to the pre-Day-4 behavior.
+        label: optional results-filename prefix (see ``_results_filename``);
+            None keeps the pre-Day-4 ``<run_date>.json`` filename.
 
     Returns the results dict (also written to disk when ``write``).
+
+    Raises:
+        ValueError: ``embedding_model`` is not a key of
+            ``EMBEDDING_MODEL_REGISTRY``. Checked FIRST, before any stack
+            access (``get_db()`` et al.), so a bad model name fails fast
+            without ever touching the DB.
     """
-    from auth.workspace_roles import WorkspaceRole
     from config.constants import EMBEDDING_MODEL_REGISTRY
+
+    if embedding_model is not None and embedding_model not in EMBEDDING_MODEL_REGISTRY:
+        raise ValueError(
+            f"unknown embedding_model {embedding_model!r}; valid models are "
+            f"{sorted(EMBEDDING_MODEL_REGISTRY)}"
+        )
+
+    from auth.workspace_roles import WorkspaceRole
     from config.settings import get_settings
     from db.base import get_db
     from db.qdrant import ensure_kagura_memories_collection, get_collection_name
@@ -269,7 +303,7 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
     from services.memory_service import MemoryService
     from utils.datetime import utcnow
 
-    corpus = load_corpus()
+    corpus = load_corpus(Path(corpus_path)) if corpus_path else load_corpus()
     docs_by_id = corpus.docs_by_id
     run_date = run_date or utcnow().strftime("%Y-%m-%d")
 
@@ -305,9 +339,19 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
         # not exist on non-default embedding stacks (e.g. a local
         # qwen3-embedding:0.6b/1024 rig) — stamp the config and ensure the
         # collection exactly like the production create path.
-        settings = get_settings()
-        emb_model = settings.embedding_model
-        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        #
+        # An explicit ``embedding_model`` (Day-4 factorial arm) overrides the
+        # settings-derived stamp entirely; None keeps the byte-identical
+        # pre-Day-4 behavior of deriving it from settings.
+        if embedding_model is not None:
+            emb_model = embedding_model
+            emb_dims = EMBEDDING_MODEL_REGISTRY[emb_model][0]
+        else:
+            settings = get_settings()
+            emb_model = settings.embedding_model
+            emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[
+                0
+            ]
         # Stamp the full ContextSearchConfig (not just the embedding fields) so
         # an eval context behaves like a created one if any reranking / weighting
         # default is ever consulted. Reranker fields target the local self_hosted
@@ -342,7 +386,19 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
             )
             await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
             return await _run_queries_and_score(
-                svc, corpus, docs_by_id, id_map, owner, ctx.id, ws.id, run_date, write
+                svc,
+                corpus,
+                docs_by_id,
+                id_map,
+                owner,
+                ctx.id,
+                ws.id,
+                run_date,
+                write,
+                embedding_model=emb_model,
+                embedding_dimensions=emb_dims,
+                corpus_path=corpus_path,
+                label=label,
             )
         finally:
             await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
@@ -389,6 +445,63 @@ def _bucket_metrics(rankings: list[tuple[list[str], set[str]]]) -> dict[str, Any
     }
 
 
+def _per_query_records(
+    queries: Sequence[Any],
+    rankings: Sequence[tuple[list[str], set[str]]],
+) -> list[dict[str, Any]]:
+    """Per-query P@5 / RR@10 records, in the SAME order as ``queries``.
+
+    Feeds a downstream stats CLI (paired bootstrap CIs need per-query values,
+    not just aggregates). ``queries`` and ``rankings`` must already be aligned
+    (corpus order) — this function does not reorder or group anything, it just
+    zips them and formats. ``split`` is always present in the record, even when
+    ``None`` (golden corpus), so downstream consumers can rely on the key.
+    """
+    if len(queries) != len(rankings):
+        raise ValueError(f"queries and rankings length mismatch: {len(queries)} != {len(rankings)}")
+    return [
+        {
+            "query_id": q.id,
+            "bucket": q.bucket,
+            "split": q.split,
+            "p@5": round(precision_at_k(ranked, relevant, 5), 4),
+            "rr@10": round(reciprocal_rank_at_k(ranked, relevant, 10), 4),
+        }
+        for q, (ranked, relevant) in zip(queries, rankings, strict=True)
+    ]
+
+
+def _split_metrics(
+    queries: Sequence[Any],
+    rankings: Sequence[tuple[list[str], set[str]]],
+) -> dict[str, dict[str, Any]] | None:
+    """Metric block per ``split`` value present in ``queries`` (kagura_L: {heldout,
+    public}), or ``None`` when no query carries a split (golden corpus) — the
+    caller omits the ``by_split`` key entirely in that case so the legacy
+    results shape is unchanged.
+
+    Queries with ``split is None`` are excluded from EVERY block (not folded
+    into some default bucket).
+    """
+    by_split: dict[str, list[tuple[list[str], set[str]]]] = {}
+    for q, ranking in zip(queries, rankings, strict=True):
+        if q.split is None:
+            continue
+        by_split.setdefault(q.split, []).append(ranking)
+    if not by_split:
+        return None
+    return {split: _bucket_metrics(split_rankings) for split, split_rankings in by_split.items()}
+
+
+def _results_filename(label: str | None, run_date: str) -> str:
+    """Results JSON filename: ``<run_date>.json`` (legacy, unlabeled) or
+    ``<label>-<run_date>.json`` when a ``label`` (e.g. an embedder arm name) is
+    given — keeps parallel factorial-arm runs from clobbering each other's
+    results file for the same day.
+    """
+    return f"{label}-{run_date}.json" if label else f"{run_date}.json"
+
+
 async def _score_arm(
     svc: Any,
     corpus: Corpus,
@@ -425,7 +538,7 @@ async def _score_arm(
             docs_by_id[d].source for d in ranked_docs[:_RECALL_K] if d in docs_by_id
         )
 
-    return {
+    result: dict[str, Any] = {
         "overall": _bucket_metrics(all_rankings),
         "per_bucket": {b: _bucket_metrics(per_bucket_rankings[b]) for b in BUCKETS},
         "source_recall@10": {
@@ -434,7 +547,12 @@ async def _score_arm(
                 all_retrieved_sources, len(all_retrieved_sources)
             ).items()
         },
+        "per_query": _per_query_records(corpus.queries, all_rankings),
     }
+    by_split = _split_metrics(corpus.queries, all_rankings)
+    if by_split is not None:
+        result["by_split"] = by_split
+    return result
 
 
 async def _run_queries_and_score(
@@ -447,6 +565,11 @@ async def _run_queries_and_score(
     ws_id: Any,
     run_date: str,
     write: bool,
+    *,
+    embedding_model: str,
+    embedding_dimensions: int,
+    corpus_path: str | None,
+    label: str | None,
 ) -> dict[str, Any]:
     """Score every comparison arm, compute metrics, optionally write results JSON.
 
@@ -482,11 +605,16 @@ async def _run_queries_and_score(
         "per_bucket": production["per_bucket"],
         "source_recall@10": production["source_recall@10"],
         "arms": arms,
+        # Day-4 factorial stamp — additive only, never replaces the keys above.
+        "embedding_model": embedding_model,
+        "embedding_dimensions": embedding_dimensions,
+        "corpus_path": corpus_path,
+        "label": label,
     }
 
     if write:
         _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-        out = _RESULTS_DIR / f"{run_date}.json"
+        out = _RESULTS_DIR / _results_filename(label, run_date)
         out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
         print(f"eval-retrieval: wrote {out}")
     return results
@@ -495,7 +623,38 @@ async def _run_queries_and_score(
 def _main() -> int:
     import asyncio
 
-    results = asyncio.run(run_retrieval_eval())
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--corpus",
+        dest="corpus_path",
+        default=None,
+        help="corpus YAML path (default: the golden corpus)",
+    )
+    ap.add_argument(
+        "--embedder",
+        dest="embedding_model",
+        default=None,
+        help="embedding model name, a key of EMBEDDING_MODEL_REGISTRY "
+        "(default: settings.embedding_model)",
+    )
+    ap.add_argument(
+        "--label",
+        default=None,
+        help="results filename prefix, e.g. an arm name (default: none, legacy filename)",
+    )
+    ap.add_argument(
+        "--no-write", action="store_true", help="print only, skip the results JSON artifact"
+    )
+    args = ap.parse_args()
+
+    results = asyncio.run(
+        run_retrieval_eval(
+            write=not args.no_write,
+            corpus_path=args.corpus_path,
+            embedding_model=args.embedding_model,
+            label=args.label,
+        )
+    )
     print(json.dumps(results, indent=2, ensure_ascii=False))
     return 0
 

--- a/backend/tests/eval/stats.py
+++ b/backend/tests/eval/stats.py
@@ -1,0 +1,278 @@
+"""Confirmatory statistics for the Day-4 pre-registered retrieval evaluation.
+
+Pure Python 3.11 stdlib only (``statistics.NormalDist``, ``random.Random``,
+``math`` — no numpy/scipy, which are not dependencies of the backend test
+environment). This is the ONLY statistics implementation for the prereg;
+downstream analysis (Task 3) imports exactly these five functions.
+
+Estimands, per the prereg:
+
+- ``paired_bca_ci``: BCa (bias-corrected and accelerated) bootstrap CI for the
+  mean of paired per-query differences — the primary interval for hypothesis
+  contrasts (>= 10,000 resamples per the prereg).
+- ``permutation_omnibus``: a within-query (paired) permutation test of the
+  null that k arms share the same mean — gates the family before per-pair
+  contrasts are interpreted.
+- ``unpaired_percentile_ci_diff``: percentile-method CI for a difference of
+  means between two INDEPENDENT groups (not paired by query) — used where
+  pairing isn't available.
+- ``sigma_d`` / ``achieved_power``: sample sd of paired differences and the
+  closed-form two-sided normal-approximation power, for the prereg's power
+  re-estimation.
+
+All resampling is seed-explicit (``random.Random(seed)``) for reproducibility;
+every function documents its exact draw order so results are byte-for-byte
+reproducible across runs and machines.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from collections.abc import Sequence
+from statistics import NormalDist
+from statistics import stdev as _stdev
+
+
+def _nearest_rank_idx(p: float, b: int) -> int:
+    """Nearest-rank index into a length-``b`` sorted sample for quantile ``p``.
+
+    ``idx = min(b-1, max(0, ceil(p*b) - 1))`` — shared by the BCa and the
+    plain percentile method so both index the same way into their sorted
+    bootstrap distributions.
+    """
+    return min(b - 1, max(0, math.ceil(p * b) - 1))
+
+
+def paired_bca_ci(
+    diffs: Sequence[float],
+    *,
+    n_resamples: int = 10_000,
+    alpha: float = 0.05,
+    seed: int,
+) -> dict[str, float]:
+    """BCa bootstrap CI for the mean of paired per-query differences.
+
+    Statistic is the sample mean of ``diffs``. Bootstrap resamples ``diffs``
+    with replacement ``n_resamples`` times using ``random.Random(seed)``
+    (``rng.randrange(n)`` per draw, ``n`` draws per resample, in that order —
+    this exact sequence is part of the contract so a caller replaying the same
+    seed/n/n_resamples can reproduce the underlying bootstrap distribution).
+
+    Bias correction ``z0`` uses the midpoint tie rule
+    ``(#{boot < observed} + 0.5*#{boot == observed}) / B``, with the
+    proportion clamped into the open interval ``(1/(B+1), B/(B+1))`` before
+    ``inv_cdf`` so ``z0`` is always finite. Acceleration ``a`` is the jackknife
+    estimate over leave-one-out means (0 if the denominator vanishes — e.g. a
+    3rd-moment-symmetric sample). Adjusted percentiles are computed per the
+    standard BCa formula and mapped to order statistics of the sorted
+    bootstrap distribution via ``_nearest_rank_idx``.
+
+    Degenerate input (every diff equal) short-circuits to that constant for
+    mean/ci_low/ci_high before any bootstrapping — avoids a zero jackknife
+    denominator and a meaningless CI around a fixed point.
+
+    Raises ``ValueError`` if ``diffs`` is empty.
+    """
+    if not diffs:
+        raise ValueError("paired_bca_ci: diffs is empty — nothing to bootstrap")
+
+    n = len(diffs)
+    observed = sum(diffs) / n
+
+    first = diffs[0]
+    if all(d == first for d in diffs):
+        # Also covers n == 1 (a single value is trivially "all equal"), which
+        # would otherwise make the n-1 jackknife denominator below zero.
+        return {
+            "mean": float(observed),
+            "ci_low": float(observed),
+            "ci_high": float(observed),
+            "n": n,
+        }
+
+    rng = random.Random(seed)
+    boot_means: list[float] = []
+    for _ in range(n_resamples):
+        resample_sum = 0.0
+        for _ in range(n):
+            resample_sum += diffs[rng.randrange(n)]
+        boot_means.append(resample_sum / n)
+
+    dist = NormalDist()
+    b = n_resamples
+    n_less = sum(1 for m in boot_means if m < observed)
+    n_equal = sum(1 for m in boot_means if m == observed)
+    proportion = (n_less + 0.5 * n_equal) / b
+    proportion = min(max(proportion, 1 / (b + 1)), b / (b + 1))
+    z0 = dist.inv_cdf(proportion)
+
+    # Jackknife acceleration over leave-one-out means.
+    total = sum(diffs)
+    thetas = [(total - d) / (n - 1) for d in diffs]
+    theta_bar = sum(thetas) / n
+    numerator = sum((theta_bar - t) ** 3 for t in thetas)
+    denominator = 6 * (sum((theta_bar - t) ** 2 for t in thetas)) ** 1.5
+    a = numerator / denominator if denominator != 0 else 0.0
+
+    z_alpha_2 = dist.inv_cdf(alpha / 2)
+    z_1_alpha_2 = dist.inv_cdf(1 - alpha / 2)
+
+    def _adjusted_percentile(z: float) -> float:
+        s = z0 + z
+        arg = z0 + s / (1 - a * s)
+        return min(max(dist.cdf(arg), 0.0), 1.0)
+
+    alpha1 = _adjusted_percentile(z_alpha_2)
+    alpha2 = _adjusted_percentile(z_1_alpha_2)
+
+    sorted_boot = sorted(boot_means)
+    idx1 = _nearest_rank_idx(alpha1, b)
+    idx2 = _nearest_rank_idx(alpha2, b)
+
+    return {
+        "mean": observed,
+        "ci_low": sorted_boot[idx1],
+        "ci_high": sorted_boot[idx2],
+        "n": n,
+    }
+
+
+def permutation_omnibus(
+    arm_values: dict[str, Sequence[float]],
+    *,
+    n_permutations: int = 10_000,
+    seed: int,
+) -> dict[str, float]:
+    """Within-query (paired) permutation test that k arms share equal means.
+
+    Observed statistic ``T = sum_arms (mean_arm - grand_mean)**2`` where
+    ``grand_mean`` is the mean of the arm means. Each of ``n_permutations``
+    iterations independently shuffles every query's k-tuple of arm values
+    (``random.Random(seed)``, one ``rng.shuffle`` call per query per
+    iteration, queries visited in ``arm_values``'s common order) and
+    recomputes T; ``p_value = (1 + #{T_perm >= T_obs}) / (1 + n_permutations)``
+    (add-one smoothing — never exactly 0, so a "highly significant" result
+    still reads as a probability, not a false certainty).
+
+    Raises ``ValueError`` if fewer than 2 arms, if arms have unequal lengths
+    (naming the offending arm), or if there are 0 queries.
+    """
+    arm_names = list(arm_values.keys())
+    if len(arm_names) < 2:
+        raise ValueError(f"permutation_omnibus needs >= 2 arms, got {len(arm_names)}")
+
+    n = len(arm_values[arm_names[0]])
+    for name in arm_names:
+        length = len(arm_values[name])
+        if length != n:
+            raise ValueError(
+                f"permutation_omnibus: arm {name!r} has {length} queries, expected "
+                f"{n} (all arms must have equal length)"
+            )
+    if n == 0:
+        raise ValueError("permutation_omnibus: 0 queries — nothing to test")
+
+    k = len(arm_names)
+    rows = [[arm_values[name][i] for name in arm_names] for i in range(n)]
+
+    def _stat(data_rows: list[list[float]]) -> float:
+        arm_means = [sum(row[j] for row in data_rows) / n for j in range(k)]
+        grand_mean = sum(arm_means) / k
+        return sum((m - grand_mean) ** 2 for m in arm_means)
+
+    t_obs = _stat(rows)
+
+    rng = random.Random(seed)
+    count = 0
+    for _ in range(n_permutations):
+        permuted_rows: list[list[float]] = []
+        for row in rows:
+            shuffled = list(row)
+            rng.shuffle(shuffled)
+            permuted_rows.append(shuffled)
+        if _stat(permuted_rows) >= t_obs:
+            count += 1
+
+    p_value = (1 + count) / (1 + n_permutations)
+    return {"stat": t_obs, "p_value": p_value, "n_queries": n, "n_arms": k}
+
+
+def unpaired_percentile_ci_diff(
+    a: Sequence[float],
+    b: Sequence[float],
+    *,
+    n_resamples: int = 10_000,
+    alpha: float = 0.05,
+    seed: int,
+) -> dict[str, float]:
+    """Percentile-method bootstrap CI for ``mean(a) - mean(b)``.
+
+    ``a`` and ``b`` are resampled independently (their own size, with
+    replacement) ``n_resamples`` times using a single ``random.Random(seed)``
+    — ``a`` drawn before ``b`` within each iteration — and the CI is the
+    ``alpha/2`` / ``1 - alpha/2`` order statistics of the resampled
+    differences, via the same nearest-rank rule as ``paired_bca_ci``.
+
+    Raises ``ValueError`` if either group is empty.
+    """
+    if not a:
+        raise ValueError("unpaired_percentile_ci_diff: group 'a' is empty")
+    if not b:
+        raise ValueError("unpaired_percentile_ci_diff: group 'b' is empty")
+
+    na = len(a)
+    nb = len(b)
+    mean_diff = sum(a) / na - sum(b) / nb
+
+    rng = random.Random(seed)
+    boot_diffs: list[float] = []
+    for _ in range(n_resamples):
+        sum_a = sum(a[rng.randrange(na)] for _ in range(na))
+        sum_b = sum(b[rng.randrange(nb)] for _ in range(nb))
+        boot_diffs.append(sum_a / na - sum_b / nb)
+    boot_diffs.sort()
+
+    idx_lo = _nearest_rank_idx(alpha / 2, n_resamples)
+    idx_hi = _nearest_rank_idx(1 - alpha / 2, n_resamples)
+
+    return {
+        "mean": mean_diff,
+        "ci_low": boot_diffs[idx_lo],
+        "ci_high": boot_diffs[idx_hi],
+        "n_a": na,
+        "n_b": nb,
+    }
+
+
+def sigma_d(diffs: Sequence[float]) -> float:
+    """Sample standard deviation of paired differences (n-1 denominator).
+
+    Raises ``ValueError`` if fewer than 2 values (``statistics.stdev``'s own
+    floor, surfaced here with an actionable message for the prereg context).
+    """
+    if len(diffs) < 2:
+        raise ValueError(f"sigma_d needs >= 2 values, got {len(diffs)}")
+    return _stdev(diffs)
+
+
+def achieved_power(delta: float, sd: float, n: int, *, alpha: float = 0.05) -> float:
+    """Two-sided normal-approximation power for a paired mean-difference test.
+
+    ``Phi(delta*sqrt(n)/sd - z_{1-alpha/2})``. When ``sd == 0`` every
+    resample is a perfect detection of a nonzero ``delta`` (power 1.0) or a
+    trivially unfalsifiable null (power 0.0) — returned directly rather than
+    dividing by zero.
+
+    Raises ``ValueError`` if ``n < 1`` or ``sd < 0``.
+    """
+    if n < 1:
+        raise ValueError(f"achieved_power needs n >= 1, got {n}")
+    if sd < 0:
+        raise ValueError(f"achieved_power needs sd >= 0, got {sd}")
+    if sd == 0:
+        return 1.0 if delta > 0 else 0.0
+
+    dist = NormalDist()
+    z_crit = dist.inv_cdf(1 - alpha / 2)
+    return dist.cdf(delta * math.sqrt(n) / sd - z_crit)

--- a/backend/tests/eval/stats.py
+++ b/backend/tests/eval/stats.py
@@ -84,10 +84,13 @@ def paired_bca_ci(
     if all(d == first for d in diffs):
         # Also covers n == 1 (a single value is trivially "all equal"), which
         # would otherwise make the n-1 jackknife denominator below zero.
+        # Return the constant itself, not sum/n: mean of identical values IS
+        # the constant, and summation rounding differs across Python versions
+        # (3.12 switched sum() to compensated summation).
         return {
-            "mean": float(observed),
-            "ci_low": float(observed),
-            "ci_high": float(observed),
+            "mean": float(first),
+            "ci_low": float(first),
+            "ci_high": float(first),
             "n": n,
         }
 

--- a/backend/tests/eval/test_day4_analysis.py
+++ b/backend/tests/eval/test_day4_analysis.py
@@ -1,0 +1,361 @@
+"""Unit tests for ``tests.eval.day4_analysis`` — the Day-4 verdict CLI.
+
+Pure functions over synthetic result JSONs (``tmp_path``) — no DB/stack, no
+live embedder. Drives the analysis via its public ``analyze()`` entry point
+(the ``_main`` argparse wrapper is exercised indirectly by the module's own
+``--help`` smoke, not here) so these tests pin the confirmatory semantics
+independently of the CLI plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.eval.day4_analysis import (
+    ALPHA,
+    DELTA_LEAK,
+    GATED_ARMS,
+    PRODUCTION_ARM,
+    analyze,
+)
+
+_N_HELDOUT = 40
+_N_PUBLIC = 10
+
+
+def _splits(n_heldout: int = _N_HELDOUT, n_public: int = _N_PUBLIC) -> list[str]:
+    return ["heldout"] * n_heldout + ["public"] * n_public
+
+
+def _per_query(values: list[float], splits: list[str]) -> list[dict[str, Any]]:
+    return [
+        {
+            "query_id": f"q{i}",
+            "bucket": "b",
+            "split": split,
+            "p@5": v,
+            "rr@10": min(1.0, v + 0.1),
+        }
+        for i, (v, split) in enumerate(zip(values, splits, strict=True))
+    ]
+
+
+def _write_run(
+    tmp_path: Path,
+    *,
+    embedding_model: str,
+    label: str,
+    arm_values: dict[str, list[float]],
+    n_heldout: int = _N_HELDOUT,
+    n_public: int = _N_PUBLIC,
+) -> Path:
+    """Write one synthetic result JSON (``tests.eval.runner`` shape) to ``tmp_path``."""
+    splits = _splits(n_heldout, n_public)
+    arms = {arm: {"per_query": _per_query(values, splits)} for arm, values in arm_values.items()}
+    result = {"embedding_model": embedding_model, "label": label, "arms": arms}
+    path = tmp_path / f"{label}.json"
+    path.write_text(json.dumps(result), encoding="utf-8")
+    return path
+
+
+def _near_identical_arms(n: int, *, base_seed: int) -> dict[str, list[float]]:
+    """4 arms sharing one base signal plus tiny independent per-arm noise —
+    i.e. the H0 null (no real arm-level effect) is true by construction."""
+    base = [random.Random(base_seed).uniform(0.3, 0.7) for _ in range(n)]
+    arms: dict[str, list[float]] = {}
+    for i, arm in enumerate(GATED_ARMS):
+        noise_rng = random.Random(base_seed + 100 + i)
+        arms[arm] = [b + noise_rng.uniform(-0.01, 0.01) for b in base]
+    return arms
+
+
+class TestH0Omnibus:
+    def test_rejects_when_one_arm_clearly_shifted(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        base = [random.Random(111).uniform(0.1, 0.3) for _ in range(n)]
+        arm_values: dict[str, list[float]] = {}
+        for i, arm in enumerate(GATED_ARMS):
+            noise_rng = random.Random(500 + i)
+            shift = 0.4 if arm == "hybrid" else 0.0
+            arm_values[arm] = [b + shift + noise_rng.uniform(-0.01, 0.01) for b in base]
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        h0 = result["per_embedder"]["m1"]["h0"]
+        assert h0["reject"] is True
+        assert h0["p_value"] < ALPHA
+
+    def test_does_not_reject_when_arms_near_identical(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        arm_values = _near_identical_arms(n, base_seed=222)
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        h0 = result["per_embedder"]["m1"]["h0"]
+        assert h0["reject"] is False
+        assert h0["p_value"] > ALPHA
+
+
+class TestH1:
+    def test_pass_case_hybrid_beats_best_single_with_margin(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        base = [random.Random(333).uniform(0.2, 0.5) for _ in range(n)]
+        arm_values = {
+            "keyword": base,
+            "semantic": [b - 0.05 for b in base],
+            "hybrid": [b + 0.15 for b in base],
+            "hybrid_neural": [b + 0.15 for b in base],
+        }
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        block = result["per_embedder"]["m1"]
+        h1 = block["h1"]
+        assert h1["best_single"] == "keyword"
+        assert h1["ci_low"] > 0
+        assert h1["mean"] >= 0.05
+        assert h1["pass"] is True
+        assert h1["tested"] == block["h0"]["reject"]
+        # Strong, noiseless, consistent 0.15 offset across 50 queries — the
+        # omnibus should reject decisively, making pass_gated demonstrably True.
+        assert block["h0"]["reject"] is True
+        assert h1["pass_gated"] is True
+
+    def test_fail_case_hybrid_equals_best_single(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        base = [random.Random(444).uniform(0.2, 0.5) for _ in range(n)]
+        arm_values = {
+            "keyword": base,
+            "semantic": [b - 0.05 for b in base],
+            "hybrid": base,
+            "hybrid_neural": base,
+        }
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        h1 = result["per_embedder"]["m1"]["h1"]
+        assert h1["mean"] == 0.0
+        assert h1["pass"] is False
+        assert h1["pass_gated"] is False
+
+    def test_best_single_picks_semantic_when_its_mean_is_higher(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        base = [random.Random(555).uniform(0.2, 0.4) for _ in range(n)]
+        arm_values = {
+            "keyword": base,
+            "semantic": [b + 0.1 for b in base],
+            "hybrid": [b + 0.2 for b in base],
+            "hybrid_neural": [b + 0.2 for b in base],
+        }
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        assert result["per_embedder"]["m1"]["h1"]["best_single"] == "semantic"
+
+    def test_best_single_ties_pick_keyword(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        base = [random.Random(666).uniform(0.2, 0.4) for _ in range(n)]
+        arm_values = {
+            "keyword": base,
+            "semantic": base,
+            "hybrid": [b + 0.2 for b in base],
+            "hybrid_neural": [b + 0.2 for b in base],
+        }
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        assert result["per_embedder"]["m1"]["h1"]["best_single"] == "keyword"
+
+
+class TestH3:
+    def test_gap_is_public_minus_heldout_on_the_production_arm(self, tmp_path):
+        heldout_vals = [random.Random(777).uniform(0.25, 0.35) for _ in range(_N_HELDOUT)]
+        public_vals = [random.Random(888).uniform(0.45, 0.55) for _ in range(_N_PUBLIC)]
+        other = [random.Random(999).uniform(0.2, 0.4) for _ in range(_N_HELDOUT + _N_PUBLIC)]
+        arm_values = {arm: list(other) for arm in GATED_ARMS if arm != PRODUCTION_ARM}
+        arm_values[PRODUCTION_ARM] = heldout_vals + public_vals
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        h3 = result["per_embedder"]["m1"]["h3"]
+        assert h3 is not None
+        expected_gap = round(
+            sum(public_vals) / len(public_vals) - sum(heldout_vals) / len(heldout_vals), 4
+        )
+        assert h3["gap_mean"] == pytest.approx(expected_gap, abs=1e-4)
+        assert h3["within_delta_leak"] == (h3["gap_mean"] <= DELTA_LEAK)
+
+    def test_null_when_corpus_has_no_public_queries(self, tmp_path):
+        arm_values = {
+            arm: [random.Random(1000 + i).uniform(0.2, 0.5) for _ in range(_N_HELDOUT)]
+            for i, arm in enumerate(GATED_ARMS)
+        }
+        path = _write_run(
+            tmp_path,
+            embedding_model="m1",
+            label="day4-m1-run0",
+            arm_values=arm_values,
+            n_heldout=_N_HELDOUT,
+            n_public=0,
+        )
+
+        result = analyze([path], inferential_run="day4-m1-run0")
+
+        block = result["per_embedder"]["m1"]
+        assert block["h3"] is None
+        assert block["n_public"] == 0
+
+
+class TestAlignmentGuard:
+    def test_shuffled_query_id_order_in_one_arm_raises_naming_it(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        splits = _splits()
+        values = [random.Random(11).uniform(0.2, 0.5) for _ in range(n)]
+        arms = {arm: {"per_query": _per_query(values, splits)} for arm in GATED_ARMS}
+
+        shuffled = list(arms["hybrid"]["per_query"])
+        random.Random(2).shuffle(shuffled)
+        assert shuffled != arms["hybrid"]["per_query"]  # sanity: the shuffle actually moved things
+        arms["hybrid"]["per_query"] = shuffled
+
+        result_json = {"embedding_model": "m1", "label": "day4-m1-run0", "arms": arms}
+        path = tmp_path / "day4-m1-run0.json"
+        path.write_text(json.dumps(result_json), encoding="utf-8")
+
+        with pytest.raises(SystemExit, match="hybrid"):
+            analyze([path], inferential_run="day4-m1-run0")
+
+
+class TestArmMeansAcrossRuns:
+    def test_min_median_max_over_three_synthetic_runs(self, tmp_path):
+        n_heldout = 10
+        means_by_label = {"day4-m1-run0": 0.2, "day4-m1-run1": 0.5, "day4-m1-run2": 0.8}
+        paths = []
+        for label, m in means_by_label.items():
+            arm_values = {arm: [m] * n_heldout for arm in GATED_ARMS}
+            paths.append(
+                _write_run(
+                    tmp_path,
+                    embedding_model="m1",
+                    label=label,
+                    arm_values=arm_values,
+                    n_heldout=n_heldout,
+                    n_public=0,
+                )
+            )
+
+        result = analyze(paths, inferential_run="day4-m1-run0")
+
+        arm_means = result["per_embedder"]["m1"]["arm_means_across_runs"]
+        for arm in GATED_ARMS:
+            assert arm_means[arm] == {"min": 0.2, "median": 0.5, "max": 0.8}
+
+
+class TestDeterminism:
+    def test_same_inputs_analyzed_twice_are_identical_modulo_run_date(self, tmp_path):
+        n = _N_HELDOUT + _N_PUBLIC
+        arm_values = _near_identical_arms(n, base_seed=42)
+        path = _write_run(
+            tmp_path, embedding_model="m1", label="day4-m1-run0", arm_values=arm_values
+        )
+
+        r1 = analyze([path], inferential_run="day4-m1-run0")
+        r2 = analyze([path], inferential_run="day4-m1-run0")
+
+        r1.pop("run_date")
+        r2.pop("run_date")
+        assert r1 == r2
+
+
+class TestFatalInputErrors:
+    def test_missing_per_query_for_a_gated_arm_is_fatal(self, tmp_path):
+        arms = {arm: {"per_query": []} for arm in GATED_ARMS}
+        del arms["hybrid"]["per_query"]
+        result_json = {"embedding_model": "m1", "label": "day4-m1-run0", "arms": arms}
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps(result_json), encoding="utf-8")
+
+        with pytest.raises(SystemExit, match="hybrid"):
+            analyze([path], inferential_run="day4-m1-run0")
+
+    def test_missing_embedding_model_is_fatal(self, tmp_path):
+        arms = {arm: {"per_query": []} for arm in GATED_ARMS}
+        result_json = {"label": "day4-m1-run0", "arms": arms}
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps(result_json), encoding="utf-8")
+
+        with pytest.raises(SystemExit, match="embedding_model"):
+            analyze([path], inferential_run="day4-m1-run0")
+
+    def test_missing_label_is_fatal(self, tmp_path):
+        arms = {arm: {"per_query": []} for arm in GATED_ARMS}
+        result_json = {"embedding_model": "m1", "arms": arms}
+        path = tmp_path / "bad.json"
+        path.write_text(json.dumps(result_json), encoding="utf-8")
+
+        with pytest.raises(SystemExit, match="label"):
+            analyze([path], inferential_run="day4-m1-run0")
+
+    def test_ambiguous_inferential_run_resolution_is_fatal(self, tmp_path):
+        # Neither an exact --inferential-run match nor a unique '-run0' label
+        # exists in this group -> 0 candidates either way.
+        arm_values = {arm: [0.5] * _N_HELDOUT for arm in GATED_ARMS}
+        path = _write_run(
+            tmp_path,
+            embedding_model="m1",
+            label="day4-m1-alpha",
+            arm_values=arm_values,
+            n_heldout=_N_HELDOUT,
+            n_public=0,
+        )
+
+        with pytest.raises(SystemExit, match="ambiguous|could not resolve"):
+            analyze([path], inferential_run="day4-m1-run0")
+
+
+class TestRunCountWarning:
+    def test_group_with_two_runs_warns_but_does_not_raise(self, tmp_path, capsys):
+        arm_values = {arm: [0.5] * _N_HELDOUT for arm in GATED_ARMS}
+        paths = [
+            _write_run(
+                tmp_path,
+                embedding_model="m1",
+                label=f"day4-m1-run{i}",
+                arm_values=arm_values,
+                n_heldout=_N_HELDOUT,
+                n_public=0,
+            )
+            for i in range(2)
+        ]
+
+        analyze(paths, inferential_run="day4-m1-run0")
+
+        captured = capsys.readouterr()
+        assert "WARNING" in captured.err
+        assert "m1" in captured.err

--- a/backend/tests/eval/test_day4_analysis.py
+++ b/backend/tests/eval/test_day4_analysis.py
@@ -18,9 +18,11 @@ import pytest
 
 from tests.eval.day4_analysis import (
     ALPHA,
+    DELTA_HYBRID,
     DELTA_LEAK,
     GATED_ARMS,
     PRODUCTION_ARM,
+    _h1_verdict,
     analyze,
 )
 
@@ -190,6 +192,32 @@ class TestH1:
         assert result["per_embedder"]["m1"]["h1"]["best_single"] == "keyword"
 
 
+class TestH1VerdictPure:
+    """``_h1_verdict`` is the small pure gating function factored out of the
+    H1 block precisely so combinations like "H1 passes but H0 does not
+    reject" can be unit-tested directly — a hybrid arm that decisively beats
+    best_single tends to also make the omnibus reject, so that combination
+    is awkward (not impossible, but not something worth relying on the RNG
+    for) to hit by constructing a full synthetic run."""
+
+    def test_pass_true_but_h0_does_not_reject_yields_pass_gated_false_and_untested(self):
+        verdict = _h1_verdict(mean_=0.1, ci_low=0.02, h0_reject=False)
+        assert verdict == {"pass": True, "pass_gated": False, "tested": False}
+
+    def test_pass_true_and_h0_rejects_yields_pass_gated_true_and_tested(self):
+        verdict = _h1_verdict(mean_=0.1, ci_low=0.02, h0_reject=True)
+        assert verdict == {"pass": True, "pass_gated": True, "tested": True}
+
+    def test_ci_low_not_above_zero_fails_regardless_of_h0(self):
+        assert _h1_verdict(mean_=0.1, ci_low=0.0, h0_reject=True)["pass"] is False
+        assert _h1_verdict(mean_=0.1, ci_low=-0.01, h0_reject=True)["pass"] is False
+
+    def test_mean_below_delta_hybrid_fails_even_with_positive_ci_low(self):
+        verdict = _h1_verdict(mean_=DELTA_HYBRID - 0.001, ci_low=0.01, h0_reject=True)
+        assert verdict["pass"] is False
+        assert verdict["pass_gated"] is False
+
+
 class TestH3:
     def test_gap_is_public_minus_heldout_on_the_production_arm(self, tmp_path):
         heldout_vals = [random.Random(777).uniform(0.25, 0.35) for _ in range(_N_HELDOUT)]
@@ -249,6 +277,39 @@ class TestAlignmentGuard:
         path.write_text(json.dumps(result_json), encoding="utf-8")
 
         with pytest.raises(SystemExit, match="hybrid"):
+            analyze([path], inferential_run="day4-m1-run0")
+
+    def test_swapped_split_pattern_same_length_different_identities_is_fatal(self, tmp_path):
+        """Two arms can have equal-length heldout subsets that nonetheless
+        name different query_ids — e.g. one arm's split labels are swapped
+        for a heldout/public pair, leaving the FULL query_id sequence (and
+        therefore ``_assert_aligned``) untouched but changing exactly which
+        query_ids the heldout filter picks out. Positional pairing would
+        silently misalign here; the query_id-keyed join must catch it."""
+        n = _N_HELDOUT + _N_PUBLIC
+        splits = _splits()
+        values = [random.Random(21).uniform(0.2, 0.5) for _ in range(n)]
+        arms = {arm: {"per_query": _per_query(values, splits)} for arm in GATED_ARMS}
+
+        hybrid_records = [dict(rec) for rec in arms["hybrid"]["per_query"]]
+        hybrid_records[0]["split"], hybrid_records[_N_HELDOUT]["split"] = (
+            hybrid_records[_N_HELDOUT]["split"],
+            hybrid_records[0]["split"],
+        )
+        arms["hybrid"]["per_query"] = hybrid_records
+        # Sanity: still 40 heldout records for "hybrid" (same length as every
+        # other arm) — only the query_id identities differ (q0 dropped out,
+        # q40 came in), and the FULL query_id sequence is untouched.
+        assert sum(1 for rec in hybrid_records if rec["split"] == "heldout") == _N_HELDOUT
+        assert [rec["query_id"] for rec in hybrid_records] == [
+            rec["query_id"] for rec in arms["keyword"]["per_query"]
+        ]
+
+        result_json = {"embedding_model": "m1", "label": "day4-m1-run0", "arms": arms}
+        path = tmp_path / "day4-m1-run0.json"
+        path.write_text(json.dumps(result_json), encoding="utf-8")
+
+        with pytest.raises(SystemExit, match="q0"):
             analyze([path], inferential_run="day4-m1-run0")
 
 

--- a/backend/tests/eval/test_runner_records.py
+++ b/backend/tests/eval/test_runner_records.py
@@ -1,0 +1,157 @@
+"""Unit tests for the Day-4 static-runner parameterization (Issue #344 follow-up).
+
+Pure-function tests only — no DB/stack. ``tests.eval.runner`` keeps its heavy
+(DB/services) imports function-local specifically so this module (and the
+runner module itself) stays importable in plain CI; these tests exercise that
+by never touching anything beyond the pure helpers plus one guarded call into
+``run_retrieval_eval`` that must fail *before* any stack access.
+
+Stub queries are ``types.SimpleNamespace`` objects carrying only the
+``.id`` / ``.bucket`` / ``.split`` / ``.relevant`` attributes the helpers
+under test actually read — the real ``Query`` dataclass lives in
+``tests.eval.tools.corpus`` and pulls in the YAML loader, which is irrelevant
+here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+import pytest
+
+from tests.eval import runner
+
+
+def _q(id_: str, bucket: str, split: str | None, relevant: list[str]):
+    return types.SimpleNamespace(id=id_, bucket=bucket, split=split, relevant=relevant)
+
+
+class TestPerQueryRecords:
+    def test_hand_computable_metrics_and_split_passthrough(self):
+        queries = [
+            _q("q1", "retrieval-exact", "heldout", ["a"]),
+            _q("q2", "cross-source", "public", ["x", "y"]),
+            _q("q3", "memory-only", None, ["z"]),
+        ]
+        rankings = [
+            (["a", "b", "c", "d", "e"], {"a"}),  # p@5: 1/5 hit; rr@10: rank 1 -> 1.0
+            (["x2", "y", "b", "c", "d"], {"x", "y"}),  # p@5: 1/5 hit; rr@10: rank 2 -> 0.5
+            (["m", "n"], {"z"}),  # p@5: 0 hits; rr@10: no hit -> 0.0
+        ]
+
+        records = runner._per_query_records(queries, rankings)
+
+        assert records == [
+            {
+                "query_id": "q1",
+                "bucket": "retrieval-exact",
+                "split": "heldout",
+                "p@5": 0.2,
+                "rr@10": 1.0,
+            },
+            {
+                "query_id": "q2",
+                "bucket": "cross-source",
+                "split": "public",
+                "p@5": 0.2,
+                "rr@10": 0.5,
+            },
+            {
+                "query_id": "q3",
+                "bucket": "memory-only",
+                "split": None,
+                "p@5": 0.0,
+                "rr@10": 0.0,
+            },
+        ]
+
+    def test_corpus_order_is_preserved_not_reordered(self):
+        # Alternating hit/miss so any accidental sort/group-by would scramble it.
+        queries = [_q(f"q{i}", "b", None, ["x"]) for i in range(5)]
+        rankings = [(["x"], {"x"}) if i % 2 == 0 else (["y"], {"x"}) for i in range(5)]
+
+        records = runner._per_query_records(queries, rankings)
+
+        assert [r["query_id"] for r in records] == [f"q{i}" for i in range(5)]
+        assert [r["rr@10"] for r in records] == [1.0, 0.0, 1.0, 0.0, 1.0]
+
+    def test_length_mismatch_raises_value_error(self):
+        queries = [_q("q1", "b", None, ["a"])]
+        rankings: list[tuple[list[str], set[str]]] = []
+
+        with pytest.raises(ValueError, match="length"):
+            runner._per_query_records(queries, rankings)
+
+
+class TestSplitMetrics:
+    def test_all_none_split_returns_none(self):
+        # Golden corpus shape: no query carries a split.
+        queries = [_q(f"q{i}", "b", None, ["a"]) for i in range(3)]
+        rankings = [(["a"], {"a"}) for _ in queries]
+
+        assert runner._split_metrics(queries, rankings) is None
+
+    def test_mixed_splits_only_present_ones_with_matching_n(self):
+        queries = [
+            _q("q1", "b", "heldout", ["a"]),
+            _q("q2", "b", "heldout", ["a"]),
+            _q("q3", "b", "public", ["a"]),
+            _q("q4", "b", None, ["a"]),
+        ]
+        rankings = [
+            (["a"], {"a"}),
+            (["x"], {"a"}),
+            (["a"], {"a"}),
+            (["a"], {"a"}),
+        ]
+
+        result = runner._split_metrics(queries, rankings)
+
+        assert result is not None
+        assert set(result) == {"heldout", "public"}
+        assert result["heldout"]["n"] == 2
+        assert result["public"]["n"] == 1
+
+    def test_none_split_query_excluded_from_every_block(self):
+        queries = [
+            _q("q1", "b", "heldout", ["a"]),
+            _q("q2", "b", None, ["a"]),
+        ]
+        rankings = [
+            (["a"], {"a"}),
+            (["zzz"], {"a"}),  # would tank metrics if ever counted anywhere
+        ]
+
+        result = runner._split_metrics(queries, rankings)
+
+        assert result is not None
+        assert set(result) == {"heldout"}
+        assert result["heldout"]["n"] == 1
+
+
+class TestResultsFilename:
+    def test_no_label_keeps_legacy_filename(self):
+        assert runner._results_filename(None, "2026-07-03") == "2026-07-03.json"
+
+    def test_label_prefixes_filename(self):
+        assert (
+            runner._results_filename("day4-x-run0", "2026-07-03") == "day4-x-run0-2026-07-03.json"
+        )
+
+
+class TestEmbeddingModelValidation:
+    def test_unknown_model_raises_before_touching_db(self):
+        """Registry check must happen before ``async for db in get_db()`` so this
+        test needs no live stack — an unavailable DB would raise a different
+        error (or hang), not ``ValueError``.
+        """
+        from config.constants import EMBEDDING_MODEL_REGISTRY
+
+        with pytest.raises(ValueError) as exc_info:
+            asyncio.run(runner.run_retrieval_eval(embedding_model="nope"))
+
+        message = str(exc_info.value)
+        assert "nope" in message
+        for key in EMBEDDING_MODEL_REGISTRY:
+            assert key in message

--- a/backend/tests/eval/test_stats.py
+++ b/backend/tests/eval/test_stats.py
@@ -1,0 +1,213 @@
+"""Unit tests for ``tests.eval.stats`` — the Day-4 confirmatory statistics.
+
+Pure functions, no infra — these pin the exact resampling / bias-correction
+math so a regression in the confirmatory analysis (paired BCa bootstrap,
+permutation omnibus, power) is caught independently of the live harness and
+of the Day-4 analysis script (Task 3) that imports these names.
+
+Written before ``tests/eval/stats.py`` existed (TDD RED step).
+"""
+
+from __future__ import annotations
+
+import random
+import statistics
+
+import pytest
+
+from tests.eval.stats import (
+    achieved_power,
+    paired_bca_ci,
+    permutation_omnibus,
+    sigma_d,
+    unpaired_percentile_ci_diff,
+)
+
+
+def _iid_arms(
+    n_queries: int, k: int, *, shift: dict[int, float] | None = None
+) -> dict[str, list[float]]:
+    """``k`` arms that are near-identical copies of a shared per-query signal.
+
+    Each arm is ``base + shift.get(arm_idx, 0) + tiny_independent_noise``, so
+    with no shift the arms are (up to noise) the same distribution — the null
+    permutation_omnibus is built for — and a shift on one arm index is a
+    clean, large, arm-level effect.
+    """
+    shift = shift or {}
+    base = [random.Random(555).gauss(0.0, 1.0) for _ in range(n_queries)]
+    arms: dict[str, list[float]] = {}
+    for a in range(k):
+        noise_rng = random.Random(1000 + a)
+        arms[f"arm{a}"] = [b + shift.get(a, 0.0) + noise_rng.gauss(0.0, 0.01) for b in base]
+    return arms
+
+
+class TestPairedBcaCiDeterminism:
+    def test_repeat_call_same_seed_identical(self):
+        diffs = [random.Random(11).gauss(0.2, 0.1) for _ in range(50)]
+        r1 = paired_bca_ci(diffs, seed=42, n_resamples=500)
+        r2 = paired_bca_ci(diffs, seed=42, n_resamples=500)
+        assert r1 == r2
+
+
+class TestPairedBcaCiShape:
+    def test_within_tolerance_of_percentile_and_contains_mean(self):
+        diffs = [random.Random(7).gauss(0.1, 0.05) for _ in range(200)]
+        n_resamples = 10_000
+        seed = 123
+
+        bca = paired_bca_ci(diffs, seed=seed, n_resamples=n_resamples)
+
+        # Plain percentile CI computed inline, using the IDENTICAL resampling
+        # sequence (same seed/n/n_resamples as paired_bca_ci uses internally)
+        # so this isolates the BCa bias/acceleration adjustment, not
+        # resampling noise between two independent bootstrap runs.
+        rng = random.Random(seed)
+        n = len(diffs)
+        boot_means = []
+        for _ in range(n_resamples):
+            resample = [diffs[rng.randrange(n)] for _ in range(n)]
+            boot_means.append(sum(resample) / n)
+        boot_means.sort()
+        lo = boot_means[int(0.025 * n_resamples)]
+        hi = boot_means[int(0.975 * n_resamples)]
+
+        assert bca["ci_low"] == pytest.approx(lo, abs=0.01)
+        assert bca["ci_high"] == pytest.approx(hi, abs=0.01)
+        assert bca["ci_low"] <= bca["mean"] <= bca["ci_high"]
+
+
+class TestPairedBcaCiLocationShift:
+    def test_shift_moves_mean_and_bounds_by_exact_constant(self):
+        diffs = [random.Random(3).gauss(0.0, 0.2) for _ in range(80)]
+        shifted = [d + 0.5 for d in diffs]
+
+        base = paired_bca_ci(diffs, seed=99, n_resamples=2_000)
+        shifted_r = paired_bca_ci(shifted, seed=99, n_resamples=2_000)
+
+        # Same seed => identical resample indices for both calls, so adding a
+        # constant to every diff shifts the whole bootstrap distribution (and
+        # z0/a, which depend only on shape) by exactly that constant.
+        assert shifted_r["mean"] == pytest.approx(base["mean"] + 0.5, abs=1e-12)
+        assert shifted_r["ci_low"] == pytest.approx(base["ci_low"] + 0.5, abs=1e-12)
+        assert shifted_r["ci_high"] == pytest.approx(base["ci_high"] + 0.5, abs=1e-12)
+
+
+class TestPairedBcaCiDegenerate:
+    def test_all_equal_diffs_collapse_to_constant(self):
+        diffs = [0.37] * 30
+        result = paired_bca_ci(diffs, seed=1, n_resamples=500)
+        assert result["mean"] == 0.37
+        assert result["ci_low"] == 0.37
+        assert result["ci_high"] == 0.37
+        assert result["n"] == 30
+
+
+class TestPairedBcaCiErrors:
+    def test_empty_diffs_raises(self):
+        with pytest.raises(ValueError):
+            paired_bca_ci([], seed=1)
+
+
+class TestPermutationOmnibusDeterminism:
+    def test_repeat_call_same_seed_identical(self):
+        arms = _iid_arms(30, 3)
+        r1 = permutation_omnibus(arms, seed=5, n_permutations=500)
+        r2 = permutation_omnibus(arms, seed=5, n_permutations=500)
+        assert r1 == r2
+
+
+class TestPermutationOmnibus:
+    def test_identical_distribution_arms_high_p(self):
+        arms = _iid_arms(60, 4)
+        result = permutation_omnibus(arms, seed=1, n_permutations=2_000)
+        assert result["p_value"] > 0.05
+        assert result["n_arms"] == 4
+        assert result["n_queries"] == 60
+
+    def test_one_arm_shifted_low_p(self):
+        arms = _iid_arms(60, 4, shift={3: 5.0})
+        result = permutation_omnibus(arms, seed=1, n_permutations=2_000)
+        assert result["p_value"] < 0.001
+
+    def test_two_arm_direction_agrees_with_bca_ci(self):
+        arms = _iid_arms(60, 2, shift={1: 2.0})
+        result = permutation_omnibus(arms, seed=1, n_permutations=2_000)
+        assert result["p_value"] < 0.001
+
+        diffs = [b - a for a, b in zip(arms["arm0"], arms["arm1"], strict=True)]
+        ci = paired_bca_ci(diffs, seed=1, n_resamples=2_000)
+        assert ci["ci_low"] > 0  # CI excludes 0, consistent with the significant omnibus
+
+
+class TestPermutationOmnibusErrors:
+    def test_mismatched_lengths_names_arm(self):
+        with pytest.raises(ValueError, match="bad_arm"):
+            permutation_omnibus({"good": [1.0, 2.0], "bad_arm": [1.0, 2.0, 3.0]}, seed=1)
+
+    def test_fewer_than_two_arms_raises(self):
+        with pytest.raises(ValueError):
+            permutation_omnibus({"only": [1.0, 2.0]}, seed=1)
+
+    def test_zero_queries_raises(self):
+        with pytest.raises(ValueError):
+            permutation_omnibus({"a": [], "b": []}, seed=1)
+
+
+class TestUnpairedPercentileCiDiff:
+    def test_determinism(self):
+        a = [random.Random(1).gauss(0, 1) for _ in range(40)]
+        b = [random.Random(2).gauss(0.3, 1) for _ in range(40)]
+        r1 = unpaired_percentile_ci_diff(a, b, seed=7, n_resamples=500)
+        r2 = unpaired_percentile_ci_diff(a, b, seed=7, n_resamples=500)
+        assert r1 == r2
+
+    def test_mean_and_counts(self):
+        a = [1.0, 2.0, 3.0]
+        b = [10.0, 20.0]
+        result = unpaired_percentile_ci_diff(a, b, seed=3, n_resamples=500)
+        assert result["mean"] == pytest.approx((2.0) - (15.0))
+        assert result["n_a"] == 3
+        assert result["n_b"] == 2
+        assert result["ci_low"] <= result["mean"] <= result["ci_high"]
+
+    def test_empty_group_raises(self):
+        with pytest.raises(ValueError):
+            unpaired_percentile_ci_diff([], [1.0], seed=1)
+        with pytest.raises(ValueError):
+            unpaired_percentile_ci_diff([1.0], [], seed=1)
+
+
+class TestSigmaD:
+    def test_matches_statistics_stdev(self):
+        diffs = [1.0, 2.0, 3.0, 4.0]
+        assert sigma_d(diffs) == statistics.stdev(diffs)
+
+    def test_single_value_raises(self):
+        with pytest.raises(ValueError):
+            sigma_d([1.0])
+
+
+class TestAchievedPower:
+    def test_prereg_anchor_n200(self):
+        # prereg §5 anchor: delta=0.05, sd=0.25, n=200 -> ~0.80 power.
+        assert achieved_power(0.05, 0.25, 200) == pytest.approx(0.80, abs=0.02)
+
+    def test_prereg_anchor_n50(self):
+        assert achieved_power(0.05, 0.25, 50) == pytest.approx(0.30, abs=0.05)
+
+    def test_zero_sd_positive_delta_is_full_power(self):
+        assert achieved_power(0.1, 0.0, 100) == 1.0
+
+    def test_zero_sd_nonpositive_delta_is_zero_power(self):
+        assert achieved_power(0.0, 0.0, 100) == 0.0
+        assert achieved_power(-0.1, 0.0, 100) == 0.0
+
+    def test_n_less_than_one_raises(self):
+        with pytest.raises(ValueError):
+            achieved_power(0.1, 0.2, 0)
+
+    def test_negative_sd_raises(self):
+        with pytest.raises(ValueError):
+            achieved_power(0.1, -0.2, 100)


### PR DESCRIPTION
## What

**Day-4 static factorial** (week1-derisk Day 4, eval-repo prereg-v1): first absolute significance
claims on the frozen `kagura_L` corpus — 4 gated arms × 2 embedder capacities × 3 re-runs, with the
statistics pre-declared in the eval repo (plan commit `001af3d`) BEFORE the live run.

- **`stats.py`** — pure-stdlib statistics (no scipy): paired **BCa bootstrap** CI (bias correction
  with midpoint tie handling + jackknife acceleration), within-query **permutation omnibus**
  (`T = Σ(mean_arm − grand_mean)²`, add-one p), unpaired percentile CI, σ_d, achieved power. 23 tests
  incl. the prereg §5 power-table anchors.
- **`runner.py`** — parameterized: `--corpus` (any fixture), `--embedder` (any
  `EMBEDDING_MODEL_REGISTRY` key; overrides the `ContextSearchConfig` stamp + collection ensure —
  per-context routing does the rest), `--label` (results filename). Per-arm **`per_query`** records
  (`query_id/bucket/split/p@5/rr@10`) and **`by_split`** metric blocks. No-arg golden run is
  byte-compatible (new keys additive only; filename unchanged).
- **`day4_analysis.py`** — the pre-declared verdict CLI (seed 20260703, 10k resamples baked in):
  H0 omnibus → H1 hybrid-vs-best-single (paired BCa, pass = CI low > 0 AND mean ≥ δ=0.05) → H3
  public−heldout leak check; σ_d + achieved power; min/median/max across re-runs; H0/H1 inputs joined
  **by query_id** (not position) with cross-arm key-set guards. 21 tests.
- **Design note (D1, pre-declared):** the docs/02 §2.1 "+Sleep" static arm was **dropped** — Issue
  #120 lane separation means `recall()` never reads graph edges, so a recall-scored Sleep arm is
  definitionally identical to `hybrid_neural`. The gated family stays the tagged prereg's exact 4
  arms. (Two disclosed spec-ambiguity resolutions: `h1.gated_by_h0` key kept per the brief's prose;
  the H3 skip reason goes to stderr since the pinned output shape has no reason slot.)

## Results (live, pgx01 GB10 rig — `results/day4-*.json`, `day4-analysis-2026-07-03.json`)

| | qwen3-embedding:0.6b (inferential) | qwen3-embedding:4b (replication) |
|---|---|---|
| H0 omnibus | **reject** (p = 0.0001) | **reject** (p = 0.0001) |
| held-out P@5 | semantic **0.180** > hybrid_neural 0.172 > hybrid 0.167 > keyword 0.116 | semantic **0.193** > hybrid_neural 0.188 > hybrid 0.175 > keyword 0.119 |
| H1 hybrid − semantic | −0.0133, CI [−0.0267, +0.0008] → **null** | −0.0175, CI [−0.0317, −0.0017] → **null (CI < 0)** |
| σ_d / achieved power (δ=0.05, N=240) | 0.109 / **> 0.999** | 0.119 / > 0.999 |
| H3 public−heldout gap | +0.003 ≤ δ_leak ✓ | −0.013 ≤ δ_leak ✓ |

The harness is **sound and powered** (tight re-runs: arm-mean spread ≤ 0.002), and the hybrid-lift
claim is a **well-powered, capacity-replicated null** — at 4b, hybrid is significantly *below*
semantic at P@5. Per-bucket pattern is design-consistent (keyword wins retrieval-exact, semantic wins
retrieval-semantic/cross-source, BM25-side wins hiragana). σ_d + achieved power are stamped into the
eval repo's prereg-v1 Appendix A (`8d40cea`); the golden-46 arm ordering (hybrid top) did not survive
corpus scale — which is exactly what Day-3/Day-4 existed to test.

## Testing

- Whole eval suite **177 passed** (live tests skip without `KAGURA_EVAL_LIVE=1`); ruff clean.
- Per-task spec+quality reviews + a final whole-branch review (READY; the H0/H1 pairing hardening in
  `78cb3eb7` was review-driven, with byte-identical outputs verified for well-formed runner input).
- 6 live runs, all exit 0; analysis artifact generated by the pre-declared CLI, never hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
