### PR TITLE
feat(frontend): surface dedup split stats and judge failures in Sleep report UI (#1190)

### DIFF
--- a/frontend/src/components/sleep-reports/SleepReportDetailView.tsx
+++ b/frontend/src/components/sleep-reports/SleepReportDetailView.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   ArrowLeft,
+  AlertTriangle,
   CheckCircle2,
   XCircle,
   MinusCircle,
@@ -30,6 +31,7 @@ import {
   TrendingUp,
   Sparkles,
 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   formatDateTime,
   formatDuration,
@@ -37,6 +39,7 @@ import {
 } from "@/lib/utils/datetime";
 import {
   buildHeadline,
+  buildJudgeFailureNote,
   buildPhaseNarrative,
   type PhaseName,
 } from "@/lib/utils/sleep-narrative";
@@ -165,6 +168,20 @@ export function SleepReportDetailView({
           />
         )}
 
+        {report.status === "degraded" && (
+          // #1183/#1190: degraded = run finished but SOME judge-LLM calls
+          // failed. Informational (not an error) — an ErrorBanner would
+          // overstate it, but badge-only understates it.
+          <Alert className="border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-400">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              {t("detail.narrative.runDegraded", {
+                count: report.llm_call_failures ?? 0,
+              })}
+            </AlertDescription>
+          </Alert>
+        )}
+
         <div className="p-6 bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700">
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div className="flex items-center gap-3">
@@ -223,6 +240,7 @@ export function SleepReportDetailView({
           <CardContent className="space-y-2">
             {phaseResults.map(({ key, result }) => {
               const narrative = buildPhaseNarrative(key, result);
+              const judgeNote = buildJudgeFailureNote(result);
               return (
                 <details
                   key={key}
@@ -237,6 +255,11 @@ export function SleepReportDetailView({
                       {narrative && (
                         <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
                           {t(narrative.key, narrative.values)}
+                        </div>
+                      )}
+                      {judgeNote && (
+                        <div className="text-xs text-yellow-700 dark:text-yellow-400 truncate">
+                          {t(judgeNote.key, judgeNote.values)}
                         </div>
                       )}
                     </div>

--- a/frontend/src/components/sleep-reports/SleepReportDetailView.tsx
+++ b/frontend/src/components/sleep-reports/SleepReportDetailView.tsx
@@ -172,7 +172,13 @@ export function SleepReportDetailView({
           // #1183/#1190: degraded = run finished but SOME judge-LLM calls
           // failed. Informational (not an error) — an ErrorBanner would
           // overstate it, but badge-only understates it.
-          <Alert className="border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-400">
+          <Alert
+            // Informational, not an error — role="status" (polite) instead of
+            // the Alert default role="alert" (assertive) so screen readers
+            // don't announce it with error urgency (#1190 review).
+            role="status"
+            className="border-yellow-300 bg-yellow-50 text-yellow-800 dark:border-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300 [&>svg]:text-yellow-600 dark:[&>svg]:text-yellow-400"
+          >
             <AlertTriangle className="h-4 w-4" />
             <AlertDescription>
               {t("detail.narrative.runDegraded", {

--- a/frontend/src/lib/api/sleep-reports.ts
+++ b/frontend/src/lib/api/sleep-reports.ts
@@ -32,6 +32,10 @@ export interface SleepReportSummary {
   memories_flagged: number;
   llm_calls_made: number;
   llm_tokens_used: number;
+  // #1183: judge-LLM calls that raised across all phases — the magnitude
+  // behind a 'degraded'/'failed' grading. Optional: reports written before
+  // v0.43.0 lack the column in older cached payloads.
+  llm_call_failures?: number;
 }
 
 export interface PhaseResult {
@@ -40,6 +44,9 @@ export interface PhaseResult {
   skip_reason: string | null;
   error: string | null;
   llm_calls: number;
+  // #1183: judge calls that raised in THIS phase. Absent on pre-v0.43.0
+  // report blobs (JSONB written by older reporters).
+  llm_call_failures?: number;
   memories_processed: number;
   details: Record<string, unknown> | null;
 }

--- a/frontend/src/lib/utils/sleep-narrative.test.ts
+++ b/frontend/src/lib/utils/sleep-narrative.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildHeadline,
+  buildJudgeFailureNote,
   buildPhaseNarrative,
   type NarrativePhaseResult,
 } from "./sleep-narrative";
@@ -173,6 +174,46 @@ describe("buildPhaseNarrative", () => {
       const n = buildPhaseNarrative("dedup", phase({ details: {} }));
       expect(n?.key).toBe("detail.narrative.phases.dedup.empty");
     });
+
+    it("uses successWithSplit when oversize clusters were split (#1190)", () => {
+      const n = buildPhaseNarrative(
+        "dedup",
+        phase({
+          details: {
+            candidates: 782,
+            merged: 4,
+            clusters: 3,
+            deferred_clusters: 1,
+            oversize_clusters: 1,
+            oversize_max_size: 40,
+            split_subclusters: 3,
+            deferred_pairs: 120,
+          },
+        }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.dedup.successWithSplit");
+      expect(n?.values.count).toBe(782);
+      expect(n?.values.merged).toBe(4);
+      expect(n?.values.oversize).toBe(1);
+      expect(n?.values.subclusters).toBe(3);
+      expect(n?.values.deferredPairs).toBe(120);
+    });
+
+    it("legacy pre-v0.43.0 blob (deferred_clusters only) keeps plain success", () => {
+      // No split happened on those runs — "split into 0 batches" would lie.
+      const n = buildPhaseNarrative(
+        "dedup",
+        phase({
+          details: {
+            candidates: 12,
+            merged: 0,
+            clusters: 0,
+            deferred_clusters: 2,
+          },
+        }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.dedup.success");
+    });
   });
 
   describe("importance", () => {
@@ -254,5 +295,25 @@ describe("buildPhaseNarrative", () => {
       );
       expect(n?.values.failed).toBe(0);
     });
+  });
+});
+
+describe("buildJudgeFailureNote", () => {
+  it("returns null for a null result", () => {
+    expect(buildJudgeFailureNote(null)).toBeNull();
+  });
+
+  it("returns null when the field is absent (pre-v0.43.0 blob)", () => {
+    expect(buildJudgeFailureNote(phase())).toBeNull();
+  });
+
+  it("returns null when zero calls failed", () => {
+    expect(buildJudgeFailureNote(phase({ llm_call_failures: 0 }))).toBeNull();
+  });
+
+  it("builds the note with the failure count", () => {
+    const n = buildJudgeFailureNote(phase({ llm_call_failures: 5 }));
+    expect(n?.key).toBe("detail.narrative.judgeFailures");
+    expect(n?.values.count).toBe(5);
   });
 });

--- a/frontend/src/lib/utils/sleep-narrative.ts
+++ b/frontend/src/lib/utils/sleep-narrative.ts
@@ -10,17 +10,16 @@
  */
 
 export type PhaseName =
-  | "edgeDiscovery"
-  | "dedup"
-  | "importance"
-  | "consolidation"
-  | "reindex";
+  "edgeDiscovery" | "dedup" | "importance" | "consolidation" | "reindex";
 
 export interface NarrativePhaseResult {
   success: boolean;
   skipped: boolean;
   skip_reason: string | null;
   error: string | null;
+  // #1183: judge calls that raised in this phase. Optional — pre-v0.43.0
+  // report blobs don't carry it.
+  llm_call_failures?: number;
   details: Record<string, unknown> | null;
 }
 
@@ -171,13 +170,34 @@ export function buildPhaseNarrative(
       const candidates = num(d, "candidates") ?? 0;
       const merged = num(d, "merged") ?? 0;
       const clusters = num(d, "clusters") ?? 0;
-      const deferred = num(d, "deferred_clusters") ?? 0;
+      // #1184: oversize mega-clusters are split into judgeable subclusters;
+      // report the split + the deferred (unjudged) pair volume so "0 merges
+      // because everything was deferred" is visible. Keyed on the NEW
+      // `oversize_clusters` only — pre-v0.43.0 blobs carry the legacy
+      // `deferred_clusters` (wholesale deferral, no split happened), and
+      // rendering "split into 0 batches" for those would be a lie; they
+      // keep the plain success line.
+      const oversize = num(d, "oversize_clusters") ?? 0;
+      const subclusters = num(d, "split_subclusters") ?? 0;
+      const deferredPairs = num(d, "deferred_pairs") ?? 0;
       if (candidates === 0 && merged === 0) {
         return { key: "detail.narrative.phases.dedup.empty", values: {} };
       }
+      if (oversize > 0) {
+        return {
+          key: "detail.narrative.phases.dedup.successWithSplit",
+          values: {
+            count: candidates,
+            merged,
+            oversize,
+            subclusters,
+            deferredPairs,
+          },
+        };
+      }
       return {
         key: "detail.narrative.phases.dedup.success",
-        values: { count: candidates, merged, clusters, deferred },
+        values: { count: candidates, merged, clusters },
       };
     }
     case "importance": {
@@ -242,4 +262,24 @@ export function buildPhaseNarrative(
       };
     }
   }
+}
+
+/**
+ * Build the judge-failure sub-note for a phase card (#1183 / #1190).
+ *
+ * A phase whose judge-LLM calls partially failed still renders a plain
+ * success narrative; this companion note surfaces the failure count so a
+ * `degraded` run is explainable at the phase level. Returns null when the
+ * phase was not run, the field is absent (pre-v0.43.0 blobs), or no calls
+ * failed.
+ */
+export function buildJudgeFailureNote(
+  result: NarrativePhaseResult | null,
+): Narrative | null {
+  const failures = result?.llm_call_failures;
+  if (typeof failures !== "number" || failures <= 0) return null;
+  return {
+    key: "detail.narrative.judgeFailures",
+    values: { count: failures },
+  };
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2877,6 +2877,7 @@
           "headlineNoContext": "Processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
           "headlineDeletedContext": "(deleted context) — processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
           "runFailed": "Run failed: {error}",
+          "runDegraded": "Run degraded: {count, plural, one {# judge LLM call} other {# judge LLM calls}} failed — merge/importance judgments may be incomplete. Check the phase results below.",
           "skippedNoReason": "Skipped",
           "skippedUnknown": "Skipped: {reason}",
           "skipReasons": {
@@ -2885,6 +2886,7 @@
             "sleepMode": "Skipped: sleep mode is {mode}"
           },
           "failed": "Failed: {error}",
+          "judgeFailures": "{count, plural, one {# judge LLM call} other {# judge LLM calls}} failed in this phase",
           "phases": {
             "edgeDiscovery": {
               "success": "Added {count, plural, one {# edge} other {# edges}} across {sampled, plural, one {# sampled memory} other {# sampled memories}}",
@@ -2892,6 +2894,7 @@
             },
             "dedup": {
               "success": "Detected {count, plural, one {# duplicate pair} other {# duplicate pairs}} → {merged} merged",
+              "successWithSplit": "Detected {count, plural, one {# duplicate pair} other {# duplicate pairs}} → {merged} merged · {oversize, plural, one {# oversize cluster} other {# oversize clusters}} split into {subclusters, plural, one {# batch} other {# batches}}, {deferredPairs, plural, one {# pair} other {# pairs}} deferred to the next run",
               "empty": "No duplicate candidates found"
             },
             "importance": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2877,6 +2877,7 @@
           "headlineNoContext": "{processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
           "headlineDeletedContext": "(削除済みコンテキスト) — {processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
           "runFailed": "実行に失敗しました: {error}",
+          "runDegraded": "一部失敗: judge LLM 呼び出し {count} 件が失敗しました — マージ・重要度の判定が不完全な可能性があります。下のフェーズ結果を確認してください。",
           "skippedNoReason": "スキップされました",
           "skippedUnknown": "スキップ: {reason}",
           "skipReasons": {
@@ -2885,6 +2886,7 @@
             "sleepMode": "スキップ: sleep モードが {mode}"
           },
           "failed": "失敗: {error}",
+          "judgeFailures": "このフェーズで judge LLM 呼び出し {count} 件が失敗",
           "phases": {
             "edgeDiscovery": {
               "success": "サンプル {sampled} 件から {count} 件のエッジを追加",
@@ -2892,6 +2894,7 @@
             },
             "dedup": {
               "success": "重複候補 {count} ペアを検出 → {merged} 件マージ",
+              "successWithSplit": "重複候補 {count} ペアを検出 → {merged} 件マージ・大型クラスタ {oversize} 件を {subclusters} バッチに分割、{deferredPairs} ペアは次回に持ち越し",
               "empty": "重複候補は見つかりませんでした"
             },
             "importance": {


### PR DESCRIPTION
Closes #1190

## Summary
Since v0.43.0 the backend reports Sleep judge health (#1183) and dedup oversize-split stats (#1184), but none of it reached the UI — the dedup narrative template even silently dropped the `{deferred}` value it was being passed (ICU formatter discards unreferenced values; found in the #1188 review).

**Frontend-only** — no API/backend/migration changes; deployable with `deploy.sh --web` alone.

## Changes
- **Dedup narrative** ([sleep-narrative.ts](frontend/src/lib/utils/sleep-narrative.ts)): new `successWithSplit` variant — "Detected 782 duplicate pairs → 4 merged · 1 oversize cluster split into 3 batches, 120 pairs deferred to the next run". Keyed on the NEW `oversize_clusters` only: legacy pre-v0.43.0 blobs (wholesale deferral, no split happened) keep the plain success line rather than claiming "split into 0 batches".
- **Phase cards**: `buildJudgeFailureNote` renders a yellow "N judge LLM calls failed in this phase" sub-note when `llm_call_failures > 0`.
- **Degraded runs**: informational yellow Alert (`role="status"`, not an ErrorBanner — degraded is not an error) naming the run-level failure count; matches the existing yellow `degraded` badge ramp.
- **Types**: optional `llm_call_failures` on `SleepReportSummary`/`PhaseResult` (pre-v0.43.0 payloads lack it).
- **i18n**: 3 new keys in en/ja (structural parity machine-verified).

## Testing
- `sleep-narrative.test.ts`: 31 passed (6 new — split routing, legacy-blob fallback, judge-note cases). tsc clean. en/ja JSON valid + key parity verified.
- Independent review: no Critical/Warning; verified ICU syntax of all new strings by parsing them with the exact value shapes, backend↔frontend field alignment (`phase_data.llm_call_failures` at root), and type compatibility. The one Info finding (assertive `role="alert"` on an informational note) fixed in the last commit.
- Note: full local vitest is unreliable on this host (pre-existing `useSystemFeatures` env-dependent failure reproduces on clean main; unrelated file) — CI frontend lane is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)