### PR TITLE
fix(credentials): stop leaking WorkspaceRole enum repr in 403 message

### DIFF
--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -152,8 +152,14 @@ async def _require_downgrade_target(
     """
     target_role = await MemberCredentialsService(db).get_workspace_role(user_id, workspace_id)
     if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
+        # ``.value`` via getattr (preserving the not-a-member ``None`` case):
+        # ``!r`` on a StrEnum member leaks the Python repr
+        # ``<WorkspaceRole.ADMIN: 'admin'>`` to API clients (#1180).
         raise AuthorizationError(
-            message=f"{action_desc} member/viewer targets, not role={target_role!r}."
+            message=(
+                f"{action_desc} member/viewer targets, "
+                f"not role={getattr(target_role, 'value', target_role)!r}."
+            )
         )
 
 

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -160,6 +160,20 @@ class TestOwnerProvisionedMint:
         r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
         assert r.status_code == 403
 
+    def test_admin_target_403_names_role_without_enum_repr(self, client, owner_gate, monkeypatch):
+        # Regression for #1180: the REAL service returns WorkspaceRole enum
+        # members, but the string mocks above masked the ``{target_role!r}``
+        # repr leak — pass the actual enum and pin the client-facing message.
+        from auth.workspace_roles import WorkspaceRole
+
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role=WorkspaceRole.ADMIN)
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 403
+        message = r.json()["message"]
+        assert "role='admin'" in message
+        assert "<WorkspaceRole" not in message
+
     def test_missing_expires_days_400(self, client, owner_gate, monkeypatch):
         _override(_api_key_owner())
         _mock_member_service(monkeypatch, target_role="member")


### PR DESCRIPTION
## Summary

Closes #1180.

`_require_downgrade_target` (backend/src/api/routes/member_credentials.py) formats `{target_role!r}` on a `WorkspaceRole` StrEnum, so owner-provisioned mint/revoke rejections leak the Python repr to API clients — observed live on production v0.42.0:

```
Owner-provisioned keys can only be minted for member/viewer targets, not role=<WorkspaceRole.ADMIN: 'admin'>.
```

## Fix

Format the enum **value** via `getattr(target_role, 'value', target_role)!r` → `role='admin'`; the getattr keeps the not-a-member `None` case rendering exactly as before.

## Why tests missed it

The existing tests mock `get_workspace_role` with plain strings (`target_role="owner"`), which repr as `'owner'` — masking the enum leak. The regression test passes the real `WorkspaceRole.ADMIN` and pins the client-facing message (`role='admin'` present, `<WorkspaceRole` absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)