### PR TITLE
chore: unify Memory Analysis terminology, drop 'broadlistening'

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -61,7 +61,7 @@
 | **AI Reranking** | セルフホスト (Ollama/vLLM — ローカル・無料)、Voyage AI、Cohere — cross-encoder reranker で精度向上 |
 | **Neural Memory Graph** | Hebbian 学習がバックグラウンドで知識グラフを構築。`explore()` がそれを辿り偶発的発見を提供 |
 | **Agent Memory Substrate** | 単なる知識ストアを超えて — delivery mode (pin / 時刻トリガ)、サーバー署名の trust boundary、agent state レーン、retrieval feedback シグナル。自律エージェントのループに必要なプリミティブ群 |
-| **50 の MCP ツール** | Memory、Agent Substrate、Neural edges、Contexts、Tags、Files (R2)、Analyses (broadlistening)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
+| **50 の MCP ツール** | Memory、Agent Substrate、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
 | **マルチプロバイダ** | 埋め込みに OpenAI かセルフホスト (Ollama、vLLM — ローカル・非公開・コストゼロ) |
 | **チーム対応** | Workspace、RBAC、context 分離、共有メモリ |
 | **Web UI** | Next.js ダッシュボード — context、検索設定、メンバー管理 |
@@ -355,7 +355,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `get_file_download_url` | ファイルへの presigned GET URL 発行 | Viewer+ |
 | `delete_file` | ファイルオブジェクトのソフト削除 | Member+ |
 
-### Analyses — Broadlistening (5)
+### Analyses — メモリー分析 (5)
 
 メモリを UMAP + KMeans + LLM ラベリング (kouchou-ai 方式) で大規模クラスタリング。質的分析用途。
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **AI Reranking** | Self-hosted (Ollama/vLLM — local, free), Voyage AI, or Cohere — cross-encoder reranking for precision |
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
 | **Agent Memory Substrate** | Beyond a knowledge store: delivery modes (pinned / time-triggered), a server-stamped trust boundary, an agent state lane, and a retrieval-feedback signal — the primitives an autonomous agent loop needs. |
