### PR TITLE
fix(api): format WorkspaceRole value, not enum repr, in 403 message (#1180)

### DIFF
--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -152,8 +152,14 @@ async def _require_downgrade_target(
     """
     target_role = await MemberCredentialsService(db).get_workspace_role(user_id, workspace_id)
     if target_role not in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
+        # repr() of a StrEnum member is "<WorkspaceRole.ADMIN: 'admin'>" — format
+        # the .value so the API message reads role='admin' (#1180). getattr keeps
+        # the not-a-member None case rendering as role=None.
         raise AuthorizationError(
-            message=f"{action_desc} member/viewer targets, not role={target_role!r}."
+            message=(
+                f"{action_desc} member/viewer targets, "
+                f"not role={getattr(target_role, 'value', target_role)!r}."
+            )
         )
 
 

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -160,6 +160,28 @@ class TestOwnerProvisionedMint:
         r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
         assert r.status_code == 403
 
+    def test_403_message_formats_enum_value_not_repr(self, client, owner_gate, monkeypatch):
+        # The real service returns a WorkspaceRole StrEnum member; {!r} on it
+        # leaked "<WorkspaceRole.ADMIN: 'admin'>" to API clients (#1180).
+        from auth.workspace_roles import WorkspaceRole
+
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role=WorkspaceRole.ADMIN)
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 403
+        message = r.json()["message"]
+        assert "role='admin'" in message
+        assert "<WorkspaceRole" not in message
+
+    def test_403_message_renders_none_for_non_member(self, client, owner_gate, monkeypatch):
+        # get_workspace_role returns None when the target is not a workspace
+        # member — the .value formatting must not break that case (#1180).
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role=None)
+        r = client.post(MINT_URL, json={"name": "k", "expires_days": 30})
+        assert r.status_code == 403
+        assert "role=None" in r.json()["message"]
+
     def test_missing_expires_days_400(self, client, owner_gate, monkeypatch):
         _override(_api_key_owner())
         _mock_member_service(monkeypatch, target_role="member")


### PR DESCRIPTION
Closes #1180

## Summary
The owner-provisioned mint/revoke 403 message leaked the Python StrEnum repr to API clients:

```
Owner-provisioned keys can only be minted for member/viewer targets, not role=<WorkspaceRole.ADMIN: 'admin'>.
```

`_require_downgrade_target` formatted `{target_role!r}` on a `WorkspaceRole` StrEnum. Now formats `getattr(target_role, 'value', target_role)!r` so the message reads `role='admin'`; the not-a-member `None` case still renders `role=None`.

## Changes
- `backend/src/api/routes/member_credentials.py`: format the enum's `.value` in the 403 message (shared by mint + revoke call sites).
- `backend/tests/api/test_member_credentials_owner_key.py`: regression test pinning `role='admin'` / no `<WorkspaceRole` in the body, plus a `None`-case sanity guard.

## Testing
- `tests/api/test_member_credentials_owner_key.py`: 17 passed (container harness).
- ruff check + format: clean.
- Code review (independent reviewer): no Critical/Warning findings; confirmed the service always returns `WorkspaceRole | None` and both call sites compose grammatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)