### PR TITLE
style(eval): explicit raise on _resolve_inferential's last path (PR #1177 code-quality feedback)

### DIFF
--- a/backend/tests/eval/day4_analysis.py
+++ b/backend/tests/eval/day4_analysis.py
@@ -153,10 +153,12 @@ def _resolve_inferential(
     run0 = [r for r in group if r["label"].endswith("-run0")]
     if len(run0) == 1:
         return run0[0]
-    _fatal(
-        f"embedding_model {embedding_model!r}: could not resolve an inferential run "
-        f"(no run labeled {inferential_run!r}, and {len(run0)} run(s) end with '-run0'; "
-        "need exactly 1 candidate)"
+    # Explicit raise (not _fatal) so static analysis sees every path of this
+    # value-returning function terminate explicitly (PR #1177 CodeQL feedback).
+    raise SystemExit(
+        f"day4_analysis: embedding_model {embedding_model!r}: could not resolve an "
+        f"inferential run (no run labeled {inferential_run!r}, and {len(run0)} run(s) "
+        "end with '-run0'; need exactly 1 candidate)"
     )
 
 

--- a/backend/tests/eval/day5_analysis.py
+++ b/backend/tests/eval/day5_analysis.py
@@ -176,9 +176,11 @@ def _resolve_inferential(runs: list[dict[str, Any]], inferential_run: str) -> di
     run0 = [r for r in runs if r["label"].endswith("-run0")]
     if len(run0) == 1:
         return run0[0]
-    _fatal(
-        f"could not resolve an inferential run (no run labeled {inferential_run!r}, and "
-        f"{len(run0)} run(s) end with '-run0'; need exactly 1 candidate)"
+    # Explicit raise (not _fatal) so static analysis sees every path of this
+    # value-returning function terminate explicitly (PR #1177 CodeQL feedback).
+    raise SystemExit(
+        f"day5_analysis: could not resolve an inferential run (no run labeled "
+        f"{inferential_run!r}, and {len(run0)} run(s) end with '-run0'; need exactly 1 candidate)"
     )
 
 


### PR DESCRIPTION
Addresses the github-code-quality inline comment on #1177 (mixed explicit/implicit returns in `day5_analysis._resolve_inferential`): the final branch ended in `_fatal()`, whose `NoReturn` annotation the analyzer does not propagate through the call. The last path is now an explicit `raise SystemExit` with the identical prefixed message, in both `day5_analysis.py` and its `day4_analysis.py` twin (same pattern). No behavior change — 37 analysis tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)