### PR TITLE
feat(neural): enable cold-start recency re-rank by default (#1207)

### DIFF
--- a/backend/alembic/versions/e55_1207_reinforce_default_on.py
+++ b/backend/alembic/versions/e55_1207_reinforce_default_on.py
@@ -1,0 +1,57 @@
+"""Flip reinforce_enabled column default to true (#1207).
+
+The pre-registered kagura-memory-eval program attributed the
+update-correctness headline (+0.36 conditional lift over vanilla RAG,
+BCa 95% [0.24, 0.50]) entirely to the bounded reinforce recency re-rank
+(#1048). New contexts should get the eval-proven update kernel without
+discovering a flag, so the per-context default flips to ON.
+
+This migration changes ONLY the DDL default (``ALTER COLUMN … SET
+DEFAULT``). It deliberately does NOT rewrite existing rows:
+
+- contexts with an explicit ``reinforce_enabled=false`` keep their opt-out;
+- contexts enabled during the Phase-C graduation keep ``true``;
+- legacy contexts without a ``context_search_configs`` row adopt the new
+  default lazily — the search path materializes the row via
+  ``create_or_get`` on their next recall — so effectively every context
+  without a stored ``false`` converges to ON. This lazy adoption is the
+  recorded #1207 decision (only an explicit stored opt-out is honored).
+
+Blue-green safe: the previous app version inserts rows with an explicit
+Python-side ``default=False`` value, so it is unaffected by the DDL
+default; the new version sends ``true`` explicitly. The server default
+only governs raw-SQL inserts that omit the column.
+
+Revision ID: e55_1207_reinforce_default_on
+Revises: e54_1183_sleep_status_degraded
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision = "e55_1207_reinforce_default_on"
+down_revision = "e54_1183_sleep_status_degraded"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "context_search_configs",
+        "reinforce_enabled",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+        server_default=sa.text("true"),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "context_search_configs",
+        "reinforce_enabled",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+        server_default=sa.text("false"),
+    )

--- a/backend/alembic/versions/e55_1207_reinforce_default_on.py
+++ b/backend/alembic/versions/e55_1207_reinforce_default_on.py
@@ -9,13 +9,16 @@ discovering a flag, so the per-context default flips to ON.
 This migration changes ONLY the DDL default (``ALTER COLUMN … SET
 DEFAULT``). It deliberately does NOT rewrite existing rows:
 
-- contexts with an explicit ``reinforce_enabled=false`` keep their opt-out;
+- contexts with a stored ``reinforce_enabled=false`` keep it — note this is
+  the COMMON case for pre-#1207 contexts, because config rows are
+  auto-stamped at context creation (and materialized by any past recall's
+  ``create_or_get``) under the old ``false`` default, so pre-existing
+  contexts stay off after the upgrade;
 - contexts enabled during the Phase-C graduation keep ``true``;
-- legacy contexts without a ``context_search_configs`` row adopt the new
-  default lazily — the search path materializes the row via
-  ``create_or_get`` on their next recall — so effectively every context
-  without a stored ``false`` converges to ON. This lazy adoption is the
-  recorded #1207 decision (only an explicit stored opt-out is honored).
+- the rare legacy context without a ``context_search_configs`` row adopts
+  the new default lazily — the search path materializes the row via
+  ``create_or_get`` on its next recall. This lazy adoption is the recorded
+  #1207 decision.
 
 Blue-green safe: the previous app version inserts rows with an explicit
 Python-side ``default=False`` value, so it is unaffected by the DDL

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1692,6 +1692,11 @@ async def recover_context(
             context_id=PyUUID(context_id),
             embedding_model=settings.embedding_model,
             embedding_dimensions=settings.embedding_dimensions,
+            # #1207: the lost row's setting is unknowable from Qdrant, so
+            # recovery pins the non-ranking-modifying value rather than the
+            # new-context default (recall ordering must not change as a side
+            # effect of disaster recovery). Re-enable via update_search_config.
+            reinforce_enabled=False,
         )
         db.add(new_config)
         await db.flush()

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1213,7 +1213,7 @@ Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fe
                     },
                     "reinforce_enabled": {
                         "type": "boolean",
-                        "description": "Enable the bounded adoption+feedback recall re-rank — memories that are deliberately referenced (adopted) and marked helpful gain a small, bounded standing boost; never-adopted recent memories keep a cold-start prior so they still surface. On by default since #1207 (the eval-proven update kernel); only a stored explicit false opts out. Does not override semantic relevance.",
+                        "description": "Enable the bounded adoption+feedback recall re-rank — memories that are deliberately referenced (adopted) and marked helpful gain a small, bounded standing boost; never-adopted recent memories keep a cold-start prior so they still surface. Contexts created since #1207 start enabled (the eval-proven update kernel); contexts created earlier keep their stored setting (typically false under the old default) — set true here to enable them. Does not override semantic relevance.",
                     },
                     "reinforce_max_boost": {
                         "type": "number",

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1213,7 +1213,7 @@ Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fe
                     },
                     "reinforce_enabled": {
                         "type": "boolean",
-                        "description": "Enable the bounded adoption+feedback recall re-rank — memories that are deliberately referenced (adopted) and marked helpful gain a small, bounded standing boost; never-adopted recent memories keep a cold-start prior so they still surface. Off by default; does not override semantic relevance.",
+                        "description": "Enable the bounded adoption+feedback recall re-rank — memories that are deliberately referenced (adopted) and marked helpful gain a small, bounded standing boost; never-adopted recent memories keep a cold-start prior so they still surface. On by default since #1207 (the eval-proven update kernel); only a stored explicit false opts out. Does not override semantic relevance.",
                     },
                     "reinforce_max_boost": {
                         "type": "number",

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -103,10 +103,12 @@ class ContextSearchConfig(Base):
     # kagura-memory-eval program attributed the update-correctness headline
     # (+0.36 conditional lift over vanilla RAG, BCa 95% [0.24, 0.50]) entirely
     # to this bounded, LLM-free, fail-safe re-rank, so fresh contexts get it
-    # without discovering a flag. Existing rows are NOT rewritten (explicit
-    # opt-outs stand). Contexts without a config row adopt the default lazily:
-    # the search path materializes the row via create_or_get on their next
-    # recall — only a stored ``false`` opts out.
+    # without discovering a flag. Existing rows are NOT rewritten — and since
+    # rows are auto-stamped at context creation (and by any past recall's
+    # create_or_get) under the old default, pre-#1207 contexts hold a stored
+    # ``false`` and stay off until enabled via update_search_config. Only the
+    # rare row-less legacy context adopts the new default lazily when the
+    # search path materializes its row.
     # ``reinforce_max_boost`` bounds the per-result multiplicative adjustment
     # to [1-boost, 1+boost] so semantic relevance always dominates (the
     # re-rank only reorders the relevance-filtered candidate pool).

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -99,12 +99,19 @@ class ContextSearchConfig(Base):
     embedding_dimensions: Mapped[int] = mapped_column(Integer, nullable=False, default=512)
 
     # Issue #1048: bounded reinforce re-ranking (adoption + retrieval feedback).
-    # Default OFF so recall ranking is byte-identical until an operator enables it
-    # after the 2-population eval. ``reinforce_max_boost`` bounds the per-result
-    # multiplicative adjustment to [1-boost, 1+boost] so semantic relevance always
-    # dominates (the re-rank only reorders the relevance-filtered candidate pool).
+    # Issue #1207: default ON for newly created rows — the pre-registered
+    # kagura-memory-eval program attributed the update-correctness headline
+    # (+0.36 conditional lift over vanilla RAG, BCa 95% [0.24, 0.50]) entirely
+    # to this bounded, LLM-free, fail-safe re-rank, so fresh contexts get it
+    # without discovering a flag. Existing rows are NOT rewritten (explicit
+    # opt-outs stand). Contexts without a config row adopt the default lazily:
+    # the search path materializes the row via create_or_get on their next
+    # recall — only a stored ``false`` opts out.
+    # ``reinforce_max_boost`` bounds the per-result multiplicative adjustment
+    # to [1-boost, 1+boost] so semantic relevance always dominates (the
+    # re-rank only reorders the relevance-filtered candidate pool).
     reinforce_enabled: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, server_default="false", default=False
+        Boolean, nullable=False, server_default="true", default=True
     )
     reinforce_max_boost: Mapped[Decimal] = mapped_column(
         DECIMAL(3, 2), nullable=False, server_default="0.15", default=Decimal("0.15")

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -860,8 +860,10 @@ class ContextSearchConfigResponse(TZAwareBaseModel):
     embedding_model: str = Field(..., description="Embedding model (immutable)")
     embedding_dimensions: int = Field(..., description="Vector dimensions (immutable)")
     # Issue #1048: surfaced so GET reflects what update_search_config set.
+    # Issue #1207: default aligned with the ORM default (new contexts start ON);
+    # inert in practice — from_attributes always populates from the row.
     reinforce_enabled: bool = Field(
-        default=False, description="Bounded adoption+feedback recall re-rank enabled"
+        default=True, description="Bounded adoption+feedback recall re-rank enabled"
     )
     reinforce_max_boost: float = Field(
         default=0.15, description="Bound on the reinforce adjustment (factor in [1-b, 1+b])"
@@ -893,8 +895,12 @@ class ContextSearchConfigUpdate(BaseModel):
     reranker_model: str = Field(..., description="Provider-specific model name")
     # Issue #1048: optional (default-preserving) so existing REST callers that omit
     # them are unaffected; the MCP handler always round-trips current values.
+    # Issue #1207: the repository applies model_dump(exclude_unset=True), so these
+    # defaults are never written on partial updates — an omitted field can never
+    # flip an explicit opt-out. Default aligned with the new ORM default anyway
+    # to avoid confusion (pinned by tests/test_reinforce_default_on.py).
     reinforce_enabled: bool = Field(
-        default=False,
+        default=True,
         description="Enable the bounded adoption+feedback recall re-rank",
     )
     reinforce_max_boost: float = Field(

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -441,7 +441,13 @@ class ReferenceResponse(TZAwareBaseModel):
 
 
 class ExportedSearchConfig(BaseModel):
-    """Per-context search configuration in a portability export (Issue #950)."""
+    """Per-context search configuration in a portability export (Issue #950).
+
+    #1207: reinforce settings are exported so an explicit opt-out survives the
+    portability boundary — without them, re-creating an exported context would
+    silently pick up the new default-on. Defaults mirror the current ORM
+    defaults so pre-#1207 export documents (which lack these keys) still parse.
+    """
 
     semantic_weight: float
     bm25_weight: float
@@ -451,6 +457,9 @@ class ExportedSearchConfig(BaseModel):
     reranker_model: str | None
     embedding_model: str
     embedding_dimensions: int
+    reinforce_enabled: bool = True
+    reinforce_max_boost: float = 0.15
+    reinforce_require_host_arbitration: bool = False
 
 
 class ExportedMemory(TZAwareBaseModel):

--- a/backend/src/repositories/config_repository.py
+++ b/backend/src/repositories/config_repository.py
@@ -153,6 +153,13 @@ class ContextSearchConfigRepository:
             use_rerank=False,
             reranker_provider="voyage",
             reranker_model="rerank-2",
+            # #1207: reset converges reinforce to the documented defaults too.
+            # These must be passed explicitly — update() applies
+            # exclude_unset, so omitting them would leave stored values
+            # behind and "reset to defaults" would not mean defaults.
+            reinforce_enabled=True,
+            reinforce_max_boost=0.15,
+            reinforce_require_host_arbitration=False,
         )
 
         config = await self.update(context_id, defaults)

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -413,6 +413,9 @@ class ContextService:
                 reranker_model=cfg.reranker_model,
                 embedding_model=cfg.embedding_model,
                 embedding_dimensions=cfg.embedding_dimensions,
+                reinforce_enabled=cfg.reinforce_enabled,
+                reinforce_max_boost=float(cfg.reinforce_max_boost),
+                reinforce_require_host_arbitration=cfg.reinforce_require_host_arbitration,
             )
             if cfg is not None
             else None

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1544,8 +1544,11 @@ class MemoryService:
         """Issue #1048: bounded, config-gated recall re-rank by adoption + feedback.
 
         No-op unless the context's ``ContextSearchConfig.reinforce_enabled`` is set
-        (default OFF → recall ranking is byte-identical to pre-#1048). Single-context
-        only — a per-context config/feedback set can't govern a cross-context pool.
+        (#1207: ON by default for config rows created since then — including rows
+        lazily materialized by the search path's ``create_or_get`` — with a stored
+        ``false`` as the opt-out; pre-#1207 rows keep their stored value).
+        Single-context only — a per-context config/feedback set can't govern a
+        cross-context pool.
         Re-sorts ``search_results`` IN PLACE by ``hybrid_score * _reinforce_factor``.
 
         Issue #1069: when the re-rank fires it emits a ``reinforce_rerank_applied``
@@ -1563,9 +1566,12 @@ class MemoryService:
         try:
             from repositories.config_repository import ContextSearchConfigRepository
 
-            # READ-ONLY lookup — recall must not create/commit a config row mid-flow
-            # (create_or_get would INSERT+COMMIT for a context with no config yet,
-            # adding a side effect to the read path). No config row → reinforce off.
+            # READ-ONLY lookup — this helper must not create/commit a config row
+            # (create_or_get would INSERT+COMMIT, adding a side effect here). In
+            # practice hybrid_search's _get_search_config has usually materialized
+            # the row earlier in this same recall (with the #1207 default), so the
+            # cfg-None branch is a fail-safe for genuinely row-less states (e.g.
+            # that materialization failed), not a legacy-context opt-out.
             cfg = await ContextSearchConfigRepository(self.db).get_by_context(context_id)
             if cfg is None or not getattr(cfg, "reinforce_enabled", False):
                 return
@@ -1951,7 +1957,7 @@ class MemoryService:
         # Hebbian learning still runs to build the graph for explore().
 
         # Issue #1048: bounded reinforce re-rank (adoption + retrieval feedback),
-        # config-gated per-context (default OFF), single-context only. Reorders the
+        # config-gated per-context (default ON since #1207), single-context only. Reorders the
         # candidate pool BEFORE the top-k slice below; uses only reference_count +
         # feedback + importance + recency — never graph signals (respects #120).
         await self._maybe_reinforce_rerank(

--- a/backend/tests/eval/_provisioning.py
+++ b/backend/tests/eval/_provisioning.py
@@ -92,6 +92,11 @@ async def provision_eval_context(
             reranker_model="qwen3-reranker-4b",
             embedding_model=emb_model,
             embedding_dimensions=emb_dims,
+            # #1207 flipped the product default to enabled; the eval stamp pins
+            # it OFF so retrieval arms stay byte-comparable with the frozen
+            # protocol and archived results. Runners that measure the re-rank
+            # itself flip it explicitly (reinforce_runner._set_reinforce).
+            reinforce_enabled=False,
         )
     )
     await db.flush()

--- a/backend/tests/eval/reinforce_gate.py
+++ b/backend/tests/eval/reinforce_gate.py
@@ -2,8 +2,10 @@
 
 Tier-C companion to the #344 static harness (``runner.py``) and the #969
 compounding harness (``replay_runner.py``). The bounded reinforce re-rank (#1048)
-ships **default-OFF**; this module defines the gate that decides whether enabling
-it on a context is safe — the eval the rollout (#1069) is gated on:
+is **default-ON since #1207** (new/materialized config rows start enabled; only a
+stored explicit ``false`` opts out); this module defines the gate that decides
+whether enabling it on an explicitly-opted-out context is safe — the eval the
+rollout (#1069) was gated on:
 
 - **current-fact** queries (the canonical answer has been adopted + confirmed
   helpful) must **improve** — that is the whole point of reinforce;

--- a/backend/tests/eval/reinforce_gate.py
+++ b/backend/tests/eval/reinforce_gate.py
@@ -2,10 +2,10 @@
 
 Tier-C companion to the #344 static harness (``runner.py``) and the #969
 compounding harness (``replay_runner.py``). The bounded reinforce re-rank (#1048)
-is **default-ON since #1207** (new/materialized config rows start enabled; only a
-stored explicit ``false`` opts out); this module defines the gate that decides
-whether enabling it on an explicitly-opted-out context is safe — the eval the
-rollout (#1069) was gated on:
+is **default-ON for newly created contexts since #1207** (pre-#1207 contexts
+keep their stored — typically ``false`` — setting); this module defines the gate
+that decides whether enabling it on such a pre-existing context is safe — the
+eval the rollout (#1069) was gated on:
 
 - **current-fact** queries (the canonical answer has been adopted + confirmed
   helpful) must **improve** — that is the whole point of reinforce;

--- a/backend/tests/eval/reinforce_runner.py
+++ b/backend/tests/eval/reinforce_runner.py
@@ -10,8 +10,10 @@ Protocol (one ingested corpus, one A/B flip — only the config changes):
     ingest reinforce_corpus
       → seed adoption (reference_count) + net-helpful feedback on the canonical
         current-fact docs (meta.adopted_docs)
-      → OFF arm: reinforce disabled (default) → score current_fact / rare + the
-        zero-adoption surfacing rate
+      → OFF arm: reinforce pinned OFF explicitly (#1207 made a materialized
+        config row default to enabled, and recall materializes the row via
+        create_or_get — so "no row yet" no longer means OFF) → score
+        current_fact / rare + the zero-adoption surfacing rate
       → flip ContextSearchConfig.reinforce_enabled = true
       → ON arm: score the same queries again
       → evaluate_reinforce_gate(off, on)  → results/reinforce-<date>.json
@@ -188,8 +190,12 @@ async def _run_reinforce_arms(
     try:
         await _seed_adoption(svc, ctx_id, owner, adopted_mem_ids)
 
-        # OFF arm: reinforce disabled by default (no config row → byte-identical
-        # to pre-#1048). Score before any config row exists.
+        # OFF arm: pin reinforce OFF explicitly. The recall path materializes
+        # the config row via create_or_get (search_service._get_search_config),
+        # and since #1207 a materialized row defaults to ENABLED — relying on
+        # "no config row yet" would silently score the OFF arm with the
+        # re-rank active.
+        await _set_reinforce(svc.db, ctx_id, enabled=False, max_boost=_MAX_BOOST)
         off = await _score_reinforce_arm(svc, corpus, id_map, owner, ctx_id, ws_id, adopted_docs)
 
         # Flip reinforce ON for the same context + same seeded signal.

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -153,6 +153,27 @@ async def _run_mode(corpus: Corpus, plan: ReplayPlan) -> dict[str, Any]:
         await db.flush()
         db.add(ctx)
         db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        # Pin reinforce OFF for the recall control lane (#1207). Pre-#1207 this
+        # row was materialized lazily by the first recall with reinforce_enabled
+        # =False; the default flip would now materialize it ENABLED, letting the
+        # re-rank contaminate the flat-by-design recall lane. The embedding
+        # stamp is settings-derived like _provisioning's, so creating the row
+        # BEFORE ingest cannot re-route embedding on non-default rigs.
+        from config.constants import EMBEDDING_MODEL_REGISTRY
+        from config.settings import get_settings
+        from models.config import ContextSearchConfig
+
+        settings = get_settings()
+        emb_model = settings.embedding_model
+        emb_dims = EMBEDDING_MODEL_REGISTRY.get(emb_model, (settings.embedding_dimensions, ""))[0]
+        db.add(
+            ContextSearchConfig(
+                context_id=ctx.id,
+                embedding_model=emb_model,
+                embedding_dimensions=emb_dims,
+                reinforce_enabled=False,
+            )
+        )
         await db.flush()
         await db.commit()
 

--- a/backend/tests/eval/test_reinforce_runner.py
+++ b/backend/tests/eval/test_reinforce_runner.py
@@ -122,9 +122,11 @@ class TestRunReinforceArms:
             svc, corpus, id_map, "owner", uuid4(), uuid4(), "2026-06-26", write=False
         )
 
-        # Seed first, OFF arm scored while reinforce is still off, THEN flip on,
-        # THEN score the ON arm — the A/B is honest only in this order.
-        assert order == ["seed", "score", "set_reinforce=True", "score"]
+        # Seed first, pin reinforce OFF explicitly (#1207: a lazily-materialized
+        # config row defaults to enabled, so "not flipped yet" no longer means
+        # off), score the OFF arm, THEN flip on, THEN score the ON arm — the
+        # A/B is honest only in this order.
+        assert order == ["seed", "set_reinforce=False", "score", "set_reinforce=True", "score"]
         assert results["gate"]["passed"] is True
         assert results["off"]["zero_adoption_surfacing_rate"] == 0.50
         assert results["on"]["populations"][POPULATION_CURRENT_FACT]["mrr@10"] == 0.88

--- a/backend/tests/eval/update_runner.py
+++ b/backend/tests/eval/update_runner.py
@@ -432,8 +432,10 @@ async def run_update_eval(
             daily_api_limit=10_000_000,
             weekly_api_limit=50_000_000,
         )
-        # ctx_vr: exactly runner.py's stamp, sleep_mode/reinforce_enabled left
-        # at their defaults ("skip" / False) — the Vanilla RAG baseline.
+        # ctx_vr: exactly runner.py's stamp, sleep_mode left at its default
+        # ("skip") and reinforce_enabled pinned False EXPLICITLY — the Vanilla
+        # RAG baseline. #1207 flipped the column default to true, so the VR
+        # arm can no longer rely on the model default staying off.
         ctx_vr = Context(
             id=uuid4(),
             workspace_id=ws.id,
@@ -466,6 +468,7 @@ async def run_update_eval(
                 reranker_model="qwen3-reranker-4b",
                 embedding_model=emb_model,
                 embedding_dimensions=emb_dims,
+                reinforce_enabled=False,
             )
         )
         db.add(

--- a/backend/tests/services/test_context_export.py
+++ b/backend/tests/services/test_context_export.py
@@ -68,6 +68,12 @@ def _cfg():
     c.reranker_model = "rerank-2"
     c.embedding_model = "text-embedding-3-small"
     c.embedding_dimensions = 512
+    # #1207: real attribute values (bare MagicMock attrs would be silently
+    # coerced by pydantic to True/1.0, making assertions vacuous). False
+    # mirrors an explicit opt-out that must survive the portability boundary.
+    c.reinforce_enabled = False
+    c.reinforce_max_boost = Decimal("0.15")
+    c.reinforce_require_host_arbitration = False
     return c
 
 
@@ -112,6 +118,11 @@ async def test_export_private_context_is_creator_scoped_and_serializes():
     assert out.search_config is not None
     assert out.search_config.semantic_weight == 0.6
     assert out.search_config.embedding_dimensions == 512
+    # #1207: an explicit opt-out must survive export — without these fields a
+    # re-created context would silently pick up the new default-on.
+    assert out.search_config.reinforce_enabled is False
+    assert out.search_config.reinforce_max_boost == 0.15
+    assert out.search_config.reinforce_require_host_arbitration is False
 
     # Private context => the memory query MUST carry a user_id (creator) filter
     # alongside context_id + the soft-delete guard.

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1367,8 +1367,10 @@ class TestReinforceFactor:
 
 
 class TestReinforceRerank:
-    """Issue #1048: _maybe_reinforce_rerank is config-gated (default OFF) and only
-    reorders the relevance-filtered pool within the bound."""
+    """Issue #1048: _maybe_reinforce_rerank is config-gated and only reorders the
+    relevance-filtered pool within the bound. (#1207: the per-context default is
+    now ON for new/materialized config rows; a stored explicit ``false`` opts
+    out — each test below pins the gate state via an explicit mock config.)"""
 
     @pytest.mark.asyncio
     async def test_noop_when_disabled(self):

--- a/backend/tests/test_reinforce_default_on.py
+++ b/backend/tests/test_reinforce_default_on.py
@@ -15,10 +15,11 @@ Pins:
 2. ``reinforce_max_boost`` stays at the eval-measured bound ``0.15`` — #1207
    changes the gate, not the magnitude.
 3. Migration ``e55_1207_*`` alters only the column default; it must NOT
-   rewrite existing rows (explicit opt-outs keep their stored value). The
-   recorded #1207 decision for contexts without a config row is **lazy
-   adoption**: the search path materializes the row via ``create_or_get`` on
-   their next recall, so only a stored explicit ``false`` opts out.
+   rewrite existing rows. Cohort truth: pre-#1207 contexts hold a stored
+   ``false`` (rows are auto-stamped at context creation / by any past
+   recall's ``create_or_get`` under the old default) and stay off; only the
+   rare genuinely row-less legacy context adopts the new default lazily when
+   its row is materialized — the recorded #1207 decision.
 4. Partial-update semantics: ``ContextSearchConfigUpdate`` +
    ``model_dump(exclude_unset=True)`` (the repository's update contract)
    drops reinforce fields the caller did not send, so a partial PUT can never
@@ -26,15 +27,25 @@ Pins:
 5. The reinforce guard's config lookup stays READ-ONLY (a fail-safe for
    genuinely row-less states) — pinned via source scan.
 6. The eval harness pins reinforce OFF explicitly wherever an arm is not
-   measuring the re-rank itself — the frozen retrieval/update protocols must
-   stay byte-comparable across product default changes: the shared
-   provisioning stamp (``_provisioning.py``), the update-slice vanilla arm
-   (``update_runner.py``), and the reinforce A/B OFF arm
-   (``reinforce_runner.py``).
+   measuring the re-rank itself — the frozen retrieval/update/compounding
+   protocols must stay byte-comparable across product default changes:
+   the shared provisioning stamp (``_provisioning.py``), the update-slice
+   vanilla arm (``update_runner.py``), the compounding harness's recall
+   control lane (``replay_runner.py``), and the reinforce A/B OFF arm
+   (``reinforce_runner.py``). Pinned via AST (constructor kwargs), not raw
+   substrings, so a docstring mention can never satisfy the pin.
+7. Recovery and reset semantics: admin context recovery pins
+   ``reinforce_enabled=False`` (the lost row's setting is unknowable — recall
+   ordering must not change as a side effect of disaster recovery), and
+   ``reset_to_default`` passes the reinforce defaults explicitly (its
+   ``update()`` applies ``exclude_unset``, so omission would leave stored
+   values behind).
 """
 
