### PR TITLE
fix(sleep): grade runs completed/degraded/failed by judge-LLM health (#1183)

### DIFF
--- a/backend/alembic/versions/e54_1183_sleep_status_degraded.py
+++ b/backend/alembic/versions/e54_1183_sleep_status_degraded.py
@@ -1,0 +1,67 @@
+"""Sleep run health grading: 'degraded' status + llm_call_failures column (#1183).
+
+Issue #1183: ``sleep_reports.status='completed'`` masked a fully
+non-functional judge LLM — a run where every judge call raised still
+reported completed (week1-derisk Day-5: llm_call_failures=5/5 under
+ok=true). The reporter now grades runs:
+
+  failed    — judge calls attempted, ALL raised
+  degraded  — some raised, some succeeded
+  completed — no judge failures
+
+This migration:
+1. Widens the ``valid_sleep_report_status`` CHECK with 'degraded'
+   (drop + recreate — same pattern as e53's reranker CHECK).
+2. Adds ``llm_call_failures`` (int, NOT NULL, default 0) so dashboards can
+   aggregate judge health without parsing per-phase JSON blobs.
+
+Blue-green safe: the CHECK is widened (old writers never emit 'degraded')
+and the new column has a server_default, so the previous app version keeps
+inserting successfully while both colors run.
+
+Revision ID: e54_1183_sleep_status_degraded
+Revises: e53_1160_self_hosted_provider
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision = "e54_1183_sleep_status_degraded"
+down_revision = "e53_1160_self_hosted_provider"
+branch_labels = None
+depends_on = None
+
+_OLD_CHECK = "status IN ('running', 'completed', 'failed', 'cancelled', 'rolled_back')"
+_NEW_CHECK = "status IN ('running', 'completed', 'degraded', 'failed', 'cancelled', 'rolled_back')"
+
+
+def upgrade() -> None:
+    op.drop_constraint("valid_sleep_report_status", "sleep_reports", type_="check")
+    op.create_check_constraint(
+        "valid_sleep_report_status",
+        "sleep_reports",
+        _NEW_CHECK,
+    )
+    op.add_column(
+        "sleep_reports",
+        sa.Column(
+            "llm_call_failures",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sleep_reports", "llm_call_failures")
+    # Re-grade 'degraded' rows as 'completed' BEFORE narrowing the CHECK —
+    # recreating the old constraint with 'degraded' rows present would fail.
+    op.execute("UPDATE sleep_reports SET status = 'completed' WHERE status = 'degraded'")
+    op.drop_constraint("valid_sleep_report_status", "sleep_reports", type_="check")
+    op.create_check_constraint(
+        "valid_sleep_report_status",
+        "sleep_reports",
+        _OLD_CHECK,
+    )

--- a/backend/alembic/versions/e54_1183_sleep_status_degraded.py
+++ b/backend/alembic/versions/e54_1183_sleep_status_degraded.py
@@ -24,6 +24,7 @@ Revises: e53_1160_self_hosted_provider
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers

--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -111,7 +111,7 @@ class SleepReportDetailResponse(BaseModel):
 # Shared validation
 # ============================================================================
 
-_VALID_STATUSES = {"running", "completed", "failed", "cancelled", "rolled_back"}
+_VALID_STATUSES = {"running", "completed", "degraded", "failed", "cancelled", "rolled_back"}
 
 
 def _validate_status(status_filter: str | None) -> None:

--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -63,6 +63,10 @@ class SleepReportSummary(TZAwareBaseModel):
     memories_flagged: int
     llm_calls_made: int
     llm_tokens_used: int
+    # #1183: judge-LLM calls that raised across all phases — the magnitude
+    # behind a 'degraded'/'failed' grading, exposed top-level so dashboards
+    # don't have to parse per-phase JSON blobs.
+    llm_call_failures: int = 0
 
 
 class SleepReportDetail(SleepReportSummary):

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1284,7 +1284,7 @@ Returns: {status, report: {report_id, context_id, status, started_at, completed_
         },
         {
             "name": "rollback_sleep_run",
-            "description": """Rollback all actions from a completed Sleep Maintenance run.
+            "description": """Rollback all actions from a finished Sleep Maintenance run.
 
 Reverses each recorded action in order:
 - create_edge → deletes the edge
@@ -1293,8 +1293,10 @@ Reverses each recorded action in order:
 - promote → reverts scope back to 'working'
 - archive → restores the deleted memory and re-embeds it
 
-Only works on reports with status 'completed'. After rollback, the
-report is marked 'rolled_back' to prevent double rollback.
+Only works on reports with status 'completed' or 'degraded' (#1183: a
+degraded run — partial judge-LLM failures — still executed real merges
+and stays rollbackable). After rollback, the report is marked
+'rolled_back' to prevent double rollback.
 
 ⚠️ This is a destructive operation — use with care.
 Requires action recording (reports created before this feature have no actions to rollback).

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -286,10 +286,13 @@ async def handle_rollback_sleep_run(
             if perm_error:
                 return perm_error
 
-            if report.status != "completed":
+            # #1183: 'degraded' runs (partial judge failures) still executed
+            # real merges/promotions — they must stay rollbackable.
+            if report.status not in ("completed", "degraded"):
                 return _error_response(
                     "invalid_status",
-                    f"Can only rollback 'completed' reports. Current status: '{report.status}'.",
+                    "Can only rollback 'completed' or 'degraded' reports. "
+                    f"Current status: '{report.status}'.",
                 )
 
             # Fetch actions in reverse order

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -38,6 +38,8 @@ def _report_to_summary(report: Any) -> dict[str, Any]:
         "memories_promoted": report.memories_promoted,
         "llm_calls_made": report.llm_calls_made,
         "llm_tokens_used": report.llm_tokens_used,
+        # #1183: magnitude behind a 'degraded'/'failed' grading.
+        "llm_call_failures": report.llm_call_failures,
     }
 
 

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -56,7 +56,9 @@ class SleepReport(Base):
         context_id: Target context
         started_at: Execution start time
         completed_at: Execution end time
-        status: running / completed / failed / cancelled
+        status: running / completed / degraded / failed / cancelled / rolled_back
+            (#1183: 'degraded' = finished with partial judge-LLM failures;
+            total judge failure is graded 'failed')
         edge_discovery_result: Phase 1 results (JSON)
         dedup_result: Phase 2 results (JSON)
         importance_result: Phase 3 results (JSON)
@@ -71,6 +73,7 @@ class SleepReport(Base):
         memories_promoted: Working -> Persistent promotions
         memories_flagged: Memories flagged for review
         error_message: Error details if failed
+        llm_call_failures: Judge-LLM calls that raised, across all phases (#1183)
     """
 
     __tablename__ = "sleep_reports"
@@ -177,9 +180,18 @@ class SleepReport(Base):
     # Error tracking
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # #1183: judge-LLM calls that raised across all phases. Backs the
+    # degraded/failed status grading in ``SleepReporter.complete_report`` and
+    # lets dashboards aggregate judge health without parsing per-phase JSON.
+    llm_call_failures: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+
     __table_args__ = (
+        # 'degraded' (#1183): run finished but SOME judge-LLM calls failed.
+        # Total judge failure grades as 'failed' (see reporter.complete_report).
         CheckConstraint(
-            "status IN ('running', 'completed', 'failed', 'cancelled', 'rolled_back')",
+            "status IN ('running', 'completed', 'degraded', 'failed', 'cancelled', 'rolled_back')",
             name="valid_sleep_report_status",
         ),
         # #523 cost-grade dimensions

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -395,6 +395,11 @@ async def persist_results(
             "labeling_failures": quality["labeling_failures"],
         },
         llm_breakdown=breakdowns,
+        # #1183: a cluster whose every fallback model raised (ClusterLabel.failed)
+        # is a judge failure — without this the sibling row always grades
+        # 'completed' even when labeling failed for ALL clusters, reproducing
+        # the exact masking bug #1183 closes for the Sleep phases.
+        llm_call_failures=quality["labeling_failures"],
     )
     await sleep_reporter.complete_report(sleep_report, [phase_result])
 

--- a/backend/src/services/sleep/consolidation.py
+++ b/backend/src/services/sleep/consolidation.py
@@ -123,6 +123,8 @@ class ConsolidationPhase:
         result = PhaseResult(phase_name="consolidation")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        # #1183: judge calls that raised (feeds run-status grading).
+        self._llm_failures = 0
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
 
@@ -295,6 +297,7 @@ class ConsolidationPhase:
         result.memories_processed = len(working)
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        result.llm_call_failures = self._llm_failures  # #1183
         # #471: attach per-(provider, model) breakdown.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
@@ -305,6 +308,7 @@ class ConsolidationPhase:
             "borderline": len(borderline),
             "llm_promoted": llm_promoted,
             "llm_archived": llm_archived,
+            "llm_call_failures": self._llm_failures,  # #1183
         }
 
         logger.info(
@@ -417,6 +421,7 @@ class ConsolidationPhase:
             self._tokens_used += llm_resp.total_tokens
             self._llm_breakdown = accumulate_llm_response(self._llm_breakdown, llm_resp)
         except Exception as e:
+            self._llm_failures += 1  # #1183
             logger.warning("consolidation_llm_failed", error=str(e))
             return {}
 

--- a/backend/src/services/sleep/consolidation.py
+++ b/backend/src/services/sleep/consolidation.py
@@ -107,6 +107,9 @@ class ConsolidationPhase:
         self.llm_service = llm_service
         self.memory_repo = MemoryRepository(db)
         self.collection_name = collection_name or "kagura_memories"
+        # #1183: judge-failure counter (init here so the LLM judge helper can
+        # be unit-tested without execute()).
+        self._llm_failures: int = 0
 
     async def execute(
         self,

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -118,6 +118,9 @@ class DedupMergePhase:
         # ``_find_similar_pairs`` can be unit-tested without execute()).
         self._embedding_calls_used: int = 0
         self._embedding_tokens_used: int = 0
+        # #1183: judge-failure counter (init here so ``_llm_judge`` can be
+        # unit-tested without execute()).
+        self._llm_failures: int = 0
 
     async def execute(
         self,

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -145,6 +145,8 @@ class DedupMergePhase:
         result = PhaseResult(phase_name="dedup_merge")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        # #1183: judge calls that raised (feeds run-status grading).
+        self._llm_failures = 0
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
         # #475: reset embedding accumulators between sleep cycles.
@@ -251,10 +253,12 @@ class DedupMergePhase:
             "clusters": len(processable),
             "deferred_clusters": len(deferred),
             "merged": merged_count,
+            "llm_call_failures": self._llm_failures,  # #1183
         }
 
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        result.llm_call_failures = self._llm_failures  # #1183
         # #471: attach per-(provider, model) breakdown for child-row write.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
@@ -454,6 +458,7 @@ class DedupMergePhase:
             return self._parse_dedup_response(llm_resp.parsed, label_to_id)
 
         except Exception as e:
+            self._llm_failures += 1  # #1183
             logger.warning("dedup_llm_judge_failed", error=str(e))
             return []
 

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -503,6 +503,7 @@ class EdgeDiscoveryPhase:
         result.memories_processed = len(sampled)
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        result.llm_call_failures = agg.failures  # #1183: feeds run-status grading
         # #471: attach per-(provider, model) breakdown for child-row write.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]

--- a/backend/src/services/sleep/importance_reeval.py
+++ b/backend/src/services/sleep/importance_reeval.py
@@ -68,6 +68,9 @@ class ImportanceReevalPhase:
         self.db = db
         self.llm_service = llm_service
         self.collection_name = collection_name
+        # #1183: judge-failure counter (init here so ``_evaluate_batch`` can
+        # be unit-tested without execute()).
+        self._llm_failures: int = 0
 
     async def execute(
         self,

--- a/backend/src/services/sleep/importance_reeval.py
+++ b/backend/src/services/sleep/importance_reeval.py
@@ -84,6 +84,8 @@ class ImportanceReevalPhase:
         result = PhaseResult(phase_name="importance_reeval")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        # #1183: judge calls that raised (feeds run-status grading).
+        self._llm_failures = 0
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
 
@@ -163,6 +165,7 @@ class ImportanceReevalPhase:
         result.memories_processed = updated_count
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        result.llm_call_failures = self._llm_failures  # #1183
         # #471: attach per-(provider, model) breakdown.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
@@ -170,6 +173,7 @@ class ImportanceReevalPhase:
             "candidates": len(candidates),
             "updated": updated_count,
             "alpha": alpha,
+            "llm_call_failures": self._llm_failures,  # #1183
         }
 
         logger.info(
@@ -247,6 +251,7 @@ class ImportanceReevalPhase:
             self._tokens_used += llm_resp.total_tokens
             self._llm_breakdown = accumulate_llm_response(self._llm_breakdown, llm_resp)
         except Exception as e:
+            self._llm_failures += 1  # #1183
             logger.warning("importance_reeval_llm_failed", error=str(e))
             return {}
 

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -134,6 +134,12 @@ class PhaseResult:
     memories_processed: int = 0
     changed_memory_ids: set[UUID] = field(default_factory=set)
     details: dict | None = None
+    # #1183: judge-LLM calls that raised (complete_json failed). First-class so
+    # the reporter can grade the RUN (completed/degraded/failed) without
+    # spelunking per-phase details dicts. Counts failures only — successful
+    # calls are ``sum(b.calls for b in llm_breakdown)`` (breakdown accumulates
+    # inside the try block, after the response parsed).
+    llm_call_failures: int = 0
     # #471: cost-grade fields.
     llm_breakdown: list[LLMCallBreakdown] = field(default_factory=list)
     embedding_provider: str | None = None
@@ -268,7 +274,26 @@ class SleepReporter:
            ``embedding_calls_made``) — populated as the sum of child rows
            for back-compat with existing dashboards / log analyzers.
         """
-        report.status = "completed"
+        # #1183: grade the run by judge-LLM health instead of blanket
+        # "completed". A fully non-functional judge (every call raised — e.g.
+        # a stale neural_config row pointing at a dead endpoint, see #1182)
+        # used to be indistinguishable from a healthy run at the status level;
+        # week1-derisk Day-5 shipped llm_call_failures=5/5 under ok=true.
+        #   failed    — judge calls were attempted and ALL of them raised.
+        #   degraded  — some judge calls raised, some succeeded.
+        #   completed — no judge failures (including runs with no LLM work).
+        judge_failures = sum(r.llm_call_failures for r in phase_results)
+        judge_successes = sum(b.calls for r in phase_results for b in r.llm_breakdown)
+        if judge_failures > 0 and judge_successes == 0:
+            report.status = "failed"
+            report.error_message = (
+                f"llm_judge_total_failure: {judge_failures} judge call(s) attempted, 0 succeeded"
+            )
+        elif judge_failures > 0:
+            report.status = "degraded"
+        else:
+            report.status = "completed"
+        report.llm_call_failures = judge_failures
         report.completed_at = utcnow()
 
         # Single pass over phase_results: write child rows + per-phase
@@ -343,6 +368,7 @@ class SleepReporter:
                 "skip_reason": result.skip_reason,
                 "error": result.error,
                 "llm_calls": result.llm_calls_used,
+                "llm_call_failures": result.llm_call_failures,  # #1183
                 "memories_processed": result.memories_processed,
                 "details": result.details,
                 "llm_breakdown": [
@@ -396,7 +422,9 @@ class SleepReporter:
         logger.info(
             "sleep_report_completed",
             report_id=str(report.id),
+            status=report.status,
             llm_calls=total_llm_calls,
+            llm_call_failures=judge_failures,
             tokens=total_tokens,
             embedding_tokens=embedding_tokens_total,
             memories=total_memories,

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -282,6 +282,12 @@ class SleepReporter:
         #   failed    — judge calls were attempted and ALL of them raised.
         #   degraded  — some judge calls raised, some succeeded.
         #   completed — no judge failures (including runs with no LLM work).
+        # The tallies are RUN-WIDE, which is sound because all phases share
+        # one (sleep_llm_provider, sleep_llm_model) today — a dead judge
+        # config fails every phase uniformly (the Day-5 shape). If per-phase
+        # LLM configs ever land, a single-phase total outage would grade only
+        # 'degraded' here; per-phase counts stay visible in each phase blob's
+        # details.llm_call_failures.
         judge_failures = sum(r.llm_call_failures for r in phase_results)
         judge_successes = sum(b.calls for r in phase_results for b in r.llm_breakdown)
         if judge_failures > 0 and judge_successes == 0:

--- a/backend/tests/eval/update_runner.py
+++ b/backend/tests/eval/update_runner.py
@@ -178,6 +178,7 @@ async def _run_mc_sleep(db: Any, owner: str, ws_id: Any, ctx_id: Any) -> dict[st
 # per-field try/except loop is easy to audit against ``models.sleep.SleepReport``.
 _SLEEP_REPORT_FIELDS: tuple[str, ...] = (
     "status",
+    "llm_call_failures",  # #1183: first-class judge-failure count
     "memories_processed",
     "edges_created",
     "memories_merged",

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -46,6 +46,7 @@ class TestGetSleepHistory:
         r.memories_promoted = 5
         r.llm_calls_made = 4
         r.llm_tokens_used = 1200
+        r.llm_call_failures = 0  # #1183
         return r
 
     def _setup_history_mocks(self, reports):
@@ -142,6 +143,7 @@ class TestGetSleepReport:
         r.memories_flagged = 0
         r.llm_calls_made = 2
         r.llm_tokens_used = 500
+        r.llm_call_failures = 0  # #1183
         r.embedding_calls_made = 0
         r.error_message = None
         r.edge_discovery_result = {"success": True}

--- a/backend/tests/services/sleep/test_reporter.py
+++ b/backend/tests/services/sleep/test_reporter.py
@@ -172,3 +172,104 @@ class TestSleepReporter:
         assert report.status == "failed"
         assert report.completed_at is not None
         assert report.error_message == "Something went wrong"
+
+
+class TestRunStatusGrading:
+    """#1183: complete_report grades runs by judge-LLM health.
+
+    A fully non-functional judge (every call raised) used to report
+    status='completed' — indistinguishable from a healthy run without
+    parsing per-phase JSON (week1-derisk Day-5: llm_call_failures=5/5
+    under ok=true).
+    """
+
+    @pytest.fixture
+    def reporter(self):
+        db = AsyncMock()
+        db.add = MagicMock()
+        return SleepReporter(db)
+
+    @staticmethod
+    def _breakdown(calls: int):
+        from services.sleep.reporter import LLMCallBreakdown
+
+        return LLMCallBreakdown(provider="self_hosted", model="qwen3.5:9b", calls=calls)
+
+    @pytest.mark.asyncio
+    async def test_total_judge_failure_grades_failed(self, reporter):
+        report = MagicMock()
+        report.id = uuid4()
+        results = [
+            PhaseResult(phase_name="edge_discovery", llm_calls_used=3, llm_call_failures=3),
+            PhaseResult(phase_name="dedup_merge", llm_calls_used=2, llm_call_failures=2),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        assert report.status == "failed"
+        assert "llm_judge_total_failure" in report.error_message
+        assert report.llm_call_failures == 5
+
+    @pytest.mark.asyncio
+    async def test_partial_judge_failure_grades_degraded(self, reporter):
+        report = MagicMock()
+        report.id = uuid4()
+        results = [
+            PhaseResult(
+                phase_name="edge_discovery",
+                llm_calls_used=3,
+                llm_call_failures=1,
+                llm_breakdown=[self._breakdown(calls=2)],
+            ),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        assert report.status == "degraded"
+        assert report.llm_call_failures == 1
+
+    @pytest.mark.asyncio
+    async def test_no_failures_grades_completed(self, reporter):
+        report = MagicMock()
+        report.id = uuid4()
+        results = [
+            PhaseResult(
+                phase_name="edge_discovery",
+                llm_calls_used=2,
+                llm_breakdown=[self._breakdown(calls=2)],
+            ),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        assert report.status == "completed"
+        assert report.llm_call_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_no_llm_work_at_all_grades_completed(self, reporter):
+        # Zero attempts is NOT a failure — e.g. no candidates, or LLM off.
+        report = MagicMock()
+        report.id = uuid4()
+        results = [PhaseResult(phase_name="reindex", memories_processed=4)]
+
+        await reporter.complete_report(report, results)
+
+        assert report.status == "completed"
+        assert report.llm_call_failures == 0
+
+    @pytest.mark.asyncio
+    async def test_phase_data_carries_llm_call_failures(self, reporter):
+        report = MagicMock()
+        report.id = uuid4()
+        results = [
+            PhaseResult(
+                phase_name="dedup_merge",
+                llm_calls_used=1,
+                llm_call_failures=1,
+                details={"merged": 0},
+            ),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        assert report.dedup_result["llm_call_failures"] == 1

--- a/frontend/src/lib/sleep-report.ts
+++ b/frontend/src/lib/sleep-report.ts
@@ -4,15 +4,12 @@
  */
 
 export type SleepStatus =
-  | "running"
-  | "completed"
-  | "failed"
-  | "cancelled"
-  | "rolled_back";
+  "running" | "completed" | "degraded" | "failed" | "cancelled" | "rolled_back";
 
 export const SLEEP_STATUS_OPTIONS: SleepStatus[] = [
   "completed",
   "running",
+  "degraded",
   "failed",
   "cancelled",
   "rolled_back",
@@ -24,6 +21,9 @@ export function getSleepStatusColor(status: SleepStatus): string {
       return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300";
     case "running":
       return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
+    case "degraded":
+      // #1183: finished, but some judge-LLM calls failed — partial results.
+      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
     case "failed":
       return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
     case "rolled_back":

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2834,6 +2834,7 @@
       "status": {
         "running": "Running",
         "completed": "Completed",
+        "degraded": "Degraded",
         "failed": "Failed",
         "cancelled": "Cancelled",
         "rolled_back": "Rolled back"

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2834,6 +2834,7 @@
       "status": {
         "running": "実行中",
         "completed": "完了",
+        "degraded": "一部失敗",
         "failed": "失敗",
         "cancelled": "キャンセル",
         "rolled_back": "ロールバック済み"


### PR DESCRIPTION
Closes #1183

## Summary
A Sleep run whose judge LLM failed on **every** call still reported `status='completed'` — a fully non-functional judge was indistinguishable from a healthy run (week1-derisk Day-5: `llm_call_failures=5/5` under `ok=true`, root cause #1182).

## Grading (in `SleepReporter.complete_report`)
- **failed** — judge calls attempted and ALL raised (`error_message="llm_judge_total_failure: N judge call(s) attempted, 0 succeeded"`)
- **degraded** — some raised, some succeeded (new status value)
- **completed** — no judge failures (including runs with no LLM work)

Success tally = `llm_breakdown[].calls` (accumulates only successful calls); failure tally = new `PhaseResult.llm_call_failures`, populated by all four judge phases (edge_discovery via `BatchStats.failures`; dedup/importance/consolidation via a counter in their `complete_json` except-branches) **and** the Analysis cluster-labeling sibling row (review finding — it had the identical masking bug).

## Changes
- `models/sleep.py` + migration `e54_1183_sleep_status_degraded`: CHECK gains `'degraded'`; new `llm_call_failures` int column (server_default 0; blue-green safe — additive CHECK + defaulted column; downgrade re-grades degraded→completed before narrowing).
- Surfacing: `llm_call_failures` top-level in `SleepReportSummary/Detail` (API), MCP `get_sleep_history`/`get_sleep_report`, per-phase `phase_data` blobs, and the eval harness (`update_runner` — its `ok = status=='completed'` now flips correctly).
- Rollback: `rollback_sleep_run` accepts `completed|degraded` (a degraded run still executed real merges); MCP tool description updated.
- Frontend: `degraded` in `SleepStatus` type/options + yellow badge + en/ja labels.

## Testing
- `TestRunStatusGrading` (failed / degraded / completed / zero-LLM-work / phase_data) — verified they fail on origin/main.
- Affected suites in container harness: sleep services + sleep_reports API + analysis + MCP sleep tools — **349 passed**. ruff clean; frontend tsc clean.
- Independent code review (find→verify agent): 1 Critical + 3 Warnings found, **all fixed in the last commit** (analysis sibling row instrumentation, top-level surfacing, MCP description, run-wide-tally docs). 2 Info items deferred as follow-ups: phase-card "N judge calls failed" sub-note and an informational banner for degraded reports.

## Migration
`e54`: widens `valid_sleep_report_status` CHECK + adds `llm_call_failures`. Please run `make test-integration` gate via CI (container harness here can't exercise Alembic — image bakes alembic/ without bind mount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)