### PR TITLE
fix(neural): clamp spreading activation to [0,1] (#1197)

### DIFF
--- a/backend/src/neural/activation.py
+++ b/backend/src/neural/activation.py
@@ -85,15 +85,19 @@ class ActivationSpreader:
                 for nid, act in seed_activations.items()
             ]
 
+        # Clamp seeds to [0,1] ONCE up front (#1197): seeds feed ActivationState
+        # at the end of spread() AND are the hop-0 source activations, so an
+        # out-of-range seed must be capped in both roles — clamping only the
+        # stored value would let the raw seed still drive downstream propagation.
+        clamped_seeds = {nid: _clamp01(act) for nid, act in seed_activations.items()}
+
         # Initialize activation map
         # Format: {node_id: {"activation": float, "hop": int, "source": str}}
-        # Seed values feed ActivationState at the end of spread(), so clamp
-        # them to [0,1] here for the same reason (#1197).
         all_activations: dict[str, dict[str, Any]] = {}
-        for nid, act in seed_activations.items():
-            all_activations[nid] = {"activation": _clamp01(act), "hop": 0, "source": None}
+        for nid, act in clamped_seeds.items():
+            all_activations[nid] = {"activation": act, "hop": 0, "source": None}
 
-        current_layer = seed_activations.copy()
+        current_layer = clamped_seeds.copy()
 
         # Propagate for max_hops iterations
         for hop in range(1, max_hops + 1):
@@ -177,13 +181,13 @@ class ActivationSpreader:
                 # GDPR compliance: user_id filtering now handled at SQL level
                 # (NeuralEdgeRepository filters by user_id)
 
-                # Calculate propagated activation
-                # activation(dst) = activation(src) * decay * weight(src→dst)
-                # Clamp to [0, 1] (#1197): weight can exceed 1.0 (up to
-                # weight_max=3.0), so the raw product can too — but activation
-                # is a [0, 1] quantity by contract. This is the value that
-                # feeds ActivationState (via all_activations below), so this is
-                # where the crash is sealed.
+                # Per-edge contribution: activation(src) * decay * weight(src→dst)
+                # (summed across paths into next_layer below; see the module Σ
+                # formula). Clamp to [0, 1] (#1197): weight can exceed 1.0 (up to
+                # weight_max=3.0), so the raw product can too — but activation is
+                # a [0, 1] quantity by contract. This clamped per-edge value is
+                # what feeds ActivationState (via all_activations below), so this
+                # is where the crash is sealed.
                 propagated_activation = _clamp01(src_activation * self.config.spread_decay * weight)
 
                 # Check threshold

--- a/backend/src/neural/activation.py
+++ b/backend/src/neural/activation.py
@@ -24,6 +24,22 @@ from .models import ActivationState
 logger = logging.getLogger(__name__)
 
 
+def _clamp01(value: float) -> float:
+    """Clamp an activation to the [0, 1] contract (#1197).
+
+    Edge weights are Hebbian association strengths clipped only to
+    ``config.weight_max`` (default 3.0) — they are NOT probabilities — so a
+    reinforced-edge product ``src * spread_decay * weight`` can exceed 1.0.
+    ``ActivationState`` hard-requires [0, 1], so the spreader clamps at every
+    point a raw activation ENTERS an ``ActivationState``: the per-edge
+    propagated value and the seed passthrough. The clamp only ever pulls a
+    would-crash (>1) value down to 1.0 — it never changes an in-range value, so
+    retrieval ranking is untouched. The validator itself is kept a strict raise
+    on purpose (the last line of defence, not a silent clamp).
+    """
+    return max(0.0, min(1.0, value))
+
+
 class ActivationSpreader:
     """Activation spreading manager for graph-based associative retrieval."""
 
@@ -60,17 +76,22 @@ class ActivationSpreader:
         max_hops = max_hops if max_hops is not None else self.config.spread_hops
 
         if max_hops == 0:
-            # No spreading, return only seed nodes
+            # No spreading, return only seed nodes. Clamp the seed too (#1197):
+            # seed_activations is a documented [0,1] precondition but callers
+            # aren't validated, and an out-of-range seed would hit the same
+            # hard ActivationState guard.
             return [
-                ActivationState(node_id=nid, activation=act, hop=0)
+                ActivationState(node_id=nid, activation=_clamp01(act), hop=0)
                 for nid, act in seed_activations.items()
             ]
 
         # Initialize activation map
         # Format: {node_id: {"activation": float, "hop": int, "source": str}}
+        # Seed values feed ActivationState at the end of spread(), so clamp
+        # them to [0,1] here for the same reason (#1197).
         all_activations: dict[str, dict[str, Any]] = {}
         for nid, act in seed_activations.items():
