### PR TITLE
feat(eval): scheduled update-correctness + retrieval CI gates (#1210)

### DIFF
--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -1,0 +1,240 @@
+# Nightly eval contract gates (#1210) — claims become contracts.
+#
+# The kagura-memory-eval program's headline numbers (update_success@10,
+# stale_only 0 post-#1198) were protected by nothing but memory. This
+# workflow re-measures them on the frozen corpora every night and fails
+# on contract breach (see backend/tests/eval/ci_gates.py for the contract
+# definitions and backend/tests/eval/fixtures/ci_baseline.json for the
+# pinned baseline + its governance rule).
+#
+# Design (gate1/COO, #1210):
+# - Secret-gated: needs OPENAI_API_KEY (embeddings + a small Sleep judge).
+#   Scheduled runs on main have repo secrets; fork PRs never trigger this
+#   workflow. Without the secret the run exits neutral with a notice.
+# - Three-value gate: PASS / BREACH (red) / INFRA (measurement unavailable —
+#   warn + file an infra issue, never a false red).
+# - Staged promotion (#336 pattern): the gate mode comes from the repo
+#   variable EVAL_GATES_MODE (advisory | blocking), default advisory for the
+#   first soak week. Flip the variable to "blocking" after flakiness < 1%.
+# - Failure visibility: breaches/infra auto-file (or comment on) a tracking
+#   issue — scheduled failures must not rely on someone watching the Actions
+#   tab.
+
+name: eval-nightly
+
+on:
+  schedule:
+    - cron: "17 17 * * *" # 02:17 JST
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "Gate mode (overrides the EVAL_GATES_MODE repo variable)"
+        type: choice
+        options: [advisory, blocking]
+        required: false
+
+concurrency:
+  group: eval-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  eval-nightly:
+    # Fork clones inherit the schedule; never run (or burn minutes) there.
+    if: github.repository == 'kagura-ai/memory-cloud'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: kagura
+          POSTGRES_PASSWORD: kagura_dev_password
+          POSTGRES_DB: kagura_eval
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U kagura -d kagura_eval"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      qdrant:
+        # No --health-cmd: the qdrant image ships no shell utilities usable
+        # for container-side health probes; the "Wait for Qdrant" step below
+        # polls /readyz from the host instead.
+        image: qdrant/qdrant:v1.15.0
+        ports:
+          - 6333:6333
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_eval
+      QDRANT_URL: http://localhost:6333
+      REDIS_URL: redis://localhost:6379
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      EMBEDDING_MODEL: text-embedding-3-small
+      EMBEDDING_DIMENSIONS: "512"
+      SLEEP_LLM_PROVIDER: openai
+      # Small judge tier; override via repo variable without editing the workflow.
+      SLEEP_LLM_MODEL: ${{ vars.EVAL_SLEEP_LLM_MODEL || 'gpt-5-nano' }}
+      KAGURA_EVAL_LIVE: "1"
+
+    steps:
+      - name: Check secrets
+        id: check
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::notice::OPENAI_API_KEY not available — eval-nightly skipped (secret-gated)."
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        if: steps.check.outputs.ok == 'true'
+
+      - uses: actions/setup-python@v5
+        if: steps.check.outputs.ok == 'true'
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - name: Install dependencies
+        if: steps.check.outputs.ok == 'true'
+        run: cd backend && pip install -e ".[dev]"
+
+      - name: Wait for Qdrant
+        if: steps.check.outputs.ok == 'true'
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:6333/readyz >/dev/null; then
+              echo "qdrant up"; exit 0
+            fi
+            sleep 2
+          done
+          echo "Qdrant did not become ready within 60s" >&2
+          exit 1
+
+      - name: Run migrations
+        if: steps.check.outputs.ok == 'true'
+        run: cd backend && alembic upgrade head
+
+      - name: Run update-slice eval (retry once on infra failure)
+        id: update
+        if: steps.check.outputs.ok == 'true'
+        run: |
+          cd backend
+          rm -f tests/eval/results/ci-nightly-update-*.json
+          for attempt in 1 2; do
+            if PYTHONPATH=src:. python -m tests.eval.update_runner \
+                --corpus tests/eval/fixtures/update_slice.yaml \
+                --label ci-nightly-update; then
+              break
+            fi
+            echo "::warning::update-slice runner failed (attempt $attempt)"
+            sleep 30
+          done
+          RESULT=$(ls -t tests/eval/results/ci-nightly-update-*.json 2>/dev/null | head -1 || true)
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
+      - name: Run retrieval eval (retry once on infra failure)
+        id: retrieval
+        if: steps.check.outputs.ok == 'true'
+        run: |
+          cd backend
+          BEFORE=$(ls tests/eval/results/*.json 2>/dev/null | sort || true)
+          for attempt in 1 2; do
+            if PYTHONPATH=src:. python -m tests.eval.runner; then
+              break
+            fi
+            echo "::warning::retrieval runner failed (attempt $attempt)"
+            sleep 30
+          done
+          AFTER=$(ls tests/eval/results/*.json 2>/dev/null | sort || true)
+          RESULT=$(comm -13 <(echo "$BEFORE") <(echo "$AFTER") | head -1 || true)
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate contracts
+        id: gates
+        if: steps.check.outputs.ok == 'true'
+        # Step outputs are bound via env (never interpolated into the script
+        # body) so a maliciously named file under results/ cannot inject shell.
+        env:
+          UPDATE_RESULT: ${{ steps.update.outputs.result }}
+          RETRIEVAL_RESULT: ${{ steps.retrieval.outputs.result }}
+          GATE_MODE: ${{ github.event.inputs.mode || vars.EVAL_GATES_MODE || 'advisory' }}
+        run: |
+          cd backend
+          # --require makes a crashed runner (no results file) INFRA — a
+          # missing slice must never yield a shortened-but-green table.
+          ARGS=(--baseline tests/eval/fixtures/ci_baseline.json --mode "$GATE_MODE" --require update,retrieval)
+          [ -n "$UPDATE_RESULT" ] && ARGS+=(--update "$UPDATE_RESULT")
+          [ -n "$RETRIEVAL_RESULT" ] && ARGS+=(--retrieval "$RETRIEVAL_RESULT")
+          set +e
+          PYTHONPATH=src:. python -m tests.eval.ci_gates "${ARGS[@]}"
+          CODE=$?
+          set -e
+          echo "exit_code=$CODE" >> "$GITHUB_OUTPUT"
+          if [ "$CODE" -eq 3 ]; then
+            echo "::warning::eval measurement unavailable (INFRA) — contracts not evaluated"
+            echo "infra=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          exit "$CODE"
+
+      - name: Upload results artifact
+        if: always() && steps.check.outputs.ok == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-nightly-results
+          path: backend/tests/eval/results/ci-nightly-*.json
+          if-no-files-found: ignore
+          retention-days: 90
+
+      - name: File or update tracking issue on breach/infra
+        if: >-
+          always() && steps.check.outputs.ok == 'true' &&
+          (failure() || steps.gates.outputs.infra == 'true')
+        uses: actions/github-script@v7
+        env:
+          GATES_EXIT_CODE: ${{ steps.gates.outputs.exit_code }}
+        with:
+          script: |
+            // Only a gates exit code of 1 is a contract breach; every other
+            // failure (pip/qdrant/migrations/runner crash, gate INFRA) is an
+            // infrastructure problem and must not be reported as a product
+            // regression ("never a false red").
+            const breach = process.env.GATES_EXIT_CODE === '1';
+            const label = breach ? 'eval-regression' : 'eval-infra';
+            const title = breach
+              ? 'eval-nightly: contract breach'
+              : 'eval-nightly: measurement unavailable (infra)';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Scheduled eval run: ${runUrl}\n\nSee the run's step summary for the contract table (#1210).`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: label, per_page: 1,
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: existing.data[0].number, body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title, body, labels: [label],
+              });
+            }

--- a/.github/workflows/eval-nightly.yml
+++ b/.github/workflows/eval-nightly.yml
@@ -28,9 +28,10 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: "Gate mode (overrides the EVAL_GATES_MODE repo variable)"
+        description: "Gate mode (use-repo-var honors the EVAL_GATES_MODE repo variable — the UI preselects the first choice, so the sentinel must come first or manual re-runs of a blocking breach would silently evaluate as advisory)"
         type: choice
-        options: [advisory, blocking]
+        options: [use-repo-var, advisory, blocking]
+        default: use-repo-var
         required: false
 
 concurrency:
@@ -154,16 +155,15 @@ jobs:
         if: steps.check.outputs.ok == 'true'
         run: |
           cd backend
-          BEFORE=$(ls tests/eval/results/*.json 2>/dev/null | sort || true)
+          rm -f tests/eval/results/ci-nightly-retrieval-*.json
           for attempt in 1 2; do
-            if PYTHONPATH=src:. python -m tests.eval.runner; then
+            if PYTHONPATH=src:. python -m tests.eval.runner --label ci-nightly-retrieval; then
               break
             fi
             echo "::warning::retrieval runner failed (attempt $attempt)"
             sleep 30
           done
-          AFTER=$(ls tests/eval/results/*.json 2>/dev/null | sort || true)
-          RESULT=$(comm -13 <(echo "$BEFORE") <(echo "$AFTER") | head -1 || true)
+          RESULT=$(ls -t tests/eval/results/ci-nightly-retrieval-*.json 2>/dev/null | head -1 || true)
           echo "result=$RESULT" >> "$GITHUB_OUTPUT"
 
       - name: Evaluate contracts
@@ -174,7 +174,10 @@ jobs:
         env:
           UPDATE_RESULT: ${{ steps.update.outputs.result }}
           RETRIEVAL_RESULT: ${{ steps.retrieval.outputs.result }}
-          GATE_MODE: ${{ github.event.inputs.mode || vars.EVAL_GATES_MODE || 'advisory' }}
+          # use-repo-var (the dispatch default) falls through to the repo
+          # variable, which falls through to advisory. Schedule events have no
+          # inputs (null-safe: the != comparison is false, chain falls through).
+          GATE_MODE: ${{ (github.event.inputs.mode != 'use-repo-var' && github.event.inputs.mode) || vars.EVAL_GATES_MODE || 'advisory' }}
         run: |
           cd backend
           # --require makes a crashed runner (no results file) INFRA — a
@@ -204,19 +207,27 @@ jobs:
           retention-days: 90
 
       - name: File or update tracking issue on breach/infra
+        # Fires on: hard failure (blocking breach or unexpected error), gate
+        # INFRA, or an ADVISORY breach (exit 0 but breach output true) — the
+        # visibility contract: breaches never rely on someone watching the
+        # Actions tab, even during the advisory soak week.
         if: >-
           always() && steps.check.outputs.ok == 'true' &&
-          (failure() || steps.gates.outputs.infra == 'true')
+          (failure() || steps.gates.outputs.infra == 'true' ||
+           steps.gates.outputs.breach == 'true')
         uses: actions/github-script@v7
         env:
           GATES_EXIT_CODE: ${{ steps.gates.outputs.exit_code }}
+          GATES_BREACH: ${{ steps.gates.outputs.breach }}
         with:
           script: |
-            // Only a gates exit code of 1 is a contract breach; every other
-            // failure (pip/qdrant/migrations/runner crash, gate INFRA) is an
-            // infrastructure problem and must not be reported as a product
-            // regression ("never a false red").
-            const breach = process.env.GATES_EXIT_CODE === '1';
+            // A contract breach (blocking exit 1, or advisory breach=true) is
+            // labeled eval-regression; every other failure (pip/qdrant/
+            // migrations/runner crash, gate INFRA) is an infrastructure
+            // problem and must not be reported as a product regression
+            // ("never a false red").
+            const breach = process.env.GATES_EXIT_CODE === '1'
+              || process.env.GATES_BREACH === 'true';
             const label = breach ? 'eval-regression' : 'eval-infra';
             const title = breach
               ? 'eval-nightly: contract breach'

--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,21 @@ eval-placebo:
 	@echo "Writes backend/tests/eval/results/placebo-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.placebo_runner
 
+.PHONY: eval-update
+eval-update:
+	@echo "Running live update-correctness eval (H4 update-slice, needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/update-<date>.json — real run only, never fabricated."
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.update_runner --corpus tests/eval/fixtures/update_slice.yaml --label update
+
+.PHONY: eval-ci-gates
+eval-ci-gates:
+	@echo "Evaluating #1210 eval contracts against the newest update results JSON..."
+	@echo "Exit codes: 0=pass, 1=contract breach, 3=measurement unavailable (infra)."
+	cd $(BACKEND_DIR) && PYTHONPATH=src:. python -m tests.eval.ci_gates \
+		--baseline tests/eval/fixtures/ci_baseline.json \
+		--require update \
+		--update "$$(ls -t tests/eval/results/update-*.json 2>/dev/null | head -1)"
+
 .PHONY: eval-reinforce
 eval-reinforce:
 	@echo "Running live reinforce ON-vs-OFF rollout gate (Issue #1069, needs the stack: make up)..."

--- a/backend/tests/eval/README.md
+++ b/backend/tests/eval/README.md
@@ -21,13 +21,47 @@ An **offline harness** for detecting hybrid-search (dense + BM25) retrieval-qual
 | `tools/stratify.py` | Difficulty stratification (IDF-spec, BM25-rank, corpus-overlap) | ✅ (`test_stratification.py`) |
 | `test_corpus_schema.py` | Structural contract (buckets, labels, sources) | ✅ |
 | `compounding.py` | Pure #969 experiment logic: replay plan, companion-recovery metric, lift table, gate audit | ✅ (`test_compounding.py`) |
-| `test_retrieval_quality.py` + `runner.py` | **Live** multi-arm P@5/MRR/nDCG measurement → `results/<date>.json` | ❌ skip-guarded |
+| `test_retrieval_quality.py` + `runner.py` | **Live** multi-arm P@5/MRR/nDCG measurement → `results/<date>.json` | 🌙 nightly (`eval-nightly.yml`) |
 | `test_compounding_live.py` + `replay_runner.py` | **Live** cold→replay→warm compounding experiment (#969) → `results/compounding-<date>.json` | ❌ skip-guarded |
+| `update_runner.py` | **Live** H4 update-correctness experiment (update-slice) → `results/<label>-<date>.json` | 🌙 nightly (`eval-nightly.yml`) |
+| `ci_gates.py` + `fixtures/ci_baseline.json` | #1210 contract gates over live results (claims → contracts) | ✅ (`test_ci_gates.py`) + 🌙 nightly |
 
 The deterministic layer (everything but the live rows) is pure token analysis and
-runs in normal CI. The live measurements need Postgres + Qdrant + Redis + an
-embedding provider + Sudachi, which is **not currently CI-realistic** (#336
-unscheduled), so they are skip-guarded behind `KAGURA_EVAL_LIVE=1`.
+runs in normal CI (`backend-unit`). The live measurements need Postgres + Qdrant +
+Redis + an embedding provider + Sudachi; since #1210 the update-slice and
+retrieval slices run **nightly** via `.github/workflows/eval-nightly.yml`
+(secret-gated on `OPENAI_API_KEY`; fork clones and secret-less runs exit neutral).
+Locally they remain skip-guarded behind `KAGURA_EVAL_LIVE=1`.
+
+## Claims → contracts (#1210)
+
+Every headline number from the eval program is a standing contract the nightly
+workflow re-measures. Defined in `ci_gates.py`, bounded by
+`fixtures/ci_baseline.json`:
+
+| Contract | Bound | Why |
+|---|---|---|
+| `update.stale_only_zero` | 0 | the #1195 failure mode (judged merge deletes the CURRENT fact) stays extinct; hard even with a flaky judge — the #1198 veto is deterministic |
+| `update.mc_update_success_floor` | ≥ 0.80 | headline metric floor = min across archived judged runs |
+| `update.vr_sanity_band` | [0.30, 0.78] | the no-update-path vanilla arm stays a coin flip; drift = broken harness/corpus |
+| `update.llm_call_failures_zero` | 0 | silent judge death (#1177) cannot hide behind a green run |
+| `retrieval.overall_p5_floor` | ≥ 0.18 | golden-corpus drift signal with embedding-jitter margin |
+
+Rules:
+
+- **Three-value gate**: PASS (0) / BREACH (1, the only red) / INFRA (3 —
+  measurement unavailable; the workflow warns and files an `eval-infra` issue
+  instead of a false red).
+- **Staged promotion** (#336 pattern): gate mode comes from the
+  `EVAL_GATES_MODE` repo variable — `advisory` (report only) for the first
+  soak week, flip to `blocking` once flakiness < 1%.
+- **Baseline governance**: `fixtures/ci_baseline.json` is updated ONLY via a
+  normal PR that justifies the intentional change and links its issue. CI
+  never rewrites the baseline — auto-updating teaches the gate to accept
+  regressions as the new normal.
+- Breaches/infra auto-file (or comment on) a tracking issue labeled
+  `eval-regression` / `eval-infra` — nightly failures must not depend on
+  someone watching the Actions tab.
 
 ## Running
 
@@ -38,6 +72,12 @@ cd backend && pytest tests/eval/ -m "not asyncio" -q   # all deterministic gates
 
 # Live retrieval measurement (needs the stack up: make up):
 make eval-retrieval              # sets KAGURA_EVAL_LIVE=1, writes results/<date>.json
+
+# Live update-correctness measurement (needs the stack up: make up):
+make eval-update                 # writes results/update-<date>.json
+
+# Contract gates over the newest update results (0=pass 1=breach 3=infra):
+make eval-ci-gates
 
 # Live compounding experiment (#969, needs the stack up: make up):
 make eval-compounding            # writes results/compounding-<date>.json

--- a/backend/tests/eval/ci_gates.py
+++ b/backend/tests/eval/ci_gates.py
@@ -343,6 +343,16 @@ def main(argv: list[str] | None = None) -> int:
 
     code = exit_code_for(entries, args.mode)
     breaches = [e["name"] for e in entries if e["status"] == "breach"]
+
+    # Advisory-mode breaches exit 0, so the workflow cannot see them in the
+    # exit code — expose a dedicated `breach` step output so the auto-issue
+    # step can still notify ("breaches must not rely on someone watching the
+    # Actions tab" — the workflow's own visibility contract).
+    step_output = os.environ.get("GITHUB_OUTPUT")
+    if step_output:
+        with open(step_output, "a", encoding="utf-8") as fh:
+            fh.write(f"breach={'true' if breaches else 'false'}\n")
+
     if breaches:
         print(
             f"ci-gates: {len(breaches)} contract breach(es): {', '.join(breaches)}"

--- a/backend/tests/eval/ci_gates.py
+++ b/backend/tests/eval/ci_gates.py
@@ -1,0 +1,356 @@
+"""CI contract gates over live eval results (#1210) — claims become contracts.
+
+The kagura-memory-eval program's headline numbers (update_success@10 0.92-0.96
+vs vanilla 0.54-0.56, ``stale_only`` 0/50 post-#1198) were protected by nothing
+but memory. This module turns them into standing contracts a scheduled
+workflow evaluates every night against fresh live-run results.
+
+Three-value exit model (COO gate1 design for #1210):
+
+- ``EXIT_PASS`` (0) — every evaluated contract holds (or mode is advisory).
+- ``EXIT_BREACH`` (1) — a contract is violated. This is the only red.
+- ``EXIT_INFRA`` (3) — the measurement itself is unavailable (results file
+  missing/undecodable — typically an upstream runner crash or provider
+  outage). The workflow warns and files an infra issue instead of redding:
+  "we could not measure" must never masquerade as "the contract holds" OR
+  as "the contract broke".
+
+Contract semantics:
+
+- ``update.stale_only_zero`` — the worst failure mode (judged merge deletes
+  the CURRENT fact, #1195) stays extinct. HARD even with a flaky judge: the
+  #1198 ``_enforce_newer_wins`` veto is deterministic regardless of which
+  winner the judge proposes.
+- ``update.mc_update_success_floor`` — the headline metric stays above the
+  minimum observed across archived judged runs (baseline governance: see
+  ``fixtures/ci_baseline.json``).
+- ``update.vr_sanity_band`` — the no-update-path vanilla arm stays a coin
+  flip; drift outside the band means the harness or corpus broke, not the
+  product.
+- ``update.llm_call_failures_zero`` — silent judge death (#1177) cannot hide
+  behind a green run. SKIPs (never passes vacuously) when the field is
+  absent (pre-#1183 result files).
+- ``retrieval.overall_p5_floor`` — golden-corpus drift signal with a jitter
+  margin (absolute numbers are drift signals, not quality claims — #344).
+
+Fields absent from a results file SKIP their contract with a note; a skip is
+surfaced in the summary so a schema regression cannot silently disable a
+contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+EXIT_PASS = 0
+EXIT_BREACH = 1
+EXIT_INFRA = 3
+
+_SUCCESS_OUTCOMES = {"current_over_stale", "current_only"}
+
+
+def derive_update_metrics(results: dict[str, Any]) -> dict[str, Any]:
+    """Aggregate an update-runner results dict into per-arm contract inputs.
+
+    Mirrors the tech report's definitions:
+
+    - ``update_success_at_k``: current retrieved with no stale above it
+      (``current_over_stale`` + ``current_only``) / N — the unconditional
+      supporting metric.
+    - ``conditional_rate``: current_over_stale / both-retrievable pairs — the
+      pre-registered H4 estimand (None when no pair is both-retrievable).
+    """
+    arms: dict[str, Any] = {}
+    for arm_name, block in results.get("arms", {}).items():
+        per_query = block.get("per_query", [])
+        n = len(per_query)
+        outcomes: dict[str, int] = {}
+        for q in per_query:
+            outcomes[q["outcome"]] = outcomes.get(q["outcome"], 0) + 1
+        both = outcomes.get("current_over_stale", 0) + outcomes.get("stale_over_current", 0)
+        arms[arm_name] = {
+            "n": n,
+            "outcomes": {
+                key: outcomes.get(key, 0)
+                for key in (
+                    "current_over_stale",
+                    "stale_over_current",
+                    "current_only",
+                    "stale_only",
+                    "neither",
+                )
+            },
+            "update_success_at_k": (
+                sum(outcomes.get(o, 0) for o in _SUCCESS_OUTCOMES) / n if n else None
+            ),
+            "conditional_rate": (outcomes.get("current_over_stale", 0) / both if both else None),
+        }
+    sleep_summary = results.get("sleep_summary") or {}
+    return {
+        "arms": arms,
+        "llm_call_failures_total": sleep_summary.get("llm_call_failures_total"),
+        "k": results.get("k"),
+    }
+
+
+def _entry(name: str, status: str, observed: Any, bound: Any, note: str = "") -> dict[str, Any]:
+    return {"name": name, "status": status, "observed": observed, "bound": bound, "note": note}
+
+
+def evaluate_contracts(
+    baseline: dict[str, Any],
+    update_results: dict[str, Any] | None = None,
+    retrieval_results: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Evaluate every applicable contract; returns one entry per contract."""
+    entries: list[dict[str, Any]] = []
+
+    if update_results is not None:
+        cfg = baseline["update"]
+        metrics = derive_update_metrics(update_results)
+        mc = metrics["arms"].get("mc_update")
+        vr = metrics["arms"].get("vanilla_rag")
+
+        # Sum over every MC-machinery arm (mc_update AND mc_prod) — VR has no
+        # update machinery to blame. mc_update and mc_prod score the same MC
+        # context, so one real deletion may appear in both arms; the double
+        # count is harmless while stale_only_max is pinned to exactly 0 (any
+        # nonzero total breaches regardless of multiplicity).
+        stale_only = sum(
+            arm["outcomes"]["stale_only"]
+            for name, arm in metrics["arms"].items()
+            if name != "vanilla_rag"
+        )
+        entries.append(
+            _entry(
+                "update.stale_only_zero",
+                "breach" if stale_only > cfg["stale_only_max"] else "pass",
+                stale_only,
+                f"<= {cfg['stale_only_max']}",
+                "the #1195 failure mode must stay extinct (#1198 veto is deterministic)",
+            )
+        )
+
+        if mc is None or mc["update_success_at_k"] is None:
+            entries.append(
+                _entry(
+                    "update.mc_update_success_floor",
+                    "breach",
+                    None,
+                    f">= {cfg['mc_update_success_min']}",
+                    "mc_update arm missing from results — harness regression",
+                )
+            )
+        else:
+            entries.append(
+                _entry(
+                    "update.mc_update_success_floor",
+                    (
+                        "pass"
+                        if mc["update_success_at_k"] >= cfg["mc_update_success_min"]
+                        else "breach"
+                    ),
+                    round(mc["update_success_at_k"], 4),
+                    f">= {cfg['mc_update_success_min']}",
+                )
+            )
+
+        lo, hi = cfg["vr_update_success_band"]
+        if vr is None or vr["update_success_at_k"] is None:
+            entries.append(
+                _entry(
+                    "update.vr_sanity_band",
+                    "breach",
+                    None,
+                    f"[{lo}, {hi}]",
+                    "vanilla arm missing from results — harness regression",
+                )
+            )
+        else:
+            entries.append(
+                _entry(
+                    "update.vr_sanity_band",
+                    ("pass" if lo <= vr["update_success_at_k"] <= hi else "breach"),
+                    round(vr["update_success_at_k"], 4),
+                    f"[{lo}, {hi}]",
+                    "outside the band = harness/corpus broke, not the product",
+                )
+            )
+
+        failures = metrics["llm_call_failures_total"]
+        if failures is None:
+            entries.append(
+                _entry(
+                    "update.llm_call_failures_zero",
+                    "skip",
+                    None,
+                    f"<= {cfg['llm_call_failures_max']}",
+                    "field absent (pre-#1183 results file) — skipped, not passed",
+                )
+            )
+        else:
+            entries.append(
+                _entry(
+                    "update.llm_call_failures_zero",
+                    "breach" if failures > cfg["llm_call_failures_max"] else "pass",
+                    failures,
+                    f"<= {cfg['llm_call_failures_max']}",
+                    "silent judge death (#1177) cannot hide behind a green run",
+                )
+            )
+
+    if retrieval_results is not None:
+        cfg = baseline["retrieval"]
+        overall_p5 = (retrieval_results.get("overall") or {}).get("p@5")
+        if overall_p5 is None:
+            entries.append(
+                _entry(
+                    "retrieval.overall_p5_floor",
+                    "skip",
+                    None,
+                    f">= {cfg['overall_p5_min']}",
+                    "overall p@5 absent from retrieval results",
+                )
+            )
+        else:
+            entries.append(
+                _entry(
+                    "retrieval.overall_p5_floor",
+                    "pass" if overall_p5 >= cfg["overall_p5_min"] else "breach",
+                    overall_p5,
+                    f">= {cfg['overall_p5_min']}",
+                    "drift signal vs frozen golden corpus (#344), jitter margin included",
+                )
+            )
+
+    return entries
+
+
+def exit_code_for(entries: list[dict[str, Any]], mode: str) -> int:
+    """Map contract entries to the process exit code for the given mode."""
+    breached = any(e["status"] == "breach" for e in entries)
+    if breached and mode == "blocking":
+        return EXIT_BREACH
+    return EXIT_PASS
+
+
+def render_summary(entries: list[dict[str, Any]]) -> str:
+    """Markdown table for stdout + the GitHub Actions step summary."""
+    lines = [
+        "| contract | status | observed | bound | note |",
+        "|---|---|---|---|---|",
+    ]
+    for e in entries:
+        lines.append(
+            f"| {e['name']} | {e['status'].upper()} | {e['observed']} | {e['bound']} | {e['note']} |"
+        )
+    return "\n".join(lines)
+
+
+def _load_json(path: str, what: str) -> dict[str, Any] | None:
+    """Load a JSON input; None signals INFRA (missing/undecodable)."""
+    p = Path(path)
+    if not p.is_file():
+        print(f"ci-gates: INFRA — {what} file not found: {p}", file=sys.stderr)
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"ci-gates: INFRA — {what} file unreadable: {p} ({exc})", file=sys.stderr)
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Evaluate #1210 eval contracts (claims -> contracts)")
+    ap.add_argument(
+        "--baseline", required=True, help="pinned baseline JSON (fixtures/ci_baseline.json)"
+    )
+    ap.add_argument("--update", help="update-runner results JSON")
+    ap.add_argument("--retrieval", help="retrieval-runner results JSON")
+    ap.add_argument(
+        "--require",
+        default="",
+        help=(
+            "comma-separated slice names (update,retrieval) that MUST have a "
+            "results input — a required slice with no input is INFRA, so a "
+            "runner that crashed and produced nothing can never yield a "
+            "shortened-but-green contract table"
+        ),
+    )
+    ap.add_argument(
+        "--mode",
+        choices=("blocking", "advisory"),
+        default="blocking",
+        help="advisory reports breaches but always exits 0 (week-1 soak, #336-style staged promotion)",
+    )
+    args = ap.parse_args(argv)
+
+    baseline = _load_json(args.baseline, "baseline")
+    if baseline is None:
+        return EXIT_INFRA
+
+    if not args.update and not args.retrieval:
+        print(
+            "ci-gates: INFRA — no results input given (need --update and/or --retrieval)",
+            file=sys.stderr,
+        )
+        return EXIT_INFRA
+
+    required = {name.strip() for name in args.require.split(",") if name.strip()}
+    unknown = required - {"update", "retrieval"}
+    if unknown:
+        print(f"ci-gates: INFRA — unknown --require slice(s): {sorted(unknown)}", file=sys.stderr)
+        return EXIT_INFRA
+    missing = [
+        name
+        for name in sorted(required)
+        if not {"update": args.update, "retrieval": args.retrieval}[name]
+    ]
+    if missing:
+        print(
+            f"ci-gates: INFRA — required slice(s) have no results input: {', '.join(missing)} "
+            "(the runner likely crashed before writing results)",
+            file=sys.stderr,
+        )
+        return EXIT_INFRA
+
+    update_results = None
+    retrieval_results = None
+    if args.update:
+        update_results = _load_json(args.update, "update results")
+        if update_results is None:
+            return EXIT_INFRA
+    if args.retrieval:
+        retrieval_results = _load_json(args.retrieval, "retrieval results")
+        if retrieval_results is None:
+            return EXIT_INFRA
+
+    entries = evaluate_contracts(
+        baseline, update_results=update_results, retrieval_results=retrieval_results
+    )
+    summary = render_summary(entries)
+    print(summary)
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as fh:
+            fh.write("## Eval contract gates (#1210)\n\n" + summary + "\n")
+
+    code = exit_code_for(entries, args.mode)
+    breaches = [e["name"] for e in entries if e["status"] == "breach"]
+    if breaches:
+        print(
+            f"ci-gates: {len(breaches)} contract breach(es): {', '.join(breaches)}"
+            + (" [advisory mode — not failing the run]" if args.mode == "advisory" else ""),
+            file=sys.stderr,
+        )
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/tests/eval/fixtures/ci_baseline.json
+++ b/backend/tests/eval/fixtures/ci_baseline.json
@@ -1,0 +1,20 @@
+{
+  "_meta": {
+    "issue": "#1210",
+    "governance": "Update this file ONLY via a normal PR that justifies the intentional behavior change and links the issue that caused it. CI must never rewrite this file — auto-updating a baseline teaches the gate to accept regressions as the new normal.",
+    "sources": {
+      "update": "Archived campaign runs results/day5-update-run0..2-2026-07-03.json (mc_update update_success@10 = 0.92, vanilla 0.56) and the v0.43.1 dedup replication results/day5r-v0431-run0..2-2026-07-06.json (mc 0.88/0.84/0.80) — the floor is the minimum observed across archived judged runs; the vanilla band brackets the no-update-path coin flip (0.54-0.56 observed).",
+      "retrieval": "results/2026-06-10.json golden-corpus production-arm baseline (overall p@5 0.2133); the floor allows ~0.03 embedding-provider jitter."
+    }
+  },
+  "update": {
+    "k": 10,
+    "mc_update_success_min": 0.8,
+    "vr_update_success_band": [0.3, 0.78],
+    "stale_only_max": 0,
+    "llm_call_failures_max": 0
+  },
+  "retrieval": {
+    "overall_p5_min": 0.18
+  }
+}

--- a/backend/tests/eval/test_ci_gates.py
+++ b/backend/tests/eval/test_ci_gates.py
@@ -1,0 +1,229 @@
+"""Deterministic tests for the #1210 CI contract gates.
+
+The gate script turns the eval program's headline numbers into standing
+contracts (claims → contracts). These tests pin:
+
+1. Metric derivation from a REAL archived results file
+   (``results/day5-update-run0-2026-07-03.json`` — the campaign run whose
+   numbers appear in the tech report: mc_update 0.92, vanilla 0.56).
+2. The canary criterion from the #1210 acceptance list: a results file where
+   the stale-deletion failure mode reappears (``stale_only > 0``) MUST breach
+   — this is "revert the #1198 veto turns the workflow red" made testable
+   without actually reverting.
+3. The 3-value exit model (COO gate1 design): PASS(0) / BREACH(1) / INFRA(3),
+   with ``advisory`` mode always exiting 0 while still reporting breaches.
+4. Contracts on fields that may be absent in older files (e.g.
+   ``llm_call_failures_total``) SKIP instead of breaching or passing
+   vacuously.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.eval.ci_gates import (
+    EXIT_BREACH,
+    EXIT_INFRA,
+    EXIT_PASS,
+    derive_update_metrics,
+    evaluate_contracts,
+    exit_code_for,
+    main,
+    render_summary,
+)
+
+_EVAL_ROOT = Path(__file__).resolve().parent
+_ARCHIVED_RUN = _EVAL_ROOT / "results" / "day5-update-run0-2026-07-03.json"
+_BASELINE = _EVAL_ROOT / "fixtures" / "ci_baseline.json"
+
+
+def _load_archived() -> dict:
+    return json.loads(_ARCHIVED_RUN.read_text(encoding="utf-8"))
+
+
+def _load_baseline() -> dict:
+    return json.loads(_BASELINE.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------- derivation
+
+
+def test_derive_update_metrics_matches_published_numbers() -> None:
+    """The derivation reproduces the tech report's campaign-run numbers."""
+    metrics = derive_update_metrics(_load_archived())
+    mc = metrics["arms"]["mc_update"]
+    vr = metrics["arms"]["vanilla_rag"]
+    assert mc["n"] == 50
+    assert mc["update_success_at_k"] == pytest.approx(0.92)
+    assert mc["outcomes"]["stale_only"] == 0
+    assert vr["update_success_at_k"] == pytest.approx(0.56)
+    # Conditional ordering (the prereg estimand): both-retrievable pairs only.
+    assert mc["conditional_rate"] == pytest.approx(46 / 50)
+    assert vr["conditional_rate"] == pytest.approx(28 / 50)
+    # Old files predate the llm_call_failures_total summary field.
+    assert metrics["llm_call_failures_total"] is None
+
+
+# ---------------------------------------------------------------- contracts
+
+
+def test_archived_run_passes_baseline_contracts() -> None:
+    entries = evaluate_contracts(_load_baseline(), update_results=_load_archived())
+    assert entries, "expected at least one contract entry"
+    assert all(e["status"] in {"pass", "skip"} for e in entries), render_summary(entries)
+    # llm_call_failures is absent in the archived file → skip, never a pass.
+    failures = [e for e in entries if e["name"] == "update.llm_call_failures_zero"]
+    assert failures and failures[0]["status"] == "skip"
+
+
+def test_stale_only_canary_breaches() -> None:
+    """#1210 acceptance: re-introduced stale-deletion turns the gate red."""
+    results = _load_archived()
+    for q in results["arms"]["mc_update"]["per_query"][:5]:
+        q["outcome"] = "stale_only"
+        q["current_rank"] = None
+        q["stale_rank"] = 1
+    entries = evaluate_contracts(_load_baseline(), update_results=results)
+    breached = {e["name"] for e in entries if e["status"] == "breach"}
+    assert "update.stale_only_zero" in breached
+    assert exit_code_for(entries, mode="blocking") == EXIT_BREACH
+    # Advisory mode reports the breach but does not fail the run.
+    assert exit_code_for(entries, mode="advisory") == EXIT_PASS
+
+
+def test_stale_only_in_mc_prod_arm_alone_breaches() -> None:
+    """stale_only is summed over EVERY MC-machinery arm, not just mc_update.
+
+    Pins the arm filter (``name != "vanilla_rag"``): a refactor narrowing it
+    to ``name == "mc_update"`` would silently drop mc_prod coverage.
+    """
+    results = _load_archived()
+    q = results["arms"]["mc_prod"]["per_query"][0]
+    q["outcome"] = "stale_only"
+    q["current_rank"] = None
+    q["stale_rank"] = 1
+    entries = evaluate_contracts(_load_baseline(), update_results=results)
+    breached = {e["name"] for e in entries if e["status"] == "breach"}
+    assert "update.stale_only_zero" in breached
+
+
+def test_update_success_floor_breaches() -> None:
+    results = _load_archived()
+    # Degrade mc_update below the pinned floor: flip wins to losses.
+    for q in results["arms"]["mc_update"]["per_query"][:12]:
+        q["outcome"] = "stale_over_current"
+        q["current_rank"] = 2
+        q["stale_rank"] = 1
+    entries = evaluate_contracts(_load_baseline(), update_results=results)
+    breached = {e["name"] for e in entries if e["status"] == "breach"}
+    assert "update.mc_update_success_floor" in breached
+
+
+def test_llm_call_failures_breaches_when_present_and_nonzero() -> None:
+    results = _load_archived()
+    results["sleep_summary"]["llm_call_failures_total"] = 5
+    entries = evaluate_contracts(_load_baseline(), update_results=results)
+    breached = {e["name"] for e in entries if e["status"] == "breach"}
+    assert "update.llm_call_failures_zero" in breached
+
+
+def test_vanilla_sanity_band_breaches_on_harness_corruption() -> None:
+    """A VR arm far outside its band means the harness/corpus broke."""
+    results = _load_archived()
+    for q in results["arms"]["vanilla_rag"]["per_query"]:
+        q["outcome"] = "current_over_stale"
+        q["current_rank"] = 1
+        q["stale_rank"] = 2
+    entries = evaluate_contracts(_load_baseline(), update_results=results)
+    breached = {e["name"] for e in entries if e["status"] == "breach"}
+    assert "update.vr_sanity_band" in breached
+
+
+def test_retrieval_floor_contract() -> None:
+    baseline = _load_baseline()
+    retrieval_ok = {"overall": {"p@5": 0.2133}, "per_bucket": {}}
+    entries = evaluate_contracts(baseline, retrieval_results=retrieval_ok)
+    overall = [e for e in entries if e["name"] == "retrieval.overall_p5_floor"]
+    assert overall and overall[0]["status"] == "pass"
+
+    retrieval_bad = {"overall": {"p@5": 0.10}, "per_bucket": {}}
+    entries = evaluate_contracts(baseline, retrieval_results=retrieval_bad)
+    overall = [e for e in entries if e["name"] == "retrieval.overall_p5_floor"]
+    assert overall and overall[0]["status"] == "breach"
+
+
+# ---------------------------------------------------------------- CLI / exits
+
+
+def test_main_pass_on_archived_run(tmp_path: Path) -> None:
+    code = main(
+        [
+            "--baseline",
+            str(_BASELINE),
+            "--update",
+            str(_ARCHIVED_RUN),
+            "--mode",
+            "blocking",
+        ]
+    )
+    assert code == EXIT_PASS
+
+
+def test_main_missing_results_is_infra_not_breach(tmp_path: Path) -> None:
+    """A runner crash (no results file) is a measurement failure, not a
+    contract breach — INFRA(3), so the workflow can warn instead of redding."""
+    code = main(
+        [
+            "--baseline",
+            str(_BASELINE),
+            "--update",
+            str(tmp_path / "does-not-exist.json"),
+            "--mode",
+            "blocking",
+        ]
+    )
+    assert code == EXIT_INFRA
+
+
+def test_main_undecodable_results_is_infra(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    code = main(["--baseline", str(_BASELINE), "--update", str(bad), "--mode", "blocking"])
+    assert code == EXIT_INFRA
+
+
+def test_main_requires_at_least_one_results_input() -> None:
+    assert main(["--baseline", str(_BASELINE)]) == EXIT_INFRA
+
+
+def test_main_required_slice_without_input_is_infra() -> None:
+    """--require makes a crashed runner (no results file for that slice)
+    INFRA — a missing required slice must never yield a shortened-but-green
+    contract table (the exact silent-unmeasured scenario #1210 exists to
+    catch)."""
+    code = main(
+        [
+            "--baseline",
+            str(_BASELINE),
+            "--retrieval",
+            str(_ARCHIVED_RUN),  # any readable JSON — retrieval contracts skip
+            "--require",
+            "update,retrieval",
+        ]
+    )
+    assert code == EXIT_INFRA
+
+
+def test_main_unknown_require_slice_is_infra() -> None:
+    code = main(
+        ["--baseline", str(_BASELINE), "--update", str(_ARCHIVED_RUN), "--require", "updat"]
+    )
+    assert code == EXIT_INFRA
+
+
+def test_render_summary_is_markdown_table() -> None:
+    entries = evaluate_contracts(_load_baseline(), update_results=_load_archived())
+    text = render_summary(entries)
+    assert "| contract |" in text
+    assert "update.stale_only_zero" in text

--- a/backend/tests/eval/test_ci_gates.py
+++ b/backend/tests/eval/test_ci_gates.py
@@ -222,6 +222,35 @@ def test_main_unknown_require_slice_is_infra() -> None:
     assert code == EXIT_INFRA
 
 
+def test_main_writes_breach_output_even_in_advisory_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Advisory breaches exit 0, so the workflow reads the `breach` step
+    output to keep the visibility contract (auto-issue) during the soak week."""
+    results = _load_archived()
+    for q in results["arms"]["mc_update"]["per_query"][:3]:
+        q["outcome"] = "stale_only"
+        q["current_rank"] = None
+        q["stale_rank"] = 1
+    breached_file = tmp_path / "breached.json"
+    breached_file.write_text(json.dumps(results), encoding="utf-8")
+    gh_output = tmp_path / "gh_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+
+    code = main(
+        ["--baseline", str(_BASELINE), "--update", str(breached_file), "--mode", "advisory"]
+    )
+    assert code == EXIT_PASS  # advisory never fails the run...
+    assert "breach=true" in gh_output.read_text(encoding="utf-8")  # ...but says so
+
+    gh_output.unlink()
+    code = main(
+        ["--baseline", str(_BASELINE), "--update", str(_ARCHIVED_RUN), "--mode", "advisory"]
+    )
+    assert code == EXIT_PASS
+    assert "breach=false" in gh_output.read_text(encoding="utf-8")
+
+
 def test_render_summary_is_markdown_table() -> None:
     entries = evaluate_contracts(_load_baseline(), update_results=_load_archived())
     text = render_summary(entries)


### PR DESCRIPTION
Closes #1210

## Summary
- **Claims become contracts**: `backend/tests/eval/ci_gates.py` evaluates the eval program's headline numbers as standing contracts — `stale_only == 0` (the #1195 failure mode stays extinct; hard even with a flaky judge because the #1198 veto is deterministic), `mc update_success@10 ≥ 0.80` (min across archived judged runs), vanilla sanity band `[0.30, 0.78]` (harness-corruption canary), `llm_call_failures == 0` (silent judge death #1177 can't hide; SKIPs — never passes — on pre-#1183 files), retrieval `p@5 ≥ 0.18` (golden-corpus drift signal).
- **Three-value gate** (COO gate1 design): PASS(0) / BREACH(1, the only red) / INFRA(3 — measurement unavailable: warn + `eval-infra` issue, never a false red). `--require update,retrieval` makes a crashed runner INFRA so a missing slice can never yield a shortened-but-green table.
- **Nightly workflow** `.github/workflows/eval-nightly.yml`: schedule + workflow_dispatch; secret-gated on `OPENAI_API_KEY` (neutral skip without it); fork guard; postgres/redis/qdrant services; staged promotion via the `EVAL_GATES_MODE` repo variable (advisory soak week → blocking, the #336 pattern); breach/infra auto-files a labeled tracking issue (only gates exit 1 is labeled `eval-regression`; every other failure is `eval-infra`).
- **Baseline governance**: `fixtures/ci_baseline.json` is updated ONLY via a normal PR justifying the intentional change with an issue link; CI never rewrites it.
- `make eval-update` / `make eval-ci-gates` targets; eval README refreshed (stale "#336 unscheduled" note replaced; claims→contracts table).

## Implementation notes
- 15 deterministic tests (`test_ci_gates.py`) run in `backend-unit` on every PR: metric derivation pinned against the REAL archived campaign run (mc_update 0.92 / vanilla 0.56 — the tech-report numbers), the stale_only canary (the "revert #1198 turns the workflow red" acceptance criterion made testable without reverting), mc_prod arm coverage, 3-value exits, `--require` INFRA semantics.
- Workflow hardening from inner review: step outputs bound via `env:` (no GHA expression interpolation into run bodies), `ls` guarded against `set -e -o pipefail` zero-match aborts, issue labeling driven by the gates exit code (infra never reported as regression).
- 229 eval-tree tests pass; ruff clean; workflow YAML validated.

## Pre-PR review summary
- gate2 mode: advisor-only / audit: skipped / binary_gate: (none)
- cso: green — secret-gated + fork-guarded + env-bound outputs; least-privilege permissions
- qa-lead: yellow — the workflow itself is only verifiable post-merge. **Post-merge conditions**: (1) one manual `workflow_dispatch` run → record green + measured runtime in the eval README, (2) after a 1-week advisory soak with <1% flakiness, set repo variable `EVAL_GATES_MODE=blocking`, (3) confirm the `OPENAI_API_KEY` secret and (optionally) `EVAL_SLEEP_LLM_MODEL` variable exist.
- cto: green — pure contract checker; documented baseline governance; repo-variable staged promotion
- gate1: green via /ask (COO lens — 3-value gate, fork guard, auto-issue, baseline governance all incorporated)
- review provider: code-review (findings from the inner pass already applied; see commit body)

Full reviews: ~/.claude/cache/gh-issue-driven/1210-feat-feat-eval-scheduled-update-correctness-p.gate{1,2}.md

🤖 Generated via /gh-issue-driven:ship