+import ast
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 
 from models.config import ContextSearchConfig
 from models.schemas import ContextSearchConfigUpdate
@@ -42,8 +53,33 @@ from models.schemas import ContextSearchConfigUpdate
 _BACKEND_ROOT = Path(__file__).resolve().parents[1]
 
 
-def _column(name: str):
+def _column(name: str) -> Any:
     return ContextSearchConfig.__table__.c[name]
+
+
+def _call_kwarg_values(path: Path, callee: str, kwarg: str) -> list[object]:
+    """Return the literal value of ``kwarg`` for every ``callee(...)`` call.
+
+    Calls that omit the kwarg contribute ``None`` (distinct from a literal
+    ``None`` value, which does not occur for these boolean kwargs). Matching
+    is on the call's function name (``Name`` or attribute tail), so docstring
+    or comment mentions can never satisfy these pins.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    values: list[object] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != callee:
+            continue
+        value: object = None
+        for kw in node.keywords:
+            if kw.arg == kwarg and isinstance(kw.value, ast.Constant):
+                value = kw.value.value
+        values.append(value)
+    return values
 
 
 def test_reinforce_enabled_python_default_is_true() -> None:
@@ -68,7 +104,13 @@ def test_reinforce_max_boost_bound_unchanged() -> None:
 
 
 def test_migration_e55_alters_default_without_row_rewrite() -> None:
-    """The migration changes the DDL default and never UPDATEs existing rows."""
+    """The migration changes the DDL default and never UPDATEs existing rows.
+
+    ``op.execute`` is banned outright in this migration — the only legitimate
+    operation is ``alter_column``. That closes the raw-SQL/sa.update()/aliased
+    UPDATE loopholes a substring check on "update context_search_configs"
+    would miss.
+    """
     versions = _BACKEND_ROOT / "alembic" / "versions"
     matches = sorted(versions.glob("e55_1207_*.py"))
     assert matches, "expected alembic migration e55_1207_* for the default flip"
@@ -76,10 +118,12 @@ def test_migration_e55_alters_default_without_row_rewrite() -> None:
     assert "alter_column" in source
     assert "context_search_configs" in source
     assert "reinforce_enabled" in source
-    lowered = source.lower()
-    assert "update context_search_configs" not in lowered, (
-        "migration must not rewrite existing rows — explicit opt-outs and "
-        "legacy contexts keep their stored value (#1207 recorded decision)"
+    assert "op.execute" not in source, (
+        "e55 must not execute arbitrary SQL — a row rewrite would clobber "
+        "stored opt-outs (#1207 recorded decision: DDL default change only)"
+    )
+    assert "sa.update" not in source, (
+        "migration must not rewrite existing rows (#1207 recorded decision)"
     )
 
 
@@ -130,19 +174,63 @@ def test_eval_harness_pins_reinforce_off_explicitly() -> None:
 
     - ``_provisioning.py``: the shared retrieval-eval stamp (golden runner,
       placebo runner, freeze_tau) pins ``reinforce_enabled=False``;
-    - ``update_runner.py``: the vanilla-RAG arm pins it False (the MC arm
-      sets True explicitly);
-    - ``reinforce_runner.py``: the A/B OFF arm disables it explicitly before
-      scoring.
+    - ``update_runner.py``: the vanilla-RAG arm pins False, the MC arm True;
+    - ``replay_runner.py``: the compounding harness's recall control lane
+      pins False at provisioning;
+    - ``reinforce_runner.py``: the A/B OFF arm disables explicitly before
+      scoring (``_set_reinforce(..., enabled=False)``).
+
+    AST-based on constructor/call kwargs — a docstring or comment containing
+    the same text can never satisfy these pins.
     """
     eval_root = _BACKEND_ROOT / "tests" / "eval"
 
