### PR TITLE
fix(sleep): dedup winner selection prefers the newer memory (#1195)

### DIFF
--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import random
 import string
+from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -524,11 +525,16 @@ class DedupMergePhase:
         mems_shuffled = [s[1] for s in shuffled]
 
         # Format memories. The summary is untrusted (issue #919) — wrap it so an
-        # embedded instruction cannot steer the merge judgment.
+        # embedded instruction cannot steer the merge judgment. created= is
+        # trusted DB metadata and stays OUTSIDE the wrapper: the judge needs it
+        # to pick the newer version of an updated fact as winner (#1195).
         memory_lines = []
         for label, mem in zip(labels_shuffled, mems_shuffled, strict=True):
+            created = getattr(mem, "created_at", None)
+            created_s = f"{created:%Y-%m-%d}" if isinstance(created, datetime) else "unknown"
             memory_lines.append(
-                f"[{label}] type={mem.type}, importance={mem.importance:.2f}\n"
+                f"[{label}] type={mem.type}, importance={mem.importance:.2f}, "
+                f"created={created_s}\n"
                 f"    summary:\n{wrap_untrusted_content(mem.summary)}"
             )
 
@@ -606,6 +612,13 @@ class DedupMergePhase:
 
         return decisions
 
+    @staticmethod
+    def _is_newer(candidate: Memory, other: Memory) -> bool:
+        """True iff both carry datetime ``created_at`` and candidate is newer."""
+        c = getattr(candidate, "created_at", None)
+        o = getattr(other, "created_at", None)
+        return isinstance(c, datetime) and isinstance(o, datetime) and c > o
+
     def _rule_based_judge(
         self,
         cluster_memories: list[Memory],
@@ -622,13 +635,19 @@ class DedupMergePhase:
                 key = (sorted_ids[0], sorted_ids[1])
                 score = pair_scores.get(key, 0.0)
                 if score >= AUTO_MERGE_THRESHOLD:
-                    # Keep the one with higher importance or more content
+                    # Keep the one with higher importance; at equal importance
+                    # the NEWER memory wins (#1195 — was: arbitrary cluster
+                    # order, which could delete the updated version of a fact).
                     mem_a = id_to_mem[id_a]
                     mem_b = id_to_mem[id_b]
-                    if mem_a.importance >= mem_b.importance:
+                    if mem_a.importance > mem_b.importance:
                         decisions.append((id_a, id_b))
-                    else:
+                    elif mem_b.importance > mem_a.importance:
                         decisions.append((id_b, id_a))
+                    elif self._is_newer(mem_b, mem_a):
+                        decisions.append((id_b, id_a))
+                    else:
+                        decisions.append((id_a, id_b))
 
         return decisions
 

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -197,6 +197,9 @@ class DedupMergePhase:
         # #1183: judge-failure counter (init here so ``_llm_judge`` can be
         # unit-tested without execute()).
         self._llm_failures: int = 0
+        # #1195/#1198: newer-wins override counter (init here so
+        # ``_judge_cluster`` can be unit-tested without execute()).
+        self._winner_overrides: int = 0
 
     async def execute(
         self,
@@ -226,6 +229,9 @@ class DedupMergePhase:
         self._tokens_used = 0
         # #1183: judge calls that raised (feeds run-status grading).
         self._llm_failures = 0
+        # #1195/#1198: LLM winner choices flipped by the deterministic
+        # newer-wins post-check (each one is a judge misjudgment caught).
+        self._winner_overrides = 0
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
         # #475: reset embedding accumulators between sleep cycles.
@@ -363,6 +369,10 @@ class DedupMergePhase:
             "deferred_pairs": deferred_pairs,
             "merged": merged_count,
             "llm_call_failures": self._llm_failures,  # #1183
+            # #1195/#1198: LLM winner picks flipped by the deterministic
+            # newer-wins post-check — a direct measure of residual judge
+            # misdirection the prompt alone would have let through.
+            "winner_overrides": self._winner_overrides,
         }
 
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
@@ -496,6 +506,10 @@ class DedupMergePhase:
                 budget,
                 config,
             )
+            # #1195/#1198: the LLM's winner is prompt-guided only — enforce
+            # newer-wins deterministically (rule-based path is correct by
+            # construction and needs no post-check).
+            decisions = self._enforce_newer_wins(decisions, cluster_memories)
         else:
             # Rule-based fallback
             decisions = self._rule_based_judge(cluster_memories, pair_scores)
@@ -525,16 +539,18 @@ class DedupMergePhase:
         mems_shuffled = [s[1] for s in shuffled]
 
         # Format memories. The summary is untrusted (issue #919) — wrap it so an
-        # embedded instruction cannot steer the merge judgment. created= is
+        # embedded instruction cannot steer the merge judgment. last_updated= is
         # trusted DB metadata and stays OUTSIDE the wrapper: the judge needs it
         # to pick the newer version of an updated fact as winner (#1195).
+        # Minute precision so same-day update pairs stay orderable; max of
+        # created_at/updated_at so in-place edits count as recency (#1198).
         memory_lines = []
         for label, mem in zip(labels_shuffled, mems_shuffled, strict=True):
-            created = getattr(mem, "created_at", None)
-            created_s = f"{created:%Y-%m-%d}" if isinstance(created, datetime) else "unknown"
+            recency = self._recency_key(mem)
+            recency_s = f"{recency:%Y-%m-%d %H:%M}" if recency else "unknown"
             memory_lines.append(
                 f"[{label}] type={mem.type}, importance={mem.importance:.2f}, "
-                f"created={created_s}\n"
+                f"last_updated={recency_s}\n"
                 f"    summary:\n{wrap_untrusted_content(mem.summary)}"
             )
 
@@ -613,11 +629,56 @@ class DedupMergePhase:
         return decisions
 
     @staticmethod
-    def _is_newer(candidate: Memory, other: Memory) -> bool:
-        """True iff both carry datetime ``created_at`` and candidate is newer."""
-        c = getattr(candidate, "created_at", None)
-        o = getattr(other, "created_at", None)
-        return isinstance(c, datetime) and isinstance(o, datetime) and c > o
+    def _recency_key(mem: Memory) -> datetime | None:
+        """Last time this memory's content was current: max(created_at,
+        updated_at) over whichever are real datetimes, else None.
+
+        created_at alone is WRONG for recency (#1198 review): an in-place
+        edit preserves created_at and bumps updated_at, so the row holding
+        the current fact can carry the older created_at.
+        """
+        stamps = [
+            v
+            for v in (getattr(mem, "created_at", None), getattr(mem, "updated_at", None))
+            if isinstance(v, datetime)
+        ]
+        return max(stamps) if stamps else None
+
+    @classmethod
+    def _is_newer(cls, candidate: Memory, other: Memory) -> bool:
+        """True iff both carry a recency key and candidate's is strictly newer."""
+        c = cls._recency_key(candidate)
+        o = cls._recency_key(other)
+        return c is not None and o is not None and c > o
+
+    def _enforce_newer_wins(
+        self,
+        decisions: list[tuple[UUID, UUID]],
+        cluster_memories: list[Memory],
+    ) -> list[tuple[UUID, UUID]]:
+        """Deterministic post-check on LLM merge decisions (#1195/#1198).
+
+        The prompt asks for newer-wins but cannot guarantee it — the judge
+        picked the older memory in 10-18% of update pairs in the Day-5 eval.
+        The duplicate verdict is trusted; the direction is enforced: any
+        decision whose winner is strictly older than its loser is flipped.
+        """
+        id_to_mem = {m.id: m for m in cluster_memories}
+        corrected: list[tuple[UUID, UUID]] = []
+        for winner_id, loser_id in decisions:
+            winner = id_to_mem.get(winner_id)
+            loser = id_to_mem.get(loser_id)
+            if winner is not None and loser is not None and self._is_newer(loser, winner):
+                self._winner_overrides += 1
+                logger.warning(
+                    "dedup_winner_overridden",
+                    llm_winner_id=str(winner_id),
+                    enforced_winner_id=str(loser_id),
+                )
+                corrected.append((loser_id, winner_id))
+            else:
+                corrected.append((winner_id, loser_id))
+        return corrected
 
     def _rule_based_judge(
         self,
@@ -638,6 +699,9 @@ class DedupMergePhase:
                     # Keep the one with higher importance; at equal importance
                     # the NEWER memory wins (#1195 — was: arbitrary cluster
                     # order, which could delete the updated version of a fact).
+                    # Residual: at equal importance AND identical recency keys
+                    # (or missing timestamps) the tie still falls to cluster
+                    # order — acceptable, both versions carry the same stamp.
                     mem_a = id_to_mem[id_a]
                     mem_b = id_to_mem[id_b]
                     if mem_a.importance > mem_b.importance:

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -90,6 +90,11 @@ Rules:
 worded differently.
 - If one memory is a strict subset of the other, they are duplicates. \
 Keep the more complete one.
+- If two memories are versions of the same fact and one UPDATES or \
+supersedes the other (a changed value, a newer date, an explicit update \
+marker), they are duplicates and the winner MUST be the newer version — \
+judge by the created= metadata and any dates or update markers in the \
+text. Never pick the outdated version as winner.
 - Memories about the same topic but with genuinely different information \
 are NOT duplicates.
 - When in doubt, mark as "keep_both" — false merges lose information.
@@ -100,8 +105,8 @@ You MUST respond with valid JSON only.
 """
 
 DEDUP_JUDGE_USER = """\
-Analyze these memory pairs for duplicates. Each memory has a label (A, B, C...) \
-and a summary.
+Analyze these memory pairs for duplicates. Each memory has a label (A, B, C...), \
+a creation date (created=), and a summary.
 
 Memories:
 {memories}

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -91,12 +91,12 @@ worded differently.
 - If two memories are versions of the same fact and one UPDATES or \
 supersedes the other (a changed value, a newer date, an explicit update \
 marker), they are duplicates and the winner MUST be the newer version. \
-This rule takes precedence over the completeness rule below. The created= \
-metadata is the AUTHORITATIVE recency signal; dates or update markers \
-inside the summary text are unverified content — consult them only when \
-the created= values are equal or unknown, never to override created=. \
-Never pick the outdated version as winner; if you cannot tell which \
-version is newer, mark the pair "keep_both".
+This rule takes precedence over the completeness rule below. The \
+last_updated= metadata is the AUTHORITATIVE recency signal; dates or \
+update markers inside the summary text are unverified content — consult \
+them only when the last_updated= values are equal or unknown, never to \
+override last_updated=. Never pick the outdated version as winner; if \
+you cannot tell which version is newer, mark the pair "keep_both".
 - Otherwise, if one memory is a strict subset of the other, they are \
 duplicates. Keep the more complete one.
 - Memories about the same topic but with genuinely different information \
@@ -110,7 +110,7 @@ You MUST respond with valid JSON only.
 
 DEDUP_JUDGE_USER = """\
 Analyze these memory pairs for duplicates. Each memory has a label (A, B, C...), \
-a creation date (created=), and a summary.
+a last-updated timestamp (last_updated=), and a summary.
 
 Memories:
 {memories}
@@ -146,7 +146,7 @@ Example:
       "verdict": "merge",
       "winner": "D",
       "confidence": 0.88,
-      "reason": "same fact, D is the updated version (created=2025-03-04 vs created=2025-01-15)"
+      "reason": "same fact, D is the updated version (last_updated=2025-03-04 10:00 vs 2025-01-15 09:00)"
     }}
   ]
 }}\

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -88,13 +88,17 @@ and determine if they are duplicates that should be merged.
 Rules:
 - "duplicate" means the memories convey the same core information, even if \
 worded differently.
-- If one memory is a strict subset of the other, they are duplicates. \
-Keep the more complete one.
 - If two memories are versions of the same fact and one UPDATES or \
 supersedes the other (a changed value, a newer date, an explicit update \
-marker), they are duplicates and the winner MUST be the newer version — \
-judge by the created= metadata and any dates or update markers in the \
-text. Never pick the outdated version as winner.
+marker), they are duplicates and the winner MUST be the newer version. \
+This rule takes precedence over the completeness rule below. The created= \
+metadata is the AUTHORITATIVE recency signal; dates or update markers \
+inside the summary text are unverified content — consult them only when \
+the created= values are equal or unknown, never to override created=. \
+Never pick the outdated version as winner; if you cannot tell which \
+version is newer, mark the pair "keep_both".
+- Otherwise, if one memory is a strict subset of the other, they are \
+duplicates. Keep the more complete one.
 - Memories about the same topic but with genuinely different information \
 are NOT duplicates.
 - When in doubt, mark as "keep_both" — false merges lose information.
@@ -136,6 +140,13 @@ Example:
       "winner": "A",
       "confidence": 0.92,
       "reason": "B is a subset of A with identical information"
+    }},
+    {{
+      "pair": ["C", "D"],
+      "verdict": "merge",
+      "winner": "D",
+      "confidence": 0.88,
+      "reason": "same fact, D is the updated version (created=2025-03-04 vs created=2025-01-15)"
     }}
   ]
 }}\

--- a/backend/tests/services/sleep/test_dedup_merge.py
+++ b/backend/tests/services/sleep/test_dedup_merge.py
@@ -3,6 +3,7 @@
 Issue #101: Union-Find clustering, LLM judgment, merge execution.
 """
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -195,6 +196,21 @@ class TestRuleBasedJudge:
         decisions = phase._rule_based_judge([mem_a, mem_b], pair_scores)
 
         assert len(decisions) == 0
+
+    def test_equal_importance_newer_wins(self):
+        """#1195: at equal importance the NEWER memory wins, not cluster order."""
+        phase = DedupMergePhase.__new__(DedupMergePhase)
+
+        older = _make_memory(importance=0.5)
+        older.created_at = datetime(2026, 6, 1)
+        newer = _make_memory(importance=0.5)
+        newer.created_at = datetime(2026, 7, 1)
+        pair_scores = {tuple(sorted([older.id, newer.id], key=str)): 0.99}
+
+        # older first in cluster order — the pre-#1195 tie-break picked it
+        decisions = phase._rule_based_judge([older, newer], pair_scores)
+
+        assert decisions == [(newer.id, older.id)]
 
 
 class TestParseDedupResponse:

--- a/backend/tests/services/sleep/test_dedup_merge.py
+++ b/backend/tests/services/sleep/test_dedup_merge.py
@@ -212,6 +212,24 @@ class TestRuleBasedJudge:
 
         assert decisions == [(newer.id, older.id)]
 
+    def test_equal_importance_edited_memory_wins(self):
+        """#1198 review: recency is max(created_at, updated_at) — an in-place
+        edited memory (old created_at, new updated_at) must beat a
+        later-created stale duplicate."""
+        phase = DedupMergePhase.__new__(DedupMergePhase)
+
+        edited = _make_memory(importance=0.5)
+        edited.created_at = datetime(2026, 6, 1)
+        edited.updated_at = datetime(2026, 7, 15)
+        stale_dup = _make_memory(importance=0.5)
+        stale_dup.created_at = datetime(2026, 7, 1)
+        stale_dup.updated_at = datetime(2026, 7, 1)
+        pair_scores = {tuple(sorted([edited.id, stale_dup.id], key=str)): 0.99}
+
+        decisions = phase._rule_based_judge([edited, stale_dup], pair_scores)
+
+        assert decisions == [(edited.id, stale_dup.id)]
+
 
 class TestParseDedupResponse:
     """Test LLM response parsing with ID validation."""

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -412,9 +412,12 @@ class TestLLMJudgeRecency:
     rule. The prompt must carry created_at and an explicit newer-wins rule."""
 
     async def test_prompt_includes_created_at(self, dedup_phase):
+        # Summaries deliberately carry NO dates: the asserts below must be
+        # satisfiable only by the trusted created= metadata rendering
+        # (PR #1198 review: a date in the summary would mask a dropped field).
         mem_a = _make_memory(summary="deploy target is blue")
         mem_a.created_at = datetime(2026, 6, 1)
-        mem_b = _make_memory(summary="deploy target is green (updated 2026-07-01)")
+        mem_b = _make_memory(summary="deploy target is green")
         mem_b.created_at = datetime(2026, 7, 1)
         scores = {tuple(sorted([mem_a.id, mem_b.id], key=str)): 0.96}
         dedup_phase.llm_service.complete_json = AsyncMock(
@@ -428,8 +431,8 @@ class TestLLMJudgeRecency:
         )
 
         prompt = dedup_phase.llm_service.complete_json.call_args.kwargs["prompt"]
-        assert "2026-06-01" in prompt
-        assert "2026-07-01" in prompt
+        assert "created=2026-06-01" in prompt
+        assert "created=2026-07-01" in prompt
 
     def test_system_prompt_has_newer_wins_rule(self):
         from services.sleep.prompts import DEDUP_JUDGE_SYSTEM

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -411,14 +411,18 @@ class TestLLMJudgeRecency:
     judged pairs because it never saw timestamps and had no update-pair winner
     rule. The prompt must carry created_at and an explicit newer-wins rule."""
 
-    async def test_prompt_includes_created_at(self, dedup_phase):
+    async def test_prompt_includes_last_updated(self, dedup_phase):
         # Summaries deliberately carry NO dates: the asserts below must be
-        # satisfiable only by the trusted created= metadata rendering
+        # satisfiable only by the trusted last_updated= metadata rendering
         # (PR #1198 review: a date in the summary would mask a dropped field).
+        # mem_b was edited in place (created_at preserved, updated_at bumped):
+        # the prompt must show max(created_at, updated_at), minute precision.
         mem_a = _make_memory(summary="deploy target is blue")
-        mem_a.created_at = datetime(2026, 6, 1)
+        mem_a.created_at = datetime(2026, 6, 1, 9, 0)
+        mem_a.updated_at = datetime(2026, 6, 1, 9, 0)
         mem_b = _make_memory(summary="deploy target is green")
-        mem_b.created_at = datetime(2026, 7, 1)
+        mem_b.created_at = datetime(2026, 6, 15, 8, 0)
+        mem_b.updated_at = datetime(2026, 7, 1, 15, 30)
         scores = {tuple(sorted([mem_a.id, mem_b.id], key=str)): 0.96}
         dedup_phase.llm_service.complete_json = AsyncMock(
             return_value=_make_llm_response({"judgments": []})
@@ -431,8 +435,8 @@ class TestLLMJudgeRecency:
         )
 
         prompt = dedup_phase.llm_service.complete_json.call_args.kwargs["prompt"]
-        assert "created=2026-06-01" in prompt
-        assert "created=2026-07-01" in prompt
+        assert "last_updated=2026-06-01 09:00" in prompt
+        assert "last_updated=2026-07-01 15:30" in prompt
 
     def test_system_prompt_has_newer_wins_rule(self):
         from services.sleep.prompts import DEDUP_JUDGE_SYSTEM
@@ -440,6 +444,33 @@ class TestLLMJudgeRecency:
         text = DEDUP_JUDGE_SYSTEM.lower()
         assert "newer" in text
         assert "winner" in text
+        assert "last_updated" in text
+
+    async def test_llm_winner_overridden_when_older(self, dedup_phase):
+        """#1198 review: the LLM's winner choice is prompt-guided only; a
+        deterministic post-check must flip any decision whose winner is
+        strictly older than its loser (the #1195 failure the prompt cannot
+        guarantee away)."""
+        mem_old = _make_memory(summary="deploy target is blue")
+        mem_old.created_at = datetime(2026, 6, 1, 9, 0)
+        mem_old.updated_at = datetime(2026, 6, 1, 9, 0)
+        mem_new = _make_memory(summary="deploy target is green")
+        mem_new.created_at = datetime(2026, 7, 1, 15, 30)
+        mem_new.updated_at = datetime(2026, 7, 1, 15, 30)
+        scores = {tuple(sorted([mem_old.id, mem_new.id], key=str)): 0.96}
+        # Labels are assigned in cluster order: mem_old=A, mem_new=B.
+        # The LLM (wrongly) picks the OLDER memory as winner.
+        parsed = {"judgments": [{"pair": ["A", "B"], "verdict": "merge", "winner": "A"}]}
+        dedup_phase.llm_service.complete_json = AsyncMock(return_value=_make_llm_response(parsed))
+        dedup_phase._tokens_used = 0
+        dedup_phase._llm_breakdown = None
+
+        decisions = await dedup_phase._judge_cluster(
+            [mem_old, mem_new], scores, True, "u", "ctx", "ws", SleepBudget(), _make_config()
+        )
+
+        assert decisions == [(mem_new.id, mem_old.id)]
+        assert dedup_phase._winner_overrides == 1
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -12,6 +12,7 @@ audit rows, rule-based end-to-end merge).
 Target module: ``services.sleep.dedup_merge``.
 """
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -398,6 +399,44 @@ class TestLLMJudge:
         assert decisions == []
         assert budget.llm_calls_used == 0  # no consume on the failure path
         assert dedup_phase._tokens_used == 0
+
+
+# ---------------------------------------------------------------------------
+# #1195 — winner selection must see and prefer recency
+# ---------------------------------------------------------------------------
+
+
+class TestLLMJudgeRecency:
+    """#1195: the judge deleted the NEWER fact of an update pair in 10-18% of
+    judged pairs because it never saw timestamps and had no update-pair winner
+    rule. The prompt must carry created_at and an explicit newer-wins rule."""
+
+    async def test_prompt_includes_created_at(self, dedup_phase):
+        mem_a = _make_memory(summary="deploy target is blue")
+        mem_a.created_at = datetime(2026, 6, 1)
+        mem_b = _make_memory(summary="deploy target is green (updated 2026-07-01)")
+        mem_b.created_at = datetime(2026, 7, 1)
+        scores = {tuple(sorted([mem_a.id, mem_b.id], key=str)): 0.96}
+        dedup_phase.llm_service.complete_json = AsyncMock(
+            return_value=_make_llm_response({"judgments": []})
+        )
+        dedup_phase._tokens_used = 0
+        dedup_phase._llm_breakdown = None
+
+        await dedup_phase._llm_judge(
+            [mem_a, mem_b], scores, "u", "ctx", "ws", SleepBudget(), _make_config()
+        )
+
+        prompt = dedup_phase.llm_service.complete_json.call_args.kwargs["prompt"]
+        assert "2026-06-01" in prompt
+        assert "2026-07-01" in prompt
+
+    def test_system_prompt_has_newer_wins_rule(self):
+        from services.sleep.prompts import DEDUP_JUDGE_SYSTEM
+
+        text = DEDUP_JUDGE_SYSTEM.lower()
+        assert "newer" in text
+        assert "winner" in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1195.

## Root cause

Found via systematic code trace after the Day-5 v0.43.1 replication measured `stale_only` (current fact deleted by dedup) at 10–18% per run:

1. `_llm_judge` formatted each memory as `type= / importance= / summary` — **no timestamps ever reached the judge**, so it could not know which version was newer except from in-text dates.
2. `DEDUP_JUDGE_SYSTEM`'s only winner rule was "subset → keep the more complete one". **Update pairs (same fact, changed value) matched no rule**, leaving winner selection unguided — a "more complete-looking" stale doc could win.
3. `_rule_based_judge` (LLM-off ≥0.98 path) tie-broke equal importance by **arbitrary cluster order** (`>=` comparison).

## Fix (minimal, 3 changes)

- `_llm_judge`: adds `created=YYYY-MM-DD` to each memory line — trusted DB metadata placed OUTSIDE the untrusted-summary wrapper (#919 posture preserved).
- `DEDUP_JUDGE_SYSTEM`: new explicit rule — a version that updates/supersedes the other IS a duplicate and **the winner MUST be the newer version; never pick the outdated version**. `DEDUP_JUDGE_USER` documents the `created=` field.
- `_rule_based_judge`: equal-importance tie-break now goes to the newer `created_at` (unequal importance behavior unchanged).

## Tests (TDD — all three watched fail first)

- `TestLLMJudgeRecency::test_prompt_includes_created_at` — judge prompt carries both memories' dates
- `TestLLMJudgeRecency::test_system_prompt_has_newer_wins_rule` — prompt-text guard
- `TestRuleBasedJudge::test_equal_importance_newer_wins` — deterministic tie-break

`tests/services/sleep/` 268 passed; ruff lint + format clean.

## Verification note

The prompt change's real-world effect needs a live-judge run: the plan is one confirmation run of the Day-5 update eval (`update_runner`, same frozen corpus) on the rig after merge, expecting `stale_only ≈ 0` — the eval side will track that (pgx02 is currently serving the brain campaign, so it will be scheduled around it). The deterministic code paths (metadata injection, rule-based tie-break) are fully covered by the unit tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)