### PR TITLE
eval(day5-replication): v0.43.1 dedup-ACTIVE replication artifacts (3 runs + analysis)

### DIFF
--- a/backend/tests/eval/results/day5r-v0431-analysis-2026-07-06.json
+++ b/backend/tests/eval/results/day5r-v0431-analysis-2026-07-06.json
@@ -1,0 +1,141 @@
+{
+  "run_date": "2026-07-06",
+  "experiment": "day5-update-correctness",
+  "seed": 20260703,
+  "n_resamples": 10000,
+  "alpha": 0.05,
+  "delta_update": 0.15,
+  "k": 10,
+  "run_labels": [
+    "day5r-v0431-run0",
+    "day5r-v0431-run1",
+    "day5r-v0431-run2"
+  ],
+  "inferential_run": "day5r-v0431-run0",
+  "h4": {
+    "n_complete_pairs": 19,
+    "mean": 0.4737,
+    "ci_low": 0.2632,
+    "ci_high": 0.6842,
+    "pass": true,
+    "underpowered": true
+  },
+  "decomposition": {
+    "vanilla_rag": {
+      "n": 50,
+      "counts": {
+        "current_over_stale": 27,
+        "stale_over_current": 23,
+        "current_only": 0,
+        "stale_only": 0,
+        "neither": 0
+      },
+      "rates": {
+        "current_over_stale": 0.54,
+        "stale_over_current": 0.46,
+        "current_only": 0.0,
+        "stale_only": 0.0,
+        "neither": 0.0
+      }
+    },
+    "mc_update": {
+      "n": 50,
+      "counts": {
+        "current_over_stale": 19,
+        "stale_over_current": 0,
+        "current_only": 25,
+        "stale_only": 5,
+        "neither": 1
+      },
+      "rates": {
+        "current_over_stale": 0.38,
+        "stale_over_current": 0.0,
+        "current_only": 0.5,
+        "stale_only": 0.1,
+        "neither": 0.02
+      }
+    },
+    "mc_prod": {
+      "n": 50,
+      "counts": {
+        "current_over_stale": 19,
+        "stale_over_current": 0,
+        "current_only": 25,
+        "stale_only": 5,
+        "neither": 1
+      },
+      "rates": {
+        "current_over_stale": 0.38,
+        "stale_over_current": 0.0,
+        "current_only": 0.5,
+        "stale_only": 0.1,
+        "neither": 0.02
+      }
+    }
+  },
+  "supporting": {
+    "update_success_at_10": {
+      "vanilla_rag": {
+        "mean": 0.54,
+        "n": 50
+      },
+      "mc_update": {
+        "mean": 0.88,
+        "n": 50
+      },
+      "mc_prod": {
+        "mean": 0.88,
+        "n": 50
+      }
+    },
+    "vs_vanilla_rag": {
+      "mc_update": {
+        "mean": 0.34,
+        "ci_low": 0.2,
+        "ci_high": 0.48,
+        "n": 50
+      },
+      "mc_prod": {
+        "mean": 0.34,
+        "ci_low": 0.2,
+        "ci_high": 0.48,
+        "n": 50
+      }
+    }
+  },
+  "sigma_d": 0.513,
+  "achieved_power": {
+    "delta": 0.15,
+    "n": 19,
+    "power": 0.2465
+  },
+  "across_runs": {
+    "gated_conditional_mean_diff": {
+      "min": 0.3913,
+      "median": 0.4737,
+      "max": 0.5
+    },
+    "update_success_at_10": {
+      "vanilla_rag": {
+        "min": 0.54,
+        "median": 0.54,
+        "max": 0.54
+      },
+      "mc_update": {
+        "min": 0.8,
+        "median": 0.84,
+        "max": 0.88
+      },
+      "mc_prod": {
+        "min": 0.8,
+        "median": 0.84,
+        "max": 0.88
+      }
+    }
+  },
+  "design_notes": [
+    "D1: gated arms differ ONLY in update machinery -- vanilla_rag (sleep_mode=skip, reinforce_enabled=False, neural off, search_mode=semantic) vs mc_update (sleep_mode=full, one Sleep full pass w/ judge-LLM as configured, reinforce_enabled=True, search_mode=semantic); mc_prod (hybrid + neural, production posture) is supporting only, scored after mc_update so its Hebbian writes cannot contaminate the gated pass.",
+    "D3: longitudinal simulation -- every stale (-v1) memory's created_at/updated_at backdated 30 days in BOTH contexts before scoring; a seconds-apart ingest would make every recency mechanism inert by construction.",
+    "D4: gated conditional = complete pairs (both arms' outcome in {current_over_stale, stale_over_current}); diffs = mc_update_correct - vanilla_rag_correct, paired BCa (10k resamples, seed 20260703) on the mean diff; pass = ci_low > 0 AND mean >= delta_update (0.15); underpowered if complete pairs < 25; dedup removal of the stale doc lands in current_only ('update-by-removal') -- reported, not gated."
+  ]
+}