-    provisioning = (eval_root / "_provisioning.py").read_text(encoding="utf-8")
-    assert "reinforce_enabled=False" in provisioning
+    prov = _call_kwarg_values(
+        eval_root / "_provisioning.py", "ContextSearchConfig", "reinforce_enabled"
+    )
+    assert prov == [False], f"_provisioning stamp must pin False, got {prov}"
 
-    update_runner = (eval_root / "update_runner.py").read_text(encoding="utf-8")
-    assert "reinforce_enabled=False" in update_runner
-    assert "reinforce_enabled=True" in update_runner  # MC arm stays explicit
+    upd = _call_kwarg_values(
+        eval_root / "update_runner.py", "ContextSearchConfig", "reinforce_enabled"
+    )
+    assert sorted(upd, key=str) == [False, True], (
+        f"update_runner must pin VR arm False and MC arm True explicitly, got {upd}"
+    )
 
-    reinforce_runner = (eval_root / "reinforce_runner.py").read_text(encoding="utf-8")
-    assert "_set_reinforce(svc.db, ctx_id, enabled=False" in reinforce_runner
+    replay = _call_kwarg_values(
+        eval_root / "replay_runner.py", "ContextSearchConfig", "reinforce_enabled"
+    )
+    assert replay == [False], f"replay_runner control lane must pin False, got {replay}"
+
+    reinforce = _call_kwarg_values(eval_root / "reinforce_runner.py", "_set_reinforce", "enabled")
+    assert False in reinforce and True in reinforce, (
+        f"reinforce_runner must set the OFF arm (enabled=False) and the ON arm "
+        f"(enabled=True) explicitly, got {reinforce}"
+    )
+
+
+def test_recovery_and_reset_pin_reinforce_explicitly() -> None:
+    """Recovery restores conservatively; reset converges to documented defaults.
+
+    - Admin context recovery reconstructs the config row from Qdrant, where the
+      lost row's reinforce setting is unknowable — it pins ``False`` so recall
+      ordering never changes as a side effect of disaster recovery.
+    - ``reset_to_default`` must pass the reinforce defaults explicitly: its
+      ``update()`` applies ``exclude_unset``, so omitting the fields would
+      silently leave stored values behind and "reset" would not mean defaults.
+    """
+    admin = _call_kwarg_values(
+        _BACKEND_ROOT / "src" / "api" / "routes" / "admin.py",
+        "ContextSearchConfig",
+        "reinforce_enabled",
+    )
+    assert admin == [False], f"admin recovery must pin reinforce_enabled=False, got {admin}"
+
+    reset = _call_kwarg_values(
+        _BACKEND_ROOT / "src" / "repositories" / "config_repository.py",
+        "ContextSearchConfigUpdate",
+        "reinforce_enabled",
+    )
+    assert True in reset, (
+        f"reset_to_default must pass reinforce_enabled=True explicitly, got {reset}"
+    )

