### PR TITLE
feat(api,frontend): surface per-user identity in Sleep reports (#1201)

### DIFF
--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -53,6 +53,12 @@ class SleepReportSummary(TZAwareBaseModel):
     workspace_id: UUID | None
     context_id: UUID | None
     context_name: str | None = None
+    # #1201: email of the user whose partition this run belongs to. Sleep runs
+    # per (user_id, workspace_id, context_id), so a workspace-scoped list can
+    # show the same context on multiple rows; this disambiguates them. None
+    # when the user_id is a non-human/connector identity absent from ``users``
+    # (the frontend falls back to a shortened user_id).
+    user_email: str | None = None
     status: str
     started_at: datetime
     completed_at: datetime | None
@@ -169,6 +175,14 @@ async def list_sleep_reports(
     for r in reports:
         r.context_name = ctx_map.get(r.context_id) if r.context_id else None  # type: ignore[attr-defined]
 
+    # #1201: batch-resolve user_id → email so same-named contexts on different
+    # partitions are distinguishable. None → the frontend falls back to a
+    # shortened user_id.
+    user_ids = {r.user_id for r in reports}  # type: ignore[misc]
+    uid_map = await service.resolve_user_labels(user_ids)
+    for r in reports:
+        r.user_email = uid_map.get(r.user_id)  # type: ignore[attr-defined]
+
     return SleepReportListResponse(
         reports=[SleepReportSummary.model_validate(r, from_attributes=True) for r in reports],
         total=total,
@@ -208,6 +222,9 @@ async def get_sleep_report_detail(
 
     report.context_name = context_name  # type: ignore[attr-defined]
     report.context_deleted = context_deleted  # type: ignore[attr-defined]
+    # #1201: resolve the owning user's email (None → frontend fallback).
+    uid_map = await service.resolve_user_labels({report.user_id})
+    report.user_email = uid_map.get(report.user_id)  # type: ignore[attr-defined]
     report_detail = SleepReportDetail.model_validate(report, from_attributes=True)
 
     return SleepReportDetailResponse(
@@ -290,6 +307,14 @@ async def workspace_list_sleep_reports(
     for r in reports:
         r.context_name = ctx_map.get(r.context_id) if r.context_id else None  # type: ignore[attr-defined]
 
+    # #1201: batch-resolve user_id → email so same-named contexts on different
+    # partitions are distinguishable. None → the frontend falls back to a
+    # shortened user_id.
+    user_ids = {r.user_id for r in reports}  # type: ignore[misc]
+    uid_map = await service.resolve_user_labels(user_ids)
+    for r in reports:
+        r.user_email = uid_map.get(r.user_id)  # type: ignore[attr-defined]
+
     return SleepReportListResponse(
         reports=[SleepReportSummary.model_validate(r, from_attributes=True) for r in reports],
         total=total,
@@ -337,6 +362,9 @@ async def workspace_get_sleep_report_detail(
 
     report.context_name = context_name  # type: ignore[attr-defined]
     report.context_deleted = context_deleted  # type: ignore[attr-defined]
+    # #1201: resolve the owning user's email (None → frontend fallback).
+    uid_map = await service.resolve_user_labels({report.user_id})
+    report.user_email = uid_map.get(report.user_id)  # type: ignore[attr-defined]
     report_detail = SleepReportDetail.model_validate(report, from_attributes=True)
 
     return SleepReportDetailResponse(

--- a/backend/src/services/sleep_reporter_service.py
+++ b/backend/src/services/sleep_reporter_service.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.auth import Context
+from models.auth import Context, User
 from models.sleep import SleepAction, SleepReport
 from utils.logger import get_logger
 
@@ -164,3 +164,38 @@ class SleepReporterService:
         if ctx_deleted_at is not None:
             return None, True
         return ctx_display_name or ctx_name, False
+
+    # ------------------------------------------------------------------
+    # User identity resolution helper (#1201)
+    # ------------------------------------------------------------------
+
+    async def resolve_user_labels(self, user_ids: set[str]) -> dict[str, str]:
+        """Batch-resolve ``user_id → email`` for Sleep report rows.
+
+        Issue #1201: Sleep runs per ``(user_id, workspace_id, context_id)``
+        partition, so a workspace-scoped list can show the same context name on
+        multiple rows (one per member / connector identity). Resolving the
+        owning user's email lets the UI tell those rows apart.
+
+        The join key is ``User.user_id`` (the OAuth ``sub`` claim, a String) —
+        NOT ``User.id`` (an Integer autoincrement PK). ``sleep_reports.user_id``
+        stores the ``sub`` claim, so it matches ``User.user_id``.
+
+        One query, no N+1 — mirrors ``resolve_context_names``.
+
+        Returns:
+            Map of ``user_id → email`` for ids that resolve to a ``users`` row.
+            Ids with no matching user (e.g. connector/service identities that
+            wrote memories) are OMITTED from the map, so the caller can fall
+            back to a shortened id in the UI rather than rendering a bare UUID.
+        """
+        labels: dict[str, str] = {}
+        if not user_ids:
+            return labels
+
+        result = await self.db.execute(
+            select(User.user_id, User.email).where(User.user_id.in_(user_ids))
+        )
+        for uid, email in result.all():
+            labels[uid] = email
+        return labels

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -76,6 +76,13 @@ def _make_mock_context(
     return ctx
 
 
+def _user_result(rows=(("local:admin", "admin@test.com"),)):
+    """Mock result for the #1201 batch ``user_id → email`` query."""
+    r = MagicMock()
+    r.all.return_value = list(rows)
+    return r
+
+
 def _make_mock_action(phase: str = "edge_discovery", action_type: str = "create_edge"):
     a = MagicMock()
     a.id = 1
@@ -126,7 +133,7 @@ class TestListSleepReports:
         # Call 3: batch context query → .all()=[(id, name, display_name, deleted_at)]
         ctx_result = MagicMock()
         ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
-        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -141,6 +148,7 @@ class TestListSleepReports:
         assert data["reports"][0]["started_at"].endswith("Z")
         # Verify context_name is resolved via batch lookup
         assert data["reports"][0]["context_name"] == "Kagura Dev"
+        assert data["reports"][0]["user_email"] == "admin@test.com"
 
     def test_filters_by_status(self, client):
         ctx = _make_mock_context()
@@ -153,7 +161,7 @@ class TestListSleepReports:
         ]
         ctx_result = MagicMock()
         ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
-        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -214,8 +222,8 @@ class TestListSleepReports:
         count_result.scalar.return_value = 1
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
-        # No context query because all context_ids are None
-        mock_db.execute.side_effect = [count_result, list_result]
+        # No context batch query (all context_ids None); then the user query.
+        mock_db.execute.side_effect = [count_result, list_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -223,8 +231,8 @@ class TestListSleepReports:
         assert response.status_code == 200
         data = response.json()
         assert data["reports"][0]["context_name"] is None
-        # Only 2 DB calls: count + list (no context batch query)
-        assert mock_db.execute.call_count == 2
+        # 3 DB calls: count + list + user resolution (context batch skipped)
+        assert mock_db.execute.call_count == 3
 
     def test_list_context_name_falls_back_to_name(self, client):
         """When display_name is None, context_name should fall back to name."""
@@ -238,7 +246,7 @@ class TestListSleepReports:
         list_result.scalars.return_value.all.return_value = reports
         ctx_result = MagicMock()
         ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
-        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -258,15 +266,15 @@ class TestListSleepReports:
         list_result.scalars.return_value.all.return_value = reports
         ctx_result = MagicMock()
         ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
-        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
         response = client.get("/api/v1/admin/sleep-reports")
         assert response.status_code == 200
         assert response.json()["reports"][0]["context_name"] is None
-        # 3 DB calls: count + list + context batch query (deleted path exercised)
-        assert mock_db.execute.call_count == 3
+        # 4 DB calls: count + list + context batch + user resolution
+        assert mock_db.execute.call_count == 4
 
     def test_list_context_name_none_when_context_row_missing(self, client):
         """Reports referencing a non-existent context should have context_name=None."""
@@ -279,7 +287,7 @@ class TestListSleepReports:
         list_result.scalars.return_value.all.return_value = reports
         ctx_result = MagicMock()
         ctx_result.all.return_value = []  # No matching context
-        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -310,7 +318,7 @@ class TestGetSleepReportDetail:
         # 1. service.get_report_detail: SleepReport query → report_result
         # 2. service.get_report_detail: SleepAction query → actions_result
         # 3. service.resolve_context_name: Context query → ctx_result
-        mock_db.execute.side_effect = [report_result, actions_result, ctx_result]
+        mock_db.execute.side_effect = [report_result, actions_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -321,6 +329,7 @@ class TestGetSleepReportDetail:
         assert data["report"]["memories_processed"] == 7
         assert data["report"]["context_name"] == "Kagura Dev"
         assert data["report"]["context_deleted"] is False
+        assert data["report"]["user_email"] == "admin@test.com"
         # Verify Z suffix on both report and action timestamps
         assert data["report"]["started_at"].endswith("Z")
         assert data["actions"][0]["created_at"].endswith("Z")
@@ -338,7 +347,7 @@ class TestGetSleepReportDetail:
         ctx_result.one_or_none.return_value = (ctx.name, ctx.display_name, ctx.deleted_at)
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = []
-        mock_db.execute.side_effect = [report_result, actions_result, ctx_result]
+        mock_db.execute.side_effect = [report_result, actions_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -359,7 +368,7 @@ class TestGetSleepReportDetail:
         ctx_result.one_or_none.return_value = (ctx.name, ctx.display_name, ctx.deleted_at)
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = []
-        mock_db.execute.side_effect = [report_result, actions_result, ctx_result]
+        mock_db.execute.side_effect = [report_result, actions_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -379,7 +388,7 @@ class TestGetSleepReportDetail:
         ctx_result.one_or_none.return_value = None
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = []
-        mock_db.execute.side_effect = [report_result, actions_result, ctx_result]
+        mock_db.execute.side_effect = [report_result, actions_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -397,8 +406,8 @@ class TestGetSleepReportDetail:
         report_result.scalar_one_or_none.return_value = report
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = []
-        # No Context query because context_id is None
-        mock_db.execute.side_effect = [report_result, actions_result]
+        # No Context query (context_id None); then the user query.
+        mock_db.execute.side_effect = [report_result, actions_result, _user_result()]
 
         _install_overrides(mock_db)
 
@@ -441,7 +450,7 @@ class TestGetSleepReportDetail:
         ctx_result.one_or_none.return_value = (ctx.name, ctx.display_name, ctx.deleted_at)
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = []
-        mock_db.execute.side_effect = [report_result, actions_result, ctx_result]
+        mock_db.execute.side_effect = [report_result, actions_result, ctx_result, _user_result()]
 
         _install_overrides(mock_db)
 

--- a/backend/tests/api/test_sleep_reports_workspace.py
+++ b/backend/tests/api/test_sleep_reports_workspace.py
@@ -78,6 +78,13 @@ def _make_mock_action():
     return a
 
 
+def _user_result(rows=(("local:owner", "owner@test.com"),)):
+    """Mock result for the #1201 batch ``user_id → email`` query."""
+    r = MagicMock()
+    r.all.return_value = list(rows)
+    return r
+
+
 @pytest.fixture
 def client(monkeypatch):
     """TestClient that exposes monkeypatch + auto-clears overrides."""
@@ -162,8 +169,8 @@ class TestWorkspaceListSleepReports:
         count_result.scalar.return_value = 3
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
-        # No context query because all context_ids are None
-        mock_db.execute.side_effect = [count_result, list_result]
+        # No context query (all context_ids None); then the batch user query.
+        mock_db.execute.side_effect = [count_result, list_result, _user_result()]
 
         _install_workspace_overrides(client, user=_owner_user(), db_mock=mock_db)
 
@@ -212,7 +219,7 @@ class TestWorkspaceListSleepReports:
         count_result.scalar.return_value = 1
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
-        mock_db.execute.side_effect = [count_result, list_result]
+        mock_db.execute.side_effect = [count_result, list_result, _user_result()]
 
         _install_workspace_overrides(client, user=_owner_user(), db_mock=mock_db)
 
@@ -241,6 +248,50 @@ class TestWorkspaceListSleepReports:
         assert data["offset"] == 50
         assert data["total"] == 100
 
+    def test_list_includes_user_email(self, client):
+        """#1201: each row carries the owning user's email so same-named
+        contexts on different partitions are distinguishable."""
+        report = _make_mock_report()  # user_id = "local:owner"
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = [report]
+        # No context query (context_id None); then the batch user resolution.
+        user_result = MagicMock()
+        user_result.all.return_value = [("local:owner", "owner@test.com")]
+        mock_db.execute.side_effect = [count_result, list_result, user_result]
+
+        _install_workspace_overrides(client, user=_owner_user(), db_mock=mock_db)
+
+        response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reports"][0]["user_email"] == "owner@test.com"
+
+    def test_list_user_email_null_when_unresolved(self, client):
+        """A connector/non-human user_id with no users row → user_email is null,
+        letting the frontend fall back to a shortened id."""
+        report = _make_mock_report()
+        report.user_id = "connector:worker"
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = [report]
+        user_result = MagicMock()
+        user_result.all.return_value = []  # not in users table
+        mock_db.execute.side_effect = [count_result, list_result, user_result]
+
+        _install_workspace_overrides(client, user=_owner_user(), db_mock=mock_db)
+
+        response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reports"][0]["user_email"] is None
+
 
 # ============================================================================
 # Workspace detail route
@@ -259,8 +310,8 @@ class TestWorkspaceGetSleepReportDetail:
         report_result.scalar_one_or_none.return_value = report
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = actions
-        # No context query because context_id is None
-        mock_db.execute.side_effect = [report_result, actions_result]
+        # No context query (context_id None); then the user query.
+        mock_db.execute.side_effect = [report_result, actions_result, _user_result()]
 
         _install_workspace_overrides(client, user=_owner_user(), db_mock=mock_db)
 
@@ -269,6 +320,28 @@ class TestWorkspaceGetSleepReportDetail:
         data = response.json()
         assert data["action_count"] == 1
         assert data["report"]["memories_processed"] == 7
+
+    def test_detail_includes_user_email(self, client):
+        """#1201: detail view also carries the owning user's email."""
+        report = _make_mock_report()  # user_id = "local:owner", context_id None
+        actions = [_make_mock_action()]
+
+        mock_db = AsyncMock()
+        report_result = MagicMock()
+        report_result.scalar_one_or_none.return_value = report
+        actions_result = MagicMock()
+        actions_result.scalars.return_value.all.return_value = actions
+        # report + actions; context skipped (context_id None); then user resolution.
+        user_result = MagicMock()
+        user_result.all.return_value = [("local:owner", "owner@test.com")]
+        mock_db.execute.side_effect = [report_result, actions_result, user_result]
+
+        _install_workspace_overrides(client, user=_owner_user(), db_mock=mock_db)
+
+        response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports/{report.id}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["report"]["user_email"] == "owner@test.com"
 
     def test_report_from_other_workspace_returns_404(self, client):
         """Cross-workspace report probe returns 404 (not 403) — CWE-639 uniform disclosure."""

--- a/backend/tests/services/test_sleep_reporter_service.py
+++ b/backend/tests/services/test_sleep_reporter_service.py
@@ -1,0 +1,59 @@
+"""Unit tests for SleepReporterService identity/name resolution helpers.
+
+Issue #1201: batch-resolve ``user_id → email`` so the Sleep report list can
+distinguish same-named contexts that belong to different user partitions.
+Mirrors the existing ``resolve_context_names`` batch pattern.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.sleep_reporter_service import SleepReporterService
+
+
+class TestResolveUserLabels:
+    """SleepReporterService.resolve_user_labels — batch user_id → email."""
+
+    @pytest.mark.asyncio
+    async def test_maps_user_ids_to_emails(self):
+        db = AsyncMock()
+        result = MagicMock()
+        result.all.return_value = [
+            ("user_a", "a@test.com"),
+            ("user_b", "b@test.com"),
+        ]
+        db.execute.return_value = result
+
+        svc = SleepReporterService(db)
+        labels = await svc.resolve_user_labels({"user_a", "user_b"})
+
+        assert labels == {"user_a": "a@test.com", "user_b": "b@test.com"}
+
+    @pytest.mark.asyncio
+    async def test_omits_unresolved_ids(self):
+        """A connector/non-human user_id absent from ``users`` is omitted (not None),
+        so the caller can fall back to a shortened id in the UI."""
+        db = AsyncMock()
+        result = MagicMock()
+        result.all.return_value = [("human", "h@test.com")]  # 'connector_x' absent
+        db.execute.return_value = result
+
+        svc = SleepReporterService(db)
+        labels = await svc.resolve_user_labels({"human", "connector_x"})
+
+        assert labels == {"human": "h@test.com"}
+        assert "connector_x" not in labels
+
+    @pytest.mark.asyncio
+    async def test_empty_input_skips_query(self):
+        """No ids → no DB round-trip (mirrors resolve_context_names)."""
+        db = AsyncMock()
+
+        svc = SleepReporterService(db)
+        labels = await svc.resolve_user_labels(set())
+
+        assert labels == {}
+        db.execute.assert_not_called()

--- a/frontend/src/components/sleep-reports/SleepReportDetailView.tsx
+++ b/frontend/src/components/sleep-reports/SleepReportDetailView.tsx
@@ -43,7 +43,10 @@ import {
   buildPhaseNarrative,
   type PhaseName,
 } from "@/lib/utils/sleep-narrative";
-import { getSleepStatusColor } from "@/lib/sleep-report";
+import {
+  getSleepStatusColor,
+  formatUserPartitionLabel,
+} from "@/lib/sleep-report";
 import type { SleepReportDetailResponse } from "@/lib/api/sleep-reports";
 
 function PhaseResultJson({ result }: { result: object }): React.ReactElement {
@@ -370,6 +373,17 @@ export function SleepReportDetailView({
                     {t("detail.userId")}
                   </dt>
                   <dd className="font-mono break-all">{report.user_id}</dd>
+                </div>
+                <div>
+                  <dt className="text-gray-500 dark:text-gray-400">
+                    {t("detail.userEmail")}
+                  </dt>
+                  <dd className="break-all">
+                    {formatUserPartitionLabel(
+                      report.user_email,
+                      report.user_id,
+                    )}
+                  </dd>
                 </div>
                 <div>
                   <dt className="text-gray-500 dark:text-gray-400">

--- a/frontend/src/components/sleep-reports/SleepReportsList.tsx
+++ b/frontend/src/components/sleep-reports/SleepReportsList.tsx
@@ -35,6 +35,7 @@ import { ApiError } from "@/lib/api";
 import { formatRelativeTime } from "@/lib/utils/datetime";
 import {
   getSleepStatusColor,
+  formatUserPartitionLabel,
   SLEEP_STATUS_OPTIONS,
   type SleepStatus,
 } from "@/lib/sleep-report";
@@ -129,8 +130,7 @@ export function SleepReportsList({
       const apiErr = err instanceof ApiError ? err : null;
       if (apiErr?.status === 409) {
         const runningReportId = apiErr.details?.running_report_id as
-          | string
-          | undefined;
+          string | undefined;
         toast({
           title: t("messages.runConflict"),
           description: runningReportId ? (
@@ -275,6 +275,7 @@ export function SleepReportsList({
                 <TableRow>
                   <TableHead>{t("table.startedAt")}</TableHead>
                   <TableHead>{t("table.context")}</TableHead>
+                  <TableHead>{t("table.user")}</TableHead>
                   <TableHead>{t("table.status")}</TableHead>
                   <TableHead className="text-right">
                     {t("table.memoriesProcessed")}
@@ -304,6 +305,12 @@ export function SleepReportsList({
                     </TableCell>
                     <TableCell className="text-sm">
                       {report.context_name ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-sm whitespace-nowrap">
+                      {formatUserPartitionLabel(
+                        report.user_email,
+                        report.user_id,
+                      )}
                     </TableCell>
                     <TableCell>
                       <span

--- a/frontend/src/lib/api/sleep-reports.ts
+++ b/frontend/src/lib/api/sleep-reports.ts
@@ -22,10 +22,12 @@ export interface SleepReportSummary {
   workspace_id: string | null;
   context_id: string | null;
   context_name: string | null;
-  // #1201: email of the user whose partition this run belongs to. null when the
-  // user_id is a non-human/connector identity absent from the users table — the
-  // UI falls back to a shortened user_id (see formatUserPartitionLabel).
-  user_email?: string | null;
+  // #1201: email of the user whose partition this run belongs to. Always present
+  // on the wire (computed fresh per response, mirroring context_name — hence
+  // required, not optional). null when the user_id is a non-human/connector
+  // identity absent from the users table — the UI then falls back to a shortened
+  // user_id (see formatUserPartitionLabel).
+  user_email: string | null;
   status: SleepStatus;
   started_at: string;
   completed_at: string | null;

--- a/frontend/src/lib/api/sleep-reports.ts
+++ b/frontend/src/lib/api/sleep-reports.ts
@@ -22,6 +22,10 @@ export interface SleepReportSummary {
   workspace_id: string | null;
   context_id: string | null;
   context_name: string | null;
+  // #1201: email of the user whose partition this run belongs to. null when the
+  // user_id is a non-human/connector identity absent from the users table — the
+  // UI falls back to a shortened user_id (see formatUserPartitionLabel).
+  user_email?: string | null;
   status: SleepStatus;
   started_at: string;
   completed_at: string | null;

--- a/frontend/src/lib/sleep-report.test.ts
+++ b/frontend/src/lib/sleep-report.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+
+import { formatUserPartitionLabel } from "./sleep-report";
+
+describe("formatUserPartitionLabel (#1201)", () => {
+  it("returns the email when present", () => {
+    expect(formatUserPartitionLabel("owner@test.com", "local:owner")).toBe(
+      "owner@test.com",
+    );
+  });
+
+  it("falls back to uid:<first8> when email is null (connector/non-human)", () => {
+    expect(formatUserPartitionLabel(null, "connector-1234567890")).toBe(
+      "uid:connecto",
+    );
+  });
+
+  it("falls back when email is undefined", () => {
+    expect(formatUserPartitionLabel(undefined, "abcdefghxyz")).toBe(
+      "uid:abcdefgh",
+    );
+  });
+
+  it("falls back when email is an empty string", () => {
+    expect(formatUserPartitionLabel("", "shortid")).toBe("uid:shortid");
+  });
+});

--- a/frontend/src/lib/sleep-report.ts
+++ b/frontend/src/lib/sleep-report.ts
@@ -15,6 +15,23 @@ export const SLEEP_STATUS_OPTIONS: SleepStatus[] = [
   "rolled_back",
 ];
 
+/**
+ * #1201: label for the user partition a Sleep run belongs to.
+ *
+ * Sleep runs per (user_id, workspace_id, context_id), so a workspace-scoped
+ * list can show the same context on multiple rows. Prefer the resolved email;
+ * fall back to a shortened user_id when the backend could not resolve it (a
+ * connector/service identity absent from the users table) so the row is still
+ * distinguishable without dumping a full opaque id.
+ */
+export function formatUserPartitionLabel(
+  userEmail: string | null | undefined,
+  userId: string,
+): string {
+  if (userEmail) return userEmail;
+  return `uid:${userId.slice(0, 8)}`;
+}
+
 export function getSleepStatusColor(status: SleepStatus): string {
   switch (status) {
     case "completed":

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2823,6 +2823,7 @@
       "table": {
         "startedAt": "Started",
         "context": "Context",
+        "user": "User",
         "status": "Status",
         "memoriesProcessed": "Memories",
         "edgesCreated": "Edges",
@@ -2844,6 +2845,7 @@
         "actionLog": "Action Log ({count})",
         "reportId": "Report ID",
         "userId": "User ID",
+        "userEmail": "User",
         "contextId": "Context ID",
         "workspaceId": "Workspace ID",
         "startedAt": "Started at",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2823,6 +2823,7 @@
       "table": {
         "startedAt": "開始時刻",
         "context": "コンテキスト",
+        "user": "ユーザー",
         "status": "ステータス",
         "memoriesProcessed": "処理メモリ数",
         "edgesCreated": "作成エッジ数",
@@ -2844,6 +2845,7 @@
         "actionLog": "アクションログ ({count})",
         "reportId": "レポート ID",
         "userId": "ユーザー ID",
+        "userEmail": "ユーザー",
         "contextId": "コンテキスト ID",
         "workspaceId": "ワークスペース ID",
         "startedAt": "開始時刻",


### PR DESCRIPTION
Closes #1201

## Summary
- Sleep Maintenance runs per `(user_id, workspace_id, context_id)`, so a workspace-scoped report list can show the same context name on multiple rows — one per member / connector identity. This surfaces the owning user's email on each row so those partitions are distinguishable (previously only `context_name` was shown, making same-named rows indistinguishable).
- **Backend**: new `SleepReporterService.resolve_user_labels` batch-resolves `user_id → email`, keyed on `User.user_id` (the OAuth `sub` claim) — NOT `User.id` (an Integer PK). Mirrors `resolve_context_names` (one query, no N+1). Wired into all four admin/workspace list + detail routes. New `user_email` field on `SleepReportSummary` (inherited by `SleepReportDetail`).
- **Frontend**: shared `formatUserPartitionLabel` helper (email, else `uid:<first8>`), a "User" column in the report list and a row in the detail view; en/ja i18n.

## Implementation notes
- Non-human/connector identities absent from `users` resolve to `null` → the frontend falls back to a shortened `uid:` label rather than a bare UUID.
- Access control unchanged: workspace routes stay gated by `check_workspace_admin` (owner/admin) + the Pro-plan gate; admin routes by `require_admin`. The resolved id set is derived server-side from already-authorized report rows — no client-supplied id is resolved to an email (no IDOR surface).
- Deferred follow-up: extract a `_attach_report_labels` helper — the context + user attach is now duplicated across the 4 handlers (consistent with the pre-existing `context_name` pattern; worth consolidating when a 3rd label appears).

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- cso: green · qa-lead: green · cto: green
- gate1: green via /ask (CTO lens)
- Local verification: backend 38 tests pass + ruff clean; frontend `tsc` clean, vitest green, en/ja i18n key parity.

Full reviews are saved in the plugin cache (`<branch>.gate1.md`, `<branch>.gate2.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