--- a/backend/tests/eval/results/day5r-v0431-run0-2026-07-06.json
+++ b/backend/tests/eval/results/day5r-v0431-run0-2026-07-06.json
@@ -1,0 +1,1105 @@
+{
+  "run_date": "2026-07-06",
+  "experiment": "day5-update-correctness",
+  "label": "day5r-v0431-run0",
+  "corpus_path": "fixtures/update_slice.yaml",
+  "content_sha256": "68181b5f8589cd646c58702dde44f22fda15a75b73ec1d735448053ca3d9725e",
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "k": 10,
+  "backdate_days": 30,
+  "judge_model": "qwen3.5-9b",
+  "sleep_summary": {
+    "ran": true,
+    "ok": false,
+    "status": "degraded",
+    "llm_call_failures": 15,
+    "memories_processed": 349,
+    "edges_created": 3,
+    "memories_merged": 29,
+    "memories_promoted": 59,
+    "memories_flagged": 101,
+    "error_message": null,
+    "edge_discovery_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 4,
+      "llm_call_failures": 0,
+      "memories_processed": 30,
+      "details": {
+        "sampled": 30,
+        "candidates": 43,
+        "filtered": 43,
+        "edges_created": 3,
+        "llm_accepted": 3,
+        "llm_rejected": 2,
+        "llm_call_failures": 0,
+        "auto_accepted": 0,
+        "edge_type_dist": {
+          "related_to": 3
+        },
+        "avg_confidence": 0.7733333333333333,
+        "median_confidence": 0.75,
+        "p25_confidence": 0.75,
+        "p75_confidence": 0.7849999999999999,
+        "confidence_n": 3,
+        "confidence_imputed": 0,
+        "confidence_histogram": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 3,
+          "0.85-1.0": 0
+        },
+        "avg_confidence_rejected": 0.0,
+        "median_confidence_rejected": 0.0,
+        "p25_confidence_rejected": 0.0,
+        "p75_confidence_rejected": 0.0,
+        "confidence_n_rejected": 2,
+        "confidence_imputed_rejected": 0,
+        "confidence_histogram_rejected": {
+          "0.0-0.5": 2,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "llm_model": "qwen3.5-9b",
+        "prompt_revision": "v3"
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 3852,
+          "output_tokens": 591,
+          "cached_input_tokens": 0,
+          "calls": 4
+        }
+      ],
+      "embedding_calls": 30,
+      "embedding_tokens": 0
+    },
+    "dedup_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 24,
+      "llm_call_failures": 7,
+      "memories_processed": 130,
+      "details": {
+        "candidates": 782,
+        "clusters": 31,
+        "deferred_clusters": 1,
+        "oversize_clusters": 1,
+        "oversize_max_size": 130,
+        "split_subclusters": 31,
+        "deferred_pairs": 583,
+        "merged": 29,
+        "llm_call_failures": 7
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 23054,
+          "output_tokens": 12036,
+          "cached_input_tokens": 0,
+          "calls": 24
+        }
+      ],
+      "embedding_calls": 130,
+      "embedding_tokens": 0
+    },
+    "importance_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 3,
+      "llm_call_failures": 0,
+      "memories_processed": 21,
+      "details": {
+        "candidates": 21,
+        "updated": 21,
+        "alpha": 0.3,
+        "llm_call_failures": 0
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 3667,
+          "output_tokens": 1147,
+          "cached_input_tokens": 0,
+          "calls": 3
+        }
+      ],
+      "embedding_calls": 0,
+      "embedding_tokens": 0
+    },
+    "consolidation_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 13,
+      "llm_call_failures": 8,
+      "memories_processed": 101,
+      "details": {
+        "working_count": 101,
+        "rule_promoted": 0,
+        "rule_deleted": 0,
+        "borderline": 101,
+        "llm_promoted": 59,
+        "llm_archived": 3,
+        "llm_call_failures": 8
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 13020,
+          "output_tokens": 3523,
+          "cached_input_tokens": 0,
+          "calls": 13
+        }
+      ],
+      "embedding_calls": 0,
+      "embedding_tokens": 0
+    },
+    "reindex_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 0,
+      "llm_call_failures": 0,
+      "memories_processed": 67,
+      "details": {
+        "reindexed": 67,
+        "failed": 0,
+        "failed_ids": []
+      },
+      "llm_breakdown": [],
+      "embedding_calls": 67,
+      "embedding_tokens": 0
+    },
+    "llm_call_failures_total": 7
+  },
+  "arms": {
+    "vanilla_rag": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        }
+      ]
+    },
+    "mc_update": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "neither",
+          "current_rank": null,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        }
+      ]
+    },
+    "mc_prod": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 4,
+          "stale_rank": 5
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 5
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 6
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 6
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_only",
+          "current_rank": 7,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "neither",
+          "current_rank": null,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 5
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 5
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        }
+      ]
+    }
+  }
+}