-            all_activations[nid] = {"activation": act, "hop": 0, "source": None}
+            all_activations[nid] = {"activation": _clamp01(act), "hop": 0, "source": None}
 
         current_layer = seed_activations.copy()
 
@@ -157,14 +178,24 @@ class ActivationSpreader:
                 # (NeuralEdgeRepository filters by user_id)
 
                 # Calculate propagated activation
-                # activation(dst) += activation(src) * decay * weight(src→dst)
-                propagated_activation = src_activation * self.config.spread_decay * weight
+                # activation(dst) = activation(src) * decay * weight(src→dst)
+                # Clamp to [0, 1] (#1197): weight can exceed 1.0 (up to
+                # weight_max=3.0), so the raw product can too — but activation
+                # is a [0, 1] quantity by contract. This is the value that
+                # feeds ActivationState (via all_activations below), so this is
+                # where the crash is sealed.
+                propagated_activation = _clamp01(src_activation * self.config.spread_decay * weight)
 
                 # Check threshold
                 if propagated_activation < self.config.spread_threshold:
                     continue
 
-                # Accumulate activation (sum from multiple paths)
+                # Accumulate activation (sum from multiple paths). Deliberately
+                # NOT clamped: next_layer never becomes an ActivationState (only
+                # the per-edge propagated value above does), so it cannot crash.
+                # Clamping the sum here would shrink deep fan-in propagation and
+                # change non-crashing retrieval results — a ranking change that
+                # does not belong in a crash fix (#1197 review).
                 next_layer[dst_id] += propagated_activation
 
                 # Update global activation map (keep max activation)

--- a/backend/tests/neural/test_activation.py
+++ b/backend/tests/neural/test_activation.py
@@ -160,3 +160,133 @@ class TestActivationSpreader:
         n3_result = next(r for r in results if r.node_id == n3)
         assert abs(n3_result.activation - 0.4032) < 0.001
         assert n3_result.hop == 2
