### PR TITLE
chore(release): v0.43.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Kagura Memory Cloud plugin — restore session context, recall & save durable project knowledge, setup help, and an MCP smoke test",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.42.0"
+version = "0.43.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.42.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.43.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.42.0"
+APP_VERSION = "0.43.0"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
## v0.43.0

Version bump across all 7 version files. Canonical: `backend/src/config/constants.py` `APP_VERSION`.

### Highlights (since v0.42.0)
- **fix(credentials)**: owner-provisioning 403 no longer leaks the `WorkspaceRole` enum repr — message reads `role='admin'` (#1180, #1181)
- **fix(neural)**: `neural_config` DB rows overriding `SLEEP_LLM_*` env now WARN on mismatch; `SLEEP_LLM_FORCE_ENV=1` operator escape hatch (#1182, #1186)
- **fix(sleep)**: runs are graded `completed` / `degraded` / `failed` by judge-LLM health — total judge failure can no longer report success; `llm_call_failures` surfaced top-level in API/MCP; Analysis cluster-labeling sibling reports instrumented too (#1183, #1187)
- **fix(sleep/dedup)**: oversize union-find mega-clusters are split into judgeable ≤5-member subclusters (capacity-capped greedy agglomeration) instead of wholesale unjudged deferral; deferred volume now observable (#1184, #1188)

### Migration
`e54_1183_sleep_status_degraded`: widens the `sleep_reports` status CHECK with `'degraded'` and adds `llm_call_failures` (int, NOT NULL, server_default 0). **Additive + defaulted → blue-green safe**; deploy runs it before the color flip as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)