--- a/backend/tests/test_reinforce_default_on.py
+++ b/backend/tests/test_reinforce_default_on.py
@@ -1,0 +1,148 @@
+"""Regression tests for #1207: cold-start recency re-rank enabled by default.
+
+The kagura-memory-eval program attributed the update-correctness headline
+(+0.36 conditional lift over vanilla RAG, BCa 95% [0.24, 0.50]) entirely to
+the bounded reinforce recency re-rank. #1207 flips the per-context default to
+ON for newly created config rows so fresh contexts get the eval-proven update
+kernel without discovering a flag.
+
+Pins:
+
+1. ORM defaults: ``ContextSearchConfig.reinforce_enabled`` has Python default
+   ``True`` and ``server_default "true"`` — new rows (ORM inserts from
+   ``context_service`` / ``resource setup`` / ``config_repository.create_or_get``
+   and raw-SQL inserts alike) start enabled.
+2. ``reinforce_max_boost`` stays at the eval-measured bound ``0.15`` — #1207
+   changes the gate, not the magnitude.
+3. Migration ``e55_1207_*`` alters only the column default; it must NOT
+   rewrite existing rows (explicit opt-outs keep their stored value). The
+   recorded #1207 decision for contexts without a config row is **lazy
+   adoption**: the search path materializes the row via ``create_or_get`` on
+   their next recall, so only a stored explicit ``false`` opts out.
+4. Partial-update semantics: ``ContextSearchConfigUpdate`` +
+   ``model_dump(exclude_unset=True)`` (the repository's update contract)
+   drops reinforce fields the caller did not send, so a partial PUT can never
+   silently flip an explicit opt-out in either direction.
+5. The reinforce guard's config lookup stays READ-ONLY (a fail-safe for
+   genuinely row-less states) — pinned via source scan.
+6. The eval harness pins reinforce OFF explicitly wherever an arm is not
+   measuring the re-rank itself — the frozen retrieval/update protocols must
+   stay byte-comparable across product default changes: the shared
+   provisioning stamp (``_provisioning.py``), the update-slice vanilla arm
+   (``update_runner.py``), and the reinforce A/B OFF arm
+   (``reinforce_runner.py``).
+"""
+
+from decimal import Decimal
+from pathlib import Path
+
+from models.config import ContextSearchConfig
+from models.schemas import ContextSearchConfigUpdate
+
+_BACKEND_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _column(name: str):
+    return ContextSearchConfig.__table__.c[name]
+
+
+def test_reinforce_enabled_python_default_is_true() -> None:
+    """New ORM rows (context creation paths omit the kwarg) start enabled."""
+    col = _column("reinforce_enabled")
+    assert col.default is not None, "reinforce_enabled must keep a Python-side default"
+    assert col.default.arg is True
+
+
+def test_reinforce_enabled_server_default_is_true() -> None:
+    """Raw-SQL inserts get the same default as ORM inserts (DDL parity)."""
+    col = _column("reinforce_enabled")
+    assert col.server_default is not None
+    assert str(col.server_default.arg) == "true"
+
+
+def test_reinforce_max_boost_bound_unchanged() -> None:
+    """#1207 flips the gate only — the eval-measured ±0.15 bound stays."""
+    col = _column("reinforce_max_boost")
+    assert col.default.arg == Decimal("0.15")
+    assert str(col.server_default.arg) == "0.15"
+
+
+def test_migration_e55_alters_default_without_row_rewrite() -> None:
+    """The migration changes the DDL default and never UPDATEs existing rows."""
+    versions = _BACKEND_ROOT / "alembic" / "versions"
+    matches = sorted(versions.glob("e55_1207_*.py"))
+    assert matches, "expected alembic migration e55_1207_* for the default flip"
+    source = matches[0].read_text(encoding="utf-8")
+    assert "alter_column" in source
+    assert "context_search_configs" in source
+    assert "reinforce_enabled" in source
+    lowered = source.lower()
+    assert "update context_search_configs" not in lowered, (
+        "migration must not rewrite existing rows — explicit opt-outs and "
+        "legacy contexts keep their stored value (#1207 recorded decision)"
+    )
+
+
+def test_partial_update_preserves_omitted_reinforce_fields() -> None:
+    """A PUT that omits reinforce fields must not touch them.
+
+    ``ContextSearchConfigRepository.update`` applies
+    ``model_dump(exclude_unset=True)``; this pin fails if someone replaces
+    that with a plain ``model_dump()`` or makes the reinforce fields required,
+    either of which would let a partial update overwrite an explicit opt-out.
+    """
+    update = ContextSearchConfigUpdate(
+        semantic_weight=0.6,
+        bm25_weight=0.4,
+        fetch_factor=3,
+        use_rerank=False,
+        reranker_provider="voyage",
+        reranker_model="rerank-2",
+    )
+    dumped = update.model_dump(exclude_unset=True)
+    assert "reinforce_enabled" not in dumped
+    assert "reinforce_max_boost" not in dumped
+    assert "reinforce_require_host_arbitration" not in dumped
+
+
+def test_reinforce_guard_is_readonly_failsafe() -> None:
+    """The re-rank's own config lookup stays read-only and fails closed.
+
+    ``_maybe_reinforce_rerank`` must use ``get_by_context`` (never
+    ``create_or_get``) and treat a missing row as OFF. In practice the search
+    path has usually materialized the row earlier in the same recall — with
+    the #1207 default — so this guard is a fail-safe for genuinely row-less
+    states, not a legacy-context opt-out. Pinning it prevents a refactor from
+    adding a write side effect or defaulting a missing row to ON here.
+    """
+    source = (_BACKEND_ROOT / "src" / "services" / "memory_service.py").read_text(encoding="utf-8")
+    assert 'if cfg is None or not getattr(cfg, "reinforce_enabled", False):' in source
+    assert "READ-ONLY lookup" in source
+
+
+def test_eval_harness_pins_reinforce_off_explicitly() -> None:
+    """Eval arms that are not measuring the re-rank pin it OFF explicitly.
+
+    Since #1207 a lazily-materialized config row defaults to enabled, so any
+    eval context relying on "default off" or "no config row yet" would
+    silently score with the re-rank active, breaking comparability with the
+    frozen protocols and archived results:
+
+    - ``_provisioning.py``: the shared retrieval-eval stamp (golden runner,
+      placebo runner, freeze_tau) pins ``reinforce_enabled=False``;
+    - ``update_runner.py``: the vanilla-RAG arm pins it False (the MC arm
+      sets True explicitly);
+    - ``reinforce_runner.py``: the A/B OFF arm disables it explicitly before
+      scoring.
+    """
+    eval_root = _BACKEND_ROOT / "tests" / "eval"
+
+    provisioning = (eval_root / "_provisioning.py").read_text(encoding="utf-8")
+    assert "reinforce_enabled=False" in provisioning
+
+    update_runner = (eval_root / "update_runner.py").read_text(encoding="utf-8")
+    assert "reinforce_enabled=False" in update_runner
+    assert "reinforce_enabled=True" in update_runner  # MC arm stays explicit
+
+    reinforce_runner = (eval_root / "reinforce_runner.py").read_text(encoding="utf-8")
+    assert "_set_reinforce(svc.db, ctx_id, enabled=False" in reinforce_runner

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -102,6 +102,37 @@ When you search with `recall()`, Kagura uses **Hybrid Search** combining two app
 - Use **tag filters** for precision: `filters={"tags": ["python"]}`
 - Use **importance filters**: `filters={"importance": {"gte": 0.8}}`
 