+
+
+class TestActivationClampedToUnitInterval:
+    """#1197: spread() must never emit activation > 1.0.
+
+    Edge weights are Hebbian association strengths clipped to
+    ``config.weight_max`` (default 3.0), NOT probabilities — but
+    ``propagated = src * spread_decay * weight`` was fed verbatim into
+    ``ActivationState`` whose ``__post_init__`` hard-requires [0, 1]. A
+    reinforced edge whose weight passed ``1 / spread_decay`` (~1.667 at the
+    0.6 default) made explore raise
+    ``ValueError('activation must be in [0, 1], got 1.004...')`` — the field
+    report's 13 crashes over one campaign, value climbing per recall.
+    """
+
+    @pytest.fixture
+    def node_ids(self):
+        return {f"node{i}": str(uuid4()) for i in range(1, 8)}
+
+    def _config(self):
+        # Production defaults: spread_decay=0.6, weight_max=3.0. The pairing
+        # itself is what makes activation exceed 1.0 for weight > 1.667.
+        return NeuralMemoryConfig(spread_hops=1, spread_decay=0.6, spread_threshold=0.01)
+
+    @pytest.mark.asyncio
+    async def test_hot_edge_does_not_raise_and_stays_in_range(self, mock_graph, node_ids):
+        """A single reinforced edge (weight 1.673 → the ticket's 1.004) must
+        not crash spread(), and the neighbour's activation clamps to <= 1.0."""
+        spreader = ActivationSpreader(mock_graph, self._config())
+        n1, n2 = node_ids["node1"], node_ids["node2"]
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(
+            return_value=[MagicMock(dst_id=n2, weight=1.673)]
+        )
+
+        results = await spreader.spread({n1: 1.0}, max_hops=1)
+
+        for r in results:
+            assert 0.0 <= r.activation <= 1.0
+        n2_result = next(r for r in results if r.node_id == n2)
+        assert n2_result.activation == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("weight", [1.7, 2.0, 3.0])
+    async def test_ticket_weights_never_exceed_one(self, mock_graph, node_ids, weight):
+        """Reproduce #1197 across the reinforced-weight range up to weight_max:
+        every one currently raises; post-fix none raise and all clamp to 1.0."""
+        spreader = ActivationSpreader(mock_graph, self._config())
+        n1, n2 = node_ids["node1"], node_ids["node2"]
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(
+            return_value=[MagicMock(dst_id=n2, weight=weight)]
+        )
+
+        results = await spreader.spread({n1: 1.0}, max_hops=1)
+
+        n2_result = next(r for r in results if r.node_id == n2)
+        assert n2_result.activation == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_normal_weight_behaviour_is_unchanged(self, mock_graph, node_ids):
+        """The clamp must be a no-op in the normal regime (weight <= 1.667):
+        activation stays exactly src * spread_decay * weight."""
+        spreader = ActivationSpreader(mock_graph, self._config())
+        n1, n2 = node_ids["node1"], node_ids["node2"]
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(
+            return_value=[MagicMock(dst_id=n2, weight=0.9)]
+        )
+
+        results = await spreader.spread({n1: 1.0}, max_hops=1)
+
+        n2_result = next(r for r in results if r.node_id == n2)
+        # 1.0 * 0.6 * 0.9 = 0.54 — untouched by the clamp.
+        assert n2_result.activation == pytest.approx(0.54)
+
+    @pytest.mark.asyncio
+    async def test_deep_fanin_stays_crash_safe(self, mock_graph, node_ids):
+        """A fan-in hub sums activation across incoming edges (next_layer +=),
+        so its running total can exceed 1.0 even with every weight <= 1.0. That
+        sum only ever re-enters as the NEXT hop's source (never as an
+        ActivationState directly), where the per-edge clamp bounds the product —
+        so deep fan-in must stay crash-safe. The accumulation is deliberately
+        left UN-clamped (clamping it would shrink deep-hop propagation and
+        change non-crashing retrieval results — out of scope for the crash fix),
+        so the downstream node reflects the un-capped hub."""
+        spreader = ActivationSpreader(mock_graph, self._config())
+        seed = node_ids["node1"]
+        a, b, c = node_ids["node2"], node_ids["node3"], node_ids["node4"]
+        hub = node_ids["node5"]
+        downstream = node_ids["node6"]
+
+        async def edges(user_id, src_id, **kwargs):
+            s = str(src_id)
+            if s == seed:
+                return [
+                    MagicMock(dst_id=a, weight=1.0),
+                    MagicMock(dst_id=b, weight=1.0),
+                    MagicMock(dst_id=c, weight=1.0),
+                ]
+            if s in (a, b, c):
+                return [MagicMock(dst_id=hub, weight=1.0)]
+            if s == hub:
+                return [MagicMock(dst_id=downstream, weight=1.0)]
+            return []
+
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(side_effect=edges)
+
+        results = await spreader.spread({seed: 1.0}, max_hops=3)
+
+        # No ActivationState escapes [0, 1] — the crash invariant holds.
+        for r in results:
+            assert 0.0 <= r.activation <= 1.0
+        # hub accumulates 3 * (0.6 * 0.6) = 1.08 (un-clamped source); downstream
+        # = clamp(1.08 * 0.6 * 1.0) = 0.648. This pins that the fix does NOT cap
+        # the accumulator, i.e. non-crashing propagation is preserved.
+        ds = next(r for r in results if r.node_id == downstream)
+        assert ds.activation == pytest.approx(0.648)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("max_hops", [0, 1])
+    async def test_out_of_range_seed_is_clamped_not_crashed(self, mock_graph, node_ids, max_hops):
+        """Seeds are a documented [0,1] precondition but callers are not
+        validated; an out-of-range seed must clamp, not hit the hard guard —
+        both on the max_hops==0 fast path and the main path."""
+        spreader = ActivationSpreader(mock_graph, self._config())
+        n1 = node_ids["node1"]
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(return_value=[])
+
+        results = await spreader.spread({n1: 1.5}, max_hops=max_hops)
+
+        seed_result = next(r for r in results if r.node_id == n1)
+        assert seed_result.activation == pytest.approx(1.0)

--- a/backend/tests/neural/test_activation.py
+++ b/backend/tests/neural/test_activation.py
@@ -290,3 +290,21 @@ class TestActivationClampedToUnitInterval:
 
         seed_result = next(r for r in results if r.node_id == n1)
         assert seed_result.activation == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_seed_clamped_as_propagation_source(self, mock_graph, node_ids):
+        """The clamped seed must also drive DOWNSTREAM propagation, not just its
+        own stored value: an out-of-range seed whose product stays in range
+        (so _clamp01 is a per-edge no-op) must still propagate as if it were 1.0
+        — otherwise behaviour would depend on the invalid input magnitude."""
+        spreader = ActivationSpreader(mock_graph, self._config())
+        n1, n2 = node_ids["node1"], node_ids["node2"]
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(
+            return_value=[MagicMock(dst_id=n2, weight=0.9)]
+        )
+
+        results = await spreader.spread({n1: 1.5}, max_hops=1)
+
+        n2_result = next(r for r in results if r.node_id == n2)
+        # Clamped seed 1.0 * 0.6 * 0.9 = 0.54 (NOT the raw 1.5 * 0.6 * 0.9 = 0.81).
+        assert n2_result.activation == pytest.approx(0.54)