-| **50 MCP Tools** | Memory, Agent Substrate, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
+| **50 MCP Tools** | Memory, Agent Substrate, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
 | **Multi-Provider** | OpenAI or self-hosted (Ollama, vLLM — local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |
@@ -480,7 +480,7 @@ The primitives an autonomous agent loop needs beyond a knowledge store — see [
 | `get_file_download_url` | Issue presigned GET URL for a file | Viewer+ |
 | `delete_file` | Soft-delete a file object | Member+ |
 
-### Analyses — Broadlistening (5)
+### Analyses — Memory Analysis (5)
 
 Cluster memories into themes (kouchou-ai-style UMAP + KMeans + LLM labeling) for large-scale qualitative analysis.
 

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -206,7 +206,7 @@ openapi_tags = [
     {
         "name": "analyses",
         "description": (
-            "Memory Broadlistening analysis runs. REST companion to the "
+            "Memory Analysis runs. REST companion to the "
             "5 MCP tools (analyze_context / get_analysis / list_analyses "
             "/ get_active_analysis / get_cluster). Behind a 4-stage gate: "
             "workspace owner + Pro tier + per-day quota + workspace allowlist."
@@ -498,7 +498,7 @@ from api.routes import (  # noqa: E402
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
     admin_sleep,  # Issue #247: Manual Sleep Maintenance trigger
     agent_state,  # Issue #906: REST surface for the agent session-state lane
-    analyses,  # Issue #496: Memory Broadlistening API endpoints
+    analyses,  # Issue #496: Memory Analysis API endpoints
     api_keys,
     attachments,  # Issue #330 → deprecated by #555 (returns HTTP 410 Gone)
     auth,
@@ -603,7 +603,7 @@ app.include_router(sleep_reports.router, prefix="/api/v1")
 # Cost Aggregation routes (Issue #472 - admin cross-workspace + workspace-scoped)
 app.include_router(cost_aggregation.router, prefix="/api/v1")
 
-# Memory Broadlistening API (Issue #496 - 4-stage gate + 6 endpoints)
+# Memory Analysis API (Issue #496 - 4-stage gate + 6 endpoints)
 app.include_router(analyses.router, prefix="/api/v1")
 
 # Admin Sleep trigger (Issue #247 - Manual Sleep Maintenance trigger)

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -1,4 +1,4 @@
-"""Memory Broadlistening API routes (Issue #496).
+"""Memory Analysis API routes (Issue #496).
 
 REST surface for the analysis pipeline (#495 backend) sitting behind the
 4-stage gate composed in ``auth.analysis_gates``:
@@ -382,7 +382,7 @@ async def preview_analysis(
     "",
     response_model=AnalysisStartResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    summary="Start a memory broadlistening analysis run",
+    summary="Start a Memory Analysis run",
 )
 async def start_analysis(
     context_id: UUID,

--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -57,7 +57,7 @@ class PlanLimits(BaseModel):
 
 
 class AnalysisUsage(BaseModel):
-    """Memory broadlistening daily quota usage (Issue #496).
+    """Memory Analysis daily quota usage (Issue #496).
 
     Mirrors the response detail shape of the 429 quota-exceeded body
     so the dashboard, the new-analysis modal (#497), and the gate
@@ -140,7 +140,7 @@ class CurrentUsage(BaseModel):
     analysis: AnalysisUsage | None = Field(
         default=None,
         description=(
-            "Memory broadlistening daily quota stats (Issue #496). "
+            "Memory Analysis daily quota stats (Issue #496). "
             "NULL when the caller has no current workspace selected."
         ),
     )

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -99,7 +99,7 @@ class WorkspaceResponse(BaseModel):
     context_count: int
     created_at: str
     current_user_role: str | None = None  # Current user's role in this workspace
-    analyses_enabled: bool = False  # Memory broadlistening allowlist (#497)
+    analyses_enabled: bool = False  # Memory Analysis allowlist (#497)
 
     class Config:
         from_attributes = True

--- a/backend/src/auth/analysis_allowlist.py
+++ b/backend/src/auth/analysis_allowlist.py
@@ -1,4 +1,4 @@
-"""Pure allowlist primitive for the Memory Broadlistening kill switch.
+"""Pure allowlist primitive for the Memory Analysis kill switch.
 
 Split out of ``auth.analysis_gates`` (PR #538 / #497 review) so callers
 that only need the membership check (e.g. ``api.routes.workspaces``

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -1,4 +1,4 @@
-"""Memory Broadlistening access gates (Issue #496).
+"""Memory Analysis access gates (Issue #496).
 
 Composes the 4 access gates that every analysis-mutating endpoint
 (REST + MCP) must pass through, in this order:

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -82,7 +82,7 @@ class PlanTier:
     public_calls_per_day: int = 0  # Issue #238: Public REST API quota
     public_calls_per_week: int = 0  # Issue #238: Public REST API quota
     bound_public_calls_per_minute: int = 0  # Issue #626: per-key bucket for bound public keys
-    analysis_runs_per_day: int = 0  # Issue #494: Memory Broadlistening analyses/day
+    analysis_runs_per_day: int = 0  # Issue #494: Memory Analysis runs/day
     storage_limit_bytes: int = 0  # Issue #485: File-storage hard cap per workspace
     sleep_enabled_contexts_limit: int = 0  # Issue #560: Sleep-mode contexts cap (PRO-only)
     # Issue #709: Per-workspace BYOK embedding spend cap (USD). ``None`` means
@@ -173,7 +173,7 @@ PLAN_PRO = PlanTier(
     public_calls_per_day=1000,
     public_calls_per_week=5000,
     bound_public_calls_per_minute=100,  # Issue #626: per-key bucket (PRO only)
-    analysis_runs_per_day=3,  # Issue #494: Memory Broadlistening (Pro only; FREE/BASIC=0)
+    analysis_runs_per_day=3,  # Issue #494: Memory Analysis (Pro only; FREE/BASIC=0)
     storage_limit_bytes=10 * 1024 * 1024 * 1024,  # Issue #485: 10 GiB
     sleep_enabled_contexts_limit=3,  # Issue #560: Sleep mode (Pro only; FREE/BASIC=0)
     embedding_daily_cap_usd=10.0,  # Issue #709: PRO ceiling, conservative
@@ -186,7 +186,7 @@ PLAN_PRO = PlanTier(
             "team_invitations",  # Issue #165: Team collaboration
             "shared_contexts",  # Issue #165: Shared contexts with role-based access
             "public_contexts",  # Issue #238: Public contexts
-            "memory_analysis",  # Issue #496: Memory Broadlistening
+            "memory_analysis",  # Issue #496: Memory Analysis
             "managed_embeddings",  # Issue #1030: platform-managed embeddings (M/L)
             "secret_store",  # Issue #1128: zero-knowledge secret store (all tiers)
         }
@@ -208,7 +208,7 @@ FEATURE_MIN_PLANS: dict[str, str] = {
     "team_invitations": "pro",  # Issue #165: Team collaboration requires Pro
     "shared_contexts": "pro",  # Issue #165: Shared contexts require Pro
     "public_contexts": "pro",  # Issue #242: Public contexts require PRO only
-    "memory_analysis": "pro",  # Issue #496: Memory Broadlistening (Pro only; FREE/BASIC=0)
+    "memory_analysis": "pro",  # Issue #496: Memory Analysis (Pro only; FREE/BASIC=0)
     "managed_embeddings": "basic",  # Issue #1030: platform-managed embeddings (M/L; FREE=BYOK/self-hosted)
 }
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -564,7 +564,7 @@ class Settings(BaseSettings):
         ),
     )
 
-    # Memory Broadlistening allowlist (Issue #496) — kill switch.
+    # Memory Analysis allowlist (Issue #496) — kill switch.
     # Empty (default) → feature 403 globally. Comma-separated UUIDs → only listed
     # workspaces can run analyses. Env: ANALYSIS_ENABLED_WORKSPACE_IDS.
     # Production deploy starts empty; ops adds the kagura-dev workspace UUID first

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -203,7 +203,7 @@ def _build_registry() -> dict[str, Any]:
         "get_resource_impact": handle_get_resource_impact,
         "get_resource_schema": handle_get_resource_schema,
         "list_resource_tokens": handle_list_resource_tokens,
-        # Issue #496: Memory Broadlistening — 5 tools sharing the same
+        # Issue #496: Memory Analysis — 5 tools sharing the same
         # 4-stage gate chain as REST /api/v1/contexts/{id}/analyses.
         "analyze_context": handle_analyze_context,
         "get_analysis": handle_get_analysis,

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1656,12 +1656,12 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
             },
         },
         # ====================================================================
-        # Memory Broadlistening Analysis Tools (Issue #496)
+        # Memory Analysis Tools (Issue #496)
         # ====================================================================
         {
             "name": "analyze_context",
             "description": (
-                "Start a memory broadlistening analysis run on a context, "
+                "Start a Memory Analysis run on a context, "
                 "or preview the cost when ``dry_run=true``. The analysis "
                 "clusters memories into themes (kouchou-ai-style UMAP + "
                 "KMeans + LLM labeling) and exposes them via "

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -1,4 +1,4 @@
-"""MCP tool handlers for memory broadlistening analyses (Issue #496).
+"""MCP tool handlers for Memory Analysis (Issue #496).
 
 Five tools that mirror the REST endpoints in
 ``api/routes/analyses.py`` — same gate chain, same data flow, same

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -1,4 +1,4 @@
-"""SQLAlchemy models for Memory Broadlistening analyses.
+"""SQLAlchemy models for Memory Analysis.
 
 Issue #494 (umbrella #493): persistence layer for memory clustering
 analyses. v1 is flat + snapshot-only — one ``memory_analyses`` row per
@@ -60,7 +60,7 @@ def _check_in_sql(column: str, values: tuple[str, ...]) -> str:
 
 
 class MemoryAnalysis(Base):
-    """One broadlistening run over a context's memories.
+    """One Memory Analysis run over a context's memories.
 
     Attributes:
         id: UUID primary key

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1523,7 +1523,7 @@ class Workspace(Base):
     embedding_monthly_cap_usd: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
 
     # Issue #494: per-workspace default + quality model selection for
-    # Memory Broadlistening analyses. Both nullable — analysis is gated
+    # Memory Analysis. Both nullable — analysis is gated
     # by a separate allowlist; until a workspace is opted-in there's no
     # need for a model choice. SET NULL on llm_pricing delete so a
     # pricing row removal does not cascade into the workspace.
@@ -1608,7 +1608,7 @@ class Workspace(Base):
 
     @property
     def effective_analysis_runs_per_day(self) -> int:
-        """Memory Broadlistening analysis runs/day: plan tier base + addon (Issue #494).
+        """Memory Analysis runs/day: plan tier base + addon (Issue #494).
 
         FREE and BASIC have ``analysis_runs_per_day == 0``. Access is also
         gated by ``auth.analysis_gates.require_pro_tier`` which checks the

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -48,7 +48,7 @@ DERIVED_MOAT_TABLES: frozenset[str] = frozenset(
         "sleep_reports",  # Sleep consolidation phase results
         "sleep_actions",  # individual consolidation decisions
         "hub_tag_cache",  # computed tag co-occurrence hubs
-        "memory_analyses",  # Broadlistening analysis runs
+        "memory_analyses",  # Memory Analysis runs
         "memory_analysis_assignments",  # memory→cluster assignments
         "memory_analysis_clusters",  # computed cluster structure
         "retrieval_feedback",  # learning signal (content-reuse policy: feedback only)

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -28,7 +28,7 @@ from db.base import Base
 # Allowed values for the sleep_reports cost-grade dimensions (#523).
 # Mirror the ``LLM_PRICING_UNIT_TYPES`` pattern: the DB CHECK constraint is
 # the source of truth, these tuples exist for service-layer validation and
-# are imported by future call sites (#495 broadlistening pipeline) to
+# are imported by future call sites (#495 Memory Analysis pipeline) to
 # validate inputs cleanly with ValueError rather than IntegrityError.
 # Keep in sync with the ``valid_sleep_report_source`` /
 # ``valid_sleep_report_paid_by`` CHECK strings in ``SleepReport.__table_args__``
@@ -352,7 +352,7 @@ class SleepReportLLMUsage(Base):
         # phase name slips in via reporter changes — same defensive pattern
         # as ``valid_sleep_report_status`` on ``sleep_reports``.
         # ``cluster_labeling`` was added by the d07_495 migration for the
-        # broadlistening pipeline (#495); the model CHECK must list the
+        # Memory Analysis pipeline (#495); the model CHECK must list the
         # SAME values as the migration, otherwise tests using
         # ``Base.metadata.create_all`` (rather than alembic) build a table
         # with the stricter old CHECK and analysis inserts fail.

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -31,7 +31,7 @@ ADDON_UNIT_VALUES = {
     "extra_public_quota": 500,  # calls/day per unit
     "extra_members": 5,  # members per unit
     "extra_contexts": 5,  # contexts per unit
-    "extra_analysis_runs": 1,  # Issue #494: +1 broadlistening run/day per unit
+    "extra_analysis_runs": 1,  # Issue #494: +1 Memory Analysis run/day per unit
     "extra_sleep_contexts": 1,  # Issue #560: +1 sleep-enabled context per unit (PRO-only)
     "extra_connectors": 1,  # Spec 2026-06-02: +1 ai-worker connector seat per unit
 }

--- a/backend/src/services/analysis/__init__.py
+++ b/backend/src/services/analysis/__init__.py
@@ -1,4 +1,4 @@
-"""Memory Broadlistening pipeline (Issue #495 / umbrella #493).
+"""Memory Analysis pipeline (Issue #495 / umbrella #493).
 
 B2 of the v0.15.0 atomic split. The pipeline pulls existing Qdrant
 embeddings, clusters them on **high-dimensional** vectors (NOT the

--- a/backend/src/services/analysis/byok_resolver.py
+++ b/backend/src/services/analysis/byok_resolver.py
@@ -115,7 +115,7 @@ async def assert_openai_byok_key_available(
         raise ValidationError(
             "OpenAI API key not configured for this workspace. "
             "Configure a workspace OpenAI key in External Keys settings "
-            "before running broadlistening analysis.",
+            "before running Memory Analysis.",
             field="byok",
             provider="openai",
             workspace_id=str(workspace_uuid),

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -238,7 +238,7 @@ async def _resolve_pricing_row(db: AsyncSession, model_id: int | None) -> tuple[
 
 
 class AnalysisOrchestrator:
-    """Coordinator for one broadlistening run.
+    """Coordinator for one Memory Analysis run.
 
     Usage from ``tasks/analysis_tasks.py``:
 

--- a/backend/src/services/analysis/vector_pull.py
+++ b/backend/src/services/analysis/vector_pull.py
@@ -87,7 +87,7 @@ class EmbeddingMismatchError(ValidationError):
         super().__init__(
             message=(
                 "Memories in scope use multiple embedding models "
-                f"({embedding_models}); broadlistening cannot cluster "
+                f"({embedding_models}); Memory Analysis cannot cluster "
                 "across models. Filter to a single model or reindex."
             ),
             field="embedding_models",

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -197,7 +197,7 @@ class SleepReporter:
 
         The ``source`` and ``paid_by`` keyword arguments default to the
         scheduler-driven sleep run shape so existing callers receive the
-        same behavior. Issue #495 broadlistening overrides them at its
+        same behavior. Issue #495 Memory Analysis overrides them at its
         own call site with ``source='analysis'`` / ``paid_by='byok'``.
 
         Raises:

--- a/backend/src/tasks/analysis_tasks.py
+++ b/backend/src/tasks/analysis_tasks.py
@@ -1,4 +1,4 @@
-"""Async task entry point for broadlistening analysis runs.
+"""Async task entry point for Memory Analysis runs.
 
 Mirrors ``backend/src/tasks/sleep_tasks.py``'s shape but does NOT
 register an APScheduler cron job — analysis is on-demand only.
@@ -41,7 +41,7 @@ logger = get_logger(__name__)
 
 
 async def run_analysis_task(analysis_id: UUID) -> None:
-    """Run the broadlistening pipeline for one ``memory_analyses`` row.
+    """Run the Memory Analysis pipeline for one ``memory_analyses`` row.
 
     Args:
         analysis_id: The UUID of the row already at status='running'.

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -348,7 +348,7 @@ List resource-token metadata for the workspace (owner/admin; no plaintext tokens
 
 ### analyze_context
 
-Start (or dry-run cost-preview) a broadlistening analysis run that clusters a context's memories into themes.
+Start (or dry-run cost-preview) a Memory Analysis run that clusters a context's memories into themes.
 
 - **Required**: `context_id` — string ⚠ missing `format: "uuid"` — the analysis bundle (analyze_context, list_analyses, get_active_analysis), feedback, set_state, get_state all drop the uuid format annotation that the rest of the surface carries on context_id
 - **Optional**:

--- a/docs/api-surface-1.0/rest-response-models.md
+++ b/docs/api-surface-1.0/rest-response-models.md
@@ -1302,7 +1302,7 @@ Notes:
 - `public_calls_per_week: int` — optional (default `0`)
 
 ### AnalysisUsage (BaseModel, L59)
-> Memory broadlistening daily quota usage (Issue #496).
+> Memory Analysis daily quota usage (Issue #496).
 - `used_today: int` — optional (default `0`)
 - `limit_today: int` — optional (default `0`)
 - `addon_bonus: int` — optional (default `0`)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -225,7 +225,7 @@ Kagura Memory Cloud exposes 50 tools via the [Model Context Protocol (MCP)](http
 | Contexts | 7 | `get_context_info`, `list_contexts`, `create_context`, `update_context`, `delete_context`, `merge_contexts`, `update_search_config` |
 | Tags | 1 | `list_tags` — tag vocabulary discovery for alignment before `remember`/`recall` |
 | Files / R2 | 5 | `init_file_upload`, `complete_file_upload`, `list_files`, `get_file_download_url`, `delete_file` — binary attachments via R2 |
-| Analyses (Broadlistening) | 5 | `analyze_context`, `list_analyses`, `get_analysis`, `get_active_analysis`, `get_cluster` — large-scale qualitative clustering (Owner + Pro plan) |
+| Analyses (Memory Analysis) | 5 | `analyze_context`, `list_analyses`, `get_analysis`, `get_active_analysis`, `get_cluster` — large-scale qualitative clustering (Owner + Pro plan) |
 | Resources | 6 | `setup_resource`, `setup_connector`, `list_resource_tokens`, `ingest_events`, `get_resource_impact`, `get_resource_schema` — external data ingestion + connector provisioning |
 | Secrets | 5 | `secret_register_pubkey`, `secret_put`, `secret_get`, `secret_list`, `secret_revoke_grant` — zero-knowledge secret store (age ciphertext; server never decrypts) |
 | Sleep Maintenance | 3 | `get_sleep_history`, `get_sleep_report`, `rollback_sleep_run` — background consolidation observability |

--- a/docs/derived-layer-boundary.md
+++ b/docs/derived-layer-boundary.md
@@ -69,7 +69,7 @@ link topology and its user-set initial weight are user-authored data.
 | `sleep_reports` | Per-phase Sleep results (`edge_discovery_result`, `dedup_result`, `importance_result`, `consolidation_result`, `reindex_result`) | Consolidation history; each run builds on prior structure |
 | `sleep_actions` | Individual consolidation decisions (merges, promotions, flags) | Same |
 | `hub_tag_cache` | Computed tag co-occurrence hubs (`hub_tags`, `threshold_used`) | Recomputed nightly from observed tag usage |
-| `memory_analyses` / `memory_analysis_assignments` / `memory_analysis_clusters` | Broadlistening cluster structure | Computed structure over the corpus |
+| `memory_analyses` / `memory_analysis_assignments` / `memory_analysis_clusters` | Memory Analysis cluster structure | Computed structure over the corpus |
 | `retrieval_feedback` | Recall feedback signal (#888) | The only sanctioned learning input under the content-reuse policy |
 | `bm25_idf_drift_log` | Corpus-derived index statistics | Tracks how the lexical index adapts to the corpus |
 

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -51,7 +51,7 @@ const GraphTabPanel = dynamic(
     })),
   { ssr: false },
 );
-// Issue #497: analyses tab — lazy-loaded so the broadlistening bundle
+// Issue #497: analyses tab — lazy-loaded so the Memory Analysis bundle
 // (recharts placeholder + scatter SVG + modal) stays out of the
 // non-owner sessions even though the tab itself is owner-gated upstream.
 const AnalysesTabPanel = dynamic(

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -28,7 +28,7 @@
     --chart-3: 197 37% 44%;
     --chart-4: 43 74% 56%;
     --chart-5: 27 87% 57%;
-    /* Issue #497 (broadlistening cluster palette).
+    /* Issue #497 (Memory Analysis cluster palette).
      * chart-3/4/5 lightness was nudged from the prior 24%/66%/67%
      * values so the small (2.5px radius) scatter dots stay legible
      * against the grey grid background — chart-3 too dark, chart-4/5
@@ -108,7 +108,7 @@
 }
 
 @layer utilities {
-  /* Memory broadlistening scatter focus mode (#497).
+  /* Memory Analysis scatter focus mode (#497).
    * The cluster-layer transitions + parent-state-driven dim live here
    * because Tailwind utility classes cannot express
    * ``.scatter.focused .cluster-layer:not(.is-focused)`` without a

--- a/frontend/src/lib/api/analyses.ts
+++ b/frontend/src/lib/api/analyses.ts
@@ -1,5 +1,5 @@
 /**
- * Memory Broadlistening Analyses API Client (Issue #497)
+ * Memory Analysis API Client (Issue #497)
  *
  * Wraps the REST surface from #496 plus the cluster + position
  * endpoints added in #497 (extending the run-level reads with the

--- a/frontend/src/lib/api/cost-aggregation.ts
+++ b/frontend/src/lib/api/cost-aggregation.ts
@@ -25,7 +25,7 @@ export type CostAggregationPeriod = (typeof COST_AGGREGATION_PERIODS)[number];
 /**
  * Source classification for a cost row. Mirrors the DB enum on
  * ``sleep_reports.source`` (#523): scheduler-driven sleep runs vs
- * on-demand broadlistening analysis.
+ * on-demand Memory Analysis.
  */
 export const COST_SOURCES = ["sleep", "analysis"] as const;
 export type CostSource = (typeof COST_SOURCES)[number];

--- a/frontend/src/lib/api/workspaces.ts
+++ b/frontend/src/lib/api/workspaces.ts
@@ -23,7 +23,7 @@ export interface Workspace {
   created_at: string;
   current_user_role?: string | null; // Current user's role in this workspace
   /**
-   * Memory broadlistening allowlist gate (#497). True iff this workspace
+   * Memory Analysis allowlist gate (#497). True iff this workspace
    * is in ANALYSIS_ENABLED_WORKSPACE_IDS on the server. The other 3 gates
    * (Pro tier / BYOK / quota) are evaluated lazily on the actual API call;
    * this flag exists purely so the UI can hide the analyses tab + kebab

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3694,7 +3694,7 @@
   "analyses": {
     "tabLabel": "Analyses",
     "header": {
-      "title": "Meta Analysis",
+      "title": "Memory Analysis",
       "subtitle": "Survey the shape of your memories with cluster overview · Owner only"
     },
     "actions": {
@@ -3827,7 +3827,7 @@
       },
       "notEnabled": {
         "title": "Analyses are not yet enabled for this workspace",
-        "description": "Meta analysis is gated to selected workspaces during the v1 rollout. Reach out if you would like access."
+        "description": "Memory Analysis is gated to selected workspaces during the v1 rollout. Reach out if you would like access."
       },
       "loadFailed": "Failed to load analyses — check connection and try again."
     }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3694,7 +3694,7 @@
   "analyses": {
     "tabLabel": "分析",
     "header": {
-      "title": "メタ分析",
+      "title": "メモリー分析",
       "subtitle": "クラスタ俯瞰で memory の地形を見る · Owner のみ"
     },
     "actions": {
@@ -3827,7 +3827,7 @@
       },
       "notEnabled": {
         "title": "この workspace では Analyses はまだ有効化されていません",
-        "description": "メタ分析は v1 ロールアウト中、選定された workspace に限定されています。アクセスをご希望の場合はお問い合わせください。"
+        "description": "メモリー分析は v1 ロールアウト中、選定された workspace に限定されています。アクセスをご希望の場合はお問い合わせください。"
       },
       "loadFailed": "Analyses の読み込みに失敗しました — 接続を確認してください。"
     }


### PR DESCRIPTION
Closes #1202

## Summary
- Finish the terminology unification started in #495: drop the deprecated feature name **"broadlistening"** → **"Memory Analysis"** (EN) / **メモリー分析** (JA), per the 2026-05-20 decision. Load-bearing identifiers were already unified in prior work, so this is copy/comment only.
- **Part A** (user-facing): `README.md` / `README.ja.md`, the `analyze_context` MCP tool description, OpenAPI operation summary + tag/quota descriptions, the BYOK error message, and public docs (`concepts`, `derived-layer-boundary`, `api-surface-1.0/*`).
- **Part B** (internal sweep): module docstrings/comments across `backend/src` + `frontend/src`. **kouchou-ai** attribution and issue refs (#493–#497) are kept.
- **Part C** (i18n): reconcile the stale #545 「メタ分析 / Meta Analysis」 to 「メモリー分析 / Memory Analysis」 in `ja.json` + `en.json`.

## Implementation notes
- 35 files, +52 / −52 — every hunk is a one-line comment / docstring / display-string / i18n-**value** swap. Load-bearing identifiers (DB table `memory_analyses`, feature key `memory_analysis`, MCP tool names, API paths, i18n **keys**) sit in unchanged context lines.
- `backend/tests/*` deliberately left as internal citations (out of the acceptance-grep scope; documented in the issue).
- **No behavior change**: MCP/API tool names, DB tables/enums, and API paths untouched.

## Verification
- Acceptance grep `broad[_ ]?listening` over `backend/src frontend/src docs README*` = **0**.
- `py_compile` + `ruff check` on all changed `.py` = pass; `ja.json` / `en.json` valid JSON.
- `/code-review` (low) over the full diff = **(none)**.
- No test asserts on any changed string; no code reads the changed i18n values as keys.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (DX Lead) — README added to scope, reflected in the issue body
- review provider: code-review

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/1202-docs-chore-unify-memory-analysis-terminology.gate1.md`
- `~/.claude/cache/gh-issue-driven/1202-docs-chore-unify-memory-analysis-terminology.gate2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via /gh-issue-driven:ship
