### PR TITLE
fix(api): split oversize dedup clusters instead of wholesale deferral (#1184)

### DIFF
--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -129,8 +129,11 @@ def _split_oversize_cluster(
         max_size: per-subcluster member cap (defaults to MAX_CLUSTER_SIZE).
 
     Returns:
-        (subclusters with >= 2 members, count of internal pairs skipped by
-        the size cap — i.e. candidate pairs left unjudged this run).
+        (subclusters with >= 2 members, count of union attempts blocked by
+        the size cap — an order-of-magnitude PROXY for candidate pairs left
+        unjudged this run, not an exact count of final cross-subcluster
+        edges: an early cap-blocked pair may still end up same-component via
+        other edges, and same-component skips are never counted).
     """
     internal = sorted(
         (p for p in pairs if p[0] in cluster and p[1] in cluster),
@@ -260,6 +263,9 @@ class DedupMergePhase:
             subclusters, skipped = _split_oversize_cluster(big, pairs)
             split_subclusters += len(subclusters)
             deferred_pairs += skipped
+            # Appended AFTER the normal-size clusters deliberately: under
+            # budget exhaustion the pre-existing cluster set keeps priority
+            # and mega-cluster subclusters only consume the margin.
             processable.extend(subclusters)
 
         if oversize:
@@ -336,8 +342,9 @@ class DedupMergePhase:
             "oversize_clusters": len(oversize),
             "oversize_max_size": max((len(c) for c in oversize), default=0),
             "split_subclusters": split_subclusters,
-            # Candidate pairs left unjudged this run by the size cap —
-            # distinguishes "0 merges: nothing matched" from "0 merges:
+            # Cap-blocked union attempts — a PROXY for candidate volume left
+            # unjudged this run (see _split_oversize_cluster docstring).
+            # Distinguishes "0 merges: nothing matched" from "0 merges:
             # work was deferred".
             "deferred_pairs": deferred_pairs,
             "merged": merged_count,

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -120,7 +120,11 @@ def _split_oversize_cluster(
     stays within ``max_size``. The tightest duplicates coalesce first, every
     component stays judgeable in one LLM batch, and skipped cross-component
     pairs are re-candidates next run (post-merge, the landscape shrinks).
-    Deterministic: ties break on the stringified pair ids.
+    Deterministic: pair endpoints are CANONICALIZED (str-ascending) before
+    ties break on the stringified ids — ``_find_similar_pairs`` emits
+    ``(memory.id, hit_id)`` in Qdrant-iteration orientation, so sorting on
+    the raw orientation would make equal-score splits vary run-to-run
+    (Copilot, PR #1188).
 
     Args:
         cluster: member ids of one oversize union-find cluster.
@@ -136,7 +140,11 @@ def _split_oversize_cluster(
         other edges, and same-component skips are never counted).
     """
     internal = sorted(
-        (p for p in pairs if p[0] in cluster and p[1] in cluster),
+        (
+            (*sorted((p[0], p[1]), key=str), p[2])
+            for p in pairs
+            if p[0] in cluster and p[1] in cluster
+        ),
         key=lambda p: (-p[2], str(p[0]), str(p[1])),
     )
 

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -5,14 +5,18 @@ clustering and optional LLM judgment.
 
 Algorithm:
 1. For each memory, find high-similarity neighbors in Qdrant (>= threshold)
-2. Build candidate pairs, cluster with Union-Find (cap cluster size at 5)
+2. Build candidate pairs, cluster with Union-Find (cap cluster size at 5);
+   oversize clusters are re-split into <=5-member subclusters by descending
+   pair similarity (#1184) instead of deferred wholesale
 3. LLM on: batch judgment (merge/keep_both)
 4. LLM off: similarity >= 0.98 → auto-merge, else → flag
 5. Merge: keep winner, soft-delete losers, transfer edges, merge tags
 
 Academic notes:
 - Union-Find transitivity: A~B + B~C clusters all three even if A~C is low.
-  Cluster size cap (5) + LLM second gate mitigate runaway merges.
+  Cluster size cap (5) + LLM second gate mitigate runaway merges. Templated
+  corpora collapse into one mega-cluster (Day-5: 782 pairs → 1 cluster);
+  capacity-capped greedy agglomeration (#1184) restores partial progress.
 - Positional bias: batch order is shuffled before LLM calls.
 - ID hallucination: short labels (A, B, C) used in prompts, mapped back to UUIDs.
 """
@@ -99,6 +103,66 @@ class UnionFind:
         return list(groups.values())
 
 
+def _split_oversize_cluster(
+    cluster: set[UUID],
+    pairs: list[tuple[UUID, UUID, float]],
+    max_size: int = MAX_CLUSTER_SIZE,
+) -> tuple[list[set[UUID]], int]:
+    """Split an oversize union-find cluster into judgeable subclusters (#1184).
+
+    Templated corpora (daily standups, status logs) push cross-unit similarity
+    over the candidate threshold, union-find collapses everything into one
+    mega-cluster (Day-5 eval: 782 pairs → 1 cluster), and the old wholesale
+    deferral disabled dedup for exactly the corpora that need it most.
+
+    Greedy capacity-capped agglomeration: walk the cluster's internal pairs in
+    DESCENDING similarity and union two components only while the merged size
+    stays within ``max_size``. The tightest duplicates coalesce first, every
+    component stays judgeable in one LLM batch, and skipped cross-component
+    pairs are re-candidates next run (post-merge, the landscape shrinks).
+    Deterministic: ties break on the stringified pair ids.
+
+    Args:
+        cluster: member ids of one oversize union-find cluster.
+        pairs: ALL candidate pairs from the run; only pairs internal to
+            ``cluster`` are considered.
+        max_size: per-subcluster member cap (defaults to MAX_CLUSTER_SIZE).
+
+    Returns:
+        (subclusters with >= 2 members, count of internal pairs skipped by
+        the size cap — i.e. candidate pairs left unjudged this run).
+    """
+    internal = sorted(
+        (p for p in pairs if p[0] in cluster and p[1] in cluster),
+        key=lambda p: (-p[2], str(p[0]), str(p[1])),
+    )
+
+    parent: dict[UUID, UUID] = {m: m for m in cluster}
+    comp_size: dict[UUID, int] = dict.fromkeys(cluster, 1)
+
+    def find(x: UUID) -> UUID:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    skipped_pairs = 0
+    for id_a, id_b, _score in internal:
+        root_a, root_b = find(id_a), find(id_b)
+        if root_a == root_b:
+            continue
+        if comp_size[root_a] + comp_size[root_b] > max_size:
+            skipped_pairs += 1
+            continue
+        parent[root_b] = root_a
+        comp_size[root_a] += comp_size[root_b]
+
+    groups: dict[UUID, set[UUID]] = {}
+    for member in cluster:
+        groups.setdefault(find(member), set()).add(member)
+    return [g for g in groups.values() if len(g) >= 2], skipped_pairs
+
+
 class DedupMergePhase:
     """Detect and merge duplicate memories."""
 
@@ -183,13 +247,28 @@ class DedupMergePhase:
         clusters = uf.clusters()
         # Filter to clusters with 2+ members, cap at MAX_CLUSTER_SIZE
         processable = [c for c in clusters if 2 <= len(c) <= MAX_CLUSTER_SIZE]
-        deferred = [c for c in clusters if len(c) > MAX_CLUSTER_SIZE]
+        oversize = [c for c in clusters if len(c) > MAX_CLUSTER_SIZE]
 
-        if deferred:
+        # #1184: oversize clusters used to be deferred WHOLESALE — on a
+        # templated corpus everything union-finds into one mega-cluster and
+        # dedup goes structurally inert ("0 merges" indistinguishable from
+        # "nothing to merge"). Split them into judgeable subclusters instead;
+        # cross-subcluster pairs are counted as deferred, not silently lost.
+        split_subclusters = 0
+        deferred_pairs = 0
+        for big in oversize:
+            subclusters, skipped = _split_oversize_cluster(big, pairs)
+            split_subclusters += len(subclusters)
+            deferred_pairs += skipped
+            processable.extend(subclusters)
+
+        if oversize:
             logger.info(
-                "dedup_clusters_deferred",
-                count=len(deferred),
-                sizes=[len(c) for c in deferred],
+                "dedup_oversize_clusters_split",
+                count=len(oversize),
+                sizes=[len(c) for c in oversize],
+                split_subclusters=split_subclusters,
+                deferred_pairs=deferred_pairs,
             )
 
         # Step 4: Process each cluster
@@ -249,7 +328,18 @@ class DedupMergePhase:
         result.details = {
             "candidates": len(pairs),
             "clusters": len(processable),
-            "deferred_clusters": len(deferred),
+            # #1184: 'deferred_clusters' now counts ORIGINAL oversize clusters
+            # (kept under its pre-split key for narrative/reader continuity);
+            # their members are re-clustered into judgeable subclusters below
+            # rather than skipped wholesale.
+            "deferred_clusters": len(oversize),
+            "oversize_clusters": len(oversize),
+            "oversize_max_size": max((len(c) for c in oversize), default=0),
+            "split_subclusters": split_subclusters,
+            # Candidate pairs left unjudged this run by the size cap —
+            # distinguishes "0 merges: nothing matched" from "0 merges:
+            # work was deferred".
+            "deferred_pairs": deferred_pairs,
             "merged": merged_count,
         }
 

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -571,9 +571,11 @@ class TestExecuteOrchestration:
         # No LLM tokens on the rule path.
         assert result.llm_calls_used == 0
 
-    async def test_deferred_oversized_cluster_not_processed(self, dedup_phase):
-        """A 6-member fully-connected cluster exceeds MAX_CLUSTER_SIZE → deferred,
-        zero merges, deferred_clusters counted."""
+    async def test_oversized_cluster_split_and_partially_processed(self, dedup_phase):
+        """#1184: a 6-member chained cluster exceeds MAX_CLUSTER_SIZE — instead
+        of wholesale deferral it is re-split into <=5-member subclusters, the
+        rule path merges within them, and the observability keys expose the
+        oversize volume + pairs left unjudged."""
         mems = [_make_memory(importance=0.5) for _ in range(MAX_CLUSTER_SIZE + 1)]
         config = _make_config(provider="")
         budget = SleepBudget()
@@ -586,10 +588,43 @@ class TestExecuteOrchestration:
 
         result = await dedup_phase.execute(config, "u", "ws", "ctx", budget)
 
-        assert result.details["deferred_clusters"] == 1
-        assert result.details["clusters"] == 0  # nothing processable
-        assert result.details["merged"] == 0
-        dedup_phase._execute_merge.assert_not_called()
+        assert result.details["oversize_clusters"] == 1
+        assert result.details["deferred_clusters"] == 1  # legacy key: original count
+        assert result.details["oversize_max_size"] == MAX_CLUSTER_SIZE + 1
+        # 6 chained members at cap 5: equal scores tie-break on random UUIDs,
+        # so the terminal partition is (5,1), (4,2) or (3,3) — 1 or 2
+        # judgeable subclusters, and always exactly one blocked chain edge.
+        assert result.details["split_subclusters"] in (1, 2)
+        assert result.details["clusters"] == result.details["split_subclusters"]
+        assert result.details["deferred_pairs"] == 1
+        # Partial progress: merges happen INSIDE the subcluster (0.99 >= auto).
+        assert result.details["merged"] > 0
+        dedup_phase._execute_merge.assert_awaited()
+
+    async def test_mega_cluster_yields_multiple_subclusters(self, dedup_phase):
+        """#1184 Day-5 shape: ALL memories pairwise-similar → one mega-cluster;
+        splitting must yield multiple judgeable subclusters, not zero."""
+        n = 12
+        mems = [_make_memory(importance=0.5) for _ in range(n)]
+        config = _make_config(provider="")
+        budget = SleepBudget()
+
+        dedup_phase._fetch_active_memories = AsyncMock(return_value=mems)
+        # Fully-connected candidate graph (all pairs above threshold).
+        pairs = [(mems[i].id, mems[j].id, 0.99) for i in range(n) for j in range(i + 1, n)]
+        dedup_phase._find_similar_pairs = AsyncMock(return_value=pairs)
+        dedup_phase._execute_merge = AsyncMock()
+
+        result = await dedup_phase.execute(config, "u", "ws", "ctx", budget)
+
+        assert result.details["oversize_clusters"] == 1
+        assert result.details["oversize_max_size"] == n
+        # 12 members at cap 5: any terminal partition has pairwise component
+        # sums > 5, i.e. (5,5,2)/(5,4,3)/(4,4,4) → 3, or (3,3,3,3) → 4.
+        # The point is MULTIPLE judgeable subclusters, never zero.
+        assert result.details["split_subclusters"] in (3, 4)
+        assert result.details["merged"] > 0
+        assert result.details["deferred_pairs"] > 0
 
     async def test_budget_exhaustion_breaks_cluster_loop(self, dedup_phase):
         """With LLM enabled and zero budget, the can_afford guard breaks before
@@ -839,3 +874,80 @@ class TestFetchActiveMemoriesRealDB:
         ids = {m.id for m in rows}
         assert in_scope.id in ids
         assert wrong_ws.id not in ids  # filtered out by workspace_id (line 296)
+
+
+# ---------------------------------------------------------------------------
+# _split_oversize_cluster (#1184)
+# ---------------------------------------------------------------------------
+
+
+class TestSplitOversizeCluster:
+    """Deterministic unit tests for the capacity-capped greedy split."""
+
+    def test_prefers_highest_similarity_pairs(self):
+        """With distinct scores the strongest pairs coalesce first: a 6-node
+        chain whose weakest link is in the middle splits exactly there."""
+        from services.sleep.dedup_merge import _split_oversize_cluster
+
+        ids = [uuid4() for _ in range(6)]
+        # Chain scores: strong at the ends, weakest in the middle (0.921).
+        scores = [0.99, 0.98, 0.921, 0.97, 0.96]
+        pairs = [(ids[i], ids[i + 1], scores[i]) for i in range(5)]
+
+        subclusters, skipped = _split_oversize_cluster(set(ids), pairs, max_size=3)
+
+        # Strong halves {0,1,2} and {3,4,5} form; the weak middle link is
+        # the only one blocked by the cap.
+        as_sets = sorted(subclusters, key=len)
+        assert {frozenset(s) for s in as_sets} == {
+            frozenset(ids[:3]),
+            frozenset(ids[3:]),
+        }
+        assert skipped == 1
+
+    def test_every_subcluster_within_cap(self):
+        from services.sleep.dedup_merge import _split_oversize_cluster
+
+        ids = [uuid4() for _ in range(23)]
+        # Fully-connected with distinct descending scores for determinism.
+        pairs = []
+        score = 0.999
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                pairs.append((ids[i], ids[j], score))
+                score -= 0.0001
+        subclusters, skipped = _split_oversize_cluster(set(ids), pairs, max_size=5)
+
+        assert all(2 <= len(s) <= 5 for s in subclusters)
+        # Every member lands in some subcluster or is a leftover singleton;
+        # no member appears twice.
+        seen = [m for s in subclusters for m in s]
+        assert len(seen) == len(set(seen))
+        assert skipped > 0
+
+    def test_pairs_outside_cluster_ignored(self):
+        from services.sleep.dedup_merge import _split_oversize_cluster
+
+        inside = [uuid4() for _ in range(3)]
+        outsider = uuid4()
+        pairs = [
+            (inside[0], inside[1], 0.99),
+            (inside[1], inside[2], 0.98),
+            (inside[0], outsider, 1.0),  # must be ignored
+        ]
+        subclusters, skipped = _split_oversize_cluster(set(inside), pairs, max_size=5)
+
+        assert subclusters == [set(inside)]
+        assert skipped == 0
+        assert outsider not in subclusters[0]
+
+    def test_no_internal_pairs_yields_no_subclusters(self):
+        """Degenerate guard: a cluster with no internal pair edges (cannot
+        happen from union-find output, but the function must not crash)."""
+        from services.sleep.dedup_merge import _split_oversize_cluster
+
+        ids = {uuid4(), uuid4()}
+        subclusters, skipped = _split_oversize_cluster(ids, [], max_size=5)
+
+        assert subclusters == []
+        assert skipped == 0

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -619,10 +619,12 @@ class TestExecuteOrchestration:
 
         assert result.details["oversize_clusters"] == 1
         assert result.details["oversize_max_size"] == n
-        # 12 members at cap 5: any terminal partition has pairwise component
-        # sums > 5, i.e. (5,5,2)/(5,4,3)/(4,4,4) → 3, or (3,3,3,3) → 4.
-        # The point is MULTIPLE judgeable subclusters, never zero.
-        assert result.details["split_subclusters"] in (3, 4)
+        # 12 members at cap 5 on a COMPLETE equal-score graph: the greedy
+        # walk always fills components to capacity before starting new ones
+        # (every node pair has an edge, so a below-cap component always finds
+        # a mergeable partner while one exists) → deterministically (5,5,2),
+        # i.e. exactly 3 subclusters regardless of UUID tie-break order.
+        assert result.details["split_subclusters"] == 3
         assert result.details["merged"] > 0
         assert result.details["deferred_pairs"] > 0
 

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -619,11 +619,12 @@ class TestExecuteOrchestration:
 
         assert result.details["oversize_clusters"] == 1
         assert result.details["oversize_max_size"] == n
-        # 12 members at cap 5 on a COMPLETE equal-score graph: the greedy
-        # walk always fills components to capacity before starting new ones
-        # (every node pair has an edge, so a below-cap component always finds
-        # a mergeable partner while one exists) → deterministically (5,5,2),
-        # i.e. exactly 3 subclusters regardless of UUID tie-break order.
+        # 12 members at cap 5 on a COMPLETE equal-score graph: with canonical
+        # (str-ascending) pair orientation the tie-break walk is lexicographic
+        # — the str-smallest node's edges come first, so its component fills
+        # to capacity (5), then the next-smallest unmerged node fills the
+        # second (5), leaving the final pair (2) → deterministically (5,5,2),
+        # exactly 3 subclusters for ANY concrete uuid values.
         assert result.details["split_subclusters"] == 3
         assert result.details["merged"] > 0
         assert result.details["deferred_pairs"] > 0
@@ -953,3 +954,19 @@ class TestSplitOversizeCluster:
 
         assert subclusters == []
         assert skipped == 0
+
+    def test_split_is_orientation_independent(self):
+        """_find_similar_pairs emits (memory.id, hit_id) in Qdrant-iteration
+        orientation — the SAME logical pair set with flipped orientations
+        must produce the SAME split (Copilot, PR #1188)."""
+        from services.sleep.dedup_merge import _split_oversize_cluster
+
+        ids = [uuid4() for _ in range(8)]
+        pairs = [(ids[i], ids[j], 0.95) for i in range(len(ids)) for j in range(i + 1, len(ids))]
+        flipped = [(b, a, s) for a, b, s in pairs]
+
+        subclusters_fwd, skipped_fwd = _split_oversize_cluster(set(ids), pairs, max_size=3)
+        subclusters_rev, skipped_rev = _split_oversize_cluster(set(ids), flipped, max_size=3)
+
+        assert {frozenset(s) for s in subclusters_fwd} == {frozenset(s) for s in subclusters_rev}
+        assert skipped_fwd == skipped_rev


### PR DESCRIPTION
Closes #1184

## Summary
On templated corpora (daily standups, status logs) every note is pairwise-similar above the 0.92 candidate threshold, union-find collapses ALL candidates into one mega-cluster (Day-5 eval: **782 pairs → 1 cluster** > `MAX_CLUSTER_SIZE=5`), and the whole set was deferred unjudged **before any LLM call** — dedup went structurally inert, with `0 merges` indistinguishable from "nothing to merge".

## Changes (`backend/src/services/sleep/dedup_merge.py`)
**Part 1 — Observability**: `dedup_result.details` now carries `oversize_clusters`, `oversize_max_size`, `split_subclusters`, and `deferred_pairs` (cap-blocked union attempts — a documented proxy for unjudged candidate volume). `deferred_clusters` is retained as the legacy key (original oversize count; consumed by the frontend narrative reader).

**Part 2 — Splitting**: new `_split_oversize_cluster` — capacity-capped greedy agglomeration. Walk the cluster's internal pairs in **descending similarity** (deterministic str-uuid tie-break) and union components only while the merged size stays ≤ `MAX_CLUSTER_SIZE`. The tightest duplicates coalesce first, every subcluster fits one LLM batch, skipped cross-component pairs are re-candidates next run (post-merge the landscape shrinks). Subclusters append after normal clusters so the pre-existing set keeps budget priority; `sleep_max_llm_calls_per_run` still bounds total cost.

Acceptance: a corpus whose candidate graph collapses into one oversize cluster now gets judged merges every run instead of zero, and the deferred volume is visible in `sleep_summary`.

## Testing
- `TestSplitOversizeCluster` (deterministic): weakest-link split point, cap invariants on a complete 23-node graph, external-pair filtering, degenerate no-pairs guard.
- Execute-level: 6-chain (split + partial merges + `deferred_pairs==1`), complete-12 Day-5 shape (deterministic 3 subclusters, merges > 0).
- Sleep suite in container harness: 233 passed; ruff clean.
- Independent code review: no Critical; 1 Warning (proxy-semantics overclaim) + 2 actionable Info — all addressed in the last commit. Verifier ran randomized simulations (2k–20k trials) confirming the split algorithm's invariants and the test math.

## Notes
- Expect a trivial additive conflict with #1187 (#1183) in the same `details` dict — whichever merges second rebases (I'll handle it).
- Follow-up (from review): surface `oversize_clusters`/`split_subclusters`/`deferred_pairs` in the dedup UI narrative — today the narrative i18n string doesn't render deferral info at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)