--- a/backend/tests/neural/test_models.py
+++ b/backend/tests/neural/test_models.py
@@ -68,6 +68,18 @@ class TestActivationState:
         assert state.hop == 1
         assert state.source_node_id == "n1"
 
+    def test_activation_above_one_rejected(self):
+        """#1197: the [0,1] guard stays a HARD guard, never a silent clamp —
+        the fix lives in the spreader (which must not produce >1 in the first
+        place), so any future overshoot reaching this dataclass must still
+        surface loudly here."""
+        with pytest.raises(ValueError, match="activation must be in"):
+            ActivationState(node_id="n", activation=1.004)
+
+    def test_activation_below_zero_rejected(self):
+        with pytest.raises(ValueError, match="activation must be in"):
+            ActivationState(node_id="n", activation=-0.1)
+
 
 class TestNeuralMemoryNode:
     """Test NeuralMemoryNode dataclass."""


### PR DESCRIPTION
Closes #1197.

## Root cause

`explore()` raised `KaguraError: explore failed (activation must be in [0, 1], got 1.004...)` 13× over a 6-hour campaign, the value climbing ~+0.01 per call.

Edge weights are **Hebbian association strengths clipped only to `weight_max` (default 3.0)** — they are not probabilities — but `ActivationSpreader._propagate_one_hop` fed `propagated = src * spread_decay * weight` verbatim into `ActivationState`, whose `__post_init__` hard-requires `[0, 1]` (`neural/models.py:113`). With the explore seed = 1.0, a hop-1 neighbour's activation = `0.6 · weight`, which crosses 1.0 the moment an edge weight passes `1 / spread_decay ≈ 1.667`.

**Why it grows per call:** the Hebbian L2 equilibrium `w* = learning_rate / decay_lambda = 0.05/0.01 = 5.0` sits **above** `weight_max = 3.0`, so every reinforcing `recall()` ratchets the hot edge upward until it pins at the clip. `explore` only reads, so it never self-heals; the 14-day decay half-life can't outpace active reinforcement, and even with zero further reinforcement a weight at ~1.88 takes ~2.4 days to fall back under the threshold. The crash recurs on every explore of that node for days.

## Fix

**Principle: clamp at every point a raw activation *enters* an `ActivationState` (crash-safety), and nowhere else (so no in-range value — hence no ranking — changes).** Two such points, both via a small `_clamp01` helper:

1. the per-edge `propagated` activation — the actual #1197 overshoot;
2. the **seed passthrough** (`max_hops==0` fast path + the seed-init loop) — seeds are a documented `[0,1]` precondition but callers aren't validated, so an out-of-range seed would hit the same hard guard. No current caller passes a seed ≠ 1.0, so this is a no-op today — pure hardening surfaced by the review.

The `models.py` validator is **deliberately kept a hard `raise`**, not converted to a silent clamp, so any future overshoot still surfaces loudly in tests.

## Deliberately out of scope (each would change behaviour or is a separate defect)

- **Not clamping the `next_layer` fan-in accumulation.** An adversarial review flagged, and I confirmed, that clamping the accumulated sum is *not* needed for the crash (the per-edge clamp already seals it — the sum never becomes an `ActivationState` directly) and *does* change non-crashing results: it shrinks deep-hop propagation from fan-in hubs, which shifts `explore` output for depth ≥ 3 queries (a memory returned at 0.648 could drop below a `min_weight` of e.g. 0.62). That is a ranking change that doesn't belong in a crash fix. A regression test pins that the accumulator is left uncapped.
- **Not normalizing by `weight_max`** to preserve relative hot-edge ranking — a retrieval-quality change that needs an eval pass.
- **Not remapping the SDK `'Unknown error'`** — the MCP dispatcher + REST route don't map this `ValueError` to a 422 with a real message. Separate error-surfacing issue.
- **`get_association_score` / `find_related_nodes` are `sync def`s that call `await`-less `spread()`** — pre-existing dead code, unrelated to this fix.

## Tests

`tests/neural/test_activation.py::TestActivationClampedToUnitInterval` — hot-edge no-crash, parametrized ticket weights `[1.7, 2.0, 3.0]` clamp to 1.0, normal-regime no-op, deep fan-in stays crash-safe (accumulator uncapped → downstream 0.648), out-of-range seed clamped on both paths. `tests/neural/test_models.py` — locks the `[0,1]` validator as a hard raise. `tests/neural/` 195 passed; ruff lint + format clean.

Process note: root cause mapped with a 5-reader analysis workflow; the fix was then run through a 3-dimension adversarial review whose CONFIRMED findings (drop the accumulator clamp; add seed clamping) are folded in above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)