--- a/backend/tests/eval/results/day5r-v0431-run1-2026-07-06.json
+++ b/backend/tests/eval/results/day5r-v0431-run1-2026-07-06.json
@@ -1,0 +1,1094 @@
+{
+  "run_date": "2026-07-06",
+  "experiment": "day5-update-correctness",
+  "label": "day5r-v0431-run1",
+  "corpus_path": "fixtures/update_slice.yaml",
+  "content_sha256": "68181b5f8589cd646c58702dde44f22fda15a75b73ec1d735448053ca3d9725e",
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "k": 10,
+  "backdate_days": 30,
+  "judge_model": "qwen3.5-9b",
+  "sleep_summary": {
+    "ran": true,
+    "ok": false,
+    "status": "degraded",
+    "llm_call_failures": 4,
+    "memories_processed": 360,
+    "edges_created": 0,
+    "memories_merged": 34,
+    "memories_promoted": 86,
+    "memories_flagged": 96,
+    "error_message": null,
+    "edge_discovery_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 0,
+      "llm_call_failures": 0,
+      "memories_processed": 30,
+      "details": {
+        "sampled": 30,
+        "candidates": 36,
+        "filtered": 36,
+        "edges_created": 0,
+        "llm_accepted": 0,
+        "llm_rejected": 0,
+        "llm_call_failures": 0,
+        "auto_accepted": 0,
+        "edge_type_dist": {},
+        "avg_confidence": 0.0,
+        "median_confidence": 0.0,
+        "p25_confidence": 0.0,
+        "p75_confidence": 0.0,
+        "confidence_n": 0,
+        "confidence_imputed": 0,
+        "confidence_histogram": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "avg_confidence_rejected": 0.0,
+        "median_confidence_rejected": 0.0,
+        "p25_confidence_rejected": 0.0,
+        "p75_confidence_rejected": 0.0,
+        "confidence_n_rejected": 0,
+        "confidence_imputed_rejected": 0,
+        "confidence_histogram_rejected": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "llm_model": "qwen3.5-9b",
+        "prompt_revision": "v3"
+      },
+      "llm_breakdown": [],
+      "embedding_calls": 30,
+      "embedding_tokens": 0
+    },
+    "dedup_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 27,
+      "llm_call_failures": 4,
+      "memories_processed": 130,
+      "details": {
+        "candidates": 782,
+        "clusters": 31,
+        "deferred_clusters": 1,
+        "oversize_clusters": 1,
+        "oversize_max_size": 130,
+        "split_subclusters": 31,
+        "deferred_pairs": 583,
+        "merged": 34,
+        "llm_call_failures": 4
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 26264,
+          "output_tokens": 14575,
+          "cached_input_tokens": 0,
+          "calls": 27
+        }
+      ],
+      "embedding_calls": 130,
+      "embedding_tokens": 0
+    },
+    "importance_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 2,
+      "llm_call_failures": 0,
+      "memories_processed": 16,
+      "details": {
+        "candidates": 16,
+        "updated": 16,
+        "alpha": 0.3,
+        "llm_call_failures": 0
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 2731,
+          "output_tokens": 877,
+          "cached_input_tokens": 0,
+          "calls": 2
+        }
+      ],
+      "embedding_calls": 0,
+      "embedding_tokens": 0
+    },
+    "consolidation_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 20,
+      "llm_call_failures": 0,
+      "memories_processed": 96,
+      "details": {
+        "working_count": 96,
+        "rule_promoted": 0,
+        "rule_deleted": 0,
+        "borderline": 96,
+        "llm_promoted": 86,
+        "llm_archived": 6,
+        "llm_call_failures": 0
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 19699,
+          "output_tokens": 5409,
+          "cached_input_tokens": 0,
+          "calls": 20
+        }
+      ],
+      "embedding_calls": 0,
+      "embedding_tokens": 0
+    },
+    "reindex_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 0,
+      "llm_call_failures": 0,
+      "memories_processed": 88,
+      "details": {
+        "reindexed": 88,
+        "failed": 0,
+        "failed_ids": []
+      },
+      "llm_breakdown": [],
+      "embedding_calls": 88,
+      "embedding_tokens": 0
+    },
+    "llm_call_failures_total": 4
+  },
+  "arms": {
+    "vanilla_rag": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        }
+      ]
+    },
+    "mc_update": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "neither",
+          "current_rank": null,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "neither",
+          "current_rank": null,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        }
+      ]
+    },
+    "mc_prod": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "neither",
+          "current_rank": null,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "neither",
+          "current_rank": null,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 3,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "current_only",
+          "current_rank": 3,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        }
+      ]
+    }
+  }
+}

