### PR TITLE
fix(compose): raise qdrant nofile ulimit to 65536 (EMFILE crash-loop)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,14 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.15.0
     container_name: kagura-qdrant
+    # Qdrant 1.15 opens many files per segment; under eval-scale ingest/delete
+    # churn the default container nofile limit is exhausted (EMFILE crash-loop
+    # at actix worker startup, os error 24 — observed 2026-07-08 on a GB10 rig
+    # after the collection grew to 8 segments). 65536 gives ample headroom.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     ports:
       - "6333:6333"
       - "6334:6334"


### PR DESCRIPTION
## Problem

Qdrant v1.15 opens many files per segment. Under sustained ingest/delete churn (eval workloads), the container's default `nofile` limit is exhausted and Qdrant enters an **EMFILE crash-loop**: startup recovers all shards, actix binds :6333, then a worker panics with `Too many open files (os error 24)` and the process aborts. Docker's healthcheck keeps reporting the container as healthy while it refuses every connection — the failure is invisible to `docker ps`.

Observed live 2026-07-08 on a GB10 eval rig after the 0.6b collection grew to 8 segments (repeated 300-doc ingest→teardown cycles). Before the crash-loop, the running instance degraded first: `Failed to flush segment state … Too many open files`, then all delete/add/search calls failed with empty error strings.

## Fix

Explicit `ulimits: nofile: 65536` (soft+hard) on the qdrant service. Verified on the affected rig: container recreated with the limit, all collections recovered intact, no data intervention needed.

## Notes

- The failure mode is worth knowing operationally: **healthcheck stays green during EMFILE** (the TCP-connect probe can succeed while accept loops error). A follow-up could probe `/healthz` over HTTP instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)