### PR TITLE
fix: resolve all v0.42.0 max code-review findings

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -6,7 +6,11 @@ paths:
 # Security Rules
 
 ## Authentication
-- All API routes MUST use auth dependency (except `/`, `/health`, `/.well-known/*`, `/docs`, `/openapi.json`)
+- All API routes MUST use auth dependency (except `/`, `/health`, `/api/v1/system/info`, `/.well-known/*`, `/docs`, `/openapi.json`)
+  - `/api/v1/system/info` is intentionally public: version + non-sensitive
+    deployment feature flags the web UI reads before workspace context exists.
+    It exposes no user/workspace data. Enforced public by
+    `tests/api/test_system_info.py` + `tests/smoke/test_health.py`.
 - Session-only routes: `Depends(get_current_user)`
 - Session + API key routes: `Depends(APIKeyOrSessionUser)`
 - Admin routes: verify `system_admin` or `workspace_admin` role after auth

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1050,7 +1050,19 @@ async def delete_user(
             .scalars()
             .all()
         )
-        await db.execute(delete(Context).where(Context.created_by == user_id))
+        # Delete EXACTLY the contexts we just purged (the FOR UPDATE snapshot),
+        # not a fresh ``created_by == user_id`` predicate. Under READ COMMITTED
+        # the latter would also delete a context the user's own session created
+        # AFTER the snapshot (e.g. in a workspace they only belong to, not own):
+        # its files were never in ``ctx_ids`` so they skipped the purge, and a
+        # ``created_by`` DELETE would SET-NULL their context_id — widening a
+        # private file into a workspace-scoped object downloadable by any viewer,
+        # with its bytes never released. Scoping the DELETE to the purged
+        # snapshot keeps purge-set == delete-set; a context raced in after the
+        # snapshot simply survives with its files intact (created_by is a plain
+        # string, not an FK, so it does not block the user delete) (v0.42 review).
+        if ctx_ids:
+            await db.execute(delete(Context).where(Context.id.in_(ctx_ids)))
 
         # Remove user from workspace memberships
         # #687: operation-on-deleted — full user erasure must purge memberships

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -35,13 +35,25 @@ logger = get_logger(__name__)
 # External API keys are workspace-level secrets (OpenAI/Cohere/Anthropic credentials)
 # that should only be managed by the workspace owner. Viewers, members, and admins
 # cannot list/create/update/toggle/delete keys.
-# Issue #1167: require_byok_enabled must stay FIRST so a BYOK-off deployment
-# returns a uniform 404 to every caller before auth/role checks run — a
-# role-dependent 403-vs-404 split would leak the feature's existence.
+# Issue #1167 / v0.42 review #32: the BYOK feature gate now applies only to the
+# WRITE paths (create + update), NOT list / toggle-off / delete. Key RESOLUTION
+# deliberately keeps using keys stored before the flag was turned off (so live
+# embeddings do not break on a flag flip) — but if management were ALSO gated
+# off, a customer would have no way to disable or delete a key that is still
+# being billed. Keeping list/toggle/delete reachable preserves that control
+# without re-enabling provisioning.
+#
+# Dependencies are declared PER-ROUTE (not router-wide) so ordering is explicit:
+# on the write paths ``require_byok_enabled`` is listed BEFORE
+# ``require_workspace_owner`` so a BYOK-off create/update returns a uniform 404
+# before auth runs (no role-dependent 403-vs-404 existence leak). Router-level
+# dependencies would run before any per-route dep and defeat that ordering, so
+# the owner gate is attached per-route too.
+_OWNER_ONLY = [Depends(require_workspace_owner)]
+_BYOK_WRITE = [Depends(require_byok_enabled), Depends(require_workspace_owner)]
 router = APIRouter(
     prefix="/external-keys",
     tags=["external-keys"],
-    dependencies=[Depends(require_byok_enabled), Depends(require_workspace_owner)],
 )
 
 
