### PR TITLE
chore(release): v0.44.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "description": "Kagura Memory Cloud plugin — restore session context, recall & save durable project knowledge, setup help, and an MCP smoke test",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.43.1"
+version = "0.44.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.43.1"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.44.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.43.1"
+APP_VERSION = "0.44.0"
 
 # ============================================================================
 # Context Field Limits (#1193)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.43.1",
+      "version": "0.44.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
Version bump 0.43.1 → 0.44.0 across the 7 manifest sites (same set as prior releases).

**Milestone [v0.44.0](https://github.com/kagura-ai/memory-cloud/milestone) — 2 closed / 0 open.** Both are eval-discovered production bug fixes:

- **#1195** (PR #1198): `fix(sleep)` dedup winner selection prefers the newer memory. The Day-5 v0.43.1 dedup-active replication measured `stale_only` at 10–18%/run — the Sleep dedup judge was deleting the *current* fact of an update pair. `last_updated=` (max of created/updated, minute precision) is now the authoritative recency signal, the update rule takes precedence over completeness, and `_enforce_newer_wins` deterministically flips any winner older than its loser (`details.winner_overrides` telemetry).
- **#1197** (PR #1199): `fix(neural)` clamp spreading activation to `[0,1]`. `explore()` crashed with `activation must be in [0, 1]` once a Hebbian-reinforced edge weight crossed `1/spread_decay` (edge weights clip to `weight_max=3.0`, not 1.0). The spreader now `_clamp01`s at every point a raw activation enters an `ActivationState` (per-edge + seed), with the validator kept a hard guard.

No schema/migration changes in this release. Deploy is blue-green (API only); no frontend rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)