### PR TITLE
feat(sleep): reversible, auditable dedup merges + retention policy (#1209)

### DIFF
--- a/backend/alembic/versions/e56_1209_merge_retention.py
+++ b/backend/alembic/versions/e56_1209_merge_retention.py
@@ -1,0 +1,47 @@
+"""Merge retention phase surfaces (#1209).
+
+1. ``sleep_reports.merge_retention_result`` — per-phase JSON blob for the
+   new merge_retention phase (mirrors the five existing ``*_result``
+   columns); without it the phase's outcome is silently discarded by
+   ``complete_report``.
+2. Seed the ``sleep_merge_retention_days`` neural_config row so the setting
+   is operable via the admin Neural Config UI / API (the PUT endpoint 404s
+   on unseeded keys). Default '0' = disabled = retain merge losers forever —
+   the pre-#1209 behavior; enabling the window is an explicit operator
+   decision.
+
+NOTE (merge coordination): this branch forks from main at e54. If
+#1207/e55 merges first, bump ``down_revision`` to
+"e55_1207_reinforce_default_on" (one line) before merging this PR — and
+vice versa for e55 if this lands first.
+
+Revision ID: e56_1209_merge_retention
+Revises: e54_1183_sleep_status_degraded
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision = "e56_1209_merge_retention"
+down_revision = "e54_1183_sleep_status_degraded"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sleep_reports",
+        sa.Column("merge_retention_result", sa.JSON(), nullable=True),
+    )
+    op.execute("""
+        INSERT INTO neural_config (key, value, value_type, category, description, min_value, max_value) VALUES
+            ('sleep_merge_retention_days', '0', 'int', 'sleep', 'Merge-loser purge window in days (0 = retain forever); per-merge undo and rollback only work inside the window (#1209)', 0, 3650)
+        ON CONFLICT (key) DO NOTHING;
+    """)
+
+
+def downgrade() -> None:
+    op.drop_column("sleep_reports", "merge_retention_result")
+    op.execute("DELETE FROM neural_config WHERE key = 'sleep_merge_retention_days';")

--- a/backend/alembic/versions/e56_1209_merge_retention.py
+++ b/backend/alembic/versions/e56_1209_merge_retention.py
@@ -25,7 +25,7 @@ from alembic import op
 
 # revision identifiers
 revision = "e56_1209_merge_retention"
-down_revision = "e54_1183_sleep_status_degraded"
+down_revision = "e55_1207_reinforce_default_on"
 branch_labels = None
 depends_on = None
 

--- a/backend/src/api/routes/admin_sleep.py
+++ b/backend/src/api/routes/admin_sleep.py
@@ -348,6 +348,7 @@ _UNDO_ERROR_STATUS = {
     response_model=UndoMergeResponse,
     summary="Undo one dedup merge (restore the merged-away memory)",
     responses={
+        400: {"description": "The action is not a dedup merge."},
         404: {"description": "Action not found or not owned by the caller."},
         409: {"description": "Memory already restored, or deleted by something else."},
         410: {

--- a/backend/src/api/routes/admin_sleep.py
+++ b/backend/src/api/routes/admin_sleep.py
@@ -310,3 +310,82 @@ async def trigger_sleep_run(
             mode="json"
         ),
     )
+
+
+# ============================================================================
+# Per-merge undo (#1209)
+# ============================================================================
+
+
+class UndoMergeResponse(BaseModel):
+    """200 response for POST /admin/sleep/actions/{action_id}/undo-merge.
+
+    Attributes:
+        restored_memory_id: The merge loser brought back into recall.
+        winner_id: The merge winner (unchanged by the undo).
+        report_id: The sleep report whose audit log records both the merge
+            and this undo.
+        undone_action_id: The original merge action that was undone.
+    """
+
+    restored_memory_id: str
+    winner_id: str | None
+    report_id: str
+    undone_action_id: int
+
+
+_UNDO_ERROR_STATUS = {
+    "action_not_found": 404,
+    "memory_purged": 410,
+    "already_restored": 409,
+    "not_a_merge": 400,
+    "not_merge_deleted": 409,
+}
+
+
+@router.post(
+    "/actions/{action_id}/undo-merge",
+    response_model=UndoMergeResponse,
+    summary="Undo one dedup merge (restore the merged-away memory)",
+    responses={
+        404: {"description": "Action not found or not owned by the caller."},
+        409: {"description": "Memory already restored, or deleted by something else."},
+        410: {
+            "description": "The merge loser was hard-deleted by the retention "
+            "policy (sleep_merge_retention_days) — no longer restorable."
+        },
+    },
+)
+async def undo_merge(
+    action_id: int,
+    admin: AdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> UndoMergeResponse:
+    """Restore the loser of ONE dedup merge — row and Qdrant vector (#1209).
+
+    Self-scoped like the manual sleep trigger: the merge's report must belong
+    to the calling admin. The undo is itself audited as an ``undo_merge``
+    action on the same sleep report, so the merge's full history reads out of
+    one audit log. Reversibility is bounded by the declared retention window;
+    a purged loser returns 410 with the setting named.
+    """
+    from services.sleep.undo import UndoMergeError, undo_merge_action
+
+    user_id = admin.get("user_id")
+    if not user_id:
+        raise MemoryCloudException(
+            message="Admin user id missing from session.",
+            status_code=500,
+            error_code="SLEEP-001",
+        )
+
+    try:
+        summary = await undo_merge_action(db, action_id, acting_user_id=user_id)
+    except UndoMergeError as exc:
+        raise MemoryCloudException(
+            message=exc.message,
+            status_code=_UNDO_ERROR_STATUS.get(exc.code, 400),
+            error_code=f"SLEEP-UNDO-{exc.code}",
+        ) from exc
+
+    return UndoMergeResponse(**summary)

--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -83,6 +83,8 @@ class SleepReportDetail(SleepReportSummary):
     error_message: str | None
     edge_discovery_result: dict[str, Any] | None
     dedup_result: dict[str, Any] | None
+    # #1209: merge_retention phase (purge window); None on pre-#1209 reports.
+    merge_retention_result: dict[str, Any] | None = None
     importance_result: dict[str, Any] | None
     consolidation_result: dict[str, Any] | None
     reindex_result: dict[str, Any] | None

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -56,6 +56,7 @@ def _report_to_detail(report: Any) -> dict[str, Any]:
             "importance_result": report.importance_result,
             "consolidation_result": report.consolidation_result,
             "reindex_result": report.reindex_result,
+            "merge_retention_result": report.merge_retention_result,
         }
     )
     return summary
@@ -95,34 +96,21 @@ async def _re_embed_to_qdrant(
     context_id: str,
     collection_name: str,
 ) -> None:
-    """Re-embed a restored memory back into Qdrant."""
-    from db.qdrant import add_memory_to_qdrant
+    """Re-embed a restored memory back into Qdrant.
 
-    vector = await embedding_svc.embed(
-        memory.summary or "",
-        user_id=user_id,
-        context_id=context_id,
-        workspace_id=workspace_id,
-    )
-    payload = {
-        "user_id": user_id,
-        "summary": memory.summary,
-        "context_summary": memory.context_summary or "",
-        "type": memory.type,
-        "importance": memory.importance,
-        "scope": memory.scope,
-        "tags": memory.tags or [],
-        "created_at": (memory.created_at.isoformat() + "Z" if memory.created_at else None),
-        "updated_at": (memory.updated_at.isoformat() + "Z" if memory.updated_at else None),
-    }
-    await add_memory_to_qdrant(
-        user_id=user_id,
-        memory_id=memory.id,
-        vector=vector,
-        payload=payload,
-        workspace_id=workspace_id,
-        context_id=context_id,
-        collection_name=collection_name,
+    #1209: thin wrapper over the shared restore helper in
+    ``services.sleep.undo`` so run-level rollback and per-merge undo cannot
+    drift in how they rebuild the vector.
+    """
+    from services.sleep.undo import re_embed_memory_to_qdrant
+
+    await re_embed_memory_to_qdrant(
+        memory,
+        user_id,
+        embedding_svc,
+        workspace_id,
+        context_id,
+        collection_name,
     )
 
 
@@ -379,7 +367,7 @@ async def handle_rollback_sleep_run(
 
                     elif action.action_type == "merge":
                         if action.target_id:
-                            await db.execute(
+                            restore_result = await db.execute(
                                 sa_update(Memory)
                                 .where(
                                     Memory.id == action.target_id,
@@ -388,7 +376,19 @@ async def handle_rollback_sleep_run(
                                 .values(deleted_at=None, deleted_by=None)
                             )
                             loser = memory_cache.get(action.target_id)
-                            if loser:
+                            # #1209: a loser hard-deleted by the merge
+                            # retention window matches 0 rows — record it as
+                            # an error instead of a phantom "reversed" (the
+                            # per-merge undo path returns 410 for the same
+                            # state; run-level rollback must not report a
+                            # restore that never happened).
+                            if restore_result.rowcount == 0 or loser is None:
+                                rollback_summary["errors"].append(
+                                    f"merge loser {action.target_id} not restorable — "
+                                    "purged by the retention policy "
+                                    "(sleep_merge_retention_days)"
+                                )
+                            else:
                                 await _re_embed_to_qdrant(
                                     loser,
                                     user_id,
@@ -397,7 +397,7 @@ async def handle_rollback_sleep_run(
                                     ctx_id_str,
                                     collection_name,
                                 )
-                            rollback_summary["merges_reversed"] += 1
+                                rollback_summary["merges_reversed"] += 1
 
                     elif action.action_type == "update_importance":
                         details = action.details or {}

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -61,6 +61,7 @@ class SleepReport(Base):
             total judge failure is graded 'failed')
         edge_discovery_result: Phase 1 results (JSON)
         dedup_result: Phase 2 results (JSON)
+        merge_retention_result: Phase 2.5 results (JSON, #1209)
         importance_result: Phase 3 results (JSON)
         consolidation_result: Phase 4 results (JSON)
         reindex_result: Phase 5 results (JSON)
@@ -108,6 +109,8 @@ class SleepReport(Base):
     # Per-phase results (JSON)
     edge_discovery_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     dedup_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    # #1209: merge_retention phase (purge window) results.
+    merge_retention_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     importance_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     consolidation_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     reindex_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -253,6 +253,10 @@ class NeuralMemoryConfig:
     sleep_max_llm_calls_per_run: int = 50  # LLM call budget per run
     sleep_dedup_enabled: bool = True  # Phase 2 on/off
     sleep_dedup_similarity_threshold: float = 0.92  # Cosine similarity for dedup
+    # #1209: merge-loser retention window in days. 0 = disabled = retain
+    # forever (pre-#1209 behavior). When > 0 the merge_retention phase
+    # hard-deletes losers past the window; undo/rollback only work inside it.
+    sleep_merge_retention_days: int = 0
     sleep_edge_discovery_enabled: bool = True  # Phase 1 on/off
     sleep_edge_discovery_sample_size: int = 30  # Memories sampled per run
     sleep_importance_reeval_enabled: bool = True  # Phase 3 on/off
@@ -458,6 +462,11 @@ class NeuralMemoryConfig:
                 f"sleep_dedup_similarity_threshold must be in [0.5, 1.0], "
                 f"got {self.sleep_dedup_similarity_threshold}"
             )
+        if self.sleep_merge_retention_days < 0:
+            raise ValueError(
+                f"sleep_merge_retention_days must be >= 0 (0 = retain forever), "
+                f"got {self.sleep_merge_retention_days}"
+            )
         if not self.sleep_edge_discovery_sample_size > 0:
             raise ValueError(
                 f"sleep_edge_discovery_sample_size must be positive, "
@@ -593,6 +602,7 @@ class NeuralMemoryConfig:
             sleep_max_llm_calls_per_run=get_int("SLEEP_MAX_LLM_CALLS_PER_RUN", 50),
             sleep_dedup_enabled=get_bool("SLEEP_DEDUP_ENABLED", True),
             sleep_dedup_similarity_threshold=get_float("SLEEP_DEDUP_SIMILARITY_THRESHOLD", 0.92),
+            sleep_merge_retention_days=get_int("SLEEP_MERGE_RETENTION_DAYS", 0),
             sleep_edge_discovery_enabled=get_bool("SLEEP_EDGE_DISCOVERY_ENABLED", True),
             sleep_edge_discovery_sample_size=get_int("SLEEP_EDGE_DISCOVERY_SAMPLE_SIZE", 30),
             sleep_importance_reeval_enabled=get_bool("SLEEP_IMPORTANCE_REEVAL_ENABLED", True),
@@ -828,6 +838,10 @@ class NeuralMemoryConfig:
             sleep_dedup_similarity_threshold=configs.get(
                 "sleep_dedup_similarity_threshold",
                 base_config.sleep_dedup_similarity_threshold,
+            ),
+            sleep_merge_retention_days=configs.get(
+                "sleep_merge_retention_days",
+                base_config.sleep_merge_retention_days,
             ),
             sleep_edge_discovery_enabled=configs.get(
                 "sleep_edge_discovery_enabled", base_config.sleep_edge_discovery_enabled

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -644,6 +644,11 @@ class DedupMergePhase:
         self._ensure_audit_state()
         decisions: list[tuple[UUID, UUID]] = []
         judgments = response.get("judgments", [])
+        # #1209: dedupe judgments by canonical pair — a malformed response
+        # listing the same pair twice (same or reversed order) would
+        # double-merge AND cross-contaminate the audit metadata when the
+        # winner rules re-key a flipped decision.
+        seen_pairs: set[tuple[UUID, UUID]] = set()
 
         for j in judgments:
             if j.get("verdict") != "merge":
@@ -669,6 +674,14 @@ class DedupMergePhase:
 
             loser_label = pair[0] if pair[1] == winner_label else pair[1]
             decision = (label_to_id[winner_label], label_to_id[loser_label])
+            canonical = tuple(sorted(decision, key=str))
+            if canonical in seen_pairs:
+                logger.warning(
+                    "dedup_duplicate_judgment_skipped",
+                    pair=[str(decision[0]), str(decision[1])],
+                )
+                continue
+            seen_pairs.add(canonical)
             decisions.append(decision)
 
             reason = j.get("reason")

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import random
 import string
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -200,6 +200,13 @@ class DedupMergePhase:
         # #1195/#1198: newer-wins override counter (init here so
         # ``_judge_cluster`` can be unit-tested without execute()).
         self._winner_overrides: int = 0
+        # #1209: per-reason override breakdown ("recency" | "source") and
+        # per-decision audit metadata (merge_reason from the judge, override
+        # info), keyed by the FINAL (winner_id, loser_id). Kept beside the
+        # tuple-shaped decision lists so the public decision shape — which
+        # existing tests and call sites rely on — stays unchanged.
+        self._override_reasons: dict[str, int] = {}
+        self._decision_meta: dict[tuple[UUID, UUID], dict[str, Any]] = {}
 
     async def execute(
         self,
@@ -232,6 +239,9 @@ class DedupMergePhase:
         # #1195/#1198: LLM winner choices flipped by the deterministic
         # newer-wins post-check (each one is a judge misjudgment caught).
         self._winner_overrides = 0
+        # #1209: reset the per-reason breakdown + per-decision audit metadata.
+        self._override_reasons = {}
+        self._decision_meta = {}
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
         # #475: reset embedding accumulators between sleep cycles.
@@ -335,6 +345,14 @@ class DedupMergePhase:
                 merged_count += 1
                 if reporter and report_id and winner and loser:
                     pair_key = tuple(sorted([winner_id, loser_id], key=str))
+                    # #1209: every merge is explainable and its inputs are
+                    # snapshotted — merge_reason (judge rationale or rule id),
+                    # override info (recency/source), and both sides'
+                    # provenance + recency keys, proving what the decision
+                    # (judge + deterministic rules) actually saw.
+                    meta = self._decision_meta.get((winner_id, loser_id), {})
+                    winner_recency = self._recency_key(winner)
+                    loser_recency = self._recency_key(loser)
                     await reporter.add_action(
                         report_id=report_id,
                         phase="dedup_merge",
@@ -346,6 +364,18 @@ class DedupMergePhase:
                             "winner_tags": list(winner.tags or []),
                             "loser_tags": list(loser.tags or []),
                             "loser_summary": (loser.summary or "")[:200],
+                            "merge_reason": meta.get("merge_reason", "unspecified"),
+                            "judge_confidence": meta.get("judge_confidence"),
+                            "winner_override": "override_reason" in meta,
+                            "override_reason": meta.get("override_reason"),
+                            "winner_source": getattr(winner, "source_type", None),
+                            "loser_source": getattr(loser, "source_type", None),
+                            "winner_recency": (
+                                f"{winner_recency:%Y-%m-%d %H:%M}" if winner_recency else None
+                            ),
+                            "loser_recency": (
+                                f"{loser_recency:%Y-%m-%d %H:%M}" if loser_recency else None
+                            ),
                         },
                     )
 
@@ -370,9 +400,11 @@ class DedupMergePhase:
             "merged": merged_count,
             "llm_call_failures": self._llm_failures,  # #1183
             # #1195/#1198: LLM winner picks flipped by the deterministic
-            # newer-wins post-check — a direct measure of residual judge
-            # misdirection the prompt alone would have let through.
+            # winner rules — a direct measure of residual judge misdirection
+            # the prompt alone would have let through.
             "winner_overrides": self._winner_overrides,
+            # #1209: per-rule breakdown ("recency" | "source") of the above.
+            "winner_override_reasons": dict(self._override_reasons),
         }
 
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
@@ -506,10 +538,11 @@ class DedupMergePhase:
                 budget,
                 config,
             )
-            # #1195/#1198: the LLM's winner is prompt-guided only — enforce
-            # newer-wins deterministically (rule-based path is correct by
-            # construction and needs no post-check).
-            decisions = self._enforce_newer_wins(decisions, cluster_memories)
+            # #1195/#1198/#1209: the LLM's winner is prompt-guided only —
+            # enforce newer-wins + the equal-recency source tie-break
+            # deterministically (rule-based path is correct by construction
+            # and needs no post-check).
+            decisions = self._enforce_winner_rules(decisions, cluster_memories)
         else:
             # Rule-based fallback
             decisions = self._rule_based_judge(cluster_memories, pair_scores)
@@ -544,13 +577,17 @@ class DedupMergePhase:
         # to pick the newer version of an updated fact as winner (#1195).
         # Minute precision so same-day update pairs stay orderable; max of
         # created_at/updated_at so in-place edits count as recency (#1198).
+        # source= is trusted #887 server-stamped provenance (#1209): the judge
+        # sees which side is human-authored ('manual') vs ingested, and the
+        # deterministic source tie-break is verifiable against it post-hoc.
         memory_lines = []
         for label, mem in zip(labels_shuffled, mems_shuffled, strict=True):
             recency = self._recency_key(mem)
             recency_s = f"{recency:%Y-%m-%d %H:%M}" if recency else "unknown"
+            source_s = getattr(mem, "source_type", None) or "unknown"
             memory_lines.append(
                 f"[{label}] type={mem.type}, importance={mem.importance:.2f}, "
-                f"last_updated={recency_s}\n"
+                f"last_updated={recency_s}, source={source_s}\n"
                 f"    summary:\n{wrap_untrusted_content(mem.summary)}"
             )
 
@@ -597,7 +634,14 @@ class DedupMergePhase:
         response: dict,
         label_to_id: dict[str, UUID],
     ) -> list[tuple[UUID, UUID]]:
-        """Parse LLM dedup response, validating all labels."""
+        """Parse LLM dedup response, validating all labels.
+
+        #1209: the judge's per-judgment ``reason`` (already part of the JSON
+        schema, previously discarded) is captured into ``_decision_meta`` so
+        every merge action is explainable in the audit log. Parsed leniently —
+        a missing/odd reason never invalidates an otherwise valid judgment.
+        """
+        self._ensure_audit_state()
         decisions: list[tuple[UUID, UUID]] = []
         judgments = response.get("judgments", [])
 
@@ -624,7 +668,17 @@ class DedupMergePhase:
                 continue
 
             loser_label = pair[0] if pair[1] == winner_label else pair[1]
-            decisions.append((label_to_id[winner_label], label_to_id[loser_label]))
+            decision = (label_to_id[winner_label], label_to_id[loser_label])
+            decisions.append(decision)
+
+            reason = j.get("reason")
+            confidence = j.get("confidence")
+            self._decision_meta[decision] = {
+                "merge_reason": (str(reason)[:300] if reason else "unspecified"),
+                "judge_confidence": (
+                    float(confidence) if isinstance(confidence, (int, float)) else None
+                ),
+            }
 
         return decisions
 
@@ -651,30 +705,98 @@ class DedupMergePhase:
         o = cls._recency_key(other)
         return c is not None and o is not None and c > o
 
-    def _enforce_newer_wins(
+    @staticmethod
+    def _is_user_authored(mem: Memory) -> bool:
+        """#1209: 'manual' provenance = human-authored (#887 source_type)."""
+        return getattr(mem, "source_type", None) == "manual"
+
+    def _ensure_audit_state(self) -> None:
+        """Lazy-init the #1209 audit state.
+
+        Several unit tests construct the phase via ``__new__`` (bypassing
+        ``__init__``) to call individual judge methods — the audit state must
+        not make those methods construction-order dependent.
+        """
+        if not hasattr(self, "_decision_meta"):
+            self._decision_meta = {}
+        if not hasattr(self, "_override_reasons"):
+            self._override_reasons = {}
+        if not hasattr(self, "_winner_overrides"):
+            self._winner_overrides = 0
+
+    def _record_override(
+        self,
+        original: tuple[UUID, UUID],
+        flipped: tuple[UUID, UUID],
+        reason: str,
+    ) -> None:
+        """Count an override and re-key the decision's audit metadata."""
+        self._ensure_audit_state()
+        self._winner_overrides += 1
+        self._override_reasons[reason] = self._override_reasons.get(reason, 0) + 1
+        meta = self._decision_meta.pop(original, {})
+        meta["override_reason"] = reason
+        self._decision_meta[flipped] = meta
+        logger.warning(
+            "dedup_winner_overridden",
+            llm_winner_id=str(original[0]),
+            enforced_winner_id=str(flipped[0]),
+            override_reason=reason,
+        )
+
+    @classmethod
+    def _recency_minute(cls, mem: Memory) -> datetime | None:
+        """Recency key truncated to the minute — the precision the judge saw.
+
+        The prompt renders ``last_updated=`` at minute precision, so the
+        deterministic rules compare at the same precision: sub-minute deltas
+        are write-ordering noise, not a recency signal, and must neither
+        trigger the newer-wins flip nor defeat the source tie-break (#1209).
+        """
+        key = cls._recency_key(mem)
+        return key.replace(second=0, microsecond=0) if key else None
+
+    def _enforce_winner_rules(
         self,
         decisions: list[tuple[UUID, UUID]],
         cluster_memories: list[Memory],
     ) -> list[tuple[UUID, UUID]]:
-        """Deterministic post-check on LLM merge decisions (#1195/#1198).
+        """Deterministic post-checks on LLM merge decisions (#1195/#1198/#1209).
 
-        The prompt asks for newer-wins but cannot guarantee it — the judge
+        The prompt asks for these rules but cannot guarantee them — the judge
         picked the older memory in 10-18% of update pairs in the Day-5 eval.
-        The duplicate verdict is trusted; the direction is enforced: any
-        decision whose winner is strictly older than its loser is flipped.
+        The duplicate verdict is trusted; the direction is enforced, in order,
+        at MINUTE precision (matching the ``last_updated=`` signal the judge
+        was shown):
+
+        1. **Newer wins** (#1198): a winner strictly older (by minute) than
+           its loser is flipped ("recency" override).
+        2. **Human-authored wins at equal recency** (#1209): when the
+           minute-precision recency keys are EQUAL (including both-unknown),
+           a non-manual winner never deletes a manual (human-authored, #887
+           provenance) loser — the "trusted over ingested" tie-break.
+           Recency stays primary: this rule never fires when one side is
+           strictly newer ("source" override).
         """
         id_to_mem = {m.id: m for m in cluster_memories}
         corrected: list[tuple[UUID, UUID]] = []
         for winner_id, loser_id in decisions:
             winner = id_to_mem.get(winner_id)
             loser = id_to_mem.get(loser_id)
-            if winner is not None and loser is not None and self._is_newer(loser, winner):
-                self._winner_overrides += 1
-                logger.warning(
-                    "dedup_winner_overridden",
-                    llm_winner_id=str(winner_id),
-                    enforced_winner_id=str(loser_id),
-                )
+            if winner is None or loser is None:
+                corrected.append((winner_id, loser_id))
+                continue
+            winner_key = self._recency_minute(winner)
+            loser_key = self._recency_minute(loser)
+            if winner_key is not None and loser_key is not None and loser_key > winner_key:
+                self._record_override((winner_id, loser_id), (loser_id, winner_id), "recency")
+                corrected.append((loser_id, winner_id))
+            elif (
+                winner_key == loser_key
+                and self._is_user_authored(loser)
+                and not self._is_user_authored(winner)
+            ):
+                self._record_override((winner_id, loser_id), (loser_id, winner_id), "source")
                 corrected.append((loser_id, winner_id))
             else:
                 corrected.append((winner_id, loser_id))
@@ -686,6 +808,7 @@ class DedupMergePhase:
         pair_scores: dict[tuple[UUID, UUID], float],
     ) -> list[tuple[UUID, UUID]]:
         """Rule-based dedup: auto-merge only at very high similarity."""
+        self._ensure_audit_state()
         decisions: list[tuple[UUID, UUID]] = []
         ids = [m.id for m in cluster_memories]
         id_to_mem = {m.id: m for m in cluster_memories}
@@ -705,13 +828,19 @@ class DedupMergePhase:
                     mem_a = id_to_mem[id_a]
                     mem_b = id_to_mem[id_b]
                     if mem_a.importance > mem_b.importance:
-                        decisions.append((id_a, id_b))
+                        decision = (id_a, id_b)
                     elif mem_b.importance > mem_a.importance:
-                        decisions.append((id_b, id_a))
+                        decision = (id_b, id_a)
                     elif self._is_newer(mem_b, mem_a):
-                        decisions.append((id_b, id_a))
+                        decision = (id_b, id_a)
                     else:
-                        decisions.append((id_a, id_b))
+                        decision = (id_a, id_b)
+                    decisions.append(decision)
+                    # #1209: rule-path merges are explainable too.
+                    self._decision_meta[decision] = {
+                        "merge_reason": f"rule:cosine>={AUTO_MERGE_THRESHOLD}",
+                        "judge_confidence": None,
+                    }
 
         return decisions
 

--- a/backend/src/services/sleep/merge_retention.py
+++ b/backend/src/services/sleep/merge_retention.py
@@ -92,9 +92,28 @@ class MergeRetentionPhase:
             }
             return result
 
-        await self.db.execute(delete(Memory).where(Memory.id.in_(ids)))
+        # Re-assert the full purge predicate in the DELETE itself (not just
+        # the ids): a concurrent per-merge undo commits in its own session,
+        # and a bare id-DELETE under READ COMMITTED would hard-delete the
+        # memory the admin just restored (TOCTOU between our SELECT and this
+        # DELETE). With the predicate repeated, a restored row (deleted_at
+        # IS NULL) no longer matches and survives.
+        await self.db.execute(
+            delete(Memory).where(
+                Memory.id.in_(ids),
+                Memory.deleted_by == _MERGE_DELETED_BY,
+                Memory.deleted_at.is_not(None),
+                Memory.deleted_at < cutoff,
+            )
+        )
 
-        result.memories_processed = len(ids)
+        # Deliberately NOT counted into memories_processed: the orchestrator
+        # consumes the shared per-run budget from that field, and purging an
+        # unbounded historical backlog of dead rows must not starve the
+        # live-memory phases (importance_reeval / consolidation) that run
+        # after this one. The purge volume is reported in details + the
+        # batch audit action instead.
+        result.memories_processed = 0
         result.details = {
             "purged": len(ids),
             "retention_days": retention_days,

--- a/backend/src/services/sleep/merge_retention.py
+++ b/backend/src/services/sleep/merge_retention.py
@@ -1,0 +1,126 @@
+"""Merge-loser retention purge (#1209) — destructive deletion as an explicit,
+telemetered second step.
+
+Dedup merges soft-delete their losers (``deleted_by='sleep_maintenance'``),
+which keeps every merge reversible — and grows storage forever. This phase
+implements the declared retention window: when
+``sleep_merge_retention_days > 0``, merge losers whose soft-deletion is older
+than the window are hard-deleted, and the run's audit log records a batch
+summary (one action, not one row per purge — a large backlog must not explode
+``sleep_actions``).
+
+Default is **0 = disabled = retain forever** (the pre-#1209 behavior). The
+undo path (`services.sleep.undo`) names this setting in its error message
+when a purged merge can no longer be restored — the rollback bound is
+declared, not silent.
+
+Merge losers' Qdrant vectors were already hard-deleted at merge time
+(orphan-vector prevention), so the purge only removes Postgres rows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from neural.config import NeuralMemoryConfig
+    from services.sleep.reporter import SleepBudget, SleepReporter
+
+from models.memory import Memory
+from services.sleep.reporter import PhaseResult
+from utils.datetime import utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_MERGE_DELETED_BY = "sleep_maintenance"
+
+
+class MergeRetentionPhase:
+    """Hard-delete merge losers past the declared retention window."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def execute(
+        self,
+        config: NeuralMemoryConfig,
+        user_id: str,
+        workspace_id: str | None,
+        context_id: str | None,
+        budget: SleepBudget,
+        *,
+        reporter: SleepReporter | None = None,
+        report_id: UUID | None = None,
+    ) -> PhaseResult:
+        """Purge merge losers older than ``sleep_merge_retention_days``.
+
+        No-op (skipped) when the retention window is disabled (<= 0).
+        """
+        result = PhaseResult(phase_name="merge_retention")
+
+        retention_days = int(getattr(config, "sleep_merge_retention_days", 0) or 0)
+        if retention_days <= 0:
+            result.skipped = True
+            result.skip_reason = "retention_disabled"
+            return result
+
+        cutoff = utcnow() - timedelta(days=retention_days)
+
+        stmt = select(Memory.id).where(
+            Memory.user_id == user_id,
+            Memory.deleted_by == _MERGE_DELETED_BY,
+            Memory.deleted_at.is_not(None),
+            Memory.deleted_at < cutoff,
+        )
+        if workspace_id:
+            stmt = stmt.where(Memory.workspace_id == UUID(workspace_id))
+        if context_id:
+            stmt = stmt.where(Memory.context_id == UUID(context_id))
+
+        ids = [row[0] for row in (await self.db.execute(stmt)).all()]
+        if not ids:
+            result.details = {
+                "purged": 0,
+                "retention_days": retention_days,
+                "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+            }
+            return result
+
+        await self.db.execute(delete(Memory).where(Memory.id.in_(ids)))
+
+        result.memories_processed = len(ids)
+        result.details = {
+            "purged": len(ids),
+            "retention_days": retention_days,
+            "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+        }
+
+        # Batch-summary audit action (deliberately NOT per-row): the purge is
+        # the moment reversibility ends, so it must be visible in the same
+        # audit log the merges live in.
+        if reporter and report_id:
+            await reporter.add_action(
+                report_id=report_id,
+                phase="merge_retention",
+                action_type="purge",
+                details={
+                    "purged": len(ids),
+                    "retention_days": retention_days,
+                    "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+                },
+            )
+
+        logger.info(
+            "merge_retention_purged",
+            purged=len(ids),
+            retention_days=retention_days,
+            user_id=user_id,
+            context_id=context_id,
+        )
+        return result

--- a/backend/src/services/sleep/orchestrator.py
+++ b/backend/src/services/sleep/orchestrator.py
@@ -27,6 +27,7 @@ from services.sleep.consolidation import ConsolidationPhase
 from services.sleep.dedup_merge import DedupMergePhase
 from services.sleep.edge_discovery import EdgeDiscoveryPhase
 from services.sleep.importance_reeval import ImportanceReevalPhase
+from services.sleep.merge_retention import MergeRetentionPhase
 from services.sleep.reindex import ReindexPhase
 from services.sleep.reporter import PhaseResult, SleepBudget, SleepReporter
 from utils.datetime import utcnow
@@ -35,7 +36,15 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 # Phase sets for each sleep mode
-FULL_PHASES = {"edge_discovery", "dedup_merge", "importance_reeval", "consolidation"}
+# #1209: merge_retention runs right after dedup_merge in full mode — it is
+# the declared (default-disabled) purge window for merge losers.
+FULL_PHASES = {
+    "edge_discovery",
+    "dedup_merge",
+    "merge_retention",
+    "importance_reeval",
+    "consolidation",
+}
 EDGES_ONLY_PHASES = {"edge_discovery"}
 
 
@@ -117,6 +126,7 @@ class SleepOrchestrator:
         phases = [
             ("edge_discovery", lambda: EdgeDiscoveryPhase(self.db, self.llm_service, em, cn)),
             ("dedup_merge", lambda: DedupMergePhase(self.db, self.llm_service, em, cn)),
+            ("merge_retention", lambda: MergeRetentionPhase(self.db)),
             ("importance_reeval", lambda: ImportanceReevalPhase(self.db, self.llm_service, cn)),
             ("consolidation", lambda: ConsolidationPhase(self.db, self.llm_service, cn)),
         ]

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -99,9 +99,17 @@ override last_updated=. Never pick the outdated version as winner; if \
 you cannot tell which version is newer, mark the pair "keep_both".
 - Otherwise, if one memory is a strict subset of the other, they are \
 duplicates. Keep the more complete one.
+- When the last_updated= values are EQUAL and the memories are otherwise \
+tied, prefer the human-authored version as winner: source=manual is \
+server-stamped provenance (a person wrote it); other source= values are \
+ingested content. Never let an ingested duplicate delete a human-authored \
+memory on a tie. Recency still takes precedence: a strictly newer ingested \
+version beats an older manual one.
 - Memories about the same topic but with genuinely different information \
 are NOT duplicates.
 - When in doubt, mark as "keep_both" — false merges lose information.
+- Always fill "reason" with a brief, specific justification for the \
+verdict and winner choice — it is persisted to the merge audit log.
 
 You MUST respond with valid JSON only.
 
@@ -110,7 +118,8 @@ You MUST respond with valid JSON only.
 
 DEDUP_JUDGE_USER = """\
 Analyze these memory pairs for duplicates. Each memory has a label (A, B, C...), \
-a last-updated timestamp (last_updated=), and a summary.
+a last-updated timestamp (last_updated=), a provenance marker (source=), and a \
+summary.
 
 Memories:
 {memories}

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -398,6 +398,8 @@ class SleepReporter:
                 report.edge_discovery_result = phase_data
             elif result.phase_name == "dedup_merge":
                 report.dedup_result = phase_data
+            elif result.phase_name == "merge_retention":
+                report.merge_retention_result = phase_data
             elif result.phase_name == "importance_reeval":
                 report.importance_result = phase_data
             elif result.phase_name == "consolidation":

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -183,7 +183,19 @@ async def undo_merge_action(
         sa_update(Memory).where(Memory.id == loser_id).values(deleted_at=None, deleted_by=None)
     )
 
+    # Resolve workspace_id — required by add_memory_to_qdrant. Mirrors the
+    # run-level rollback's Context fallback: workspace-less reports exist,
+    # and the shared-helper promise is that the two restore paths never
+    # drift (a bare "" would hard-raise inside the Qdrant layer).
     ws_id = str(report.workspace_id) if report.workspace_id else ""
+    if not ws_id and report.context_id:
+        from models.auth import Context
+
+        ctx_ws = (
+            await db.execute(select(Context.workspace_id).where(Context.id == report.context_id))
+        ).scalar_one_or_none()
+        if ctx_ws:
+            ws_id = str(ctx_ws)
     ctx_id = str(report.context_id) if report.context_id else ""
     embedding_svc = EmbeddingService(db, model=embedding_model)
     await re_embed_memory_to_qdrant(

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -1,0 +1,226 @@
+"""Per-merge undo for judged dedup merges (#1209).
+
+``rollback_sleep_run`` reverses a WHOLE run; the user-facing correction loop
+needs "restore just this memory". This module owns the shared restore
+machinery — used by the admin REST endpoint (`/admin/sleep/actions/...`) and
+by the MCP run-level rollback (which re-embeds through the same helper), so
+the two paths cannot drift.
+
+Reversibility is bounded by the retention policy (#1209): once
+``sleep_merge_retention_days`` purges a merge loser, the undo target is gone
+and the error says so explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy import update as sa_update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.memory import Memory
+from models.sleep import SleepAction, SleepReport
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class UndoMergeError(Exception):
+    """A per-merge undo could not be performed.
+
+    Attributes:
+        code: Stable machine-readable reason (``action_not_found`` |
+            ``not_a_merge`` | ``memory_purged`` | ``already_restored`` |
+            ``not_merge_deleted``).
+        message: Human-readable explanation.
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+async def re_embed_memory_to_qdrant(
+    memory: Any,
+    user_id: str,
+    embedding_svc: Any,
+    workspace_id: str,
+    context_id: str,
+    collection_name: str,
+) -> None:
+    """Re-embed a restored memory back into Qdrant.
+
+    Merge hard-deletes the loser's vector (orphan-vector prevention), so any
+    restore path must rebuild it. Shared by run-level rollback and per-merge
+    undo.
+    """
+    from db.qdrant import add_memory_to_qdrant
+
+    vector = await embedding_svc.embed(
+        memory.summary or "",
+        user_id=user_id,
+        context_id=context_id,
+        workspace_id=workspace_id,
+    )
+    payload = {
+        "user_id": user_id,
+        "summary": memory.summary,
+        "context_summary": memory.context_summary or "",
+        "type": memory.type,
+        "importance": memory.importance,
+        "scope": memory.scope,
+        "tags": memory.tags or [],
+        "created_at": (memory.created_at.isoformat() + "Z" if memory.created_at else None),
+        "updated_at": (memory.updated_at.isoformat() + "Z" if memory.updated_at else None),
+    }
+    await add_memory_to_qdrant(
+        user_id=user_id,
+        memory_id=memory.id,
+        vector=vector,
+        payload=payload,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        collection_name=collection_name,
+    )
+
+
+async def _resolve_embedding_info(
+    db: AsyncSession, context_id: UUID | None
+) -> tuple[str | None, str]:
+    """Context's embedding model + Qdrant collection (defaults when row-less)."""
+    from db.qdrant import get_collection_name
+    from models.config import ContextSearchConfig
+
+    collection_name = "kagura_memories"
+    embedding_model: str | None = None
+    if context_id:
+        result = await db.execute(
+            select(ContextSearchConfig).where(ContextSearchConfig.context_id == context_id)
+        )
+        search_config = result.scalar_one_or_none()
+        if search_config and search_config.embedding_model:
+            collection_name = get_collection_name(
+                search_config.embedding_model,
+                search_config.embedding_dimensions,
+            )
+            embedding_model = search_config.embedding_model
+    return embedding_model, collection_name
+
+
+async def undo_merge_action(
+    db: AsyncSession,
+    action_id: int,
+    *,
+    acting_user_id: str,
+) -> dict[str, Any]:
+    """Restore the loser of ONE dedup merge (row + vector) and audit the undo.
+
+    Self-scoped: the merge's report must belong to ``acting_user_id`` (the
+    same Phase-1 scoping the admin sleep trigger uses).
+
+    Returns:
+        Summary dict: restored memory id, winner id, report id, undo action id.
+
+    Raises:
+        UndoMergeError: with a stable ``code`` for every non-restorable state
+            — including ``memory_purged`` once the retention policy
+            (``sleep_merge_retention_days``) has hard-deleted the loser.
+    """
+    from services.embedding_service import EmbeddingService
+
+    result = await db.execute(
+        select(SleepAction, SleepReport)
+        .join(SleepReport, SleepAction.report_id == SleepReport.id)
+        .where(SleepAction.id == action_id, SleepReport.user_id == acting_user_id)
+    )
+    row = result.first()
+    if row is None:
+        raise UndoMergeError(
+            "action_not_found",
+            f"Sleep action {action_id} not found or not owned by you.",
+        )
+    action, report = row
+
+    if action.action_type != "merge" or action.phase != "dedup_merge":
+        raise UndoMergeError(
+            "not_a_merge",
+            f"Sleep action {action_id} is '{action.phase}/{action.action_type}', "
+            "not a dedup merge.",
+        )
+
+    loser_id = action.target_id
+    winner_id = action.memory_id
+    if loser_id is None:
+        raise UndoMergeError("not_a_merge", f"Sleep action {action_id} records no merge loser.")
+
+    mem_result = await db.execute(select(Memory).where(Memory.id == loser_id))
+    loser = mem_result.scalar_one_or_none()
+    if loser is None:
+        raise UndoMergeError(
+            "memory_purged",
+            f"Merged memory {loser_id} no longer exists — it was hard-deleted by the "
+            "merge retention policy (sleep_merge_retention_days), which bounds how "
+            "long merges stay reversible.",
+        )
+    if loser.deleted_at is None:
+        raise UndoMergeError(
+            "already_restored",
+            f"Memory {loser_id} is not deleted — this merge was already undone or rolled back.",
+        )
+    if loser.deleted_by != "sleep_maintenance":
+        raise UndoMergeError(
+            "not_merge_deleted",
+            f"Memory {loser_id} was deleted by '{loser.deleted_by}', not by sleep "
+            "maintenance — undo-merge refuses to override a different deletion.",
+        )
+
+    embedding_model, collection_name = await _resolve_embedding_info(db, report.context_id)
+
+    await db.execute(
+        sa_update(Memory).where(Memory.id == loser_id).values(deleted_at=None, deleted_by=None)
+    )
+
+    ws_id = str(report.workspace_id) if report.workspace_id else ""
+    ctx_id = str(report.context_id) if report.context_id else ""
+    embedding_svc = EmbeddingService(db, model=embedding_model)
+    await re_embed_memory_to_qdrant(
+        loser,
+        report.user_id,
+        embedding_svc,
+        ws_id,
+        ctx_id,
+        collection_name,
+    )
+
+    # Audit symmetry: the undo is a SleepAction on the SAME report, so the
+    # merge's full history (merge -> undo_merge) reads out of one audit log.
+    undo_action = SleepAction(
+        report_id=action.report_id,
+        phase="dedup_merge",
+        action_type="undo_merge",
+        memory_id=loser_id,
+        target_id=winner_id,
+        details={
+            "undone_action_id": action.id,
+            "undone_by": acting_user_id,
+        },
+    )
+    db.add(undo_action)
+    await db.commit()
+
+    logger.info(
+        "dedup_merge_undone",
+        action_id=action_id,
+        restored_memory_id=str(loser_id),
+        winner_id=str(winner_id) if winner_id else None,
+        report_id=str(action.report_id),
+    )
+    return {
+        "restored_memory_id": str(loser_id),
+        "winner_id": str(winner_id) if winner_id else None,
+        "report_id": str(action.report_id),
+        "undone_action_id": action.id,
+    }

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -59,6 +59,7 @@ def _make_mock_report(
     r.importance_result = None
     r.consolidation_result = {"success": True}
     r.reindex_result = {"success": True}
+    r.merge_retention_result = None  # #1209
     return r
 
 

--- a/backend/tests/api/test_sleep_reports_workspace.py
+++ b/backend/tests/api/test_sleep_reports_workspace.py
@@ -62,6 +62,7 @@ def _make_mock_report(
     r.importance_result = None
     r.consolidation_result = {"success": True}
     r.reindex_result = {"success": True}
+    r.merge_retention_result = None  # #1209
     return r
 
 

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -151,6 +151,7 @@ class TestGetSleepReport:
         r.importance_result = None
         r.consolidation_result = None
         r.reindex_result = None
+        r.merge_retention_result = None  # #1209
         return r
 
     def _mock_action(self, phase="edge_discovery", action_type="create_edge"):

--- a/backend/tests/services/sleep/test_dedup_winner_rules.py
+++ b/backend/tests/services/sleep/test_dedup_winner_rules.py
@@ -1,0 +1,175 @@
+"""#1209: deterministic winner rules + merge-audit metadata on dedup merges.
+
+Pins, on top of the #1195/#1198 newer-wins veto:
+
+1. The equal-recency source tie-break — a non-manual (ingested) winner never
+   deletes a manual (human-authored, #887 provenance) loser when the recency
+   keys are EQUAL. Recency stays primary: the source rule never fires when
+   one side is strictly newer.
+2. Per-reason override counters ("recency" | "source") that feed the sleep
+   report's ``winner_override_reasons`` breakdown.
+3. Decision audit metadata: the judge's ``reason`` (already in the JSON
+   schema, previously discarded) is captured leniently; the rule-based path
+   records a rule id; overrides re-key the metadata to the final decision.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from services.sleep.dedup_merge import AUTO_MERGE_THRESHOLD, DedupMergePhase
+
+
+def _phase() -> DedupMergePhase:
+    return DedupMergePhase(MagicMock(), MagicMock())
+
+
+def _mem(
+    *,
+    created: datetime,
+    updated: datetime | None = None,
+    source_type: str = "api",
+    importance: float = 0.5,
+) -> MagicMock:
+    m = MagicMock()
+    m.id = uuid4()
+    m.created_at = created
+    m.updated_at = updated
+    m.source_type = source_type
+    m.importance = importance
+    return m
+
+
+class TestWinnerRules:
+    def test_recency_flip_counts_reason(self) -> None:
+        phase = _phase()
+        older = _mem(created=datetime(2026, 1, 1))
+        newer = _mem(created=datetime(2026, 6, 1))
+        corrected = phase._enforce_winner_rules([(older.id, newer.id)], [older, newer])
+        assert corrected == [(newer.id, older.id)]
+        assert phase._winner_overrides == 1
+        assert phase._override_reasons == {"recency": 1}
+        assert phase._decision_meta[(newer.id, older.id)]["override_reason"] == "recency"
+
+    def test_equal_recency_manual_loser_flips(self) -> None:
+        """The trusted-over-ingested tie-break: at equal recency, an api
+        winner never deletes a manual loser."""
+        phase = _phase()
+        ts = datetime(2026, 6, 1, 12, 0)
+        ingested_winner = _mem(created=ts, source_type="api")
+        manual_loser = _mem(created=ts, source_type="manual")
+        corrected = phase._enforce_winner_rules(
+            [(ingested_winner.id, manual_loser.id)], [ingested_winner, manual_loser]
+        )
+        assert corrected == [(manual_loser.id, ingested_winner.id)]
+        assert phase._override_reasons == {"source": 1}
+        meta = phase._decision_meta[(manual_loser.id, ingested_winner.id)]
+        assert meta["override_reason"] == "source"
+
+    def test_strictly_newer_ingested_winner_beats_manual_loser(self) -> None:
+        """Recency stays primary — the source rule never overrides a
+        strictly newer ingested version."""
+        phase = _phase()
+        manual_old = _mem(created=datetime(2026, 1, 1), source_type="manual")
+        ingested_new = _mem(created=datetime(2026, 6, 1), source_type="url")
+        corrected = phase._enforce_winner_rules(
+            [(ingested_new.id, manual_old.id)], [ingested_new, manual_old]
+        )
+        assert corrected == [(ingested_new.id, manual_old.id)]
+        assert phase._winner_overrides == 0
+        assert phase._override_reasons == {}
+
+    def test_equal_recency_manual_winner_untouched(self) -> None:
+        phase = _phase()
+        ts = datetime(2026, 6, 1)
+        manual_winner = _mem(created=ts, source_type="manual")
+        ingested_loser = _mem(created=ts, source_type="vault")
+        corrected = phase._enforce_winner_rules(
+            [(manual_winner.id, ingested_loser.id)], [manual_winner, ingested_loser]
+        )
+        assert corrected == [(manual_winner.id, ingested_loser.id)]
+        assert phase._winner_overrides == 0
+
+    def test_equal_recency_both_manual_untouched(self) -> None:
+        phase = _phase()
+        ts = datetime(2026, 6, 1)
+        a = _mem(created=ts, source_type="manual")
+        b = _mem(created=ts, source_type="manual")
+        corrected = phase._enforce_winner_rules([(a.id, b.id)], [a, b])
+        assert corrected == [(a.id, b.id)]
+        assert phase._winner_overrides == 0
+
+    def test_same_minute_seconds_apart_counts_as_tie(self) -> None:
+        """Rules compare at MINUTE precision — the precision the judge saw.
+
+        Two writes seconds apart look identical in the prompt's
+        ``last_updated=``; sub-minute deltas are write-ordering noise, so
+        they neither trigger the recency flip nor defeat the source
+        tie-break (a manual loser 20s OLDER than an ingested winner still
+        wins the tie).
+        """
+        phase = _phase()
+        ingested_winner = _mem(created=datetime(2026, 6, 1, 12, 0, 30), source_type="api")
+        manual_loser = _mem(created=datetime(2026, 6, 1, 12, 0, 10), source_type="manual")
+        corrected = phase._enforce_winner_rules(
+            [(ingested_winner.id, manual_loser.id)], [ingested_winner, manual_loser]
+        )
+        assert corrected == [(manual_loser.id, ingested_winner.id)]
+        assert phase._override_reasons == {"source": 1}
+
+    def test_cross_minute_delta_still_flips_on_recency(self) -> None:
+        phase = _phase()
+        older_winner = _mem(created=datetime(2026, 6, 1, 12, 0, 59))
+        newer_loser = _mem(created=datetime(2026, 6, 1, 12, 1, 0))
+        corrected = phase._enforce_winner_rules(
+            [(older_winner.id, newer_loser.id)], [older_winner, newer_loser]
+        )
+        assert corrected == [(newer_loser.id, older_winner.id)]
+        assert phase._override_reasons == {"recency": 1}
+
+
+class TestDecisionMeta:
+    def test_parse_captures_reason_and_confidence(self) -> None:
+        phase = _phase()
+        id_a, id_b = uuid4(), uuid4()
+        label_to_id = {"A": id_a, "B": id_b}
+        response = {
+            "judgments": [
+                {
+                    "pair": ["A", "B"],
+                    "verdict": "merge",
+                    "winner": "A",
+                    "confidence": 0.9,
+                    "reason": "B is a subset of A",
+                }
+            ]
+        }
+        decisions = phase._parse_dedup_response(response, label_to_id)
+        assert decisions == [(id_a, id_b)]
+        meta = phase._decision_meta[(id_a, id_b)]
+        assert meta["merge_reason"] == "B is a subset of A"
+        assert meta["judge_confidence"] == 0.9
+
+    def test_parse_missing_reason_is_lenient(self) -> None:
+        """A judgment without a reason stays valid — reason parse is
+        best-effort, never a validity gate."""
+        phase = _phase()
+        id_a, id_b = uuid4(), uuid4()
+        label_to_id = {"A": id_a, "B": id_b}
+        response = {"judgments": [{"pair": ["A", "B"], "verdict": "merge", "winner": "B"}]}
+        decisions = phase._parse_dedup_response(response, label_to_id)
+        assert decisions == [(id_b, id_a)]
+        meta = phase._decision_meta[(id_b, id_a)]
+        assert meta["merge_reason"] == "unspecified"
+        assert meta["judge_confidence"] is None
+
+    def test_rule_based_records_rule_reason(self) -> None:
+        phase = _phase()
+        ts = datetime(2026, 6, 1)
+        a = _mem(created=ts, importance=0.9)
+        b = _mem(created=ts, importance=0.5)
+        key = tuple(sorted([a.id, b.id], key=str))
+        decisions = phase._rule_based_judge([a, b], {key: 0.99})
+        assert decisions == [(a.id, b.id)]
+        meta = phase._decision_meta[(a.id, b.id)]
+        assert meta["merge_reason"] == f"rule:cosine>={AUTO_MERGE_THRESHOLD}"

--- a/backend/tests/services/sleep/test_merge_retention.py
+++ b/backend/tests/services/sleep/test_merge_retention.py
@@ -59,7 +59,11 @@ async def test_purges_and_audits_batch_summary() -> None:
     )
 
     assert result.skipped is False
-    assert result.memories_processed == 3
+    # Purged dead rows must NOT consume the shared per-run budget — the
+    # orchestrator feeds memories_processed into budget.consume, and a
+    # first-enable backlog purge would otherwise starve the live-memory
+    # phases (importance_reeval / consolidation) that run after this one.
+    assert result.memories_processed == 0
     assert result.details["purged"] == 3
     assert result.details["retention_days"] == 30
 

--- a/backend/tests/services/sleep/test_merge_retention.py
+++ b/backend/tests/services/sleep/test_merge_retention.py
@@ -1,0 +1,94 @@
+"""#1209: merge-loser retention purge phase.
+
+Pins:
+
+1. Default (``sleep_merge_retention_days = 0``) is DISABLED — the phase
+   skips and deletes nothing (pre-#1209 behavior preserved: merges stay
+   reversible forever unless the operator declares a window).
+2. When enabled, only rows soft-deleted by sleep maintenance and older than
+   the cutoff are purged, and the purge is audited as ONE batch-summary
+   action (never per-row).
+3. Nothing to purge → no audit action, zero counts.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.sleep.merge_retention import MergeRetentionPhase
+
+
+def _config(days: int) -> MagicMock:
+    cfg = MagicMock()
+    cfg.sleep_merge_retention_days = days
+    return cfg
+
+
+def _budget() -> MagicMock:
+    budget = MagicMock()
+    budget.exhausted = False
+    return budget
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_skips() -> None:
+    db = AsyncMock()
+    phase = MergeRetentionPhase(db)
+    result = await phase.execute(_config(0), "user", None, None, _budget())
+    assert result.skipped is True
+    assert result.skip_reason == "retention_disabled"
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_purges_and_audits_batch_summary() -> None:
+    db = AsyncMock()
+    purged_ids = [uuid4(), uuid4(), uuid4()]
+    select_result = MagicMock()
+    select_result.all.return_value = [(mid,) for mid in purged_ids]
+    db.execute.side_effect = [select_result, MagicMock()]  # select, delete
+
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+    report_id = uuid4()
+
+    phase = MergeRetentionPhase(db)
+    result = await phase.execute(
+        _config(30), "user", None, None, _budget(), reporter=reporter, report_id=report_id
+    )
+
+    assert result.skipped is False
+    assert result.memories_processed == 3
+    assert result.details["purged"] == 3
+    assert result.details["retention_days"] == 30
+
+    reporter.add_action.assert_awaited_once()
+    kwargs = reporter.add_action.await_args.kwargs
+    assert kwargs["phase"] == "merge_retention"
+    assert kwargs["action_type"] == "purge"
+    assert kwargs["details"]["purged"] == 3
+    # Batch summary — one action total, regardless of row count.
+    assert reporter.add_action.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_purge_records_no_action() -> None:
+    db = AsyncMock()
+    select_result = MagicMock()
+    select_result.all.return_value = []
+    db.execute.return_value = select_result
+
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+
+    phase = MergeRetentionPhase(db)
+    result = await phase.execute(
+        _config(7), "user", None, None, _budget(), reporter=reporter, report_id=uuid4()
+    )
+
+    assert result.details["purged"] == 0
+    assert result.memories_processed == 0
+    reporter.add_action.assert_not_awaited()
+    # Only the select ran — no delete statement was issued.
+    assert db.execute.await_count == 1

--- a/backend/tests/services/sleep/test_undo_merge.py
+++ b/backend/tests/services/sleep/test_undo_merge.py
@@ -1,0 +1,125 @@
+"""#1209: per-merge undo service.
+
+Pins the correction-loop contract: one dedup merge is individually
+reversible (row restore + vector re-embed + audited ``undo_merge`` action on
+the same report), with a stable error code for every non-restorable state —
+including the retention-purged case, whose message names the setting that
+bounds reversibility.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from services.sleep.undo import UndoMergeError, undo_merge_action
+
+
+def _action(*, action_type: str = "merge", phase: str = "dedup_merge") -> MagicMock:
+    action = MagicMock()
+    action.id = 42
+    action.action_type = action_type
+    action.phase = phase
+    action.memory_id = uuid4()  # winner
+    action.target_id = uuid4()  # loser
+    action.report_id = uuid4()
+    return action
+
+
+def _report() -> MagicMock:
+    report = MagicMock()
+    report.user_id = "admin-user"
+    report.workspace_id = uuid4()
+    report.context_id = None  # default embedding info path (no config row)
+    return report
+
+
+def _db(first_row, memory=None) -> AsyncMock:
+    """AsyncMock db: 1st execute -> (action, report) join, 2nd -> memory,
+    3rd -> the restore UPDATE."""
+    db = AsyncMock()
+    join_result = MagicMock()
+    join_result.first.return_value = first_row
+    mem_result = MagicMock()
+    mem_result.scalar_one_or_none.return_value = memory
+    db.execute.side_effect = [join_result, mem_result, MagicMock()]
+    return db
+
+
+@pytest.mark.asyncio
+async def test_action_not_found() -> None:
+    db = _db(None)
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+    assert exc.value.code == "action_not_found"
+
+
+@pytest.mark.asyncio
+async def test_not_a_merge() -> None:
+    db = _db((_action(action_type="promote"), _report()))
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+    assert exc.value.code == "not_a_merge"
+
+
+@pytest.mark.asyncio
+async def test_purged_loser_names_the_retention_setting() -> None:
+    """Reversibility is bounded by the declared window — the error must say
+    which setting bounded it."""
+    db = _db((_action(), _report()), memory=None)
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+    assert exc.value.code == "memory_purged"
+    assert "sleep_merge_retention_days" in exc.value.message
+
+
+@pytest.mark.asyncio
+async def test_already_restored() -> None:
+    loser = MagicMock()
+    loser.deleted_at = None
+    db = _db((_action(), _report()), memory=loser)
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+    assert exc.value.code == "already_restored"
+
+
+@pytest.mark.asyncio
+async def test_refuses_non_sleep_deletion() -> None:
+    loser = MagicMock()
+    loser.deleted_at = MagicMock()
+    loser.deleted_by = "user_delete"
+    db = _db((_action(), _report()), memory=loser)
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+    assert exc.value.code == "not_merge_deleted"
+
+
+@pytest.mark.asyncio
+async def test_happy_path_restores_reembeds_and_audits() -> None:
+    action = _action()
+    report = _report()
+    loser = MagicMock()
+    loser.id = action.target_id
+    loser.deleted_at = MagicMock()
+    loser.deleted_by = "sleep_maintenance"
+    db = _db((action, report), memory=loser)
+
+    with (
+        patch("services.sleep.undo.re_embed_memory_to_qdrant", new=AsyncMock()) as re_embed,
+        patch("services.embedding_service.EmbeddingService"),
+    ):
+        summary = await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert summary["restored_memory_id"] == str(action.target_id)
+    assert summary["winner_id"] == str(action.memory_id)
+    assert summary["undone_action_id"] == 42
+
+    re_embed.assert_awaited_once()
+
+    # The undo is audited as an undo_merge action on the SAME report.
+    added = db.add.call_args.args[0]
+    assert added.action_type == "undo_merge"
+    assert added.report_id == action.report_id
+    assert added.details["undone_action_id"] == 42
+    assert added.details["undone_by"] == "admin-user"
+    db.commit.assert_awaited_once()

--- a/docs/sleep-maintenance.md
+++ b/docs/sleep-maintenance.md
@@ -208,7 +208,7 @@ Restored memories are re-embedded back into Qdrant. On full success the report m
 
 ### Per-merge undo (#1209)
 
-`rollback_sleep_run` reverses a whole run; the correction loop for a single bad merge is `POST /admin/sleep/actions/{action_id}/undo-merge` — it restores just that merge's loser (row **and** Qdrant vector) and appends an `undo_merge` action to the same report, so the merge's full history (merge → undo) reads out of one audit log. Self-scoped like the manual trigger. Error contract: `404` unknown/unowned action, `409` already restored (or deleted by something other than sleep), `410` the loser was purged by the retention window (`sleep_merge_retention_days`) — reversibility is bounded by the declared window, and the bound is named, never silent.
+`rollback_sleep_run` reverses a whole run; the correction loop for a single bad merge is `POST /admin/sleep/actions/{action_id}/undo-merge` — it restores just that merge's loser (row **and** Qdrant vector) and appends an `undo_merge` action to the same report, so the merge's full history (merge → undo) reads out of one audit log. Self-scoped like the manual trigger. Error contract: `400` the action is not a dedup merge, `404` unknown/unowned action, `409` already restored (or deleted by something other than sleep), `410` the loser was purged by the retention window (`sleep_merge_retention_days`) — reversibility is bounded by the declared window, and the bound is named, never silent.
 
 ## Admin UI
 

--- a/docs/sleep-maintenance.md
+++ b/docs/sleep-maintenance.md
@@ -59,9 +59,19 @@ Finds missing edges between related memories using medium-similarity Qdrant sear
 
 Detects and merges duplicate memories by clustering high-similarity neighbors.
 
-- **Algorithm**: per-memory high-similarity search → build candidate pairs → Union-Find clustering (cluster size capped at 5 to prevent runaway merges) → LLM batch judgment (`merge` / `keep_both`) in LLM mode, or auto-merge at similarity ≥ 0.98 in non-LLM mode → keep winner, soft-delete losers, transfer edges, merge tags.
+- **Algorithm**: per-memory high-similarity search → build candidate pairs → Union-Find clustering (cluster size capped at 5 to prevent runaway merges) → LLM batch judgment (`merge` / `keep_both`) in LLM mode, or auto-merge at similarity ≥ 0.98 in non-LLM mode → deterministic winner rules → keep winner, soft-delete losers, transfer edges, merge tags.
+- **Deterministic winner rules** (applied to every LLM decision; the duplicate verdict is trusted, the direction is enforced): **newer wins** (#1198 — the recency-aware veto that closed the stale-deletion failure mode found at 10–18% in the eval program), and at **equal recency, human-authored wins** (#1209 — a `source_type='manual'` memory never loses to ingested content on a tie). Overrides are counted in the report (`winner_overrides`, with a per-rule `winner_override_reasons` breakdown).
+- **Audit** (#1209): every merge writes a `sleep_actions` entry carrying `merge_reason` (the judge's rationale, or the rule id on the non-LLM path), override info, both sides' `source_type` provenance and recency keys — every merge is explainable and its decision inputs are snapshotted.
 - **LLM**: yes (optional).
-- **Side effects**: soft-deletes losers in PostgreSQL and removes them from Qdrant.
+- **Side effects**: soft-deletes losers in PostgreSQL and removes them from Qdrant (vectors are rebuilt on undo/rollback).
+
+### Phase 2.5 — Merge Retention (#1209)
+
+Hard-deletes merge losers whose soft-deletion is older than the declared retention window — destructive deletion as an explicit, telemetered second step, never a side effect of the merge itself.
+
+- **Default**: `sleep_merge_retention_days = 0` — **disabled, retain forever**. Merges stay reversible indefinitely unless an operator declares a window.
+- **When enabled**: losers past the window are purged and the run records one batch-summary `purge` action (`purged`, `retention_days`, `cutoff`). Per-merge undo and run rollback are only possible **inside** the window; the undo API returns 410 naming this setting once a loser is purged.
+- **LLM**: no.
 
 ### Phase 3 — Importance Re-evaluation
 
@@ -196,6 +206,10 @@ running  →  completed | failed | cancelled | rolled_back
 
 Restored memories are re-embedded back into Qdrant. On full success the report moves to `rolled_back`; if any action fails to reverse, the report is marked `failed` and the partial state is recorded in the audit log.
 
+### Per-merge undo (#1209)
+
+`rollback_sleep_run` reverses a whole run; the correction loop for a single bad merge is `POST /admin/sleep/actions/{action_id}/undo-merge` — it restores just that merge's loser (row **and** Qdrant vector) and appends an `undo_merge` action to the same report, so the merge's full history (merge → undo) reads out of one audit log. Self-scoped like the manual trigger. Error contract: `404` unknown/unowned action, `409` already restored (or deleted by something other than sleep), `410` the loser was purged by the retention window (`sleep_merge_retention_days`) — reversibility is bounded by the declared window, and the bound is named, never silent.
+
 ## Admin UI
 
 - **Sleep Reports list + detail** — `frontend/src/app/(authenticated)/admin/sleep-reports/` renders the `/admin/sleep-reports` REST endpoints as a browsable report explorer with per-action drilldown.
@@ -212,6 +226,7 @@ All Sleep-specific settings live under the Sleep category of Neural Config (`bac
 | `sleep_max_memories_per_run`  | Upper bound on memories touched per context per run.           |
 | `sleep_max_llm_calls_per_run` | Upper bound on LLM calls per context per run (budget cap).     |
 | `sleep_dedup_enabled`         | Master toggle for Phase 2.                                     |
+| `sleep_merge_retention_days`  | Merge-loser purge window (#1209). `0` = retain forever.        |
 | `sleep_edge_discovery_enabled`| Master toggle for Phase 1.                                     |
 | `sleep_importance_reeval_enabled` | Master toggle for Phase 3.                                 |
 | `sleep_consolidation_enabled` | Master toggle for Phase 4.                                     |

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2747,6 +2747,7 @@
         "sleep_max_llm_calls_per_run": "Max LLM API calls per sleep run",
         "sleep_dedup_enabled": "Enable dedup/merge phase",
         "sleep_dedup_similarity_threshold": "Cosine similarity threshold for duplicate detection",
+        "sleep_merge_retention_days": "Merge-loser purge window in days (0 = retain forever)",
         "sleep_edge_discovery_enabled": "Enable edge discovery phase",
         "sleep_edge_discovery_sample_size": "Number of memories to sample per edge discovery run",
         "sleep_importance_reeval_enabled": "Enable importance re-evaluation phase"

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2747,6 +2747,7 @@
         "sleep_max_llm_calls_per_run": "1 回の sleep 実行での最大 LLM API 呼び出し数",
         "sleep_dedup_enabled": "重複排除/マージフェーズを有効化",
         "sleep_dedup_similarity_threshold": "重複検出のコサイン類似度しきい値",
+        "sleep_merge_retention_days": "マージ敗者のパージ猶予日数（0 = 永久保持）",
         "sleep_edge_discovery_enabled": "エッジ発見フェーズを有効化",
         "sleep_edge_discovery_sample_size": "エッジ発見 1 回あたりのサンプルメモリ数",
         "sleep_importance_reeval_enabled": "重要度再評価フェーズを有効化"


### PR DESCRIPTION
Closes #1209

## Summary
- **Every merge is explainable**: merge actions persist `merge_reason` (the judge's rationale — already in the JSON schema, previously discarded — or the rule id on the non-LLM path), `winner_override` + `override_reason`, and both sides' `source_type` provenance + recency snapshots. The audit proves what the decision (judge + deterministic rules) actually saw.
- **Winner rules hardened**: the #1198 newer-wins veto gains an **equal-recency source tie-break** — a `manual` (human-authored, #887) memory never loses to ingested content on a tie. Both rules now compare at **minute precision**, the exact `last_updated=` signal the judge is shown (sub-minute deltas are write-ordering noise, not recency). Per-rule `winner_override_reasons` breakdown lands in the sleep report.
- **Per-merge undo**: `POST /admin/sleep/actions/{action_id}/undo-merge` restores one merge loser — Postgres row **and** Qdrant vector — and audits an `undo_merge` action on the same report (merge → undo reads out of one log). Stable error codes; `410` names `sleep_merge_retention_days` when the loser was purged. Run-level rollback now records purged losers as **errors** instead of phantom "reversed".
- **Retention as an explicit second step**: new `merge_retention` phase (default **0 = disabled = retain forever**, the pre-#1209 behavior). When enabled, losers past the window are hard-deleted with a batch-summary `purge` action. Wired through all three config layers (env bootstrap, DB `neural_config` incl. seed migration, validation) + admin UI labels (en/ja) — operationally enableable, not just declared.
- **Report surfaces**: `merge_retention_result` per-phase column (migration `e56`) + REST/MCP schema; judge prompt shows `source=` as trusted metadata and is instructed to always fill `reason`.

## Implementation notes
- **⚠ Migration merge coordination**: `e56_1209` chains from `e54`. #1215 (e55) and this PR fork from the same base — **whichever merges second must bump its migration's `down_revision` to the other's revision id** (one line; noted in the migration docstring). Merging both as-is leaves alembic with two heads.
- Audit metadata rides a `_decision_meta` sidecar keyed by the final (winner, loser) so the decision-tuple shape — which existing tests and call sites rely on — is unchanged; lazy-init keeps `__new__`-constructed test instances working.
- Verified: 873-test battery green (sleep/mcp/neural/api-sleep + schema guards); scratch-DB migration run (column `json`, seed row present, head `e56`); frontend Vitest exit 0 (i18n labels added to en/ja); ruff/format clean.

## Pre-PR review summary
- gate2 mode: advisor-only / audit: skipped / binary_gate: (none)
- cso: green — self-scoped undo (join-verified ownership), fail-secure error codes, trusted-metadata prompt discipline preserved
- qa-lead: yellow — no REST-route-level undo test (service layer covered); update-slice impact of minute precision guaranteed by construction (30-day backdate), not re-measured; e55/e56 coordination is a manual step
- cto: green — sidecar audit design keeps churn minimal; shared restore helper prevents undo/rollback drift; retention wired through all config layers
- gate1: green via /ask (CTO lens)
- review provider: code-review — inner pass applied 4 findings (config from_db wiring — the feature was otherwise unenableable; report-surface column; rollback phantom-reversed; minute-precision tie semantics)

Follow-ups carried out of this PR:
- Admin UI affordance for per-merge undo (endpoint + audit exist; a button in the sleep-report action drilldown is frontend work)
- Consider a generic per-phase result map if sleep phases keep growing (6th `*_result` column added here)

Full reviews: ~/.claude/cache/gh-issue-driven/1209-feat-feat-sleep-reversible-auditable-dedup-me.gate{1,2}.md

🤖 Generated via /gh-issue-driven:ship
