### PR TITLE
chore(release): v0.42.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Kagura Memory Cloud plugin — restore session context, recall & save durable project knowledge, setup help, and an MCP smoke test",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.41.0"
+version = "0.42.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.41.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.42.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.41.0"
+APP_VERSION = "0.42.0"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
Release **v0.42.0** — version bump across the 7 canonical locations (`APP_VERSION`, `pyproject.toml`, `backend/src/__init__.py`, frontend `package.json` + lock, Claude & Codex plugin manifests).

## Highlights since v0.41.0

**Features**
- Owner-key programmatic provisioning of member API keys (#1165) + owner-key access to member/invitation endpoints (#1164, #1170)
- `ENABLE_BYOK` flag to gate the BYOK surface (#1167)
- Batched `/v1/rerank` path for the self-hosted reranker (#1161)

**Fixes / hardening**
- Resolve all v0.42.0 max code-review findings (#1176) — **includes the release blocker**: `VerifiedKey.key_prefix` was unpopulated, causing a 500 on every API-key auth
- Reject `role=owner` workspace invitations (#1166)
- v0.41 security & UX hardening follow-ups (#1159)

**Refactor / internal**
- Rename provider key `ollama` → `self_hosted` (#1160) — see Migration
- Reuse audit helper + dedup member-credential SELECT (#1174)
- Eval harness Day 2–5 (placebo, kagura_L corpus, static factorial, update-correctness) (#1172, #1173, #1175, #1177, #1178)

## Migration

**Provider key rename `ollama` → `self_hosted` (#1160)** — back-compat is preserved: `EMBEDDING_PROVIDER=ollama` (and `SLEEP_LLM_PROVIDER=ollama`) are coerced to `self_hosted` at load time with a deprecation warning. No action is required to keep running, but update env/config to `self_hosted` to silence the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
