### PR TITLE
chore(release): v0.43.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Kagura Memory Cloud plugin — restore session context, recall & save durable project knowledge, setup help, and an MCP smoke test",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.43.0"
+version = "0.43.1"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.43.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.43.1"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.43.0"
+APP_VERSION = "0.43.1"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
## v0.43.1

Patch release — version bump across all 7 version files (canonical: `backend/src/config/constants.py` `APP_VERSION`).

### Highlights (since v0.43.0)
- **fix(api,frontend)**: context settings save no longer 422s when a legacy field exceeds current caps (#1193 → #1194). Context metadata length caps are now a single source of truth enforced identically on REST, MCP (`create_context`/`update_context` now actually validate; previously documented-only), workspace default-context creation, and the settings UI. `summary` cap raised 500→2000 to legitimize MCP-written data. The settings panel sends only changed fields, and 422 toasts name the failing field.
- **feat(frontend)**: Sleep report UI surfaces judge-LLM health and dedup split stats (#1190 → #1191):
  - dedup narrative renders oversize-cluster splitting ("1 oversize cluster split into 3 batches, 120 pairs deferred to the next run")
  - phase cards show a "N judge LLM calls failed" sub-note when `llm_call_failures > 0`
  - `degraded` runs get an informational banner (`role="status"`) naming the failure count

### Migration
None. No schema changes; the API redeploy updates the reported version string and the new cap enforcement.

### Merge order
Merge #1194 first, then this PR — the tag lands on the combined main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)