@@ -202,7 +214,7 @@ async def validate_reranker_exclusivity(
 # ============================================================================
 
 
-@router.get("", response_model=ExternalKeyListResponse)
+@router.get("", response_model=ExternalKeyListResponse, dependencies=_OWNER_ONLY)
 async def list_external_keys(
     user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
@@ -257,7 +269,7 @@ async def list_external_keys(
         return ExternalKeyListResponse(keys=key_responses, total=len(keys))
 
 
-@router.post("", response_model=ExternalKeyResponse)
+@router.post("", response_model=ExternalKeyResponse, dependencies=_BYOK_WRITE)
 async def create_external_key(
     request: ExternalKeyCreate,
     user: APIKeyOrSessionUser,
@@ -403,7 +415,7 @@ async def create_external_key(
         )
 
 
-@router.put("/{key_name}", response_model=ExternalKeyResponse)
+@router.put("/{key_name}", response_model=ExternalKeyResponse, dependencies=_BYOK_WRITE)
 async def update_external_key(
     key_name: str,
     request: ExternalKeyUpdate,
@@ -463,7 +475,7 @@ async def update_external_key(
         )
 
 
-@router.patch("/{key_name}/toggle", response_model=ExternalKeyResponse)
+@router.patch("/{key_name}/toggle", response_model=ExternalKeyResponse, dependencies=_OWNER_ONLY)
 async def toggle_external_key(
     key_name: str,
     request: ExternalKeyToggle,
@@ -588,7 +600,7 @@ async def toggle_external_key(
         )
 
 
-@router.delete("/{key_name}")
+@router.delete("/{key_name}", dependencies=_OWNER_ONLY)
 async def delete_external_key(
     key_name: str,
     user: APIKeyOrSessionUser,

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -23,6 +23,7 @@ from auth.programmatic_workspace_auth import (
     authorize_workspace_management,
     is_api_key_principal,
     is_oauth_principal,
+    is_session_principal,
 )
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
@@ -513,6 +514,15 @@ async def create_api_key(
     if is_api_key_principal(user):
         return await _owner_provisioned_mint(workspace_id, user_id, data, user, db)
 
+    # Fail closed: only a POSITIVELY-identified session may reach the self-mint
+    # path. Reaching it by elimination (not OAuth, not API-key => assume session)
+    # would let an unrecognized principal shape mint a key; mirror the shared
+    # authorize_workspace_management helper's positive-session default. Legit
+    # sessions always carry the OIDC ``sub`` (SessionManager.create_session
+    # requires it) (v0.42 max review).
+    if not is_session_principal(user):
+        raise AuthorizationError(message="Unrecognized principal for API key creation")
+
     # Session path (#252 unchanged): self-mint only.
     if user["user_id"] != user_id:
         raise AuthorizationError(
@@ -793,12 +803,19 @@ async def delete_api_key_by_id(
             await _require_downgrade_target(
                 db, user_id, workspace_id, action_desc="Owner-provisioned revocation is limited to"
             )
-    elif caller_id != user_id:
-        # Session path (#252 unchanged): self-only.
-        raise AuthorizationError(
-            message="You can only delete your own API keys in a session. "
-            "To revoke another member's key, use a workspace-owner API key."
-        )
+    else:
+        # Fail closed: only a POSITIVELY-identified session may reach the
+        # self-only delete path (not OAuth, not API-key => assume session would
+        # let an unrecognized principal shape through). Legit sessions always
+        # carry the OIDC ``sub`` (v0.42 max review).
+        if not is_session_principal(user):
+            raise AuthorizationError(message="Unrecognized principal for API key deletion")
+        if caller_id != user_id:
+            # Session path (#252 unchanged): self-only.
+            raise AuthorizationError(
+                message="You can only delete your own API keys in a session. "
+                "To revoke another member's key, use a workspace-owner API key."
+            )
 
     from sqlalchemy import and_, select
 

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -219,6 +219,7 @@ async def _owner_provisioned_mint(
             "created_at": to_utc_iso(new_key.created_at),
             "last_used_at": None,
             "revoked_at": None,
+            "expires_at": to_utc_iso(new_key.expires_at),  # #1165: owner-set expiry, now observable
             "bound_context_id": None,
         }
     except ValueError as e:
@@ -282,6 +283,15 @@ async def get_member_credentials(
 
         # Get target user's workspace role (for permission checks)
         target_role = await service.get_workspace_role(user_id, workspace_id)
+        if target_role is None:
+            # Target is not (or no longer) a workspace member. Without this the
+            # non-optional MemberCredentialsResponse.target_user_role would fail
+            # validation and the blanket ``except Exception`` below would turn a
+            # wrong/removed target into an opaque 500. Raise HTTPException (not
+            # NotFoundException, which subclasses MemoryCloudException and WOULD
+            # be swallowed here) so ``except HTTPException: raise`` returns a
+            # clean 404 (v0.42 max review).
+            raise HTTPException(status_code=404, detail="Member not found")
 
         return MemberCredentialsResponse(**credentials, target_user_role=target_role)
     except HTTPException:
@@ -662,6 +672,7 @@ async def create_api_key(
             "created_at": to_utc_iso(new_key.created_at),
             "last_used_at": to_utc_iso(new_key.last_used_at),
             "revoked_at": None,
+            "expires_at": to_utc_iso(new_key.expires_at),  # #1165: None for session self-mint
             "bound_context_id": (
                 str(new_key.bound_context_id) if new_key.bound_context_id else None
             ),
@@ -800,6 +811,16 @@ async def delete_api_key_by_id(
     if api_key is None:
         raise HTTPException(status_code=404, detail="API key not found")
 
+    # A soft-revoked row is a retained forensic record (#1165). Any further
+    # delete/revoke must not touch it: a SESSION self-delete would HARD-delete
+    # the evidence (the member erasing the key an owner just revoked on them),
+    # and a repeated programmatic revoke would overwrite the original
+    # revoked_at timestamp and append a duplicate audit row. Treat an
+    # already-revoked key as not-found for both paths — uniform 404 so the
+    # forensic row's continued existence is not revealed (v0.42 max review).
+    if api_key.revoked_at is not None:
+        raise HTTPException(status_code=404, detail="API key not found")
+
     # Verify the URL ``workspace_id`` matches the key's real scope.
     # Without this, an authenticated user could pass an arbitrary
     # ``workspace_id`` in the path and the AuditLog row would record a
@@ -870,6 +891,14 @@ async def delete_api_key_by_id(
             },
         )
         api_key.revoked_at = utcnow()
+        # Zero-knowledge (Migration-035): drop any at-rest plaintext on revoke.
+        # The hourly auto-hide sweeper only clears rows with revoked_at IS NULL,
+        # so a key revoked inside its visibility window would otherwise retain a
+        # Fernet-decryptable plaintext copy indefinitely. Mirror the mint path
+        # and APIKeyManager.hide_key (v0.42 max review).
+        api_key.plaintext_encrypted = None
+        api_key.visibility_expires_at = None
+        api_key.hidden_at = utcnow()
         await db.commit()
         logger.info(
             "member_api_key_revoked",

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.api_keys import APIKeyManager
+from auth.api_keys import APIKeyManager, apply_zero_knowledge_hide
 from auth.dependencies import APIKeyOrSessionUser, SessionUser
 from auth.programmatic_workspace_auth import (
     audit_programmatic_workspace_action,
@@ -50,6 +50,49 @@ router = APIRouter(
 # ============================================================================
 # Helper Functions
 # ============================================================================
+
+
+def _reject_oauth(user: dict, action: str) -> None:
+    """Reject an OAuth bearer principal on the credential surface (#1165).
+
+    Every ``kagura auth login`` device token carries ``memory:read
+    memory:write``, so accepting OAuth here would silently turn every user's
+    MCP token into a credential-management credential. One helper keeps the
+    policy message consistent across the three credential endpoints.
+    """
+    if is_oauth_principal(user):
+        raise AuthorizationError(
+            message=f"OAuth bearer tokens cannot {action}. Use a workspace-owner API key."
+        )
+
+
+def _minted_key_response(
+    new_key,
+    plaintext_key: str,
+    *,
+    is_visible: bool,
+    visibility_expires_at: str | None,
+    last_used_at: str | None,
+) -> dict:
+    """Build the one-time ``MemberAPIKeyResponse`` dict for a freshly minted key.
+
+    Shared by the owner-provisioned mint (force-hidden: not visible) and the
+    session self-mint (visible for its auto-hide window) — the two differ only
+    in ``is_visible`` / ``visibility_expires_at`` / ``last_used_at``.
+    """
+    return {
+        "id": new_key.id,
+        "name": new_key.name,
+        "key_prefix": new_key.key_prefix,
+        "plaintext_key": plaintext_key,  # shown once
+        "is_visible": is_visible,
+        "visibility_expires_at": visibility_expires_at,
+        "created_at": to_utc_iso(new_key.created_at),
+        "last_used_at": last_used_at,
+        "revoked_at": None,
+        "expires_at": to_utc_iso(new_key.expires_at),  # #1165: owner-set expiry
+        "bound_context_id": (str(new_key.bound_context_id) if new_key.bound_context_id else None),
+    }
 
 
 async def check_permission(
@@ -177,12 +220,9 @@ async def _owner_provisioned_mint(
         # null the encrypted-at-rest copy too (Migration-035 zero-knowledge). The
         # hourly auto-hide sweeper only clears rows with hidden_at IS NULL, so a
         # force-hidden row it never touches would otherwise retain a
-        # Fernet-decryptable copy of a live long-lived key indefinitely. This
-        # matches APIKeyManager.hide_key / auto_hide_expired_credentials, which
-        # both null plaintext_encrypted on hide (max code-review, PR #1171).
-        new_key.hidden_at = utcnow()
-        new_key.visibility_expires_at = None
-        new_key.plaintext_encrypted = None
+        # Fernet-decryptable copy of a live long-lived key indefinitely (max
+        # code-review, PR #1171). Shared with hide_key so the two never drift.
+        apply_zero_knowledge_hide(new_key)
 
         # Audit via the shared helper (#1164) — it records the ACTING owner key
         # under metadata["key_prefix"] and hardcodes via/workspace_id/target; we
@@ -210,19 +250,14 @@ async def _owner_provisioned_mint(
             target=user_id,
             workspace_id=str(workspace_id),
         )
-        return {
-            "id": new_key.id,
-            "name": new_key.name,
-            "key_prefix": new_key.key_prefix,
-            "plaintext_key": plaintext_key,  # shown once
-            "is_visible": False,
-            "visibility_expires_at": None,
-            "created_at": to_utc_iso(new_key.created_at),
-            "last_used_at": None,
-            "revoked_at": None,
-            "expires_at": to_utc_iso(new_key.expires_at),  # #1165: owner-set expiry, now observable
-            "bound_context_id": None,
-        }
+        # Force-hidden: plaintext exists only in this one 201 response.
+        return _minted_key_response(
+            new_key,
+            plaintext_key,
+            is_visible=False,
+            visibility_expires_at=None,
+            last_used_at=None,
+        )
     except ValueError as e:
         raise BadRequestError(message=str(e)) from e
 
@@ -250,10 +285,7 @@ async def get_member_credentials(
         HTTPException: If not authorized.
     """
     # Issue #1165: OAuth rejected; API-key principal must be workspace owner.
-    if is_oauth_principal(user):
-        raise AuthorizationError(
-            message="OAuth bearer tokens cannot view member credentials. Use a workspace-owner API key."
-        )
+    _reject_oauth(user, "view member credentials")
     programmatic = is_api_key_principal(user)
     caller_role: str | None = None
     if programmatic:
@@ -505,10 +537,7 @@ async def create_api_key(
             or the bound context is missing / not public / not in this workspace.
     """
     # Issue #1165: OAuth bearer tokens must never mint long-lived credentials.
-    if is_oauth_principal(user):
-        raise AuthorizationError(
-            message="OAuth bearer tokens cannot mint API keys. Use a workspace-owner API key."
-        )
+    _reject_oauth(user, "mint API keys")
 
     # Issue #1165: owner-provisioned programmatic minting for ANOTHER member.
     if is_api_key_principal(user):
@@ -671,22 +700,14 @@ async def create_api_key(
             bound_context_id=str(bound_context_uuid) if bound_context_uuid else None,
         )
 
-        # Return with plaintext (shown once)
-        return {
-            "id": new_key.id,
-            "name": new_key.name,
-            "key_prefix": new_key.key_prefix,
-            "plaintext_key": plaintext_key,
-            "is_visible": True,
-            "visibility_expires_at": to_utc_iso(new_key.visibility_expires_at),
-            "created_at": to_utc_iso(new_key.created_at),
-            "last_used_at": to_utc_iso(new_key.last_used_at),
-            "revoked_at": None,
-            "expires_at": to_utc_iso(new_key.expires_at),  # #1165: None for session self-mint
-            "bound_context_id": (
-                str(new_key.bound_context_id) if new_key.bound_context_id else None
-            ),
-        }
+        # Return with plaintext (shown once); visible for its auto-hide window.
+        return _minted_key_response(
+            new_key,
+            plaintext_key,
+            is_visible=True,
+            visibility_expires_at=to_utc_iso(new_key.visibility_expires_at),
+            last_used_at=to_utc_iso(new_key.last_used_at),
+        )
 
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
@@ -781,10 +802,7 @@ async def delete_api_key_by_id(
     Raises:
         HTTPException: 403 if not permitted, 404 if key not found.
     """
-    if is_oauth_principal(user):
-        raise AuthorizationError(
-            message="OAuth bearer tokens cannot revoke API keys. Use a workspace-owner API key."
-        )
+    _reject_oauth(user, "revoke API keys")
     # Fail closed on a malformed principal missing user_id — .get() (not
     # indexing) so a bad dict yields a clean 403, never a KeyError/500. The
     # programmatic branch's authorize_workspace_management re-validates; the
@@ -884,11 +902,9 @@ async def delete_api_key_by_id(
     # never a silent hard delete (Copilot review, PR #1171). The audit row and
     # the revoked_at update commit atomically in one transaction. Session
     # self-delete keeps the existing hard-delete semantics (#252, #626).
-    soft_revoke = programmatic
-
-    if soft_revoke:
-        # soft_revoke == programmatic, so authorize_workspace_management above
-        # returned a (non-None) api_key principal.
+    if programmatic:
+        # authorize_workspace_management above returned a (non-None) api_key
+        # principal for the programmatic branch.
         assert principal is not None
         # Audit via the shared helper (#1164): it records the ACTING owner key
         # under metadata["key_prefix"]; the revoked key's prefix is carried under
@@ -911,11 +927,8 @@ async def delete_api_key_by_id(
         # Zero-knowledge (Migration-035): drop any at-rest plaintext on revoke.
         # The hourly auto-hide sweeper only clears rows with revoked_at IS NULL,
         # so a key revoked inside its visibility window would otherwise retain a
-        # Fernet-decryptable plaintext copy indefinitely. Mirror the mint path
-        # and APIKeyManager.hide_key (v0.42 max review).
-        api_key.plaintext_encrypted = None
-        api_key.visibility_expires_at = None
-        api_key.hidden_at = utcnow()
+        # Fernet-decryptable plaintext copy indefinitely (v0.42 max review).
+        apply_zero_knowledge_hide(api_key)
         await db.commit()
         logger.info(
             "member_api_key_revoked",

--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -14,6 +14,35 @@ from db.base import get_db
 router = APIRouter(prefix="/system", tags=["system"])
 
 
+async def _fetch_v1_models(
+    base_url: str, api_key: str, *, timeout: float = 5.0
+) -> tuple[int | None, list[str]]:
+    """Probe ``{base_url}/v1/models`` (OpenAI-compatible; Ollama + vLLM).
+
+    Shared by the telemetry probe and the embedding-models availability check so
+    the bearer-header + null-``data`` handling live in one place. Returns
+    ``(status_code, model_ids)``; ``status_code`` is ``None`` on a connection
+    error, and ``model_ids`` is empty unless the response was 200. Best-effort:
+    never raises.
+    """
+    import httpx
+
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as http:
+            resp = await http.get(f"{base_url}/v1/models", headers=headers)
+    except Exception:  # noqa: BLE001 — best-effort observability probe
+        return None, []
+    if resp.status_code != 200:
+        return resp.status_code, []
+    # ``data`` may be null (e.g. Ollama with no models pulled → {"data": null}).
+    try:
+        model_ids = [m["id"] for m in (resp.json().get("data") or []) if "id" in m]
+    except Exception:  # noqa: BLE001 — malformed body ⇒ reachable-but-no-models
+        model_ids = []
+    return 200, model_ids
+
+
 # ============================================================================
 # Schemas (Issue #43)
 # ============================================================================
@@ -200,30 +229,11 @@ async def get_system_telemetry(
             or bool(settings.rerank_base_url)
         )
         if self_hosted_explicitly_configured:
-            import httpx
-
-            async def _probe_v1_models(base_url: str, api_key: str) -> ServiceStatus | None:
-                """Probe {base}/v1/models. ok(+models) on 200; error on non-200/exc; None never returned here."""
-                headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
-                try:
-                    async with httpx.AsyncClient(timeout=5.0) as http:
-                        resp = await http.get(f"{base_url}/v1/models", headers=headers)
-                    if resp.status_code == 200:
-                        # ``data`` may be null (e.g. Ollama with no models
-                        # pulled returns {"data": null}); coalesce to [].
-                        model_names = [
-                            m["id"] for m in (resp.json().get("data") or []) if "id" in m
-                        ]
-                        # `url` intentionally omitted (#991): the internal base
-                        # URL is not exposed on this non-admin endpoint.
-                        return ServiceStatus(status="ok", details={"models": model_names})
-                    return ServiceStatus(status="error", details={"http_status": resp.status_code})
-                except Exception as e:  # noqa: BLE001 — best-effort observability probe
-                    return ServiceStatus(status="error", details={"error": str(e)})
-
             # Probe the embedding/LLM backend when it is the configured one;
             # otherwise probe the dedicated rerank rig. First reachable ("ok")
-            # backend wins — self-hosted infrastructure is available.
+            # backend wins — self-hosted infrastructure is available. `url`
+            # intentionally omitted (#991): the internal base URL is not exposed
+            # on this non-admin endpoint.
             probe_targets: list[tuple[str, str]] = []
             if (
                 settings.embedding_provider == "self_hosted"
@@ -234,9 +244,16 @@ async def get_system_telemetry(
                 probe_targets.append((settings.rerank_base_url, settings.rerank_api_key))
 
             for base_url, api_key in probe_targets:
-                self_hosted_status = await _probe_v1_models(base_url, api_key)
-                if self_hosted_status.status == "ok":
+                status_code, model_names = await _fetch_v1_models(base_url, api_key)
+                if status_code == 200:
+                    self_hosted_status = ServiceStatus(status="ok", details={"models": model_names})
                     break
+                self_hosted_status = ServiceStatus(
+                    status="error",
+                    details=(
+                        {"http_status": status_code} if status_code else {"error": "unreachable"}
+                    ),
+                )
 
         # Memory stats (all users)
         from sqlalchemy import func
@@ -460,30 +477,20 @@ async def list_embedding_models(
     except Exception:
         pass  # Non-critical: OpenAI availability is best-effort
 
-    # Check self-hosted backend availability (only if explicitly configured).
-    # Probes the OpenAI-compatible /v1/models endpoint (Ollama + vLLM).
+    # Check self-hosted backend availability (only if explicitly configured),
+    # via the shared /v1/models probe. Detect explicit config via
+    # model_fields_set so setting SELF_HOSTED_BASE_URL to the default value
+    # still counts as configured.
     self_hosted_available = False
-    self_hosted_url = settings.self_hosted_base_url
-    # See telemetry probe above: detect explicit config via model_fields_set so
-    # setting SELF_HOSTED_BASE_URL to the default value still counts as configured.
     self_hosted_configured = (
         settings.embedding_provider == "self_hosted"
         or "self_hosted_base_url" in settings.model_fields_set
     )
     if self_hosted_configured:
-        try:
-            import httpx
-
-            headers = (
-                {"Authorization": f"Bearer {settings.self_hosted_api_key}"}
-                if settings.self_hosted_api_key
-                else None
-            )
-            async with httpx.AsyncClient(timeout=3.0) as http:
-                resp = await http.get(f"{self_hosted_url}/v1/models", headers=headers)
-                self_hosted_available = resp.status_code == 200
-        except Exception:
-            pass  # Backend not reachable — models marked as unavailable
+        status_code, _ = await _fetch_v1_models(
+            settings.self_hosted_base_url, settings.self_hosted_api_key, timeout=3.0
+        )
+        self_hosted_available = status_code == 200
 
     # Build model list
     models = []

--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -185,48 +185,58 @@ async def get_system_telemetry(
         # provider is self_hosted). Probes the OpenAI-compatible /v1/models
         # endpoint, served by both Ollama and vLLM.
         self_hosted_status = ServiceStatus(status="not_configured")
-        # "Explicitly configured" = provider is self_hosted OR the operator set
-        # SELF_HOSTED_BASE_URL. Detect the latter via model_fields_set rather
-        # than comparing to the default value — an operator who sets the base
-        # URL *to* the default (common for a local Ollama/vLLM) must still be
-        # treated as configured.
+        # "Explicitly configured" = provider is self_hosted, the operator set
+        # SELF_HOSTED_BASE_URL, OR a dedicated /v1/rerank rig is configured
+        # (RERANK_BASE_URL). The last case matters because the frontend gates the
+        # self-hosted *reranker* option on this single ``self_hosted`` signal, so
+        # a rerank-only deployment (embeddings on OpenAI, rerank on a vLLM rig)
+        # must still report available or the UI blocks enabling/saving it (#1161).
+        # SELF_HOSTED_BASE_URL is detected via model_fields_set rather than a
+        # value compare — an operator who sets it *to* the default (common for a
+        # local Ollama/vLLM) must still be treated as configured.
         self_hosted_explicitly_configured = (
             settings.embedding_provider == "self_hosted"
             or "self_hosted_base_url" in settings.model_fields_set
+            or bool(settings.rerank_base_url)
         )
         if self_hosted_explicitly_configured:
-            try:
-                import httpx
+            import httpx
 
-                headers = (
-                    {"Authorization": f"Bearer {settings.self_hosted_api_key}"}
-                    if settings.self_hosted_api_key
-                    else None
-                )
-                async with httpx.AsyncClient(timeout=5.0) as http:
-                    models_resp = await http.get(
-                        f"{settings.self_hosted_base_url}/v1/models", headers=headers
-                    )
-                    if models_resp.status_code == 200:
+            async def _probe_v1_models(base_url: str, api_key: str) -> ServiceStatus | None:
+                """Probe {base}/v1/models. ok(+models) on 200; error on non-200/exc; None never returned here."""
+                headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+                try:
+                    async with httpx.AsyncClient(timeout=5.0) as http:
+                        resp = await http.get(f"{base_url}/v1/models", headers=headers)
+                    if resp.status_code == 200:
                         # ``data`` may be null (e.g. Ollama with no models
                         # pulled returns {"data": null}); coalesce to [].
                         model_names = [
-                            m["id"] for m in (models_resp.json().get("data") or []) if "id" in m
+                            m["id"] for m in (resp.json().get("data") or []) if "id" in m
                         ]
-                        # `url` intentionally omitted (#991): the internal
-                        # base URL is not exposed on this non-admin endpoint; the
-                        # frontend consumes only status + models.
-                        self_hosted_status = ServiceStatus(
-                            status="ok",
-                            details={"models": model_names},
-                        )
-                    else:
-                        self_hosted_status = ServiceStatus(
-                            status="error",
-                            details={"http_status": models_resp.status_code},
-                        )
-            except Exception as e:
-                self_hosted_status = ServiceStatus(status="error", details={"error": str(e)})
+                        # `url` intentionally omitted (#991): the internal base
+                        # URL is not exposed on this non-admin endpoint.
+                        return ServiceStatus(status="ok", details={"models": model_names})
+                    return ServiceStatus(status="error", details={"http_status": resp.status_code})
+                except Exception as e:  # noqa: BLE001 — best-effort observability probe
+                    return ServiceStatus(status="error", details={"error": str(e)})
+
+            # Probe the embedding/LLM backend when it is the configured one;
+            # otherwise probe the dedicated rerank rig. First reachable ("ok")
+            # backend wins — self-hosted infrastructure is available.
+            probe_targets: list[tuple[str, str]] = []
+            if (
+                settings.embedding_provider == "self_hosted"
+                or "self_hosted_base_url" in settings.model_fields_set
+            ):
+                probe_targets.append((settings.self_hosted_base_url, settings.self_hosted_api_key))
+            if settings.rerank_base_url:
+                probe_targets.append((settings.rerank_base_url, settings.rerank_api_key))
+
+            for base_url, api_key in probe_targets:
+                self_hosted_status = await _probe_v1_models(base_url, api_key)
+                if self_hosted_status.status == "ok":
+                    break
 
         # Memory stats (all users)
         from sqlalchemy import func

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -700,6 +700,18 @@ async def list_members(
     return member_responses
 
 
+def _reject_programmatic_owner_assignment(principal, role) -> None:
+    """A programmatic (API-key) member mutation must NOT assign the owner role —
+    ownership changes go through the dedicated transfer flow (#254). Shared by
+    add_member and update_member_role so the rule stays identical on both."""
+    if principal.kind == "api_key" and role == WorkspaceRole.OWNER:
+        raise ValidationError(
+            "Programmatic member management cannot assign the owner role; "
+            "use the ownership transfer flow.",
+            field="role",
+        )
+
+
 @router.post("/{workspace_id}/members", response_model=WorkspaceMemberResponse, status_code=201)
 async def add_member(
     workspace_id: UUID,
@@ -718,12 +730,7 @@ async def add_member(
     principal = await authorize_workspace_management(
         user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
     )
-    if principal.kind == "api_key" and body.role == WorkspaceRole.OWNER:
-        raise ValidationError(
-            "Programmatic member management cannot assign the owner role; "
-            "use the ownership transfer flow.",
-            field="role",
-        )
+    _reject_programmatic_owner_assignment(principal, body.role)
 
     # Issue #1164: audit programmatic mutations (no-op for session). Added
     # before the service call so it commits atomically with the membership.
@@ -770,12 +777,7 @@ async def update_member_role(
         current_user, workspace_id, db, session_required_role=WorkspaceRole.ADMIN
     )
 
-    if principal.kind == "api_key" and body.role == WorkspaceRole.OWNER:
-        raise ValidationError(
-            "Programmatic member management cannot assign the owner role; "
-            "use the ownership transfer flow.",
-            field="role",
-        )
+    _reject_programmatic_owner_assignment(principal, body.role)
 
     # Issue #254: Prevent users from changing their own role
     if user_id == current_user["user_id"]:

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -47,12 +47,18 @@ class VerifiedKey(NamedTuple):
             for public-bound keys (mutually exclusive with bound_context_id).
         bound_context_id: Public-context attribution (Issue #626). None
             unless the key was created with a binding.
+        key_prefix: The key's non-secret prefix (``api_keys.key_prefix``,
+            e.g. ``kagura_abc123``). Issue #1164: surfaced onto the
+            authenticated principal (``api_key_prefix``) so audit trails for
+            programmatic member-management actions attribute the specific
+            acting key, not just the owner user_id.
     """
 
     id: int
     user_id: str
     workspace_id: UUID | None
     bound_context_id: UUID | None
+    key_prefix: str | None = None
 
 
 class APIKeyManager:
@@ -272,6 +278,7 @@ class APIKeyManager:
             user_id=key_record.user_id,
             workspace_id=key_record.workspace_id,
             bound_context_id=key_record.bound_context_id,
+            key_prefix=key_record.key_prefix,
         )
 
     async def list_keys(

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -61,6 +61,22 @@ class VerifiedKey(NamedTuple):
     key_prefix: str | None = None
 
 
+def apply_zero_knowledge_hide(key: APIKey) -> None:
+    """Apply the Migration-034/035 zero-knowledge hide mutations to ``key``.
+
+    Stops showing the plaintext (``hidden_at`` now, ``visibility_expires_at``
+    cleared) AND drops the Fernet-decryptable at-rest copy
+    (``plaintext_encrypted`` nulled). Shared by ``hide_key``, the
+    owner-provisioned force-hide (member_credentials), and the programmatic
+    soft-revoke so the three never drift — the at-rest copy must always be
+    dropped, because the hourly auto-hide sweeper skips already-hidden and
+    revoked rows and would never revisit them. Does NOT flush/commit.
+    """
+    key.hidden_at = utcnow()
+    key.visibility_expires_at = None
+    key.plaintext_encrypted = None
+
+
 class APIKeyManager:
     """Async API Key manager using SQLAlchemy.
 
@@ -388,9 +404,7 @@ class APIKeyManager:
         if key.user_id != user_id:
             raise PermissionError("Only owner can hide API key")
 
-        key.hidden_at = utcnow()
-        key.visibility_expires_at = None  # Cancel auto-hide
-        key.plaintext_encrypted = None  # Migration 035: Delete encrypted plaintext
+        apply_zero_knowledge_hide(key)
         await self.db.flush()
 
         logger.info("api_key_hidden", key_id=key_id, user_id=user_id)

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -129,6 +129,24 @@ async def authorize_workspace_management(
 
     # API-key → owner-only, with #963 confinement first.
     if is_api_key_principal(user):
+        # v0.42 review #33: deployment-level kill-switch. When owner-key member
+        # management is disabled, an owner's ordinary API key must NOT carry
+        # member/credential-management power (a stolen key would otherwise mint
+        # member keys / add members). Session owners are unaffected; they take
+        # the session branch below. Rejected uniformly so a bound-elsewhere key
+        # cannot distinguish this from the #963 confinement.
+        from config.settings import get_settings
+
+        if not get_settings().enable_owner_key_member_management:
+            logger.warning(
+                "workspace_mgmt_owner_key_disabled",
+                user_id=user_id,
+                workspace_id=str(workspace_id),
+            )
+            raise AuthorizationError(
+                "Owner-API-key member management is disabled on this deployment. "
+                "Use a workspace-owner session."
+            )
         key_workspace_id = user.get("api_key_workspace_id")
         if key_workspace_id is not None and key_workspace_id != workspace_id:
             # Uniform 404 — never reveal that the path workspace exists to a

--- a/backend/src/auth/programmatic_workspace_auth.py
+++ b/backend/src/auth/programmatic_workspace_auth.py
@@ -139,7 +139,9 @@ async def authorize_workspace_management(
                 key_workspace_id=str(key_workspace_id),
                 path_workspace_id=str(workspace_id),
             )
-            raise NotFoundException("Workspace not found")
+            # NotFoundException already appends " not found" — pass the bare
+            # resource name, else the detail reads "Workspace not found not found".
+            raise NotFoundException("Workspace")
         member = await perm_service.check_workspace_owner(user_id, workspace_id)
         return AuthorizedPrincipal(kind="api_key", member=member)
 

--- a/backend/src/cli/_env_probe.py
+++ b/backend/src/cli/_env_probe.py
@@ -20,7 +20,10 @@ def probe_self_hosted_available(base_url: str, api_key: str | None, *, timeout: 
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
     req = urllib.request.Request(f"{base_url}/v1/models", method="GET", headers=headers)
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed internal URL
+        # noqa: S310 — base_url is an operator-supplied config value (env/Docker),
+        # not attacker-controlled input; this is a local one-shot bootstrap probe
+        # of the operator's own self-hosted backend.
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
             return resp.status == 200
     except Exception:
         return False

--- a/backend/src/cli/_env_probe.py
+++ b/backend/src/cli/_env_probe.py
@@ -1,0 +1,26 @@
+"""Shared self-hosted backend probe for the CLI bootstrap scripts.
+
+v0.42 review #20: ``setup_env`` and ``create_admin`` both auto-detect a running
+self-hosted OpenAI-compatible backend the same way (bearer header + a GET to
+``/v1/models``). This is the single implementation both call.
+"""
+
+from __future__ import annotations
+
+
+def probe_self_hosted_available(base_url: str, api_key: str | None, *, timeout: int = 3) -> bool:
+    """Return True iff ``{base_url}/v1/models`` answers 200 (Ollama / vLLM).
+
+    Sends the bearer token so a vLLM backend started with ``--api-key`` answers
+    instead of returning 401 (keyless Ollama ignores it). Never raises — any
+    connection error / non-200 means "not available".
+    """
+    import urllib.request
+
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    req = urllib.request.Request(f"{base_url}/v1/models", method="GET", headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 — fixed internal URL
+            return resp.status == 200
+    except Exception:
+        return False

--- a/backend/src/cli/create_admin.py
+++ b/backend/src/cli/create_admin.py
@@ -234,18 +234,10 @@ def _configure_embedding_provider(db: Session, user_id: str, workspace_id) -> st
     self_hosted_key = os.getenv("SELF_HOSTED_API_KEY") or _get_env_from_docker(
         "SELF_HOSTED_API_KEY"
     )
-    try:
-        import urllib.request
+    from cli._env_probe import probe_self_hosted_available
 
-        # Send the bearer token so a vLLM backend started with --api-key
-        # answers the probe instead of returning 401 (keyless Ollama ignores it).
-        headers = {"Authorization": f"Bearer {self_hosted_key}"} if self_hosted_key else {}
-        req = urllib.request.Request(f"{self_hosted_url}/v1/models", method="GET", headers=headers)
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            if resp.status == 200:
-                return "self_hosted"
-    except Exception:
-        pass  # Backend not running or unreachable — expected on most setups
+    if probe_self_hosted_available(self_hosted_url, self_hosted_key):
+        return "self_hosted"
 
     return None
 

--- a/backend/src/cli/setup_env.py
+++ b/backend/src/cli/setup_env.py
@@ -142,23 +142,16 @@ def setup_env():
     has_openai = bool(env.get("OPENAI_API_KEY"))
     self_hosted_url = env.get("SELF_HOSTED_BASE_URL", "http://localhost:11434")
     self_hosted_key = env.get("SELF_HOSTED_API_KEY")
-    try:
-        import urllib.request
+    from cli._env_probe import probe_self_hosted_available
 
-        # Send the bearer token so a vLLM backend started with --api-key
-        # answers the probe instead of returning 401 (keyless Ollama ignores it).
-        headers = {"Authorization": f"Bearer {self_hosted_key}"} if self_hosted_key else {}
-        req = urllib.request.Request(f"{self_hosted_url}/v1/models", method="GET", headers=headers)
-        with urllib.request.urlopen(req, timeout=3) as resp:
-            if resp.status == 200:
-                print(f"✓ Self-hosted backend detected at {self_hosted_url}")
-                if not has_openai:
-                    print("  → You can use your self-hosted backend for embeddings:")
-                    print("    Set EMBEDDING_PROVIDER=self_hosted in .env.local")
-    except Exception:
+    if probe_self_hosted_available(self_hosted_url, self_hosted_key):
+        print(f"✓ Self-hosted backend detected at {self_hosted_url}")
         if not has_openai:
-            print(f"\n⚠ No self-hosted backend at {self_hosted_url} and no OPENAI_API_KEY.")
-            print("  Memory features require one of these. Configure before using remember/recall.")
+            print("  → You can use your self-hosted backend for embeddings:")
+            print("    Set EMBEDDING_PROVIDER=self_hosted in .env.local")
+    elif not has_openai:
+        print(f"\n⚠ No self-hosted backend at {self_hosted_url} and no OPENAI_API_KEY.")
+        print("  Memory features require one of these. Configure before using remember/recall.")
 
     print("\n" + "=" * 50)
     print("✓ Environment setup complete!")

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -304,6 +304,31 @@ class Settings(BaseSettings):
         default="openai",
         description="Embedding model provider (openai/cohere/huggingface/self_hosted)",
     )
+
+    @field_validator("embedding_provider", mode="before")
+    @classmethod
+    def _coerce_legacy_ollama_embedding_provider(cls, v: object) -> object:
+        """Coerce the retired EMBEDDING_PROVIDER=ollama value to 'self_hosted' (#1160).
+
+        The provider key was renamed ollama → self_hosted in a clean cutover,
+        but .env.example documented 'ollama' as valid for many releases. Left
+        verbatim, ``provider == "self_hosted"`` gates all miss and embedding
+        traffic silently routes into the OpenAI client path (500 without a key,
+        or wrong-model calls to api.openai.com with a platform key). Coerce with
+        a boot warning instead of accepting the broken value (mirrors
+        ``_warn_legacy_ollama_env`` for OLLAMA_BASE_URL).
+        """
+        if isinstance(v, str) and v.strip().lower() == "ollama":
+            import warnings
+
+            warnings.warn(
+                "EMBEDDING_PROVIDER=ollama is retired (renamed to 'self_hosted' "
+                "in #1160); coercing to 'self_hosted'. Update your env.",
+                stacklevel=2,
+            )
+            return "self_hosted"
+        return v
+
     embedding_model: str = Field(
         default="text-embedding-3-small", description="Embedding model name"
     )
@@ -386,8 +411,34 @@ class Settings(BaseSettings):
             "reranker_service.DEFAULT_VLLM_RERANK_MODEL."
         ),
     )
+    rerank_api_key: str = Field(
+        default="",
+        description=(
+            "Optional bearer token for the /v1/rerank endpoint (RERANK_BASE_URL) "
+            "when it is served behind auth (e.g. vLLM launched with --api-key). "
+            "Sent as 'Authorization: Bearer ...' by VLLMReranker; empty = no header."
+        ),
+    )
+    self_hosted_rerank_model: str = Field(
+        default="dengcao/Qwen3-Reranker-8B:Q5_K_M",
+        description=(
+            "Default model for the prompt-scoring SelfHostedReranker on "
+            "SELF_HOSTED_BASE_URL (the /v1/completions path, used when "
+            "RERANK_BASE_URL is unset). Defaults to the Ollama-registry id; a "
+            "pure-vLLM self-hosted stack must override it (env "
+            "SELF_HOSTED_RERANK_MODEL) with a model the backend actually serves "
+            "so scoring does not 404 to all-zero relevance. Keep in sync with "
+            "reranker_service.DEFAULT_SELF_HOSTED_RERANK_MODEL."
+        ),
+    )
 
-    @field_validator("rerank_base_url", "rerank_model", mode="before")
+    @field_validator(
+        "rerank_base_url",
+        "rerank_model",
+        "rerank_api_key",
+        "self_hosted_rerank_model",
+        mode="before",
+    )
     @classmethod
     def _strip_rerank_fields(cls, v: object) -> object:
         # rerank_base_url is used as a truthy feature toggle

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -472,15 +472,30 @@ class Settings(BaseSettings):
     enable_byok: bool = Field(
         default=True,
         description=(
-            "Enable the BYOK (bring-your-own-key) surface (#1167). ON by default "
+            "Enable BYOK (bring-your-own-key) PROVISIONING (#1167). ON by default "
             "so OSS / self-hosted keeps external API key management. When false, "
-            "the /external-keys API, the workspace cost dashboard "
-            "(GET /workspaces/{id}/cost-aggregation), and the OpenAI key-status "
-            "probe (GET /workspaces/{id}/openai-key-status) return 404 and the "
-            "web UI hides their nav entries. Key RESOLUTION is untouched: "
-            "keys stored before turning the flag off are still used by the "
-            "LLM/embedding services. Surfaced to the frontend via "
-            "GET /api/v1/system/info features.byok."
+            "the /external-keys WRITE paths (create/update), the workspace cost "
+            "dashboard (GET /workspaces/{id}/cost-aggregation), and the OpenAI "
+            "key-status probe return 404 and the web UI hides their nav entries. "
+            "v0.42 review #32: key MANAGEMENT (list / toggle-off / delete) stays "
+            "reachable so an owner can still disable/delete an already-stored key. "
+            "Key RESOLUTION is also untouched: keys stored before the flag flip "
+            "are still used by the LLM/embedding services (so live embeddings do "
+            "not break) — the customer removes them via the still-open management "
+            "paths. Surfaced to the frontend via GET /api/v1/system/info features.byok."
+        ),
+    )
+    enable_owner_key_member_management: bool = Field(
+        default=True,
+        description=(
+            "v0.42 review #33: gate for owner-API-key member/credential management "
+            "(#1164/#1165 — POST /workspaces/{id}/members, invitations, and "
+            "owner-provisioned member API keys). ON by default preserves the "
+            "shipped behavior. Set false on deployments that do not want an "
+            "owner's ordinary read/write API key to ALSO carry member-management "
+            "power (a stolen owner key would otherwise mint member keys / add "
+            "members); session owners are unaffected. This is a deployment-level "
+            "kill-switch pending per-key scopes."
         ),
     )
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1311,6 +1311,10 @@ class MemberAPIKeyResponse(BaseModel):
     created_at: str
     last_used_at: str | None = None  # Issue #943: "Last used" column
     revoked_at: str | None
+    # Issue #1165: owner-provisioned keys REQUIRE expires_days, so the resulting
+    # expiry must be observable (it was write-only before v0.42). None = never
+    # expires (session self-mint).
+    expires_at: str | None = None
     bound_context_id: str | None = None  # Issue #626: public attribution
 
 

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -255,6 +255,24 @@ class NeuralMemoryConfig:
 
     def __post_init__(self) -> None:
         """Validate configuration parameters."""
+        # #1160 back-compat: 'ollama' was renamed to 'self_hosted' in a clean
+        # cutover. A stale SLEEP_LLM_PROVIDER=ollama env (documented as valid in
+        # v0.41) or an un-migrated neural_config row would otherwise fail EVERY
+        # NeuralMemoryConfig construction here — including the from_env() call
+        # inside from_db(), before the migrated DB value is even applied —
+        # taking down explore/feedback/sleep. Coerce with a boot warning rather
+        # than crash (mirrors settings._warn_legacy_ollama_env for the base-URL).
+        if self.sleep_llm_provider == "ollama":
+            import warnings
+
+            warnings.warn(
+                "SLEEP_LLM_PROVIDER=ollama is retired (renamed to 'self_hosted' "
+                "in #1160); coercing to 'self_hosted'. Update your env / neural "
+                "config to silence this.",
+                stacklevel=2,
+            )
+            self.sleep_llm_provider = "self_hosted"
+
         # Validate ranges
         if not (0.0 <= self.learning_rate <= 1.0):
             raise ValueError(f"learning_rate must be in [0, 1], got {self.learning_rate}")

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -455,35 +455,17 @@ class EmbeddingService:
         if self.provider == "self_hosted":
             # Verify the self-hosted backend is reachable on first use only,
             # via the OpenAI-compatible /v1/models endpoint (served by both
-            # Ollama and vLLM — unlike the bare root, which only Ollama answers).
+            # Ollama and vLLM). Shared with SelfHostedProvider._verify (#18).
             if not self._self_hosted_verified:
-                import httpx
-
-                headers = (
-                    {"Authorization": f"Bearer {self.self_hosted_api_key}"}
-                    if self.self_hosted_api_key
-                    else None
+                from services.llm_providers.self_hosted_provider import (
+                    verify_self_hosted_reachable,
                 )
-                try:
-                    async with httpx.AsyncClient(timeout=5.0) as http:
-                        resp = await http.get(
-                            f"{self.self_hosted_base_url}/v1/models", headers=headers
-                        )
-                        if resp.status_code != 200:
-                            raise ConfigurationError(
-                                f"Self-hosted inference server not responding at "
-                                f"{self.self_hosted_base_url} (HTTP {resp.status_code})"
-                            )
-                except httpx.HTTPError as err:
-                    # Broad httpx.HTTPError (not just ConnectError) so a probe
-                    # timeout / protocol error surfaces as a clean
-                    # ConfigurationError rather than an unhandled 500 — matches
-                    # SelfHostedProvider._verify.
-                    raise ConfigurationError(
-                        f"Cannot connect to self-hosted inference server at "
-                        f"{self.self_hosted_base_url}. Is your backend running? "
-                        "(e.g. `ollama serve`, or a vLLM OpenAI-compatible server)"
-                    ) from err
+
+                await verify_self_hosted_reachable(
+                    self.self_hosted_base_url,
+                    self.self_hosted_api_key,
+                    label="inference server",
+                )
                 self._self_hosted_verified = True
             return AsyncOpenAI(
                 base_url=f"{self.self_hosted_base_url}/v1",

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -879,15 +879,17 @@ class FileStorageService:
         )
         files = list(result.scalars().all())
         released: dict[UUID, int] = {}
+        # Accumulate the workspace_storage_usage delta per workspace and apply it
+        # in ONE upsert per workspace after the loop — a bulk purge otherwise
+        # issued one UPSERT round-trip per uploaded file (v0.42 review #30).
+        usage_delta: dict[UUID, list[int]] = {}  # ws -> [delta_bytes, delta_files]
         now = utcnow()
         for file in files:
             file.deleted_at = now
             if file.status == "uploaded":
-                await self._upsert_workspace_usage(
-                    file.workspace_id,
-                    delta_bytes=-file.size_bytes,
-                    delta_files=-1,
-                )
+                acc = usage_delta.setdefault(file.workspace_id, [0, 0])
+                acc[0] -= file.size_bytes
+                acc[1] -= 1
                 released[file.workspace_id] = released.get(file.workspace_id, 0) + file.size_bytes
             elif file.status == "reserved":
                 # Cancel the in-flight upload (see docstring): failed status
@@ -897,6 +899,10 @@ class FileStorageService:
                 released[file.workspace_id] = released.get(file.workspace_id, 0) + file.size_bytes
             # failed rows: sweeper already released the reservation → soft-delete
             # only, no release (avoids double-releasing the Redis counter).
+        for ws_id, (delta_bytes, delta_files) in usage_delta.items():
+            await self._upsert_workspace_usage(
+                ws_id, delta_bytes=delta_bytes, delta_files=delta_files
+            )
         if files:
             logger.info(
                 "context_bound_files_purged",

--- a/backend/src/services/llm_providers/self_hosted_provider.py
+++ b/backend/src/services/llm_providers/self_hosted_provider.py
@@ -49,6 +49,15 @@ async def verify_self_hosted_reachable(
     try:
         async with httpx.AsyncClient(timeout=5.0) as http:
             resp = await http.get(f"{base_url}/v1/models", headers=headers)
+            if resp.status_code in (401, 403):
+                # The backend IS responding — it rejected auth. Distinguish this
+                # from "not responding" so a missing/wrong SELF_HOSTED_API_KEY is
+                # diagnosable at a glance (Copilot review).
+                raise ConfigurationError(
+                    f"Self-hosted {label} at {base_url} rejected the request "
+                    f"(HTTP {resp.status_code}) — set or check SELF_HOSTED_API_KEY; "
+                    "this backend requires a bearer token (e.g. vLLM --api-key)."
+                )
             if resp.status_code != 200:
                 raise ConfigurationError(
                     f"Self-hosted {label} not responding at {base_url} (HTTP {resp.status_code})"

--- a/backend/src/services/llm_providers/self_hosted_provider.py
+++ b/backend/src/services/llm_providers/self_hosted_provider.py
@@ -29,6 +29,38 @@ _PLACEHOLDER_API_KEY = "not-needed"
 logger = get_logger(__name__)
 
 
+async def verify_self_hosted_reachable(
+    base_url: str, api_key: str | None, *, label: str = "backend"
+) -> None:
+    """Probe ``{base_url}/v1/models`` (Ollama + vLLM); raise if unreachable.
+
+    v0.42 review #18: the one-time liveness check shared by
+    ``SelfHostedProvider._verify`` and ``EmbeddingService._get_client`` — same
+    OpenAI-compatible ``/v1/models`` probe, same bearer-header conditional, same
+    ``httpx.HTTPError → ConfigurationError`` mapping. ``label`` customizes the
+    subject in the error message ("LLM backend" vs "inference server").
+
+    Raises:
+        ConfigurationError: non-200 response, or any httpx transport error.
+    """
+    import httpx
+
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as http:
+            resp = await http.get(f"{base_url}/v1/models", headers=headers)
+            if resp.status_code != 200:
+                raise ConfigurationError(
+                    f"Self-hosted {label} not responding at {base_url} (HTTP {resp.status_code})"
+                )
+    except httpx.HTTPError as err:
+        raise ConfigurationError(
+            f"Cannot connect to self-hosted {label} at {base_url}. "
+            "Is your inference server running? (e.g. `ollama serve`, or a vLLM "
+            "OpenAI-compatible server)"
+        ) from err
+
+
 class SelfHostedProvider(LLMProvider):
     """Self-hosted provider using the OpenAI-compatible API.
 
@@ -82,23 +114,7 @@ class SelfHostedProvider(LLMProvider):
         if self._verified:
             return
 
-        import httpx
-
-        try:
-            async with httpx.AsyncClient(timeout=5.0) as http:
-                resp = await http.get(f"{self._base_url}/v1/models", headers=self._auth_headers())
-                if resp.status_code != 200:
-                    raise ConfigurationError(
-                        f"Self-hosted LLM backend not responding at {self._base_url} "
-                        f"(HTTP {resp.status_code})"
-                    )
-        except httpx.HTTPError as err:
-            raise ConfigurationError(
-                f"Cannot connect to self-hosted LLM backend at {self._base_url}. "
-                "Is your inference server running? (e.g. `ollama serve`, or a vLLM "
-                "OpenAI-compatible server)"
-            ) from err
-
+        await verify_self_hosted_reachable(self._base_url, self._api_key, label="LLM backend")
         self._verified = True
 
     async def complete_json(

--- a/backend/src/services/member_credentials_service.py
+++ b/backend/src/services/member_credentials_service.py
@@ -717,6 +717,7 @@ class MemberCredentialsService:
             "created_at": to_utc_iso(api_key.created_at),
             "last_used_at": to_utc_iso(api_key.last_used_at),
             "revoked_at": to_utc_iso(api_key.revoked_at),
+            "expires_at": to_utc_iso(api_key.expires_at),  # #1165: surface owner-set expiry
             "bound_context_id": (
                 str(api_key.bound_context_id) if api_key.bound_context_id else None
             ),

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -55,6 +55,28 @@ DEFAULT_SELF_HOSTED_RERANK_MODEL = "dengcao/Qwen3-Reranker-8B:Q5_K_M"
 # literals in sync.
 DEFAULT_VLLM_RERANK_MODEL = "qwen3-reranker-0.6b"
 
+# Default model names of the REMOTE reranker providers (Voyage, Cohere). A
+# per-context reranker_model still carrying one of these is a stale default left
+# over from a previous remote provider — on the self-hosted / vLLM path it must
+# be re-resolved to the local model, not sent verbatim. Single source shared by
+# both resolution branches below.
+REMOTE_RERANKER_DEFAULT_MODELS = frozenset(
+    {
+        "rerank-2",
+        "rerank-2-lite",
+        "rerank-2.5",
+        "rerank-2.5-lite",
+        "rerank-multilingual-v3.0",
+        "rerank-english-v3.0",
+    }
+)
+
+
+def _bearer_headers(api_key: str | None) -> dict[str, str] | None:
+    """Authorization header for a self-hosted OpenAI-compatible backend behind
+    auth (vLLM --api-key etc.), or ``None`` for a keyless backend (Ollama)."""
+    return {"Authorization": f"Bearer {api_key}"} if api_key else None
+
 
 class RerankerProvider(ABC):
     """Abstract base class for reranker providers.
@@ -300,7 +322,7 @@ class SelfHostedReranker(RerankerProvider):
 
         scored: list[dict[str, Any]] = []
 
-        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else None
+        headers = _bearer_headers(self.api_key)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             # Score documents concurrently in batches
@@ -420,7 +442,7 @@ class VLLMReranker(RerankerProvider):
         # which never asks for more results than it has documents.
         effective_top_n = min(top_n, len(documents))
 
-        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else None
+        headers = _bearer_headers(self.api_key)
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
@@ -597,18 +619,8 @@ class RerankerService:
                 settings = get_settings()
                 # Avoid non-local default models left over from a previous
                 # remote provider (Voyage / Cohere) — otherwise a stale remote
-                # default model name would be sent to the local reranker. Keep
-                # this in sync with the remote providers' default models
-                # (VoyageReranker "rerank-2.5-lite", CohereReranker
-                # "rerank-multilingual-v3.0") and the _get_reranker_model table.
-                non_self_hosted_defaults = {
-                    "rerank-2",
-                    "rerank-2-lite",
-                    "rerank-2.5",
-                    "rerank-2.5-lite",
-                    "rerank-multilingual-v3.0",
-                    "rerank-english-v3.0",
-                }
+                # default model name would be sent to the local reranker.
+                non_self_hosted_defaults = REMOTE_RERANKER_DEFAULT_MODELS
                 model = ctx_config.reranker_model
                 if settings.rerank_base_url:
                     # Ops-level override: a true cross-encoder is served behind an

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -444,6 +444,12 @@ class VLLMReranker(RerankerProvider):
 
         headers = _bearer_headers(self.api_key)
 
+        # v0.42 review #31: a per-call AsyncClient is deliberate here, not a
+        # cached one. Rerank runs at most one HTTP request per call, so the
+        # client-setup cost is negligible against the network round-trip, and a
+        # module-level shared client would bind to a single event loop — fine in
+        # the app but a cross-loop failure/flake source in tests and worker
+        # forks. The connection-reuse win does not justify that fragility.
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 f"{self.base_url}/v1/rerank",

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -41,9 +41,11 @@ logger = get_logger(__name__)
 # Provider constants (must match external_keys.py for API-key providers)
 RERANKER_PROVIDERS = {"cohere", "voyage"}
 
-# Default self-hosted (Ollama-engine) reranker model. The value is an
-# Ollama-registry model id; a vLLM deployment would set an HF repo id via
-# the context search config's reranker_model.
+# Hard-floor default self-hosted (Ollama-engine) reranker model. This is an
+# Ollama-registry model id, so a pure-vLLM self-hosted stack MUST override it
+# via settings.self_hosted_rerank_model (env SELF_HOSTED_RERANK_MODEL) — the
+# ops-level default that normally supplies this value; this constant is only
+# the fallback when that setting is explicitly blanked. Keep the two in sync.
 DEFAULT_SELF_HOSTED_RERANK_MODEL = "dengcao/Qwen3-Reranker-8B:Q5_K_M"
 
 # Built-in fallback model name served behind settings.rerank_base_url
@@ -368,15 +370,25 @@ class VLLMReranker(RerankerProvider):
 
     provider_name = "vllm"
 
-    def __init__(self, base_url: str, model: str = DEFAULT_VLLM_RERANK_MODEL):
+    def __init__(
+        self,
+        base_url: str,
+        model: str = DEFAULT_VLLM_RERANK_MODEL,
+        api_key: str | None = None,
+    ):
         """Initialize the /v1/rerank client.
 
         Args:
             base_url: Endpoint base URL (e.g. http://gpu:8002); /v1/rerank is appended.
             model: Served model name on the rerank endpoint.
+            api_key: Optional bearer token (RERANK_API_KEY) for a /v1/rerank
+                endpoint served behind auth (e.g. vLLM --api-key). Without it,
+                every request to a secured endpoint 401s and rerank silently
+                falls back to unranked results.
         """
         self.base_url = base_url.rstrip("/")
         self.model = model
+        self.api_key = api_key
 
     async def rerank(
         self,
@@ -408,6 +420,8 @@ class VLLMReranker(RerankerProvider):
         # which never asks for more results than it has documents.
         effective_top_n = min(top_n, len(documents))
 
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else None
+
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
                 f"{self.base_url}/v1/rerank",
@@ -417,6 +431,7 @@ class VLLMReranker(RerankerProvider):
                     "documents": documents,
                     "top_n": effective_top_n,
                 },
+                headers=headers,
             )
             resp.raise_for_status()
             payload = resp.json()
@@ -603,12 +618,33 @@ class RerankerService:
                     # reranker_model wins; otherwise fall back to the ops-level
                     # RERANK_MODEL (settings.rerank_model), then the built-in
                     # default (guards an explicitly-blanked RERANK_MODEL).
-                    if not model or model in non_self_hosted_defaults:
+                    #
+                    # "Stale" on the /v1/rerank endpoint also includes a
+                    # self-hosted /v1/completions default model — an
+                    # Ollama-registry id (the constant default or a configured
+                    # SELF_HOSTED_RERANK_MODEL) that the vLLM/TEI rerank endpoint
+                    # does not serve. The UI persists that id explicitly, so
+                    # without re-resolving it the endpoint 404s and rerank
+                    # silently dies for exactly the contexts this path targets.
+                    vllm_stale_models = non_self_hosted_defaults | {
+                        DEFAULT_SELF_HOSTED_RERANK_MODEL,
+                        settings.self_hosted_rerank_model,
+                    }
+                    if not model or model in vllm_stale_models:
                         model = settings.rerank_model or DEFAULT_VLLM_RERANK_MODEL
                     logger.debug("using_vllm_reranker", user_id=user_id, model=model)
-                    return VLLMReranker(base_url=settings.rerank_base_url, model=model)
+                    return VLLMReranker(
+                        base_url=settings.rerank_base_url,
+                        model=model,
+                        api_key=settings.rerank_api_key or None,
+                    )
+                # Prompt-scoring path on SELF_HOSTED_BASE_URL. Re-resolve only a
+                # stale REMOTE-provider default to the configurable self-hosted
+                # default (SELF_HOSTED_RERANK_MODEL) — which a pure-vLLM stack
+                # must override away from the Ollama-registry id so scoring does
+                # not 404 to all-zero relevance.
                 if not model or model in non_self_hosted_defaults:
-                    model = DEFAULT_SELF_HOSTED_RERANK_MODEL
+                    model = settings.self_hosted_rerank_model or DEFAULT_SELF_HOSTED_RERANK_MODEL
                 logger.debug("using_self_hosted_reranker", user_id=user_id, model=model)
                 return SelfHostedReranker(
                     base_url=settings.self_hosted_base_url,

--- a/backend/tests/api/test_byok_feature_gate.py
+++ b/backend/tests/api/test_byok_feature_gate.py
@@ -1,18 +1,23 @@
 """Tests for the ENABLE_BYOK deployment flag (#1167).
 
-``ENABLE_BYOK=false`` removes the BYOK surface from the deployment:
+``ENABLE_BYOK=false`` disables BYOK PROVISIONING but (v0.42 review #32) keeps
+key MANAGEMENT reachable so a customer can still disable/delete a key that is
+still being resolved (and billed):
 
-- every ``/external-keys`` CRUD endpoint returns 404 (feature-not-present
-  semantics, consistent with plan_page #1145 — 403 would read as a
-  permission problem and leak the feature's existence),
+- the ``/external-keys`` WRITE paths (POST create, PUT update) return 404
+  (feature-not-present semantics, consistent with plan_page #1145 — 403 would
+  read as a permission problem and leak the feature's existence),
+- the ``/external-keys`` MANAGEMENT paths (GET list, PATCH toggle, DELETE)
+  stay available so an owner retains control of already-stored keys; an
+  anonymous caller gets the normal 401 (route present),
 - ``GET /workspaces/{id}/cost-aggregation`` returns 404,
 - ``GET /admin/cost-aggregation`` stays available (platform env-key usage
   still accrues cost the system admin may need to see).
 
-The gate must run BEFORE auth/role dependencies so every caller — anonymous,
-member, owner — sees the same 404 (no role-dependent 403-vs-404 split).
-The anonymous-request tests below pin exactly that ordering: 404 when the
-flag is off, the usual 401 when it is on.
+On the write paths the gate must run BEFORE auth/role dependencies so every
+caller sees the same 404 (no role-dependent 403-vs-404 split). The
+anonymous-request tests below pin exactly that ordering: 404 for writes when
+the flag is off, the usual 401 for management and when the flag is on.
 """
 
 from __future__ import annotations
@@ -46,13 +51,10 @@ def byok_disabled(monkeypatch):
 
 
 class TestExternalKeysGate:
-    def test_list_returns_404_when_disabled(self, client, byok_disabled):
-        # Anonymous on purpose: the feature gate must fire before auth,
-        # so even an unauthenticated caller sees 404 (not 401).
-        response = client.get("/api/v1/external-keys")
-        assert response.status_code == 404
-
+    # --- WRITE paths: 404 before auth when disabled (no existence leak) ---
     def test_create_returns_404_when_disabled(self, client, byok_disabled):
+        # Anonymous on purpose: the write gate must fire before auth,
+        # so even an unauthenticated caller sees 404 (not 401).
         response = client.post(
             "/api/v1/external-keys",
             json={"key_name": "OPENAI_API_KEY", "provider": "openai", "value": "sk-x"},
@@ -63,9 +65,21 @@ class TestExternalKeysGate:
         response = client.put("/api/v1/external-keys/OPENAI_API_KEY", json={"value": "sk-y"})
         assert response.status_code == 404
 
-    def test_delete_returns_404_when_disabled(self, client, byok_disabled):
+    # --- MANAGEMENT paths: reachable when disabled so keys stay controllable
+    # (v0.42 review #32). Anonymous → normal 401 (route present), not 404. ---
+    def test_list_available_when_disabled(self, client, byok_disabled):
+        response = client.get("/api/v1/external-keys")
+        assert response.status_code == 401
+
+    def test_delete_available_when_disabled(self, client, byok_disabled):
         response = client.delete("/api/v1/external-keys/OPENAI_API_KEY")
-        assert response.status_code == 404
+        assert response.status_code == 401
+
+    def test_toggle_available_when_disabled(self, client, byok_disabled):
+        response = client.patch(
+            "/api/v1/external-keys/OPENAI_API_KEY/toggle", json={"enabled": False}
+        )
+        assert response.status_code == 401
 
     def test_routes_exist_when_enabled(self, client):
         # Default (flag on): the route exists, so an anonymous caller gets

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -92,6 +92,7 @@ def _mock_manager(monkeypatch):
     new_key.name = "ci-key"
     new_key.key_prefix = "kagura_abc"
     new_key.created_at = __import__("datetime").datetime(2026, 1, 1)
+    new_key.expires_at = __import__("datetime").datetime(2026, 1, 31)  # #1165: owner-set expiry
     mgr = MagicMock()
     mgr.create_key = AsyncMock(return_value=("kagura_PLAINTEXT", new_key))
     monkeypatch.setattr(mc, "APIKeyManager", lambda db: mgr)
@@ -255,6 +256,11 @@ class TestOwnerProvisionedRevoke:
         # Soft revoke: revoked_at set, row NOT deleted.
         assert api_key.revoked_at is not None
         fake_db.delete.assert_not_called()
+        # v0.42 review #9: zero-knowledge — soft revoke must drop the at-rest
+        # plaintext (sweeper skips revoked rows) and cancel the visibility window.
+        assert api_key.plaintext_encrypted is None
+        assert api_key.visibility_expires_at is None
+        assert api_key.hidden_at is not None
         # A programmatic revoke must leave a forensic AuditLog row (#1164/#1165).
         from models.auth import AuditLog
 
@@ -327,3 +333,54 @@ class TestOwnerProvisionedRevoke:
         assert r.json()["status"] == "revoked"
         assert api_key.revoked_at is not None
         fake_db.delete.assert_not_called()
+
+    def test_already_revoked_row_is_404_not_reprocessed(self, client, owner_gate, monkeypatch):
+        # v0.42 review #6: a soft-revoked (forensic) row must be untouchable — a
+        # repeated programmatic revoke must not overwrite revoked_at or append a
+        # duplicate audit row; uniform 404.
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+
+        import datetime as _dt
+
+        original_revoked_at = _dt.datetime(2026, 1, 1)
+        api_key = MagicMock()
+        api_key.id = 42
+        api_key.workspace_id = _WS
+        api_key.bound_context_id = None
+        api_key.revoked_at = original_revoked_at  # already revoked
+        api_key.key_prefix = "kagura_abc"
+        fake_db = self._fake_db_with_key(api_key)
+
+        async def _get_db():
+            yield fake_db
+
+        app.dependency_overrides[get_db] = _get_db
+
+        r = client.delete(REVOKE_URL)
+        assert r.status_code == 404
+        assert api_key.revoked_at == original_revoked_at  # not overwritten
+        fake_db.delete.assert_not_called()
+        from models.auth import AuditLog
+
+        audit_rows = [
+            c.args[0] for c in fake_db.add.call_args_list if isinstance(c.args[0], AuditLog)
+        ]
+        assert audit_rows == []  # no duplicate forensic row
+
+
+class TestGetMemberCredentialsNonMember:
+    def test_non_member_target_is_404_not_500(self, client, owner_gate, monkeypatch):
+        # v0.42 review #36: get_workspace_role returns None for a removed/mistyped
+        # target; the non-optional target_user_role field must not raise a
+        # ValidationError swallowed into a 500 — return a clean 404.
+        _override(_api_key_owner())
+        from api.routes import member_credentials as mc
+
+        svc = MagicMock()
+        svc.get_or_create_credentials = AsyncMock(return_value={"api_keys": []})
+        svc.get_workspace_role = AsyncMock(return_value=None)  # not a member
+        monkeypatch.setattr(mc, "MemberCredentialsService", lambda db: svc)
+
+        r = client.get(LIST_URL)
+        assert r.status_code == 404, r.text

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -93,6 +93,7 @@ def _mock_manager(monkeypatch):
     new_key.key_prefix = "kagura_abc"
     new_key.created_at = __import__("datetime").datetime(2026, 1, 1)
     new_key.expires_at = __import__("datetime").datetime(2026, 1, 31)  # #1165: owner-set expiry
+    new_key.bound_context_id = None  # owner-provisioned keys never bind a context
     mgr = MagicMock()
     mgr.create_key = AsyncMock(return_value=("kagura_PLAINTEXT", new_key))
     monkeypatch.setattr(mc, "APIKeyManager", lambda db: mgr)

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -303,6 +303,7 @@ class TestVerifyKeyTimingSafeComparison:
             user_id="user-1",
             workspace_id=None,
             bound_context_id=None,
+            key_prefix="kagura_test",
             key_hash=key_hash,
             revoked_at=None,
             expires_at=None,
@@ -347,6 +348,7 @@ class TestVerifyKeyLastUsedThrottle:
             user_id="user-1",
             workspace_id=None,
             bound_context_id=None,
+            key_prefix="kagura_test",
             # Must match sha256_hex of the key passed in _verify() so the
             # #964 constant-time gate accepts the row and the throttle path runs.
             key_hash=sha256_hex("kagura_test"),

--- a/backend/tests/auth/test_programmatic_workspace_auth.py
+++ b/backend/tests/auth/test_programmatic_workspace_auth.py
@@ -75,6 +75,40 @@ class TestApiKeyPrincipal:
         perm.check_workspace_owner.assert_awaited_once_with("u-key", _WS)
         perm.check_workspace_access.assert_not_called()
 
+    async def test_disabled_kill_switch_rejects_api_key(self, perm, monkeypatch):
+        # v0.42 review #33: with the deployment kill-switch off, an owner API key
+        # is denied member management BEFORE any owner lookup.
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "config.settings.get_settings",
+            lambda: SimpleNamespace(enable_owner_key_member_management=False),
+        )
+        with pytest.raises(AuthorizationError):
+            await authorize_workspace_management(
+                _api_key_user(workspace_id=None),
+                _WS,
+                db=None,
+                session_required_role=WorkspaceRole.MEMBER,
+            )
+        perm.check_workspace_owner.assert_not_called()
+
+    async def test_disabled_kill_switch_leaves_session_unaffected(self, perm, monkeypatch):
+        from types import SimpleNamespace
+
+        monkeypatch.setattr(
+            "config.settings.get_settings",
+            lambda: SimpleNamespace(enable_owner_key_member_management=False),
+        )
+        who = await authorize_workspace_management(
+            _session_user(),
+            _WS,
+            db=None,
+            session_required_role=WorkspaceRole.MEMBER,
+        )
+        assert who.kind == "session"
+        perm.check_workspace_access.assert_awaited_once()
+
     async def test_scoped_key_matching_path_owner_check(self, perm):
         await authorize_workspace_management(
             _api_key_user(workspace_id=_WS),

--- a/backend/tests/config/test_rerank_settings.py
+++ b/backend/tests/config/test_rerank_settings.py
@@ -33,6 +33,22 @@ def test_defaults_when_unset(clean_rerank_env):
     assert s.rerank_model == "qwen3-reranker-0.6b"
 
 
+def test_legacy_embedding_provider_ollama_coerced_to_self_hosted(monkeypatch):
+    """v0.42 review #4: the retired EMBEDDING_PROVIDER=ollama value must coerce
+    to 'self_hosted' (with a warning), not be accepted verbatim and route
+    self-hosted embedding traffic into the OpenAI client path."""
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "ollama")
+    with pytest.warns(UserWarning, match="EMBEDDING_PROVIDER=ollama is retired"):
+        s = Settings(_env_file=None)
+    assert s.embedding_provider == "self_hosted"
+
+
+def test_embedding_provider_self_hosted_unchanged(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_PROVIDER", "self_hosted")
+    s = Settings(_env_file=None)
+    assert s.embedding_provider == "self_hosted"
+
+
 def test_whitespace_only_base_url_collapses_to_empty(clean_rerank_env):
     """A whitespace-only RERANK_BASE_URL must NOT enable the vLLM path."""
     clean_rerank_env.setenv("RERANK_BASE_URL", "   ")

--- a/backend/tests/config/test_rerank_settings.py
+++ b/backend/tests/config/test_rerank_settings.py
@@ -49,6 +49,21 @@ def test_embedding_provider_self_hosted_unchanged(monkeypatch):
     assert s.embedding_provider == "self_hosted"
 
 
+def test_rerank_model_defaults_match_reranker_constants(clean_rerank_env):
+    """v0.42 review #25: the rerank default-model literals live in both settings
+    (for env override) and reranker_service (as the hard floor). settings.py
+    can't import reranker_service without a circular dependency, so this test is
+    the single guard that keeps the two in sync instead of a stale comment."""
+    from services.reranker_service import (
+        DEFAULT_SELF_HOSTED_RERANK_MODEL,
+        DEFAULT_VLLM_RERANK_MODEL,
+    )
+
+    s = _fresh_settings()
+    assert s.rerank_model == DEFAULT_VLLM_RERANK_MODEL
+    assert s.self_hosted_rerank_model == DEFAULT_SELF_HOSTED_RERANK_MODEL
+
+
 def test_whitespace_only_base_url_collapses_to_empty(clean_rerank_env):
     """A whitespace-only RERANK_BASE_URL must NOT enable the vLLM path."""
     clean_rerank_env.setenv("RERANK_BASE_URL", "   ")

--- a/backend/tests/eval/_provisioning.py
+++ b/backend/tests/eval/_provisioning.py
@@ -1,0 +1,99 @@
+"""Shared eval-workspace provisioning for the live eval runners.
+
+v0.42 review #19: ``runner.py``, ``placebo_runner.py`` and ``freeze_tau.py`` all
+create an isolated eval Workspace + Context + WorkspaceMember and stamp the
+per-context ContextSearchConfig from settings the same way. This is the single
+implementation; the runners call it, then ingest / measure / teardown.
+
+The raw ORM Context bypasses ContextService.create_context (which normally
+stamps the per-context embedding config and ensures the model-specific Qdrant
+collection). Without an explicit ContextSearchConfig row the lazy create_or_get
+defaults to text-embedding-3-small/512 and ingest routes to a collection that
+does not exist on a non-default embedding rig (e.g. qwen3-embedding:0.6b/1024) —
+so we stamp the config exactly like the production create path. The
+WorkspaceMember row is required because remember()/recall() resolve the context
+via PermissionService, which checks workspace_members (owner_user_id alone is
+NOT a membership).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from auth.workspace_roles import WorkspaceRole
+from config.constants import EMBEDDING_MODEL_REGISTRY
+from config.settings import get_settings
+from models.auth import Context, Workspace, WorkspaceMember
+from models.config import ContextSearchConfig
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def provision_eval_context(
+    db: AsyncSession, *, sleep_mode: str | None = None, embedding_model: str | None = None
+) -> tuple[str, Workspace, Context, str, int]:
+    """Create + commit an isolated eval workspace/context and return handles.
+
+    Args:
+        db: Async session (from the runner's ``async for db in get_db()``).
+        sleep_mode: Optional ``Context.sleep_mode`` (e.g. ``"edges_only"`` for
+            the placebo edge-graph path); left at the model default when None.
+        embedding_model: Optional explicit embedding model to stamp (Day-4
+            factorial arm, #1175). Must be a key of ``EMBEDDING_MODEL_REGISTRY``
+            (callers validate before the stack access). When None, the model is
+            derived from settings — byte-identical to the pre-Day-4 behavior.
+
+    Returns:
+        ``(owner_id, workspace, context, embedding_model, embedding_dimensions)``.
+    """
+    owner = f"eval_{uuid4().hex[:8]}"
+    ws = Workspace(
+        id=uuid4(),
+        name=f"eval-ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner,
+        daily_api_limit=10_000_000,
+        weekly_api_limit=50_000_000,
+    )
+    ctx_kwargs = {
+        "id": uuid4(),
+        "workspace_id": ws.id,
+        "name": f"eval-ctx-{uuid4().hex[:8]}",
+        "created_by": owner,
+        "is_private": False,
+    }
+    if sleep_mode is not None:
+        ctx_kwargs["sleep_mode"] = sleep_mode
+    ctx = Context(**ctx_kwargs)
+
+    db.add(ws)
+    await db.flush()
+    db.add(ctx)
+    db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+
+    # An explicit embedding_model (Day-4 factorial arm) overrides the
+    # settings-derived stamp entirely; None keeps the settings-derived behavior.
+    if embedding_model is not None:
+        emb_model = embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY[emb_model][0]
+    else:
+        settings = get_settings()
+        emb_model = settings.embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+    db.add(
+        ContextSearchConfig(
+            context_id=ctx.id,
+            semantic_weight=0.6,
+            fetch_factor=3,
+            use_rerank=False,
+            reranker_provider="self_hosted",
+            reranker_model="qwen3-reranker-4b",
+            embedding_model=emb_model,
+            embedding_dimensions=emb_dims,
+        )
+    )
+    await db.flush()
+    await db.commit()
+    return owner, ws, ctx, emb_model, emb_dims

--- a/backend/tests/eval/freeze_tau.py
+++ b/backend/tests/eval/freeze_tau.py
@@ -28,7 +28,7 @@ import argparse
 import json
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from tests.eval.placebo import median_cross_topic_gold_pair_cosine
 from tests.eval.runner import _ingest_corpus, _sudachi_version, _teardown
@@ -117,57 +117,17 @@ async def run_freeze_tau(corpus_path: str, write: bool = True) -> dict[str, Any]
 
 async def _measure_tau(corpus: Corpus, gold_pairs: set[frozenset[str]]) -> dict[str, Any]:
     """Provision, ingest, fetch vectors, compute τ, tear down (always)."""
-    from auth.workspace_roles import WorkspaceRole
-    from config.constants import EMBEDDING_MODEL_REGISTRY
-    from config.settings import get_settings
     from db.base import get_db
     from db.qdrant import ensure_kagura_memories_collection, get_collection_name, get_qdrant_client
-    from models.auth import Context, Workspace, WorkspaceMember
-    from models.config import ContextSearchConfig
     from neural.utils import cosine_similarity
     from services.memory_service import MemoryService
     from tasks.neural_calibration import _load_measure_script
+    from tests.eval._provisioning import provision_eval_context
 
     async for db in get_db():
-        owner = f"eval_{uuid4().hex[:8]}"
-        ws = Workspace(
-            id=uuid4(),
-            name=f"eval-ws-{uuid4().hex[:8]}",
-            plan_name="pro",
-            owner_user_id=owner,
-            daily_api_limit=10_000_000,
-            weekly_api_limit=50_000_000,
-        )
-        ctx = Context(
-            id=uuid4(),
-            workspace_id=ws.id,
-            name=f"eval-ctx-{uuid4().hex[:8]}",
-            created_by=owner,
-            is_private=False,
-        )
-        db.add(ws)
-        await db.flush()
-        db.add(ctx)
-        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
-        # Same provisioning as runner.py/placebo_runner.py: stamp the per-context
-        # embedding config so ingest routes to the rig's real collection.
-        settings = get_settings()
-        emb_model = settings.embedding_model
-        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
-        db.add(
-            ContextSearchConfig(
-                context_id=ctx.id,
-                semantic_weight=0.6,
-                fetch_factor=3,
-                use_rerank=False,
-                reranker_provider="self_hosted",
-                reranker_model="qwen3-reranker-4b",
-                embedding_model=emb_model,
-                embedding_dimensions=emb_dims,
-            )
-        )
-        await db.flush()
-        await db.commit()
+        # Shared eval provisioning (#19): stamp the per-context embedding config
+        # so ingest routes to the rig's real collection.
+        owner, ws, ctx, emb_model, emb_dims = await provision_eval_context(db)
 
         svc = MemoryService(db)
         id_map: dict[str, str] = {}

--- a/backend/tests/eval/placebo.py
+++ b/backend/tests/eval/placebo.py
@@ -37,15 +37,17 @@ class Edge:
     edge_type: str
 
 
-def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int = 10) -> list[Edge]:
-    """Maslov-Sneppen directed double-edge-swap null graph.
+def degree_preserving_rewire_with_stats(
+    edges: list[Edge], *, seed: int, swap_factor: int = 10
+) -> tuple[list[Edge], int]:
+    """Maslov-Sneppen rewire, returning ``(rewired_edges, accepted_swaps)``.
 
-    Repeatedly picks two edges (s1->d1),(s2->d2) and swaps their destinations to
-    (s1->d2),(s2->d1) — preserving every node's out-degree (src) and in-degree
-    (dst), the edge count, and each edge's own weight/origin/confidence/edge_type
-    (hence the exact attribute multisets). Rejects any swap that would create a
-    self-loop or a parallel edge. Attempts ``swap_factor * len(edges)`` accepted
-    swaps for mixing. Raises if fewer than two edges (nothing to swap).
+    Same algorithm as :func:`degree_preserving_rewire`; additionally returns the
+    number of ACCEPTED double-edge swaps (``done``), which is NOT the edge count
+    — a run that accepts zero swaps (e.g. a star graph where every swap makes a
+    parallel/self edge) returns the input edges unchanged with a swap count of 0.
+    Callers reporting a "swaps done" metric must use this count, not
+    ``len(rewired)`` (v0.42 review).
     """
     if len(edges) < 2:
         raise ValueError(f"need >= 2 edges to rewire, got {len(edges)}")
@@ -77,7 +79,18 @@ def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int =
         current[i] = replace(e1, dst=e2.dst)
         current[j] = replace(e2, dst=e1.dst)
         done += 1
-    return current
+    return current, done
+
+
+def degree_preserving_rewire(edges: list[Edge], *, seed: int, swap_factor: int = 10) -> list[Edge]:
+    """Maslov-Sneppen directed double-edge-swap null graph (edges only).
+
+    Thin wrapper over :func:`degree_preserving_rewire_with_stats` for callers
+    that only need the rewired edges. Preserves every node's out-degree (src) and
+    in-degree (dst), the edge count, and each edge's own
+    weight/origin/confidence/edge_type. Raises if fewer than two edges.
+    """
+    return degree_preserving_rewire_with_stats(edges, seed=seed, swap_factor=swap_factor)[0]
 
 
 def _derangement(n: int, rng: random.Random) -> list[int]:

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -26,7 +26,7 @@ from uuid import UUID, uuid4
 from tests.eval.compounding import MODE_EXCLUDE_PROBES, build_replay_plan
 from tests.eval.placebo import (
     Edge,
-    degree_preserving_rewire,
+    degree_preserving_rewire_with_stats,
     median_cross_topic_gold_pair_cosine,
     paired_delta_bootstrap,
     permute_gold,
@@ -208,7 +208,12 @@ async def _measure_placebo(svc, db, corpus, plan, id_map, owner, ctx, ws, seeds)
             )
     finally:
         if tau_info.get("seeded"):
-            await _delete_provisional_tau(db, tau_info["model"], tau_info["dimensions"])
+            await _restore_provisional_tau(
+                db,
+                tau_info["model"],
+                tau_info["dimensions"],
+                tau_info.get("prior_calibration"),
+            )
 
     d_rand = sorted(
         b["deltas"]["random_edge"]["delta"] for b in per_seed if b["deltas"].get("random_edge")
@@ -265,8 +270,10 @@ async def _placebo_arms_for_seed(
             )
             for r in snapshot
         ]
-        rewired = degree_preserving_rewire(placebo_edges, seed=seed)
-        rewire_swaps = len(rewired)
+        # Use the accepted-swap count, NOT len(rewired) (== edge count): a run
+        # that accepts zero swaps must be distinguishable from a fully-mixed one
+        # in edge_snapshot.rewire_swaps_done (v0.42 review).
+        rewired, rewire_swaps = degree_preserving_rewire_with_stats(placebo_edges, seed=seed)
         template = {"user_id": owner, "workspace_id": ws.id, "context_id": ctx.id}
         rewired_rows = [
             {
@@ -415,6 +422,15 @@ async def _seed_provisional_tau(db, corpus, plan, id_map, ctx) -> dict[str, Any]
             "cross_topic_gold_pair_count": cross_topic_count,
         }
 
+    # Snapshot any PRE-EXISTING production model-global edge_gate row BEFORE the
+    # upsert clobbers it. _upsert_calibration is a kind-scoped delete-then-insert,
+    # and this (model, dims, context_id IS NULL, kind) key is the exact one the
+    # production calibration subsystem writes — so without capturing it here, the
+    # eval would overwrite live edge-gating during the run and _restore would
+    # delete it outright at teardown, leaving production on the uncalibrated
+    # default until the next recalibration (v0.42 review).
+    prior_calibration = await _snapshot_model_global_edge_gate(db, model_name, dims)
+
     percentiles = script.compute_percentiles([tau] * 128)
     config = await NeuralMemoryConfig.from_db(db)
     now = utcnow()
@@ -433,6 +449,7 @@ async def _seed_provisional_tau(db, corpus, plan, id_map, ctx) -> dict[str, Any]
 
     result: dict[str, Any] = {
         "seeded": True,
+        "prior_calibration": prior_calibration,
         "model": model_name,
         "dimensions": dims,
         "tau_provisional": round(tau, 4),
@@ -451,10 +468,49 @@ async def _seed_provisional_tau(db, corpus, plan, id_map, ctx) -> dict[str, Any]
     return result
 
 
-async def _delete_provisional_tau(db, model_name, dimensions) -> None:
+async def _snapshot_model_global_edge_gate(db, model_name, dimensions) -> dict[str, Any] | None:
+    """Capture the current production model-global edge_gate calibration row (if
+    any) as plain values, so a placebo run can restore it after teardown."""
+    from sqlalchemy import select
+
+    from models.neural import CALIBRATION_KIND_EDGE_GATE, EmbeddingCalibration
+
+    row = (
+        await db.execute(
+            select(EmbeddingCalibration).where(
+                EmbeddingCalibration.model_name == model_name,
+                EmbeddingCalibration.dimensions == dimensions,
+                EmbeddingCalibration.context_id.is_(None),
+                EmbeddingCalibration.kind == CALIBRATION_KIND_EDGE_GATE,
+            )
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return None
+    return {
+        "percentiles": {
+            "p25": row.p25,
+            "p50": row.p50,
+            "p75": row.p75,
+            "p90": row.p90,
+            "p95": row.p95,
+            "p99": row.p99,
+        },
+        "sample_size": row.sample_size,
+        "sampled_at": row.sampled_at,
+        "valid_until": row.valid_until,
+    }
+
+
+async def _restore_provisional_tau(db, model_name, dimensions, prior) -> None:
+    """Delete the placebo edge_gate row and restore the pre-existing production
+    row captured at seed time. Deleting outright (the old behavior) destroyed a
+    real production calibration for (model, dims), silently reverting live
+    edge-gating to the uncalibrated default (v0.42 review)."""
     from sqlalchemy import delete as sa_delete
 
     from models.neural import CALIBRATION_KIND_EDGE_GATE, EmbeddingCalibration
+    from tasks.neural_calibration import _upsert_calibration
 
     await db.execute(
         sa_delete(EmbeddingCalibration).where(
@@ -464,6 +520,20 @@ async def _delete_provisional_tau(db, model_name, dimensions) -> None:
             EmbeddingCalibration.kind == CALIBRATION_KIND_EDGE_GATE,
         )
     )
+    if prior is not None:
+        # Re-insert the original production row verbatim (same percentiles,
+        # sample_size, sampled_at, valid_until) via the canonical upsert.
+        await _upsert_calibration(
+            db,
+            model_name,
+            dimensions,
+            None,
+            kind=CALIBRATION_KIND_EDGE_GATE,
+            percentiles=prior["percentiles"],
+            observations=prior["sample_size"],
+            now=prior["sampled_at"],
+            valid_until=prior["valid_until"],
+        )
     await db.commit()
 
 

--- a/backend/tests/eval/placebo_runner.py
+++ b/backend/tests/eval/placebo_runner.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from tests.eval.compounding import MODE_EXCLUDE_PROBES, build_replay_plan
 from tests.eval.placebo import (
@@ -101,60 +101,17 @@ async def run_placebo_eval(
 async def _run_placebo_mode(corpus: Any, plan: Any, seeds: tuple[int, ...]) -> dict[str, Any]:
     """Provision an isolated workspace, build the warm graph once, run every
     seed's placebo arms off it, tear down."""
-    from auth.workspace_roles import WorkspaceRole
-    from config.constants import EMBEDDING_MODEL_REGISTRY
-    from config.settings import get_settings
     from db.base import get_db
     from db.qdrant import ensure_kagura_memories_collection, get_collection_name
-    from models.auth import Context, Workspace, WorkspaceMember
-    from models.config import ContextSearchConfig
     from services.memory_service import MemoryService
+    from tests.eval._provisioning import provision_eval_context
 
     async for db in get_db():
-        owner = f"eval_{uuid4().hex[:8]}"
-        ws = Workspace(
-            id=uuid4(),
-            name=f"eval-ws-{uuid4().hex[:8]}",
-            plan_name="pro",
-            owner_user_id=owner,
-            daily_api_limit=10_000_000,
-            weekly_api_limit=50_000_000,
+        # Shared eval provisioning (#19); edges_only so the placebo edge-graph
+        # snapshot/rewire path has a co-activation graph to sample.
+        owner, ws, ctx, emb_model, emb_dims = await provision_eval_context(
+            db, sleep_mode="edges_only"
         )
-        ctx = Context(
-            id=uuid4(),
-            workspace_id=ws.id,
-            name=f"eval-ctx-{uuid4().hex[:8]}",
-            created_by=owner,
-            is_private=False,
-            sleep_mode="edges_only",
-        )
-        db.add(ws)
-        await db.flush()
-        db.add(ctx)
-        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
-        # The raw ORM Context bypasses ContextService.create_context, which stamps
-        # the per-context embedding config and ensures the model-specific Qdrant
-        # collection. Without an explicit ContextSearchConfig the lazy create_or_get
-        # defaults to text-embedding-3-small/512 and ingest routes to a collection
-        # that does not exist on a qwen3-embedding:0.6b/1024 rig — stamp it exactly
-        # like the production create path (mirrors runner.py's eval provisioning).
-        settings = get_settings()
-        emb_model = settings.embedding_model
-        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
-        db.add(
-            ContextSearchConfig(
-                context_id=ctx.id,
-                semantic_weight=0.6,
-                fetch_factor=3,
-                use_rerank=False,
-                reranker_provider="self_hosted",
-                reranker_model="qwen3-reranker-4b",
-                embedding_model=emb_model,
-                embedding_dimensions=emb_dims,
-            )
-        )
-        await db.flush()
-        await db.commit()
 
         svc = MemoryService(db)
         id_map: dict[str, str] = {}

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -16,7 +16,7 @@ import os
 from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from tests.eval.metrics import (
     mean_ndcg_at_k,
@@ -288,18 +288,16 @@ async def run_retrieval_eval(
     """
     from config.constants import EMBEDDING_MODEL_REGISTRY
 
+    # Fast-fail on a bad Day-4 factorial arm BEFORE any stack access (#1175);
+    # provision_eval_context trusts a validated model.
     if embedding_model is not None and embedding_model not in EMBEDDING_MODEL_REGISTRY:
         raise ValueError(
             f"unknown embedding_model {embedding_model!r}; valid models are "
             f"{sorted(EMBEDDING_MODEL_REGISTRY)}"
         )
 
-    from auth.workspace_roles import WorkspaceRole
-    from config.settings import get_settings
     from db.base import get_db
     from db.qdrant import ensure_kagura_memories_collection, get_collection_name
-    from models.auth import Context, Workspace, WorkspaceMember
-    from models.config import ContextSearchConfig
     from services.memory_service import MemoryService
     from utils.datetime import utcnow
 
@@ -307,70 +305,15 @@ async def run_retrieval_eval(
     docs_by_id = corpus.docs_by_id
     run_date = run_date or utcnow().strftime("%Y-%m-%d")
 
+    from tests.eval._provisioning import provision_eval_context
+
     async for db in get_db():
-        owner = f"eval_{uuid4().hex[:8]}"
-        ws = Workspace(
-            id=uuid4(),
-            name=f"eval-ws-{uuid4().hex[:8]}",
-            plan_name="pro",
-            owner_user_id=owner,
-            daily_api_limit=10_000_000,
-            weekly_api_limit=50_000_000,
+        # Shared eval provisioning (#19): isolated workspace/context with the
+        # per-context embedding config stamped from settings — unless an explicit
+        # embedding_model is supplied (the Day-4 factorial arm, #1175).
+        owner, ws, ctx, emb_model, emb_dims = await provision_eval_context(
+            db, embedding_model=embedding_model
         )
-        ctx = Context(
-            id=uuid4(),
-            workspace_id=ws.id,
-            name=f"eval-ctx-{uuid4().hex[:8]}",
-            created_by=owner,
-            is_private=False,
-        )
-        db.add(ws)
-        await db.flush()
-        db.add(ctx)
-        # remember()/recall() resolve the context via PermissionService, which
-        # checks workspace_members — owner_user_id alone is NOT a membership, so
-        # without this row get_context raises NotFoundException on first ingest.
-        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
-        # The raw ORM Context above bypasses ContextService.create_context, which
-        # is where the per-context embedding config is stamped from settings and
-        # the model-specific Qdrant collection is ensured. Without an explicit
-        # ContextSearchConfig row, the lazy create_or_get defaults to
-        # text-embedding-3-small/512 and ingest routes to a collection that does
-        # not exist on non-default embedding stacks (e.g. a local
-        # qwen3-embedding:0.6b/1024 rig) — stamp the config and ensure the
-        # collection exactly like the production create path.
-        #
-        # An explicit ``embedding_model`` (Day-4 factorial arm) overrides the
-        # settings-derived stamp entirely; None keeps the byte-identical
-        # pre-Day-4 behavior of deriving it from settings.
-        if embedding_model is not None:
-            emb_model = embedding_model
-            emb_dims = EMBEDDING_MODEL_REGISTRY[emb_model][0]
-        else:
-            settings = get_settings()
-            emb_model = settings.embedding_model
-            emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[
-                0
-            ]
-        # Stamp the full ContextSearchConfig (not just the embedding fields) so
-        # an eval context behaves like a created one if any reranking / weighting
-        # default is ever consulted. Reranker fields target the local self_hosted
-        # rig (qwen3-reranker), keeping the eval path all-local-OSS; inert here
-        # since use_rerank=False.
-        db.add(
-            ContextSearchConfig(
-                context_id=ctx.id,
-                semantic_weight=0.6,
-                fetch_factor=3,
-                use_rerank=False,
-                reranker_provider="self_hosted",
-                reranker_model="qwen3-reranker-4b",
-                embedding_model=emb_model,
-                embedding_dimensions=emb_dims,
-            )
-        )
-        await db.flush()
-        await db.commit()
 
         svc = MemoryService(db)
         # id_map is owned here and populated incrementally by _ingest_corpus, so

--- a/backend/tests/eval/test_placebo.py
+++ b/backend/tests/eval/test_placebo.py
@@ -88,6 +88,23 @@ def test_rewire_returns_pure_star_unchanged():
     assert {(e.src, e.dst) for e in out} == {(e.src, e.dst) for e in star}
 
 
+def test_rewire_with_stats_reports_accepted_swaps_not_edge_count():
+    """v0.42 review #11: the swap count is the accepted-swaps counter, NOT
+    len(rewired) (== edge count). A mixable graph reports > 0 swaps; a pure star
+    (no legal swap exists) reports exactly 0 despite returning all its edges."""
+    from tests.eval.placebo import degree_preserving_rewire_with_stats
+
+    mixable = _edges([("a", "b"), ("b", "c"), ("c", "d"), ("d", "a"), ("a", "c"), ("b", "d")])
+    out, swaps = degree_preserving_rewire_with_stats(mixable, seed=7)
+    assert len(out) == len(mixable)
+    assert swaps > 0
+
+    star = _edges([("h", x) for x in "abcdef"])
+    star_out, star_swaps = degree_preserving_rewire_with_stats(star, seed=1)
+    assert len(star_out) == len(star)
+    assert star_swaps == 0  # zero accepted swaps, NOT the edge count (6)
+
+
 def _probe(qid, seed_doc, companions):
     return ProbeSpec(
         query_id=qid,

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -62,6 +62,20 @@ class TestNeuralMemoryConfig:
         config = NeuralMemoryConfig()
         assert config.gradient_clipping >= 0
 
+    def test_legacy_sleep_llm_provider_ollama_coerced(self):
+        """v0.42 review #3: the retired sleep_llm_provider='ollama' (stale env or
+        un-migrated DB row) must coerce to 'self_hosted' with a warning, not raise
+        and take down every NeuralMemoryConfig construction."""
+        with pytest.warns(UserWarning, match="SLEEP_LLM_PROVIDER=ollama is retired"):
+            config = NeuralMemoryConfig(sleep_llm_provider="ollama")
+        assert config.sleep_llm_provider == "self_hosted"
+
+    def test_sleep_llm_provider_invalid_still_raises(self):
+        """Coercion is scoped to the legacy 'ollama' alias only — a genuinely
+        invalid provider must still raise."""
+        with pytest.raises(ValueError, match="sleep_llm_provider must be"):
+            NeuralMemoryConfig(sleep_llm_provider="bogus")
+
 
 class TestEdgeGateCalibrationConfig:
     """Edge-gate percentile calibration config fields (Issue #982).

--- a/backend/tests/services/test_file_storage_service.py
+++ b/backend/tests/services/test_file_storage_service.py
@@ -902,16 +902,17 @@ class TestPurgeFilesForContexts:
         f2.deleted_at = None
         select_result = MagicMock()
         select_result.scalars.return_value.all.return_value = [f1, f2]
-        # First execute = the SELECT; subsequent = the usage UPSERTs.
-        db.execute.side_effect = [select_result, MagicMock(), MagicMock()]
+        # First execute = the SELECT; then ONE aggregated usage UPSERT for the
+        # workspace (both uploaded rows share it), not one per row (#30).
+        db.execute.side_effect = [select_result, MagicMock()]
 
         released = await service.purge_files_for_contexts([ctx_id])
 
         assert f1.deleted_at is not None
         assert f2.deleted_at is not None
         assert released == {workspace_id: 350}
-        # SELECT + one usage UPSERT per uploaded row; the caller owns commit.
-        assert db.execute.await_count == 3
+        # SELECT + a single per-workspace usage UPSERT; the caller owns commit.
+        assert db.execute.await_count == 2
         db.commit.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/backend/tests/services/test_member_credentials_service.py
+++ b/backend/tests/services/test_member_credentials_service.py
@@ -141,6 +141,7 @@ class TestSerializeApiKeyLastUsed:
             visibility_expires_at=None,
             created_at=datetime(2026, 1, 1, 12, 0, 0),
             revoked_at=None,
+            expires_at=None,
             last_used_at=last_used_at,
             bound_context_id=None,
         )

--- a/backend/tests/services/test_reranker_service_coverage.py
+++ b/backend/tests/services/test_reranker_service_coverage.py
@@ -570,6 +570,7 @@ class TestRerankerServiceOllamaContextConfig:
         settings = MagicMock()
         settings.self_hosted_base_url = "http://ollama:11434"
         settings.self_hosted_api_key = ""
+        settings.self_hosted_rerank_model = DEFAULT_SELF_HOSTED_RERANK_MODEL
         settings.rerank_base_url = ""  # not set → SelfHostedReranker, not the vLLM path
         monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
 
@@ -587,6 +588,7 @@ class TestRerankerServiceOllamaContextConfig:
         settings = MagicMock()
         settings.self_hosted_base_url = "http://ollama:11434"
         settings.self_hosted_api_key = ""
+        settings.self_hosted_rerank_model = DEFAULT_SELF_HOSTED_RERANK_MODEL
         settings.rerank_base_url = ""  # not set → SelfHostedReranker, not the vLLM path
         monkeypatch.setattr("config.settings.get_settings", lambda: settings, raising=True)
 

--- a/backend/tests/services/test_vllm_reranker.py
+++ b/backend/tests/services/test_vllm_reranker.py
@@ -95,6 +95,35 @@ class TestVLLMReranker:
         assert out[0] == {"index": 1, "relevance_score": 0.9}
         assert out[1] == {"index": 0, "relevance_score": 0.2}
 
+    async def test_sends_bearer_auth_header_when_api_key_set(self, monkeypatch):
+        """v0.42 review #13: a /v1/rerank endpoint behind auth (vLLM --api-key,
+        RERANK_API_KEY) must receive an Authorization header, else it 401s and
+        reranking silently disables deployment-wide."""
+        seen: dict = {}
+
+        async def fake_post(self, url, json=None, headers=None, **kwargs):
+            seen["headers"] = headers
+            return _FakeHttpResponse(json_data={"results": [{"index": 0, "relevance_score": 0.5}]})
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002", model="m", api_key="secret-token")
+        await r.rerank("q", ["a"], top_n=1)
+        assert seen["headers"] == {"Authorization": "Bearer secret-token"}
+
+    async def test_no_auth_header_when_api_key_absent(self, monkeypatch):
+        seen: dict = {}
+
+        async def fake_post(self, url, json=None, headers=None, **kwargs):
+            seen["headers"] = headers
+            return _FakeHttpResponse(json_data={"results": [{"index": 0, "relevance_score": 0.5}]})
+
+        monkeypatch.setattr(httpx.AsyncClient, "post", fake_post, raising=True)
+
+        r = VLLMReranker(base_url="http://gpu:8002", model="m")  # no api_key
+        await r.rerank("q", ["a"], top_n=1)
+        assert seen["headers"] is None
+
     async def test_top_n_truncates_after_sort(self, monkeypatch):
         async def fake_post(self, url, json=None, **kwargs):
             return _FakeHttpResponse(

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -221,7 +221,6 @@ export default function ContextsPage() {
 
   useEffect(() => {
     fetchContexts();
-    checkApiKey();
     // Fetch available embedding models
     getEmbeddingModels()
       .then((resp) => {
@@ -229,7 +228,16 @@ export default function ContextsPage() {
         setDefaultEmbeddingModel(resp.default_model);
       })
       .catch(() => {}); // Non-critical: selector won't show
-  }, [fetchContexts, checkApiKey]);
+  }, [fetchContexts]);
+
+  // v0.42 review #38: the key-status probe legitimately re-runs once the byok
+  // flag resolves (checkApiKey depends on byokEnabled). Kept in its OWN effect
+  // so that late flag resolution does not re-fire fetchContexts /
+  // getEmbeddingModels above — which double-fetched contexts + models and
+  // re-flashed the loading skeleton on every first visit.
+  useEffect(() => {
+    checkApiKey();
+  }, [checkApiKey]);
 
   // Redirect ?edit=<id> to settings page (Issue #96: edit modal removed)
   const editHandled = useRef(false);

--- a/frontend/src/app/(authenticated)/workspace/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.tsx
@@ -23,11 +23,11 @@
 
 import { useCallback } from "react";
 import { useTranslations } from "next-intl";
+import { FeatureDisabledNotice } from "@/components/common/FeatureDisabledNotice";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { SpinnerLoading } from "@/components/common/LoadingState";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   CostDashboard,
   type CostDashboardFetchParams,
@@ -70,12 +70,10 @@ export default function WorkspaceCostPage() {
   }
   if (!systemFeatures.byok) {
     return (
-      <PageContainer>
-        <PageHeader title={t("title")} />
-        <Alert>
-          <AlertDescription>{t("featureDisabled")}</AlertDescription>
-        </Alert>
-      </PageContainer>
+      <FeatureDisabledNotice
+        title={t("title")}
+        message={t("featureDisabled")}
+      />
     );
   }
 

--- a/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.test.tsx
@@ -68,17 +68,28 @@ describe("ExternalKeysPage BYOK gate (#1167)", () => {
     expect(screen.queryByText("featureDisabled")).toBeNull();
   });
 
-  it("renders the not-available notice and never fetches when byok is off", async () => {
+  it("keeps a management console (fetches + no full block) when byok is off", async () => {
+    // v0.42 review #32: BYOK-off gates only provisioning — an owner keeps a
+    // list + disable/delete console for already-stored keys, with a
+    // provisioning-disabled banner instead of the whole-page block.
     mockFeatures = { byok: false };
     render(<ExternalKeysPage />);
-    expect(screen.getByText("featureDisabled")).toBeInTheDocument();
-    expect(mockListKeys).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockListKeys).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByText("provisioningDisabled")).toBeInTheDocument(),
+    );
+    expect(screen.queryByText("featureDisabled")).toBeNull();
+    // The create affordance is hidden; the empty-state "add first key" is gone.
+    expect(screen.queryByText("addApiKey")).toBeNull();
   });
 
-  it("holds fetches while feature flags load", () => {
+  it("shows a loading skeleton (no notice) while feature flags load", () => {
+    // v0.42 review #32: the key list (GET) is byok-independent, so it may fetch
+    // during the flag-loading window; while systemFeatures is null the page
+    // renders the skeleton and shows neither the disabled nor provisioning notice.
     mockFeatures = null;
     render(<ExternalKeysPage />);
-    expect(mockListKeys).not.toHaveBeenCalled();
     expect(screen.queryByText("featureDisabled")).toBeNull();
+    expect(screen.queryByText("provisioningDisabled")).toBeNull();
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
@@ -13,7 +13,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { FeatureDisabledNotice } from "@/components/common/FeatureDisabledNotice";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { FeatureGuide } from "@/components/common/FeatureGuide";
@@ -201,16 +200,17 @@ export default function ExternalKeysPage() {
   }, [currentWorkspace, router]);
 
   useEffect(() => {
-    // Re-fetch when context or workspace changes
-    // Workspace-scoped keys are shown for all contexts in the workspace
-    // Context-scoped keys are shown for specific context only
-    // Issue #213: contextId can be null (user may not have context yet)
-    // Issue #1167: don't fetch until the byok flag resolves enabled — when
-    // BYOK is off the page short-circuits to a notice and the API 404s.
-    if (currentWorkspaceId !== null && byokEnabled) {
+    // Re-fetch when context or workspace changes.
+    // Issue #213: contextId can be null (user may not have context yet).
+    // v0.42 review #32: fetch regardless of the byok flag — GET /external-keys
+    // (list) stays reachable when BYOK provisioning is off, so an owner can
+    // still see and delete/disable already-stored keys. Only create/update are
+    // gated (see byokEnabled below). The page already redirects non-owners, so
+    // the owner-only list call always succeeds here.
+    if (currentWorkspaceId !== null) {
       loadKeys();
     }
-  }, [contextId, currentWorkspaceId, byokEnabled]);
+  }, [contextId, currentWorkspaceId]);
 
   const loadKeys = async () => {
     try {
@@ -357,24 +357,17 @@ export default function ExternalKeysPage() {
     setEditDialogOpen(true);
   };
 
-  // Issue #1167: the page is gated behind the backend ENABLE_BYOK flag. Wait
-  // for it, then render a "not available" notice when it's off (the sidebar
-  // entry is hidden too, so this only fires on direct navigation).
+  // Issue #1167: wait for the feature flags before deciding whether to show the
+  // create affordances (byokEnabled). v0.42 review #32: when BYOK provisioning
+  // is OFF we do NOT block the whole page — an owner keeps a management console
+  // (list + disable + delete) for already-stored keys, only the create/update
+  // affordances are hidden (see byokEnabled gates in the render below).
   if (systemFeatures === null) {
     return (
       <PageContainer>
         <PageHeader title={t("title")} description={t("description")} />
         <LoadingState lines={3} />
       </PageContainer>
-    );
-  }
-  if (!systemFeatures.byok) {
-    return (
-      <FeatureDisabledNotice
-        title={t("title")}
-        description={t("description")}
-        message={t("featureDisabled")}
-      />
     );
   }
 
@@ -402,44 +395,54 @@ export default function ExternalKeysPage() {
               )}
               {t("refresh")}
             </Button>
-            {/* Issue #169: Dropdown for API Key creation */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="lg"
-                  className="bg-gradient-to-r from-brand-green-600 to-emerald-600 text-white shadow-lg hover:from-brand-green-700 hover:to-emerald-700"
-                >
-                  <Plus className="mr-2 h-5 w-5" />
-                  {t("addApiKey")}
-                  <ChevronDown className="ml-2 h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-64">
-                {availableProviders.length === 0 ? (
-                  <div className="px-2 py-3 text-sm text-muted-foreground text-center">
-                    {t("allProvidersConfigured")}
-                  </div>
-                ) : (
-                  availableProviders.map((provider) => (
-                    <DropdownMenuItem
-                      key={provider.value}
-                      onClick={() => handleQuickAdd(provider)}
-                    >
-                      <span className="mr-3 text-lg">{provider.icon}</span>
-                      <div>
-                        <div className="font-medium">{provider.label}</div>
-                        <div className="text-xs text-muted-foreground">
-                          {provider.description}
+            {/* Issue #169: Dropdown for API Key creation. Hidden when BYOK
+                provisioning is off (#32): create/update are gated, but the list
+                below stays manageable. */}
+            {byokEnabled && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="lg"
+                    className="bg-gradient-to-r from-brand-green-600 to-emerald-600 text-white shadow-lg hover:from-brand-green-700 hover:to-emerald-700"
+                  >
+                    <Plus className="mr-2 h-5 w-5" />
+                    {t("addApiKey")}
+                    <ChevronDown className="ml-2 h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-64">
+                  {availableProviders.length === 0 ? (
+                    <div className="px-2 py-3 text-sm text-muted-foreground text-center">
+                      {t("allProvidersConfigured")}
+                    </div>
+                  ) : (
+                    availableProviders.map((provider) => (
+                      <DropdownMenuItem
+                        key={provider.value}
+                        onClick={() => handleQuickAdd(provider)}
+                      >
+                        <span className="mr-3 text-lg">{provider.icon}</span>
+                        <div>
+                          <div className="font-medium">{provider.label}</div>
+                          <div className="text-xs text-muted-foreground">
+                            {provider.description}
+                          </div>
                         </div>
-                      </div>
-                    </DropdownMenuItem>
-                  ))
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
+                      </DropdownMenuItem>
+                    ))
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         }
       />
+
+      {!byokEnabled && (
+        <Alert>
+          <AlertDescription>{t("provisioningDisabled")}</AlertDescription>
+        </Alert>
+      )}
 
       <FeatureGuide storageKey="external-keys" title={t("featureGuide.title")}>
         <p>{t("featureGuide.overview")}</p>
@@ -496,10 +499,12 @@ export default function ExternalKeysPage() {
             <div className="text-center py-12">
               <Key className="h-12 w-12 text-gray-400 mx-auto mb-4" />
               <p className="text-gray-600 mb-4">{t("noKeysYet")}</p>
-              <Button onClick={() => setCreateDialogOpen(true)}>
-                <Plus className="h-4 w-4 mr-2" />
-                {t("addFirstKey")}
-              </Button>
+              {byokEnabled && (
+                <Button onClick={() => setCreateDialogOpen(true)}>
+                  <Plus className="h-4 w-4 mr-2" />
+                  {t("addFirstKey")}
+                </Button>
+              )}
             </div>
           ) : (
             <Table>
@@ -548,13 +553,17 @@ export default function ExternalKeysPage() {
                               : t("toggleEnabled")
                           }
                         />
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => openEditDialog(key)}
-                        >
-                          <Edit className="h-4 w-4" />
-                        </Button>
+                        {/* Edit performs an update (PUT), gated with provisioning
+                            (#32). Toggle + delete stay available when BYOK off. */}
+                        {byokEnabled && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => openEditDialog(key)}
+                          >
+                            <Edit className="h-4 w-4" />
+                          </Button>
+                        )}
                         {key.key_name !== "OPENAI_API_KEY" ? (
                           <Button
                             variant="ghost"

--- a/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { FeatureDisabledNotice } from "@/components/common/FeatureDisabledNotice";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { FeatureGuide } from "@/components/common/FeatureGuide";
@@ -369,12 +370,11 @@ export default function ExternalKeysPage() {
   }
   if (!systemFeatures.byok) {
     return (
-      <PageContainer>
-        <PageHeader title={t("title")} description={t("description")} />
-        <Alert>
-          <AlertDescription>{t("featureDisabled")}</AlertDescription>
-        </Alert>
-      </PageContainer>
+      <FeatureDisabledNotice
+        title={t("title")}
+        description={t("description")}
+        message={t("featureDisabled")}
+      />
     );
   }
 

--- a/frontend/src/components/common/FeatureDisabledNotice.tsx
+++ b/frontend/src/components/common/FeatureDisabledNotice.tsx
@@ -1,0 +1,31 @@
+import { PageContainer } from "@/components/common/PageContainer";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+/**
+ * Notice shown when a deployment feature flag (e.g. `byok`) is off and the user
+ * reached a gated page by direct navigation (the sidebar entry is hidden).
+ *
+ * v0.42 review #22: extracts the PageContainer + PageHeader + Alert boilerplate
+ * that the external-keys and cost dashboards hand-rolled identically. The
+ * loading states stay page-specific (skeleton vs spinner) per the shape-driven
+ * LoadingState rule, so only this disabled notice is shared.
+ */
+export function FeatureDisabledNotice({
+  title,
+  description,
+  message,
+}: {
+  title: string;
+  description?: string;
+  message: string;
+}) {
+  return (
+    <PageContainer>
+      <PageHeader title={title} description={description} />
+      <Alert>
+        <AlertDescription>{message}</AlertDescription>
+      </Alert>
+    </PageContainer>
+  );
+}

--- a/frontend/src/components/contexts/SearchSettingsSection.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.tsx
@@ -274,8 +274,16 @@ export function SearchSettingsSection({
   const hasCohereKey = externalKeys.some(
     (k) => k.provider.toLowerCase() === "cohere" && k.enabled,
   );
+  // Issue #1167 / v0.42 review #0: when BYOK is off the /external-keys API 404s,
+  // so we cannot enumerate voyage/cohere keys — but the backend STILL resolves
+  // any key stored before the flag was turned off. Treating the providers as
+  // "unavailable" on that uncertainty wrongly disabled Save (and even the "turn
+  // rerank off" control) for a context using a stored key. Only assert
+  // external-key availability when we could actually check it (BYOK enabled);
+  // self_hosted availability is independent (telemetry-derived).
+  const externalKeysKnown = byokEnabled;
   const hasAnyRerankerAvailable =
-    hasVoyageKey || hasCohereKey || selfHostedAvailable;
+    !externalKeysKnown || hasVoyageKey || hasCohereKey || selfHostedAvailable;
 
   const currentProvider = getCurrentValue("reranker_provider");
   const availableModels =
@@ -286,8 +294,8 @@ export function SearchSettingsSection({
         : COHERE_MODELS;
 
   const selectedProviderUnavailable =
-    (currentProvider === "voyage" && !hasVoyageKey) ||
-    (currentProvider === "cohere" && !hasCohereKey) ||
+    (externalKeysKnown && currentProvider === "voyage" && !hasVoyageKey) ||
+    (externalKeysKnown && currentProvider === "cohere" && !hasCohereKey) ||
     (currentProvider === "self_hosted" && !selfHostedAvailable);
 
   const useRerank = getCurrentValue("use_rerank");

--- a/frontend/src/components/contexts/SearchSettingsSection.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.tsx
@@ -111,6 +111,12 @@ export function SearchSettingsSection({
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [externalKeys, setExternalKeys] = useState<ExternalAPIKey[]>([]);
+  // Whether the external-keys list actually loaded. GET /external-keys is
+  // workspace-owner-only, so it 403s for a non-owner editing this config even
+  // when BYOK is on — in which case we must NOT assert a provider is
+  // unavailable (Copilot review). Only a successful load makes key presence
+  // "known".
+  const [externalKeysLoaded, setExternalKeysLoaded] = useState(false);
   const [selfHostedAvailable, setSelfHostedAvailable] = useState(false);
   const { toast } = useToast();
   const { currentWorkspace } = useWorkspace();
@@ -126,8 +132,11 @@ export function SearchSettingsSection({
     try {
       const keys = await listExternalAPIKeys();
       setExternalKeys(keys.filter((k) => k.enabled));
+      setExternalKeysLoaded(true);
     } catch {
+      // 403 (non-owner) / 404 (BYOK off) / network — key presence stays unknown.
       setExternalKeys([]);
+      setExternalKeysLoaded(false);
     }
   }, []);
 
@@ -274,14 +283,14 @@ export function SearchSettingsSection({
   const hasCohereKey = externalKeys.some(
     (k) => k.provider.toLowerCase() === "cohere" && k.enabled,
   );
-  // Issue #1167 / v0.42 review #0: when BYOK is off the /external-keys API 404s,
-  // so we cannot enumerate voyage/cohere keys — but the backend STILL resolves
-  // any key stored before the flag was turned off. Treating the providers as
-  // "unavailable" on that uncertainty wrongly disabled Save (and even the "turn
-  // rerank off" control) for a context using a stored key. Only assert
-  // external-key availability when we could actually check it (BYOK enabled);
-  // self_hosted availability is independent (telemetry-derived).
-  const externalKeysKnown = byokEnabled;
+  // Issue #1167 / v0.42 review #0: we can only assert a voyage/cohere provider
+  // is "unavailable" when the external-keys list actually loaded. It does NOT
+  // load when BYOK is off (API 404s) OR for a non-owner editing this config
+  // (GET /external-keys is owner-only → 403) — in both cases the backend may
+  // still resolve a stored key, so treating the provider as unavailable would
+  // wrongly disable Save (and the "turn rerank off" control). self_hosted
+  // availability is independent (telemetry-derived).
+  const externalKeysKnown = externalKeysLoaded;
   const hasAnyRerankerAvailable =
     !externalKeysKnown || hasVoyageKey || hasCohereKey || selfHostedAvailable;
 

--- a/frontend/src/hooks/useSystemFeatures.ts
+++ b/frontend/src/hooks/useSystemFeatures.ts
@@ -16,8 +16,36 @@ import { getSystemInfo } from "@/lib/api/system";
 
 type Features = Record<string, boolean>;
 
+// Retry a transient /system/info blip before falling back. A single failed
+// fetch used to resolve to {} (everything default-OFF), which is wrong for
+// DEFAULT-ON flags like `byok`: a momentary outage would hide the console /
+// render a definitive "not enabled" notice for a feature that is actually on
+// (v0.42 review #7/#12). Retrying keeps the hook in the `null` (loading) state
+// so callers show a loader, not a terminal disabled state, until the flag is
+// truly known.
+const MAX_ATTEMPTS = 3;
+const RETRY_BASE_MS = 500;
+
 let cache: Features | null = null;
 let inflight: Promise<Features> | null = null;
+
+async function fetchFeaturesWithRetry(): Promise<Features> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      const info = await getSystemInfo();
+      return info.features ?? {};
+    } catch (e) {
+      lastError = e;
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, RETRY_BASE_MS * attempt),
+        );
+      }
+    }
+  }
+  throw lastError;
+}
 
 export function useSystemFeatures(): Features | null {
   const [features, setFeatures] = useState<Features | null>(cache);
@@ -28,15 +56,15 @@ export function useSystemFeatures(): Features | null {
       return;
     }
     if (!inflight) {
-      inflight = getSystemInfo()
-        .then((info) => {
-          cache = info.features ?? {};
+      inflight = fetchFeaturesWithRetry()
+        .then((f) => {
+          cache = f;
           return cache;
         })
         .catch((e) => {
-          // Fetch failure → treat as no features (everything default-off, fail
-          // closed). Surface it in dev so a /system/info outage isn't silently
-          // invisible. Don't cache, so a later component mount can retry.
+          // Persistent failure after retries → fail closed (default-off).
+          // Surface it in dev so a real /system/info outage isn't silently
+          // invisible. Don't cache, so a later component mount retries.
           if (process.env.NODE_ENV === "development") {
             // eslint-disable-next-line no-console
             console.error("useSystemFeatures: /system/info fetch failed", e);

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2198,6 +2198,7 @@
     "title": "External API Keys",
     "description": "Manage your API keys for OpenAI, Anthropic, Gemini, Self-hosted, Cohere, Voyage, and other services",
     "featureDisabled": "External API keys (BYOK) are not enabled on this deployment.",
+    "provisioningDisabled": "Adding new API keys is disabled on this deployment. You can still disable or delete existing keys below.",
     "featureGuide": {
       "title": "What are External API Keys?",
       "overview": "External API Keys are workspace-scoped and let you configure third-party service credentials (OpenAI, Anthropic, Google Gemini, Self-hosted, Cohere, Voyage). LLM completions are supported by OpenAI, Anthropic, Gemini, and Self-hosted. Embedding generation is supported by OpenAI. Reranking is supported by Cohere and Voyage.",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2198,6 +2198,7 @@
     "title": "外部APIキー",
     "description": "OpenAI、Anthropic、Google Gemini、セルフホスト、Cohere、Voyageなどのサービス用APIキーを管理",
     "featureDisabled": "この環境では外部APIキー（BYOK）が有効化されていません。",
+    "provisioningDisabled": "この環境では新しいAPIキーの追加が無効化されています。既存のキーの無効化・削除は引き続き可能です。",
     "featureGuide": {
       "title": "外部APIキーとは？",
       "overview": "外部APIキーはワークスペース単位で管理され、OpenAI、Anthropic、Google Gemini、セルフホスト、Cohere、Voyageなどの認証情報を設定できます。LLM推論はOpenAI・Anthropic・Gemini・セルフホストで利用可能。エンベディング生成はOpenAIで利用可能。リランキングはCohere・Voyageで利用可能です。",


### PR DESCRIPTION
## Summary

Resolves **all findings** from the v0.42.0 max code-review (range `v0.41.0..main`, 39 CONFIRMED). Includes a **release blocker**: every API-key-authenticated request 500s on `main`. 15 commits, ~40 files; correctness fixes, three design-level fixes, the reuse/simplify/efficiency cleanups, and the conventions doc fix — each with tests.

## Blocker
**`VerifiedKey.key_prefix`** — `dependencies.py` reads `result.key_prefix` (added for #1164 audit attribution), but `VerifiedKey` never carried it → `AttributeError` → **HTTP 500 on every REST + remote-MCP request authenticated with an API key**. Route tests missed it by stubbing the auth dependency with plain dicts. Must land before tagging v0.42.0.

## Correctness / security
- **ollama→self_hosted (#1160):** `SLEEP_LLM_PROVIDER=ollama` crashed *every* `NeuralMemoryConfig`; `EMBEDDING_PROVIDER=ollama` silently routed to OpenAI — both coerced to `self_hosted` with a boot warning.
- **Reranker (#1161):** self-hosted default model is an Ollama id that 404s on vLLM (added `SELF_HOSTED_RERANK_MODEL` + re-resolution on the `/v1/rerank` path); `VLLMReranker` sent no auth (added `RERANK_API_KEY`); telemetry now accounts for `RERANK_BASE_URL`.
- **Member credentials (#1165):** soft-revoke now drops the at-rest plaintext (sweeper skips revoked rows — was Fernet-decryptable forever); an already-revoked forensic row is 404 for any further delete/revoke (a member could hard-delete the evidence; a repeated revoke duplicated the audit row); non-member target → 404 not 500; `expires_at` is now surfaced; fail-closed principal guards.
- **Admin/auth:** `delete_user` file-purge race (private-file widening) closed; the `#963` confinement's doubled `"not found not found"` message fixed.
- **BYOK UI robustness (#1167):** `useSystemFeatures` retries transient `/system/info` blips (was fail-closing a default-on flag); `SearchSettingsSection` no longer blocks Save when BYOK-off hides key enumeration; contexts page double-fetch fixed.
- **Eval (placebo):** production `edge_gate` calibration snapshotted + restored (was clobbered during the run); rewire-swap metric counts accepted swaps, not edges.

## Design-level findings
- **#32 — BYOK depth:** `ENABLE_BYOK` now gates only the `/external-keys` **write** paths; list/toggle-off/delete stay reachable so a customer can disable/delete a key that is still being resolved and billed (the write gate runs before auth → no existence leak). Resolution stays untouched so live embeddings don't break on a flag flip.
- **#33 — owner-key scope:** added `enable_owner_key_member_management` (default on). When off, an owner's ordinary API key no longer carries member-management power — a deployment kill-switch for the stolen-owner-key hazard, pending per-key scopes.
- **#35 — `/system/info` auth:** the endpoint is test-enforced public and exposes only version + non-sensitive flags, so the code is correct-by-design; `security.md`'s auth allowlist now lists it (the omission was the actual conventions gap).

## Cleanup (reuse / simplify / efficiency, #17–#31)
All applied: `apply_zero_knowledge_hide` / `_minted_key_response` / `_reject_oauth` (member-credentials); `_bearer_headers` + `REMOTE_RERANKER_DEFAULT_MODELS` (reranker); module-level `_fetch_v1_models` (system, both consumers); `_reject_programmatic_owner_assignment` (workspaces); per-workspace usage upsert aggregation (file-storage); `verify_self_hosted_reachable` (provider + embedding); `cli/_env_probe` (both CLIs); shared `provision_eval_context` (3 eval runners); `FeatureDisabledNotice` (both BYOK pages); a drift-guard test for the rerank-default literals (#25); the `soft_revoke` alias dropped (#29). #31 (per-call reranker httpx client) is documented as deliberate — a shared client would bind to one event loop and flake across test loops for a negligible single-request gain.

## Testing
- Backend: **355 tests** across auth / member-credentials / reranker / config / neural / eval / file-storage / cli / provider suites + the `account_erasure` integration test; `ruff` + `pyright` clean on all 18 changed source files.
- Frontend: **33 tests** across the BYOK consumer pages; `tsc --noEmit` clean.
- Added regression tests for each correctness fix (key_prefix, soft-revoke plaintext, forensic-404, non-member-404, vLLM auth header, ollama coercion, rewire-swap metric, BYOK write-gate split, owner-key kill-switch, rerank-default drift-guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)