--- a/backend/tests/eval/results/day5r-v0431-run2-2026-07-06.json
+++ b/backend/tests/eval/results/day5r-v0431-run2-2026-07-06.json
@@ -1,0 +1,1105 @@
+{
+  "run_date": "2026-07-06",
+  "experiment": "day5-update-correctness",
+  "label": "day5r-v0431-run2",
+  "corpus_path": "fixtures/update_slice.yaml",
+  "content_sha256": "68181b5f8589cd646c58702dde44f22fda15a75b73ec1d735448053ca3d9725e",
+  "embedding_model": "qwen3-embedding:0.6b",
+  "embedding_dimensions": 1024,
+  "k": 10,
+  "backdate_days": 30,
+  "judge_model": "qwen3.5-9b",
+  "sleep_summary": {
+    "ran": true,
+    "ok": false,
+    "status": "degraded",
+    "llm_call_failures": 8,
+    "memories_processed": 382,
+    "edges_created": 1,
+    "memories_merged": 26,
+    "memories_promoted": 90,
+    "memories_flagged": 102,
+    "error_message": null,
+    "edge_discovery_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 5,
+      "llm_call_failures": 0,
+      "memories_processed": 30,
+      "details": {
+        "sampled": 30,
+        "candidates": 39,
+        "filtered": 39,
+        "edges_created": 1,
+        "llm_accepted": 1,
+        "llm_rejected": 2,
+        "llm_call_failures": 0,
+        "auto_accepted": 0,
+        "edge_type_dist": {
+          "related_to": 1
+        },
+        "avg_confidence": 0.85,
+        "median_confidence": 0.85,
+        "p25_confidence": 0.85,
+        "p75_confidence": 0.85,
+        "confidence_n": 1,
+        "confidence_imputed": 0,
+        "confidence_histogram": {
+          "0.0-0.5": 0,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 1
+        },
+        "avg_confidence_rejected": 0.0,
+        "median_confidence_rejected": 0.0,
+        "p25_confidence_rejected": 0.0,
+        "p75_confidence_rejected": 0.0,
+        "confidence_n_rejected": 2,
+        "confidence_imputed_rejected": 0,
+        "confidence_histogram_rejected": {
+          "0.0-0.5": 2,
+          "0.5-0.7": 0,
+          "0.7-0.85": 0,
+          "0.85-1.0": 0
+        },
+        "llm_model": "qwen3.5-9b",
+        "prompt_revision": "v3"
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 4428,
+          "output_tokens": 557,
+          "cached_input_tokens": 0,
+          "calls": 5
+        }
+      ],
+      "embedding_calls": 30,
+      "embedding_tokens": 0
+    },
+    "dedup_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 23,
+      "llm_call_failures": 8,
+      "memories_processed": 130,
+      "details": {
+        "candidates": 782,
+        "clusters": 31,
+        "deferred_clusters": 1,
+        "oversize_clusters": 1,
+        "oversize_max_size": 130,
+        "split_subclusters": 31,
+        "deferred_pairs": 583,
+        "merged": 26,
+        "llm_call_failures": 8
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 21886,
+          "output_tokens": 11492,
+          "cached_input_tokens": 0,
+          "calls": 23
+        }
+      ],
+      "embedding_calls": 130,
+      "embedding_tokens": 0
+    },
+    "importance_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 3,
+      "llm_call_failures": 0,
+      "memories_processed": 24,
+      "details": {
+        "candidates": 24,
+        "updated": 24,
+        "alpha": 0.3,
+        "llm_call_failures": 0
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 4056,
+          "output_tokens": 1397,
+          "cached_input_tokens": 0,
+          "calls": 3
+        }
+      ],
+      "embedding_calls": 0,
+      "embedding_tokens": 0
+    },
+    "consolidation_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 19,
+      "llm_call_failures": 0,
+      "memories_processed": 104,
+      "details": {
+        "working_count": 104,
+        "rule_promoted": 2,
+        "rule_deleted": 0,
+        "borderline": 102,
+        "llm_promoted": 88,
+        "llm_archived": 5,
+        "llm_call_failures": 0
+      },
+      "llm_breakdown": [
+        {
+          "provider": "self_hosted",
+          "model": "qwen3.5-9b",
+          "input_tokens": 19142,
+          "output_tokens": 5122,
+          "cached_input_tokens": 0,
+          "calls": 19
+        }
+      ],
+      "embedding_calls": 0,
+      "embedding_tokens": 0
+    },
+    "reindex_result": {
+      "success": true,
+      "skipped": false,
+      "skip_reason": null,
+      "error": null,
+      "llm_calls": 0,
+      "llm_call_failures": 0,
+      "memories_processed": 94,
+      "details": {
+        "reindexed": 94,
+        "failed": 0,
+        "failed_ids": []
+      },
+      "llm_breakdown": [],
+      "embedding_calls": 94,
+      "embedding_tokens": 0
+    },
+    "llm_call_failures_total": 8
+  },
+  "arms": {
+    "vanilla_rag": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        }
+      ]
+    },
+    "mc_update": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 2,
+          "stale_rank": 1
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        }
+      ]
+    },
+    "mc_prod": {
+      "per_query": [
+        {
+          "query_id": "q-u01",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u02",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u03",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u04",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u05",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u06",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u07",
+          "outcome": "current_over_stale",
+          "current_rank": 3,
+          "stale_rank": 4
+        },
+        {
+          "query_id": "q-u08",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u09",
+          "outcome": "current_over_stale",
+          "current_rank": 3,
+          "stale_rank": 4
+        },
+        {
+          "query_id": "q-u10",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u11",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u12",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u13",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u14",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u15",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u16",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u17",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u18",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u19",
+          "outcome": "current_only",
+          "current_rank": 4,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u20",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u21",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u22",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u23",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u24",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u25",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u26",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u27",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u28",
+          "outcome": "current_over_stale",
+          "current_rank": 3,
+          "stale_rank": 4
+        },
+        {
+          "query_id": "q-u29",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u30",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u31",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u32",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u33",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u34",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u35",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u36",
+          "outcome": "current_over_stale",
+          "current_rank": 3,
+          "stale_rank": 4
+        },
+        {
+          "query_id": "q-u37",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u38",
+          "outcome": "stale_only",
+          "current_rank": null,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u39",
+          "outcome": "current_over_stale",
+          "current_rank": 2,
+          "stale_rank": 3
+        },
+        {
+          "query_id": "q-u40",
+          "outcome": "stale_over_current",
+          "current_rank": 3,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u41",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u42",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u43",
+          "outcome": "current_over_stale",
+          "current_rank": 3,
+          "stale_rank": 4
+        },
+        {
+          "query_id": "q-u44",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u45",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u46",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u47",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u48",
+          "outcome": "current_only",
+          "current_rank": 1,
+          "stale_rank": null
+        },
+        {
+          "query_id": "q-u49",
+          "outcome": "current_over_stale",
+          "current_rank": 1,
+          "stale_rank": 2
+        },
+        {
+          "query_id": "q-u50",
+          "outcome": "current_only",
+          "current_rank": 2,
+          "stale_rank": null
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What

Result artifacts for the Day-5 update-correctness **replication under the dedup-split fix** (#1184/#1188), run 2026-07-06 on the pgx01 rig at v0.43.1 (`12a347e6`):

- `day5r-v0431-run{0,1,2}-2026-07-06.json` — 3 identical invocations of `tests.eval.update_runner` on the frozen `fixtures/update_slice.yaml` (byte-identical to the original campaign), qwen3.5-9b judge live
- `day5r-v0431-analysis-2026-07-06.json` — `tests.eval.day5_analysis` over the 3 runs (inferential run = run 0)

Pre-declared BEFORE any run in the eval repo (`docs/plans/2026-07-06-day5-replication-v0431.md`, commit c3c6564). **Post-hoc / exploratory** — the prereg-anchored H4 result at `d12ae8aa` stands unchanged; these artifacts version it.

## Key numbers

| | original (d12ae8aa) | this replication (v0.43.1) |
|---|---|---|
| dedup merges/run | 0 (mega-cluster wholesale-deferred) | 26–34 (31 split subclusters, 23–27 judged calls) |
| gated conditional | +0.36 [0.24, 0.50], 50 complete pairs | +0.474 [0.263, 0.684], **19 pairs → underpowered per pre-declared floor** |
| update_success@10 (mc) | 0.92 | 0.88 / 0.84 / 0.80 |
| `stale_only` (current fact DELETED) | 0 | **5 / 5 / 9 per run (10–18%) → #1195** |

Verdict per the pre-declared interpretation rules: **ROBUST** — the headline direction survives active dedup, with the success mode shifting to update-by-removal (stale deleted: 25/31/18 per run). The destructive minority direction is filed as #1195.

All runs `status=degraded` from 4–8 judge timeouts/run — correctly surfaced by #1183 (`llm_call_failures` first-class), no longer buried under `ok=true`.

## Notes

- Results are from real runs, never edited (repo eval convention).
- Run 1's first attempt aborted with judge 404s (pgx02 :8000 contention with a concurrent brain-campaign session) — no artifact produced, relaunched clean; attempt log archived in the eval repo (`results/day5r/day5r-v0431-logs.tar.gz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)