+## The Update Kernel (reinforce recency re-rank)
+
+When a stored fact has been superseded — you remembered "the deploy target is
+staging" last month and "the deploy target is prod" yesterday — the most
+valuable thing a memory system can do is rank the **current** version above the
+stale one. Kagura's measured answer to this is the **reinforce re-rank**
+(#1048): a deterministic, LLM-free adjustment applied to the hybrid top-k
+before results are returned.
+
+Each candidate's score is multiplied by a factor bounded to
+`[1 − max_boost, 1 + max_boost]` (default `max_boost = 0.15`), combining:
+
+- **cold-start recency** — a day-scaled prior (`recency_tau_days`, default 14)
+  that favors newer memories that haven't yet earned adoption signal;
+- **adoption** — deliberate `reference()` calls (log-capped);
+- **retrieval feedback** — explicit helpful/unhelpful verdicts.
+
+Because the factor is bounded, semantic relevance always dominates: the
+re-rank reorders close calls, it cannot resurrect an irrelevant result. It is
+fail-safe — any error preserves the original hybrid ranking.
+
+This mechanism is the system's best-measured behavior: a pre-registered,
+placebo-controlled evaluation attributed a **+0.36 update-correctness lift
+over vanilla RAG (BCa 95% [0.24, 0.50])** entirely to it. Since #1207 it is
+**enabled by default**: newly created contexts start on, and contexts that
+never touched the setting adopt the default lazily on their next recall.
+Only a stored explicit `reinforce_enabled: false` opts out — set it per
+context with `update_search_config` (see
+`docs/eval/reinforce-rollout-gate.md` for the per-context graduation
+procedure and the `reinforce_rerank_applied` monitoring telemetry).
+
 ## Neural Memory
 
 **Neural Memory** creates automatic relationships between memories using brain-inspired algorithms.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -125,13 +125,15 @@ fail-safe — any error preserves the original hybrid ranking.
 
 This mechanism is the system's best-measured behavior: a pre-registered,
 placebo-controlled evaluation attributed a **+0.36 update-correctness lift
-over vanilla RAG (BCa 95% [0.24, 0.50])** entirely to it. Since #1207 it is
-**enabled by default**: newly created contexts start on, and contexts that
-never touched the setting adopt the default lazily on their next recall.
-Only a stored explicit `reinforce_enabled: false` opts out — set it per
-context with `update_search_config` (see
-`docs/eval/reinforce-rollout-gate.md` for the per-context graduation
-procedure and the `reinforce_rerank_applied` monitoring telemetry).
+over vanilla RAG (BCa 95% [0.24, 0.50])** entirely to it. Since #1207,
+**newly created contexts start with it enabled**. Contexts created before
+#1207 keep their stored setting — under the old default that stored value is
+typically `false`, so pre-existing contexts do **not** flip on upgrade;
+enable them per context with `update_search_config`
+(`reinforce_enabled: true`), guided by the graduation procedure in
+`docs/eval/reinforce-rollout-gate.md` and the `reinforce_rerank_applied`
+monitoring telemetry. (Rare legacy contexts that never got a config row
+adopt the new default the first time the row is materialized.)
 
 ## Neural Memory
 

--- a/docs/eval/reinforce-rollout-gate.md
+++ b/docs/eval/reinforce-rollout-gate.md
@@ -7,11 +7,13 @@ ships **default-on for newly created contexts** since #1207
 program attributed the update-correctness headline, +0.36 over vanilla RAG
 BCa 95% [0.24, 0.50], entirely to this re-rank's cold-start recency prior).
 Contexts created **before** #1207 keep their stored setting — the flip rewrites
-no rows — and legacy contexts without a config row adopt the new default
-lazily (recall materializes the config row via `create_or_get`), so only a
-stored explicit `false` opts out. This document defines the **eval gate** that
-decides whether enabling it on a pre-existing, explicitly-opted-out context is
-safe, and the **staged rollout + monitoring** procedure that gate feeds.
+no rows, and since config rows are auto-stamped at context creation (and were
+materialized by any past recall) under the old `false` default, **pre-existing
+contexts stay off after the upgrade**. Only the rare legacy context that never
+got a config row adopts the new default lazily when recall materializes the
+row. This document defines the **eval gate** that decides whether enabling the
+re-rank on such a pre-existing context is safe, and the **staged rollout +
+monitoring** procedure that gate feeds.
 
 The principle (from the milestone): *trust before integration*. Reinforce only
 goes live where an eval shows it helps the canonical answers **without** burying

--- a/docs/eval/reinforce-rollout-gate.md
+++ b/docs/eval/reinforce-rollout-gate.md
@@ -2,9 +2,16 @@
 
 The bounded **reinforce** recall re-rank (#1048) — adoption (`reference_count`,
 #1046) + retrieval feedback (#888) gently nudge a memory's recall standing —
-ships **default-off** per context (`ContextSearchConfig.reinforce_enabled`). This
-document defines the **eval gate** that decides whether enabling it on a context
-is safe, and the **staged rollout + monitoring** procedure that gate feeds.
+ships **default-on for newly created contexts** since #1207
+(`ContextSearchConfig.reinforce_enabled`; the pre-registered kagura-memory-eval
+program attributed the update-correctness headline, +0.36 over vanilla RAG
+BCa 95% [0.24, 0.50], entirely to this re-rank's cold-start recency prior).
+Contexts created **before** #1207 keep their stored setting — the flip rewrites
+no rows — and legacy contexts without a config row adopt the new default
+lazily (recall materializes the config row via `create_or_get`), so only a
+stored explicit `false` opts out. This document defines the **eval gate** that
+decides whether enabling it on a pre-existing, explicitly-opted-out context is
+safe, and the **staged rollout + monitoring** procedure that gate feeds.
 
 The principle (from the milestone): *trust before integration*. Reinforce only
 goes live where an eval shows it helps the canonical answers **without** burying
@@ -58,7 +65,9 @@ only** (never fabricated) and **exits non-zero if the gate FAILS**. The harness:
 1. ingests `fixtures/reinforce_corpus.yaml` (15 memory docs, 10 queries × 2 populations);
 2. seeds adoption (`reference()` ×5) + net-helpful feedback (×3) on the canonical
    `meta.adopted_docs` — the rare docs stay untouched (zero-adoption);
-3. scores the **OFF** arm (default, no config row);
+3. scores the **OFF** arm (reinforce pinned off explicitly — since #1207 a
+   lazily-materialized config row defaults to enabled, so the runner can no
+   longer rely on "no config row yet");
 4. flips `reinforce_enabled = true`, `reinforce_max_boost = 0.15`;
 5. scores the **ON** arm and evaluates the gate.
 
@@ -76,8 +85,11 @@ the seed→OFF→ON→gate orchestration is pinned DB-free with fakes
 3. **Enable** via REST `PUT /api/v1/contexts/{id}/search-config`
    (`reinforce_enabled: true`) or the `update_search_config` MCP tool.
 4. **Monitor** the telemetry below; **disable** on regression.
-5. **Graduate** context-by-context. There is **no** blanket default-on
-   (out of scope, and would cross the #120 recall/explore boundary debate).
+5. **Graduate** context-by-context. There is **no** blanket rewrite of
+   pre-existing contexts. (#1207 later flipped the default for *newly created*
+   contexts on the strength of the pre-registered update-correctness eval;
+   the graduation procedure above remains the path for contexts that predate
+   it or that were explicitly opted out.)
 
 ## Monitoring (telemetry, #1069)
 
@@ -98,7 +110,9 @@ eval corpus, the log proves it still holds on live traffic.
 
 ## Out of scope
 
-- Blanket default-on across all contexts.
+- Blanket rewrite of pre-existing contexts' stored setting. (The *default for
+  new contexts* flipped to on in #1207 — evidence-driven, not blanket: existing
+  rows and explicit opt-outs are untouched.)
 - Tuning the bounded design or the #120 boundary (separate follow-up if the
   bounded nudge proves insufficient once felt in production).
 - The forge-resistance of the signal for untrusted autonomous agents — that is


### PR DESCRIPTION
Closes #1207

## Summary
- Flip `ContextSearchConfig.reinforce_enabled` default to **true** (Python default + DDL `server_default` via migration `e55_1207`) so newly created contexts get the eval-proven update kernel — the pre-registered kagura-memory-eval program attributed the entire update-correctness headline (+0.36 over vanilla RAG, BCa 95% [0.24, 0.50]) to this bounded, LLM-free, fail-safe re-rank.
- **No row rewrite — cohort truth**: config rows are auto-stamped at context creation (and by any past recall's `create_or_get`) under the old default, so **pre-#1207 contexts hold a stored `false` and stay off after the upgrade**; enable them per context via `update_search_config` guided by the graduation gate. Only the rare genuinely row-less legacy context adopts the new default lazily when its row is materialized (the recorded #1207 decision).
- **Frozen eval protocols protected**: all four non-reinforce eval arms now pin `reinforce_enabled=False` explicitly — the shared provisioning stamp (`_provisioning.py`), the update-slice vanilla-RAG arm (`update_runner.py`), the compounding recall control lane (`replay_runner.py`), and the reinforce A/B OFF arm (`reinforce_runner.py`) — so arm designs stay byte-comparable with archived results.
- **Opt-out integrity across boundaries**: `ExportedSearchConfig` now carries the reinforce fields (an exported opt-out survives re-creation); admin context recovery pins `False` (the lost row's setting is unknowable — recovery must not change recall ordering); `reset_to_default` converges reinforce to the documented defaults explicitly.
- Docs: new "Update Kernel" section in `docs/concepts.md`; `docs/eval/reinforce-rollout-gate.md` reframed around the new default; stale default-OFF comments updated across the codebase.

## Implementation notes
- Migration `e55_1207_reinforce_default_on` is blue-green safe: `ALTER COLUMN … SET DEFAULT` only; the previous app version sends an explicit Python-side `False` on insert, the new version sends `true`. Verified by applying the full alembic chain to a scratch DB (`column_default = true`).
- `ContextSearchConfigUpdate` schema defaults aligned with the ORM default; inert in practice because the repository applies `model_dump(exclude_unset=True)` — pinned by test so a partial PUT can never flip an explicit opt-out.
- `_maybe_reinforce_rerank`'s config lookup stays read-only (fail-safe for genuinely row-less states) — pinned by test.
- `backend/tests/test_reinforce_default_on.py` (9 pins): ORM/DDL defaults, `reinforce_max_boost` bound unchanged, migration no-row-rewrite (`op.execute`/`sa.update` banned), partial-update semantics, read-only guard, AST-based eval-harness pins (docstring text cannot satisfy them), recovery/reset pins.
- 319 backend tests passed; ruff check/format clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: yellow — default-on flips the #1065 ranking-manipulation surface from opt-in to opt-out for new contexts while forge-resistance stays default-off; bounded ±0.15 + telemetry mitigate; follow-up: security note / auto-arbitration for external-exposed contexts
- qa-lead: yellow — lazy-adoption semantics pinned via AST source checks (DB-backed integration test desirable); run `make eval-update` live once before the v0.45.0 tag
- cto: green — lazy adoption is architecturally sound; blue-green safe; decision record consistent across code/docs/tests
- gate1: green via /ask (CAIO lens)
- review provider: code-review — **ran, 9 findings applied** across 2 rounds (inner) + 4-finder/verify/sweep (/code-review xhigh): missed replay_runner arm, export/recovery/reset opt-out integrity, docs cohort overstatement, pin-test hardening

Follow-ups carried out of this PR:
- Update the Phase-C graduation runbook premise (private eval repo) to the new-default world
- DB-backed integration test for lazy adoption (recall against a row-less context materializes an enabled row)
- Security note / auto host-arbitration consideration for `trust_tier='external'`-exposed contexts

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1207-feat-feat-neural-enable-the-cold-start-recenc.gate1.md
- ~/.claude/cache/gh-issue-driven/1207-feat-feat-neural-enable-the-cold-start-recenc.gate2.md

🤖 Generated via /gh-issue-driven:ship
