### PR TITLE
feat(api): supersedes/contradicts relations + recall shadowing (#1208)

### DIFF
--- a/backend/alembic/versions/e57_1208_supersedes_contradicts.py
+++ b/backend/alembic/versions/e57_1208_supersedes_contradicts.py
@@ -1,0 +1,89 @@
+"""Widen valid_edge_type CHECK with supersedes + contradicts (#1208).
+
+Fact-succession relations — the non-destructive update path the
+kagura-memory-eval program found missing (update-by-removal was the only
+mechanism preferring a current fact over a stale one, and it carries the
+worst failure semantics). Direction convention (load-bearing for recall
+shadowing): ``src`` = the SUPERSEDING (newer) memory, ``dst`` = the
+SUPERSEDED (older) memory. ``contradicts`` never hides either side.
+
+Also seeds the ``sleep_dedup_supersede_enabled`` neural_config row
+(default ``false`` — dedup keeps its update-by-removal behavior unless an
+operator opts into shadow-mode merges, which record a supersedes edge and
+leave the loser row alive-but-shadowed).
+
+### No data migration
+
+Pure CHECK widening — existing rows satisfy the wider constraint.
+
+### Index note
+
+The recall shadow query filters ``edge_type='supersedes' AND dst_id IN
+(<result ids>)`` scoped by user/workspace/context; the existing
+``idx_edges_user_dst`` / ``idx_edges_ws_ctx_dst`` composite indexes cover
+it (the candidate set is one recall's top-k×fetch_factor ids), so no new
+index is added.
+
+### Reversibility (downgrade caveats)
+
+Mirrors e25_782: downgrade remaps ``supersedes``/``contradicts`` to
+``related_to`` (lossy — succession direction and contradiction semantics
+are gone; re-upgrading does not split them back out), then narrows the
+CHECK. Offline-downgrade recommended, same concurrency contract as e25.
+
+NOTE (merge coordination): this branch forks from main at e54, in parallel
+with e55 (#1207) and e56 (#1209). Whichever PRs merge later must re-chain
+``down_revision`` onto the then-current head (one line each) — merging in
+parallel as-is leaves alembic with multiple heads.
+
+Revision ID: e57_1208_supersedes_contradicts
+Revises: e54_1183_sleep_status_degraded
+"""
+
+from alembic import op
+
+# revision identifiers
+revision = "e57_1208_supersedes_contradicts"
+down_revision = "e54_1183_sleep_status_degraded"
+branch_labels = None
+depends_on = None
+
+_NEW_CHECK_SQL = (
+    "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+    "'learned_from', 'continues_from', 'references_file', "
+    "'supersedes', 'contradicts')"
+)
+
+# Downgrade target: the post-#782 six-value set (== e25_782's _NEW_CHECK_SQL).
+_OLD_CHECK_SQL = (
+    "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+    "'learned_from', 'continues_from', 'references_file')"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _NEW_CHECK_SQL,
+    )
+    op.execute("""
+        INSERT INTO neural_config (key, value, value_type, category, description, min_value, max_value) VALUES
+            ('sleep_dedup_supersede_enabled', 'false', 'bool', 'sleep', 'Dedup merges record a supersedes edge and shadow the loser instead of soft-deleting it (#1208); off = update-by-removal (pre-#1208 behavior)', NULL, NULL)
+        ON CONFLICT (key) DO NOTHING;
+    """)
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE neural_memory_edges SET edge_type = 'related_to' "
+        "WHERE edge_type IN ('supersedes', 'contradicts')"
+    )
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _OLD_CHECK_SQL,
+    )
+    op.execute("DELETE FROM neural_config WHERE key = 'sleep_dedup_supersede_enabled';")

--- a/backend/alembic/versions/e57_1208_supersedes_contradicts.py
+++ b/backend/alembic/versions/e57_1208_supersedes_contradicts.py
@@ -31,20 +31,20 @@ Mirrors e25_782: downgrade remaps ``supersedes``/``contradicts`` to
 are gone; re-upgrading does not split them back out), then narrows the
 CHECK. Offline-downgrade recommended, same concurrency contract as e25.
 
-NOTE (merge coordination): this branch forks from main at e54, in parallel
-with e55 (#1207) and e56 (#1209). Whichever PRs merge later must re-chain
-``down_revision`` onto the then-current head (one line each) — merging in
-parallel as-is leaves alembic with multiple heads.
+NOTE (merge coordination): this branch forked from main at e54, in parallel
+with e55 (#1207) and e56 (#1209). Both merged first, so this revision was
+re-chained onto e56 (the then-current head) at merge time, per the plan in
+epic #1214.
 
 Revision ID: e57_1208_supersedes_contradicts
-Revises: e54_1183_sleep_status_degraded
+Revises: e56_1209_merge_retention
 """
 
 from alembic import op
 
 # revision identifiers
 revision = "e57_1208_supersedes_contradicts"
-down_revision = "e54_1183_sleep_status_degraded"
+down_revision = "e56_1209_merge_retention"
 branch_labels = None
 depends_on = None
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -196,6 +196,11 @@ Returns: {status, memory_id, scope, context_id, context_name, context_display_na
                         "items": {"type": "string"},
                         "description": "Explicit links by source_uri (resolved to memory_id at remember time). Unresolved URIs are silently skipped — the plugin can retry later when the target memory exists.",
                     },
+                    "supersedes": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Memory ID this new memory supersedes (#1208). The old memory is SHADOWED out of default recall — not deleted: it stays reachable via recall(include_superseded=true) and explore(), and deleting the supersedes edge restores it fully. Use when storing the updated version of a fact you previously remembered.",
+                    },
                 },
             },
         },
@@ -366,6 +371,10 @@ Returns: {status, results: [{memory_id, summary, context_summary, type, importan
                     "include_explore_hints": {
                         "type": "boolean",
                         "description": "Include up to 3 explore_hints in the response suggesting good seed memories for a follow-up explore() call (default: false). Set to true when the user is exploring a topic broadly or asks 'what else is related?' — the hints bridge recall (precision search) and explore (graph discovery) without mixing their scoring. Each hint includes a memory_id and a reason (top_result, high_centrality, or unexplored_neighbor).",
+                    },
+                    "include_superseded": {
+                        "type": "boolean",
+                        "description": "Include memories shadowed by a supersedes edge (#1208, default: false). Superseded (outdated) versions of facts are demoted out of results by default; true returns them annotated with superseded_by for audit/history purposes.",
                     },
                 },
             },
@@ -688,8 +697,10 @@ Returns: {status, edge: {source_id, target_id, edge_type, weight, confidence, cr
                             "learned_from",
                             "continues_from",
                             "references_file",
+                            "supersedes",
+                            "contradicts",
                         ],
-                        "description": "Type of relationship (default: 'related_to').",
+                        "description": "Type of relationship (default: 'related_to'). #1208: 'supersedes' (src = newer memory, dst = the outdated one it replaces — dst is shadowed out of default recall while src lives) and 'contradicts' (both sides stay visible, annotated — contradiction never hides).",
                         "default": "related_to",
                     },
                     "weight": {
@@ -754,6 +765,8 @@ Returns: {status, edge: {source_id, target_id, edge_type, weight, confidence, cr
                             "learned_from",
                             "continues_from",
                             "references_file",
+                            "supersedes",
+                            "contradicts",
                         ],
                         "description": "New edge type.",
                     },

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -25,11 +25,13 @@ from mcp_server.tools._helpers import (
 from models.memory import (
     EDGE_ORIGIN_DECLARED,
     EDGE_TYPE_CONTINUES_FROM,
+    EDGE_TYPE_CONTRADICTS,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SUPERSEDES,
 )
 
 # Issue #461 / #741 / #782: full set of edge_types accepted by the DB CHECK
@@ -50,6 +52,12 @@ from models.memory import (
 #     does not extend to GraphService.add_edge — that path is the internal
 #     Hebbian-default writer and callers wanting a non-Hebbian origin must
 #     pass it explicitly via the optional `origin=` parameter (#782).
+#   - supersedes / contradicts (#1208): fact-succession relations. Direction
+#     convention: src = superseding (newer), dst = superseded (older) — a
+#     memory that is the dst of a live supersedes edge is shadowed out of
+#     recall (include_superseded=true opts back in); contradicts never hides.
+#     NOT in LLM_EMITTABLE_EDGE_TYPES (the sleep judge must not invent
+#     supersession); origin='declared' when asserted via this MCP path.
 # Provenance for what was previously edge_type='semantic_similarity' /
 # 'declared_link' / 'tag_cooccurrence' now lives on `origin` and
 # `edge_metadata['source']` (see migration `e20_741` docstring).
@@ -61,6 +69,8 @@ VALID_EDGE_TYPES = frozenset(
         EDGE_TYPE_LEARNED_FROM,
         EDGE_TYPE_CONTINUES_FROM,
         EDGE_TYPE_REFERENCES_FILE,
+        EDGE_TYPE_SUPERSEDES,
+        EDGE_TYPE_CONTRADICTS,
     }
 )
 

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -57,6 +57,7 @@ async def handle_remember(
         source_type=args.get("source_type"),
         linked_memory_ids=args.get("linked_memory_ids"),
         linked_source_uris=args.get("linked_source_uris"),
+        supersedes=args.get("supersedes"),  # #1208
     )
 
     start_time = time.time()
@@ -435,6 +436,7 @@ async def handle_recall(
         filters=args.get("filters"),
         search_mode=args.get("search_mode", "hybrid"),
         include_explore_hints=args.get("include_explore_hints", False),
+        include_superseded=args.get("include_superseded", False),  # #1208
     )
 
     start_time = time.time()
@@ -538,6 +540,11 @@ async def handle_recall(
                     # (null if never edited) — an old value means the fact may be stale.
                     "created_at": to_utc_iso(r.created_at),
                     "updated_at": to_utc_iso(r.updated_at),
+                    # #1208: fact-succession annotations. superseded_by is only
+                    # non-null under include_superseded=true; contradicts lists
+                    # opposing memories (never hidden, both sides annotated).
+                    "superseded_by": str(r.superseded_by) if r.superseded_by else None,
+                    "contradicts": [str(c) for c in r.contradicts],
                 }
                 for r in result.results
             ]

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -375,44 +375,32 @@ async def handle_rollback_sleep_run(
                         if action.target_id:
                             if (action.details or {}).get("mode") == "shadow":
                                 # #1208 shadow-mode merge: the loser was never
-                                # deleted — undoing the merge means deleting
+                                # deleted — undoing the merge means reverting
                                 # the supersedes edge (winner=memory_id →
-                                # loser=target_id), which restores the loser's
-                                # visibility in default recall. Verify the
-                                # edge really is supersedes before deleting:
-                                # unique_edge is keyed on (user, src, dst)
-                                # regardless of edge_type, so blind deletion
-                                # could remove an unrelated association.
+                                # loser=target_id): restore the pre-merge
+                                # edge from the prior_edge snapshot, or
+                                # verified-delete it when the merge created
+                                # the edge. Shared helper with per-merge undo
+                                # so the two paths cannot drift.
                                 if action.memory_id:
-                                    from models.memory import EDGE_TYPE_SUPERSEDES
-
-                                    existing = await edge_repo.get_edge(
-                                        user_id=user_id,
-                                        src_id=action.memory_id,
-                                        dst_id=action.target_id,
-                                        workspace_id=ws_id or None,
-                                        context_id=ctx_id_str or None,
+                                    from services.sleep.undo import (
+                                        revert_shadow_merge_edge,
                                     )
-                                    if (
-                                        existing is not None
-                                        and existing.edge_type == EDGE_TYPE_SUPERSEDES
-                                    ):
-                                        await edge_repo.delete_edge(
-                                            user_id=user_id,
-                                            src_id=action.memory_id,
-                                            dst_id=action.target_id,
-                                            workspace_id=ws_id or None,
-                                            context_id=ctx_id_str or None,
-                                        )
+
+                                    reverted = await revert_shadow_merge_edge(
+                                        db,
+                                        user_id=user_id,
+                                        winner_id=action.memory_id,
+                                        loser_id=action.target_id,
+                                        prior_edge=(action.details or {}).get("prior_edge"),
+                                    )
+                                    if reverted:
                                         rollback_summary["merges_reversed"] += 1
                                     else:
                                         logger.warning(
                                             "shadow_merge_rollback_edge_mismatch",
                                             src_id=str(action.memory_id),
                                             dst_id=str(action.target_id),
-                                            found_type=(
-                                                existing.edge_type if existing else None
-                                            ),
                                         )
                             else:
                                 restore_result = await db.execute(

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -378,16 +378,42 @@ async def handle_rollback_sleep_run(
                                 # deleted — undoing the merge means deleting
                                 # the supersedes edge (winner=memory_id →
                                 # loser=target_id), which restores the loser's
-                                # visibility in default recall.
+                                # visibility in default recall. Verify the
+                                # edge really is supersedes before deleting:
+                                # unique_edge is keyed on (user, src, dst)
+                                # regardless of edge_type, so blind deletion
+                                # could remove an unrelated association.
                                 if action.memory_id:
-                                    await edge_repo.delete_edge(
+                                    from models.memory import EDGE_TYPE_SUPERSEDES
+
+                                    existing = await edge_repo.get_edge(
                                         user_id=user_id,
                                         src_id=action.memory_id,
                                         dst_id=action.target_id,
                                         workspace_id=ws_id or None,
                                         context_id=ctx_id_str or None,
                                     )
-                                    rollback_summary["merges_reversed"] += 1
+                                    if (
+                                        existing is not None
+                                        and existing.edge_type == EDGE_TYPE_SUPERSEDES
+                                    ):
+                                        await edge_repo.delete_edge(
+                                            user_id=user_id,
+                                            src_id=action.memory_id,
+                                            dst_id=action.target_id,
+                                            workspace_id=ws_id or None,
+                                            context_id=ctx_id_str or None,
+                                        )
+                                        rollback_summary["merges_reversed"] += 1
+                                    else:
+                                        logger.warning(
+                                            "shadow_merge_rollback_edge_mismatch",
+                                            src_id=str(action.memory_id),
+                                            dst_id=str(action.target_id),
+                                            found_type=(
+                                                existing.edge_type if existing else None
+                                            ),
+                                        )
                             else:
                                 restore_result = await db.execute(
                                     sa_update(Memory)

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -339,10 +339,16 @@ async def handle_rollback_sleep_run(
                     ws_id = str(ctx_ws)
             embedding_svc = EmbeddingService(db, model=embedding_model)
 
-            # Pre-fetch all memories that need re-embedding (merge/archive)
+            # Pre-fetch all memories that need re-embedding (merge/archive).
+            # #1208: shadow-mode merges never deleted the loser's vector, so
+            # they need no re-embed — their undo is deleting the edge below.
             re_embed_ids: set[UUID] = set()
             for a in actions:
-                if a.action_type == "merge" and a.target_id:
+                if (
+                    a.action_type == "merge"
+                    and a.target_id
+                    and (a.details or {}).get("mode") != "shadow"
+                ):
                     re_embed_ids.add(a.target_id)
                 elif a.action_type == "archive" and a.memory_id:
                     re_embed_ids.add(a.memory_id)
@@ -367,37 +373,53 @@ async def handle_rollback_sleep_run(
 
                     elif action.action_type == "merge":
                         if action.target_id:
-                            restore_result = await db.execute(
-                                sa_update(Memory)
-                                .where(
-                                    Memory.id == action.target_id,
-                                    Memory.user_id == user_id,
-                                )
-                                .values(deleted_at=None, deleted_by=None)
-                            )
-                            loser = memory_cache.get(action.target_id)
-                            # #1209: a loser hard-deleted by the merge
-                            # retention window matches 0 rows — record it as
-                            # an error instead of a phantom "reversed" (the
-                            # per-merge undo path returns 410 for the same
-                            # state; run-level rollback must not report a
-                            # restore that never happened).
-                            if restore_result.rowcount == 0 or loser is None:
-                                rollback_summary["errors"].append(
-                                    f"merge loser {action.target_id} not restorable — "
-                                    "purged by the retention policy "
-                                    "(sleep_merge_retention_days)"
-                                )
+                            if (action.details or {}).get("mode") == "shadow":
+                                # #1208 shadow-mode merge: the loser was never
+                                # deleted — undoing the merge means deleting
+                                # the supersedes edge (winner=memory_id →
+                                # loser=target_id), which restores the loser's
+                                # visibility in default recall.
+                                if action.memory_id:
+                                    await edge_repo.delete_edge(
+                                        user_id=user_id,
+                                        src_id=action.memory_id,
+                                        dst_id=action.target_id,
+                                        workspace_id=ws_id or None,
+                                        context_id=ctx_id_str or None,
+                                    )
+                                    rollback_summary["merges_reversed"] += 1
                             else:
-                                await _re_embed_to_qdrant(
-                                    loser,
-                                    user_id,
-                                    embedding_svc,
-                                    ws_id,
-                                    ctx_id_str,
-                                    collection_name,
+                                restore_result = await db.execute(
+                                    sa_update(Memory)
+                                    .where(
+                                        Memory.id == action.target_id,
+                                        Memory.user_id == user_id,
+                                    )
+                                    .values(deleted_at=None, deleted_by=None)
                                 )
-                                rollback_summary["merges_reversed"] += 1
+                                loser = memory_cache.get(action.target_id)
+                                # #1209: a loser hard-deleted by the merge
+                                # retention window matches 0 rows — record it
+                                # as an error instead of a phantom "reversed"
+                                # (the per-merge undo path returns 410 for the
+                                # same state; run-level rollback must not
+                                # report a restore that never happened).
+                                if restore_result.rowcount == 0 or loser is None:
+                                    rollback_summary["errors"].append(
+                                        f"merge loser {action.target_id} not restorable — "
+                                        "purged by the retention policy "
+                                        "(sleep_merge_retention_days)"
+                                    )
+                                else:
+                                    await _re_embed_to_qdrant(
+                                        loser,
+                                        user_id,
+                                        embedding_svc,
+                                        ws_id,
+                                        ctx_id_str,
+                                        collection_name,
+                                    )
+                                    rollback_summary["merges_reversed"] += 1
 
                     elif action.action_type == "update_importance":
                         details = action.details or {}

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -528,6 +528,21 @@ EDGE_TYPE_LEARNED_FROM = "learned_from"
 #   - references_file: structural reference from a chat memory to a file overview
 EDGE_TYPE_CONTINUES_FROM = "continues_from"
 EDGE_TYPE_REFERENCES_FILE = "references_file"
+# Issue #1208: fact-succession relations (the non-destructive update path the
+# kagura-memory-eval program found missing — update-by-removal was the only
+# mechanism). Direction convention, load-bearing for recall shadowing:
+#   src = the SUPERSEDING (newer/current) memory
+#   dst = the SUPERSEDED (older/stale) memory
+# A memory that is the dst of a supersedes edge is "shadowed": recall demotes
+# it out of results (opt back in with include_superseded=true) as long as the
+# superseding src is still alive — a deleted superseder stops shadowing
+# (self-healing JOIN in the shadow query; edge refs are bare UUIDs, no FK).
+# 'contradicts' NEVER hides either side — recall annotates both (resolution
+# is an arbitration problem, not a deletion problem). Deliberately NOT in
+# edge_discovery's LLM_EMITTABLE_EDGE_TYPES: the sleep judge must not invent
+# supersession (structural over-supersede prevention).
+EDGE_TYPE_SUPERSEDES = "supersedes"
+EDGE_TYPE_CONTRADICTS = "contradicts"
 
 # Issue #509 (Phase B of #461): registration-order tuple used to derive the
 # ``valid_edge_type`` CHECK constraint string in ``NeuralMemoryEdge.__table_args__``.
@@ -545,6 +560,9 @@ _ALL_EDGE_TYPES: tuple[str, ...] = (
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_CONTINUES_FROM,
     EDGE_TYPE_REFERENCES_FILE,
+    # #1208: appended (never reordered) per the byte-identity rule above.
+    EDGE_TYPE_SUPERSEDES,
+    EDGE_TYPE_CONTRADICTS,
 )
 
 # Edge origin discriminator (Issue #722).

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -117,6 +117,14 @@ class RememberRequest(BaseModel):
         default=None,
         description="Explicit links by source_uri (resolved at remember time, unresolved silently skipped)",
     )
+    # #1208: fact succession — this new memory supersedes an existing one.
+    # Creates a supersedes edge (src=new, dst=old, origin='declared'); the old
+    # memory is shadowed out of default recall but never deleted (reachable
+    # via include_superseded / explore; deleting the edge restores it fully).
+    supersedes: UUID | None = Field(
+        default=None,
+        description="Memory ID this new memory supersedes (old one is shadowed, not deleted)",
+    )
 
     @field_validator("summary")
     @classmethod
@@ -181,6 +189,12 @@ class RecallRequest(BaseModel):
         default=False,
         description="Include up to 3 explore_hints in response suggesting good seeds for explore()",
     )
+    # #1208: shadowed (superseded) memories are demoted out of results by
+    # default; true returns them annotated with superseded_by for audit.
+    include_superseded: bool = Field(
+        default=False,
+        description="Include memories shadowed by a supersedes edge (annotated with superseded_by)",
+    )
 
 
 class MemoryResponse(TZAwareBaseModel):
@@ -207,6 +221,13 @@ class MemoryResponse(TZAwareBaseModel):
     # memory would otherwise raise a Pydantic ValidationError. The *request*
     # schema (RememberRequest) intentionally omits it — the forge guard.
     source_type: Literal["file", "url", "vault", "api", "manual", "connector"] | None = None
+    # #1208: fact-succession annotations. superseded_by is set only when the
+    # memory is shadowed AND include_superseded=true opted it back into the
+    # results (default recall filters shadowed memories out entirely).
+    # contradicts lists memories linked by a contradicts edge (either
+    # direction) — contradiction never hides, it annotates both sides.
+    superseded_by: UUID | None = None
+    contradicts: list[UUID] = Field(default_factory=list)
 
     class Config:
         from_attributes = True

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -257,6 +257,10 @@ class NeuralMemoryConfig:
     # forever (pre-#1209 behavior). When > 0 the merge_retention phase
     # hard-deletes losers past the window; undo/rollback only work inside it.
     sleep_merge_retention_days: int = 0
+    # #1208: shadow-mode dedup — merges record a supersedes edge and leave the
+    # loser alive-but-shadowed instead of soft-deleting it. Default OFF =
+    # update-by-removal (pre-#1208 behavior).
+    sleep_dedup_supersede_enabled: bool = False
     sleep_edge_discovery_enabled: bool = True  # Phase 1 on/off
     sleep_edge_discovery_sample_size: int = 30  # Memories sampled per run
     sleep_importance_reeval_enabled: bool = True  # Phase 3 on/off
@@ -603,6 +607,7 @@ class NeuralMemoryConfig:
             sleep_dedup_enabled=get_bool("SLEEP_DEDUP_ENABLED", True),
             sleep_dedup_similarity_threshold=get_float("SLEEP_DEDUP_SIMILARITY_THRESHOLD", 0.92),
             sleep_merge_retention_days=get_int("SLEEP_MERGE_RETENTION_DAYS", 0),
+            sleep_dedup_supersede_enabled=get_bool("SLEEP_DEDUP_SUPERSEDE_ENABLED", False),
             sleep_edge_discovery_enabled=get_bool("SLEEP_EDGE_DISCOVERY_ENABLED", True),
             sleep_edge_discovery_sample_size=get_int("SLEEP_EDGE_DISCOVERY_SAMPLE_SIZE", 30),
             sleep_importance_reeval_enabled=get_bool("SLEEP_IMPORTANCE_REEVAL_ENABLED", True),
@@ -842,6 +847,10 @@ class NeuralMemoryConfig:
             sleep_merge_retention_days=configs.get(
                 "sleep_merge_retention_days",
                 base_config.sleep_merge_retention_days,
+            ),
+            sleep_dedup_supersede_enabled=configs.get(
+                "sleep_dedup_supersede_enabled",
+                base_config.sleep_dedup_supersede_enabled,
             ),
             sleep_edge_discovery_enabled=configs.get(
                 "sleep_edge_discovery_enabled", base_config.sleep_edge_discovery_enabled

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -17,11 +17,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.memory import (
     _ALL_EDGE_ORIGINS,
     EDGE_TYPE_CONTINUES_FROM,
+    EDGE_TYPE_CONTRADICTS,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SUPERSEDES,
 )
 from repositories.neural_edge import NeuralEdgeRepository
 from utils.datetime import to_utc_iso
@@ -96,6 +98,10 @@ class GraphService:
             EDGE_TYPE_LEARNED_FROM,
             EDGE_TYPE_CONTINUES_FROM,
             EDGE_TYPE_REFERENCES_FILE,
+            # #1208: fact-succession relations (src = superseding, dst =
+            # superseded; contradicts never hides).
+            EDGE_TYPE_SUPERSEDES,
+            EDGE_TYPE_CONTRADICTS,
         }
     )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1580,7 +1580,6 @@ class MemoryService:
         search_results: list[dict],
         memories: dict,
         *,
-        user_id: str,
         include_superseded: bool,
     ) -> tuple[dict[UUID, UUID], dict[UUID, list[UUID]]]:
         """#1208: demote superseded memories out of the candidate pool.
@@ -1624,11 +1623,17 @@ class MemoryService:
                 return {}, {}
 
             superseder = aliased(Memory)
+            # Deliberately NOT scoped to the calling user: in a shared
+            # context, member B's supersedes edge must shadow the stale fact
+            # for member A too — otherwise stale-fact suppression fails in
+            # exactly the team setting it matters most. Safe because
+            # candidate_ids are already visibility-scoped by the recall
+            # upstream, memory UUIDs are globally unique, and edge creation
+            # validates both endpoints exist in the creator's own context.
             rows = await self.db.execute(
                 select(NeuralMemoryEdge.dst_id, NeuralMemoryEdge.src_id)
                 .join(superseder, superseder.id == NeuralMemoryEdge.src_id)
                 .where(
-                    NeuralMemoryEdge.user_id == user_id,
                     NeuralMemoryEdge.edge_type == EDGE_TYPE_SUPERSEDES,
                     NeuralMemoryEdge.dst_id.in_(candidate_ids),
                     superseder.deleted_at.is_(None),
@@ -1638,7 +1643,6 @@ class MemoryService:
 
             c_rows = await self.db.execute(
                 select(NeuralMemoryEdge.src_id, NeuralMemoryEdge.dst_id).where(
-                    NeuralMemoryEdge.user_id == user_id,
                     NeuralMemoryEdge.edge_type == EDGE_TYPE_CONTRADICTS,
                     or_(
                         NeuralMemoryEdge.src_id.in_(candidate_ids),
@@ -2100,7 +2104,6 @@ class MemoryService:
         shadow_map, contradiction_map = await self._apply_supersede_shadowing(
             search_results,
             memories,
-            user_id=user_id,
             include_superseded=request.include_superseded,
         )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1183,7 +1183,11 @@ class MemoryService:
         the memory creation. Forward references (source_uri not yet in DB)
         are silently skipped.
         """
-        if not request.linked_memory_ids and not request.linked_source_uris:
+        if (
+            not request.linked_memory_ids
+            and not request.linked_source_uris
+            and not getattr(request, "supersedes", None)
+        ):
             return
 
         if not workspace_id or not context_id:
@@ -1262,6 +1266,43 @@ class MemoryService:
                         origin=EDGE_ORIGIN_DECLARED,
                     )
                     created += 1
+
+            # #1208: fact succession. src = this new memory (superseding),
+            # dst = the predecessor (superseded → shadowed out of default
+            # recall). Same-scope + active-target validation as direct links;
+            # the predecessor is never mutated — visibility is the edge's job.
+            supersedes_target = getattr(request, "supersedes", None)
+            if supersedes_target and supersedes_target != memory_id:
+                from models.memory import EDGE_TYPE_SUPERSEDES
+
+                result = await self.db.execute(
+                    select(Memory.id).where(
+                        Memory.id == supersedes_target,
+                        Memory.user_id == user_id,
+                        Memory.workspace_id == UUID(workspace_id),
+                        Memory.context_id == UUID(context_id),
+                        Memory.deleted_at.is_(None),
+                    )
+                )
+                if result.scalar_one_or_none() is not None:
+                    await edge_repo.create_edge_if_absent(
+                        user_id=user_id,
+                        src_id=memory_id,
+                        dst_id=supersedes_target,
+                        edge_type=EDGE_TYPE_SUPERSEDES,
+                        weight=1.0,
+                        confidence=1.0,
+                        workspace_id=workspace_id,
+                        context_id=context_id,
+                        origin=EDGE_ORIGIN_DECLARED,
+                    )
+                    created += 1
+                else:
+                    logger.warning(
+                        "supersedes_target_not_found",
+                        memory_id=str(memory_id),
+                        target_id=str(supersedes_target),
+                    )
 
             if created > 0:
                 await self.db.commit()
@@ -1533,6 +1574,100 @@ class MemoryService:
             "zero_adoption_in_topk": sum(1 for mid in order_after[:k] if mid in zero_adoption_ids),
             "topk": min(k, len(order_after)),
         }
+
+    async def _apply_supersede_shadowing(
+        self,
+        search_results: list[dict],
+        memories: dict,
+        *,
+        user_id: str,
+        include_superseded: bool,
+    ) -> tuple[dict[UUID, UUID], dict[UUID, list[UUID]]]:
+        """#1208: demote superseded memories out of the candidate pool.
+
+        Direction convention (models/memory.py): a ``supersedes`` edge points
+        src = superseding (newer) → dst = superseded (older). A candidate that
+        is the dst of a **live** edge — one whose superseding src memory still
+        exists and is not soft-deleted — is shadowed:
+
+        - default: removed from ``search_results`` IN PLACE (before the
+          re-rank and the top-k slice, so the slice stays full);
+        - ``include_superseded=True``: kept, and the returned shadow map lets
+          the caller annotate it with ``superseded_by``.
+
+        The liveness JOIN is the self-healing property: edge memory refs are
+        bare UUIDs (no FK), so a deleted superseder must stop shadowing —
+        deleting the edge OR the superseder restores full visibility.
+
+        ``contradicts`` edges NEVER hide anything: both sides of every edge
+        touching a candidate are collected into the returned contradiction
+        map for annotation (resolution is an arbitration problem).
+
+        Fail-open: shadowing is an enhancement on the read path — any error
+        preserves the original results (a query bug must not blank recall).
+
+        Returns:
+            (shadow_map dst→src, contradiction_map memory→[opponents]).
+        """
+        try:
+            from sqlalchemy import or_
+            from sqlalchemy.orm import aliased
+
+            from models.memory import (
+                EDGE_TYPE_CONTRADICTS,
+                EDGE_TYPE_SUPERSEDES,
+                NeuralMemoryEdge,
+            )
+
+            candidate_ids = {memories[r["id"]].id for r in search_results if r["id"] in memories}
+            if not candidate_ids:
+                return {}, {}
+
+            superseder = aliased(Memory)
+            rows = await self.db.execute(
+                select(NeuralMemoryEdge.dst_id, NeuralMemoryEdge.src_id)
+                .join(superseder, superseder.id == NeuralMemoryEdge.src_id)
+                .where(
+                    NeuralMemoryEdge.user_id == user_id,
+                    NeuralMemoryEdge.edge_type == EDGE_TYPE_SUPERSEDES,
+                    NeuralMemoryEdge.dst_id.in_(candidate_ids),
+                    superseder.deleted_at.is_(None),
+                )
+            )
+            shadow_map: dict[UUID, UUID] = dict(rows.all())
+
+            c_rows = await self.db.execute(
+                select(NeuralMemoryEdge.src_id, NeuralMemoryEdge.dst_id).where(
+                    NeuralMemoryEdge.user_id == user_id,
+                    NeuralMemoryEdge.edge_type == EDGE_TYPE_CONTRADICTS,
+                    or_(
+                        NeuralMemoryEdge.src_id.in_(candidate_ids),
+                        NeuralMemoryEdge.dst_id.in_(candidate_ids),
+                    ),
+                )
+            )
+            contradiction_map: dict[UUID, list[UUID]] = {}
+            for src, dst in c_rows.all():
+                contradiction_map.setdefault(src, []).append(dst)
+                contradiction_map.setdefault(dst, []).append(src)
+
+            if shadow_map and not include_superseded:
+                before = len(search_results)
+                search_results[:] = [
+                    r
+                    for r in search_results
+                    if r["id"] not in memories or memories[r["id"]].id not in shadow_map
+                ]
+                logger.info(
+                    "supersede_shadowing_applied",
+                    shadowed=before - len(search_results),
+                    candidates=before,
+                )
+
+            return shadow_map, contradiction_map
+        except Exception as e:
+            logger.warning("supersede_shadowing_failed", error=str(e))
+            return {}, {}
 
     async def _maybe_reinforce_rerank(
         self,
@@ -1956,6 +2091,19 @@ class MemoryService:
         # recall uses pure hybrid search scores (no UnifiedScorer).
         # Hebbian learning still runs to build the graph for explore().
 
+        # #1208: supersede shadowing — memories that are the dst of a LIVE
+        # supersedes edge are demoted out of the candidate pool BEFORE the
+        # re-rank and the top-k slice (so shadowing never leaves the slice
+        # short). include_superseded=true keeps them, annotated. This is the
+        # non-destructive counterpart of dedup's update-by-removal: the truth
+        # is shadowed, not gone.
+        shadow_map, contradiction_map = await self._apply_supersede_shadowing(
+            search_results,
+            memories,
+            user_id=user_id,
+            include_superseded=request.include_superseded,
+        )
+
         # Issue #1048: bounded reinforce re-rank (adoption + retrieval feedback),
         # config-gated per-context (default ON since #1207), single-context only. Reorders the
         # candidate pool BEFORE the top-k slice below; uses only reference_count +
@@ -2007,6 +2155,11 @@ class MemoryService:
                     score=search_result.get("hybrid_score", search_result["score"]),
                     source_uri=memory.source_uri,
                     source_type=memory.source_type,
+                    # #1208: succession annotations. superseded_by is only
+                    # non-None under include_superseded=true (default recall
+                    # filtered shadowed memories out of search_results above).
+                    superseded_by=shadow_map.get(memory.id),
+                    contradicts=contradiction_map.get(memory.id, []),
                 )
             )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -2584,6 +2584,10 @@ class MemoryService:
                 k=request.k,
                 use_rerank=False,  # No reranking for delete
                 filters=None,
+                # #1208: superseded memories must stay deletable by query —
+                # default shadowing would hide them from this search and
+                # make forget(query=...) silently skip them.
+                include_superseded=True,
             )
 
             # Issue #82: Pass project ID to recall

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1285,7 +1285,13 @@ class MemoryService:
                     )
                 )
                 if result.scalar_one_or_none() is not None:
-                    await edge_repo.create_edge_if_absent(
+                    # Upsert, not create-if-absent: unique_edge is keyed on
+                    # (user, src, dst) regardless of edge_type, so a plain
+                    # declared link created earlier in this same request
+                    # (linked_memory_ids naming the same target) would make
+                    # an if-absent insert silently drop the succession the
+                    # caller explicitly asked for.
+                    await edge_repo.create_or_update_edge(
                         user_id=user_id,
                         src_id=memory_id,
                         dst_id=supersedes_target,
@@ -1295,6 +1301,7 @@ class MemoryService:
                         workspace_id=workspace_id,
                         context_id=context_id,
                         origin=EDGE_ORIGIN_DECLARED,
+                        return_fresh_edge=False,
                     )
                     created += 1
                 else:
@@ -1630,6 +1637,11 @@ class MemoryService:
             # candidate_ids are already visibility-scoped by the recall
             # upstream, memory UUIDs are globally unique, and edge creation
             # validates both endpoints exist in the creator's own context.
+            # Ordered so the NEWEST superseder wins when multiple live
+            # supersedes edges target the same dst (allowed by the schema):
+            # dict() keeps the last row per key, so ascending created_at
+            # (id as tiebreak) makes the annotation deterministic instead
+            # of flapping with row order between runs.
             rows = await self.db.execute(
                 select(NeuralMemoryEdge.dst_id, NeuralMemoryEdge.src_id)
                 .join(superseder, superseder.id == NeuralMemoryEdge.src_id)
@@ -1638,6 +1650,7 @@ class MemoryService:
                     NeuralMemoryEdge.dst_id.in_(candidate_ids),
                     superseder.deleted_at.is_(None),
                 )
+                .order_by(superseder.created_at.asc(), superseder.id.asc())
             )
             shadow_map: dict[UUID, UUID] = dict(rows.all())
 

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -272,6 +272,22 @@ class DedupMergePhase:
             result.details = {"message": "no_duplicate_candidates"}
             return result
 
+        # #1208: in shadow mode losers stay active, so already-settled pairs
+        # (a supersedes edge exists between them) would be re-judged every
+        # run — filter them out before clustering. Remove mode is untouched
+        # (soft-deleted losers never reach _fetch_active_memories).
+        settled_pairs_skipped = 0
+        if getattr(config, "sleep_dedup_supersede_enabled", False):
+            pairs, settled_pairs_skipped = await self._filter_already_superseded_pairs(
+                pairs, user_id
+            )
+            if not pairs:
+                result.details = {
+                    "message": "all_candidates_already_superseded",
+                    "settled_pairs_skipped": settled_pairs_skipped,
+                }
+                return result
+
         # Step 3: Cluster with Union-Find
         uf = UnionFind()
         for id_a, id_b, _score in pairs:
@@ -331,17 +347,33 @@ class DedupMergePhase:
                 config,
             )
 
+            # #1208: shadow-mode merges record a supersedes edge and leave the
+            # loser alive-but-shadowed instead of soft-deleting it — the
+            # non-destructive counterpart of update-by-removal. Default OFF
+            # preserves the pre-#1208 removal behavior byte-identically.
+            shadow_mode = bool(getattr(config, "sleep_dedup_supersede_enabled", False))
+
             for winner_id, loser_id in merge_decisions:
                 winner = memory_map.get(winner_id)
                 loser = memory_map.get(loser_id)
-                await self._execute_merge(
-                    winner,
-                    loser,
-                    user_id,
-                    workspace_id,
-                    context_id,
-                )
-                result.changed_memory_ids.add(winner_id)
+                if shadow_mode:
+                    await self._execute_shadow_merge(
+                        winner,
+                        loser,
+                        user_id,
+                        workspace_id,
+                        context_id,
+                    )
+                    # Nothing on either row changed — no reindex needed.
+                else:
+                    await self._execute_merge(
+                        winner,
+                        loser,
+                        user_id,
+                        workspace_id,
+                        context_id,
+                    )
+                    result.changed_memory_ids.add(winner_id)
                 merged_count += 1
                 if reporter and report_id and winner and loser:
                     pair_key = tuple(sorted([winner_id, loser_id], key=str))
@@ -376,6 +408,8 @@ class DedupMergePhase:
                             "loser_recency": (
                                 f"{loser_recency:%Y-%m-%d %H:%M}" if loser_recency else None
                             ),
+                            # #1208: how this merge disposed of the loser.
+                            "mode": "shadow" if shadow_mode else "remove",
                         },
                     )
 
@@ -398,6 +432,9 @@ class DedupMergePhase:
             # work was deferred".
             "deferred_pairs": deferred_pairs,
             "merged": merged_count,
+            # #1208: pairs skipped because a supersedes edge already settled
+            # them (shadow mode only; always 0 in remove mode).
+            "settled_pairs_skipped": settled_pairs_skipped,
             "llm_call_failures": self._llm_failures,  # #1183
             # #1195/#1198: LLM winner picks flipped by the deterministic
             # winner rules — a direct measure of residual judge misdirection
@@ -856,6 +893,82 @@ class DedupMergePhase:
                     }
 
         return decisions
+
+    async def _execute_shadow_merge(
+        self,
+        winner: Memory | None,
+        loser: Memory | None,
+        user_id: str,
+        workspace_id: str | None,
+        context_id: str | None,
+    ) -> None:
+        """#1208 shadow-mode merge: record succession, mutate nothing.
+
+        Creates a ``supersedes`` edge (src=winner, dst=loser,
+        origin='semantic' — machine-inferred by the dedup judge, not
+        user-asserted). The loser row, vector, tags and edges are all left
+        untouched: recall shadows it out by the edge alone, so deleting the
+        edge restores full visibility. Idempotent via create_edge_if_absent —
+        re-judging the same pair on a later run is a no-op (and
+        already-superseded pairs are filtered out before judging to avoid
+        burning judge budget on settled pairs).
+        """
+        if not winner or not loser:
+            return
+        from models.memory import EDGE_ORIGIN_SEMANTIC, EDGE_TYPE_SUPERSEDES
+
+        await self.edge_repo.create_edge_if_absent(
+            user_id=user_id,
+            src_id=winner.id,
+            dst_id=loser.id,
+            edge_type=EDGE_TYPE_SUPERSEDES,
+            weight=1.0,
+            confidence=1.0,
+            workspace_id=workspace_id,
+            context_id=context_id,
+            origin=EDGE_ORIGIN_SEMANTIC,
+        )
+        logger.info(
+            "dedup_shadow_merge",
+            winner_id=str(winner.id),
+            loser_id=str(loser.id),
+        )
+
+    async def _filter_already_superseded_pairs(
+        self,
+        pairs: list[tuple[UUID, UUID, float]],
+        user_id: str,
+    ) -> tuple[list[tuple[UUID, UUID, float]], int]:
+        """#1208: drop candidate pairs already linked by a supersedes edge.
+
+        In shadow mode the loser stays active, so the same near-duplicate
+        pair would be re-detected and re-judged on EVERY sleep run — burning
+        LLM budget on pairs whose succession is already settled. Filtering
+        is direction-agnostic (either orientation settles the pair).
+
+        Returns:
+            (remaining pairs, count of pairs skipped as already settled).
+        """
+        if not pairs:
+            return pairs, 0
+        from models.memory import EDGE_TYPE_SUPERSEDES, NeuralMemoryEdge
+
+        all_ids = {mid for a, b, _ in pairs for mid in (a, b)}
+        rows = await self.db.execute(
+            select(NeuralMemoryEdge.src_id, NeuralMemoryEdge.dst_id).where(
+                NeuralMemoryEdge.user_id == user_id,
+                NeuralMemoryEdge.edge_type == EDGE_TYPE_SUPERSEDES,
+                NeuralMemoryEdge.src_id.in_(all_ids),
+                NeuralMemoryEdge.dst_id.in_(all_ids),
+            )
+        )
+        settled = {tuple(sorted((src, dst), key=str)) for src, dst in rows.all()}
+        if not settled:
+            return pairs, 0
+        remaining = [
+            (a, b, s) for a, b, s in pairs if tuple(sorted((a, b), key=str)) not in settled
+        ]
+        return remaining, len(pairs) - len(remaining)
 
     async def _execute_merge(
         self,

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -356,8 +356,9 @@ class DedupMergePhase:
             for winner_id, loser_id in merge_decisions:
                 winner = memory_map.get(winner_id)
                 loser = memory_map.get(loser_id)
+                prior_edge: dict[str, Any] | None = None
                 if shadow_mode:
-                    await self._execute_shadow_merge(
+                    prior_edge = await self._execute_shadow_merge(
                         winner,
                         loser,
                         user_id,
@@ -408,8 +409,11 @@ class DedupMergePhase:
                             "loser_recency": (
                                 f"{loser_recency:%Y-%m-%d %H:%M}" if loser_recency else None
                             ),
-                            # #1208: how this merge disposed of the loser.
+                            # #1208: how this merge disposed of the loser,
+                            # plus the pre-merge state of any edge the shadow
+                            # upsert retyped — undo restores it from here.
                             "mode": "shadow" if shadow_mode else "remove",
+                            **({"prior_edge": prior_edge} if shadow_mode else {}),
                         },
                     )
 
@@ -901,14 +905,14 @@ class DedupMergePhase:
         user_id: str,
         workspace_id: str | None,
         context_id: str | None,
-    ) -> None:
+    ) -> dict[str, Any] | None:
         """#1208 shadow-mode merge: record succession, mutate nothing.
 
         Creates a ``supersedes`` edge (src=winner, dst=loser,
         origin='semantic' — machine-inferred by the dedup judge, not
         user-asserted). The loser row, vector, tags and edges are all left
-        untouched: recall shadows it out by the edge alone, so deleting the
-        edge restores full visibility. Upserts via create_or_update_edge:
+        untouched: recall shadows it out by the edge alone, so undoing the
+        merge restores full visibility. Upserts via create_or_update_edge:
         ``unique_edge`` is keyed on (user, src, dst) regardless of edge_type,
         so a pre-existing edge between the pair (e.g. a Hebbian association
         between near-duplicates — the common case) must be retyped to
@@ -918,10 +922,30 @@ class DedupMergePhase:
         re-judging the same pair on a later run converges to the same row
         (and already-superseded pairs are filtered out before judging to
         avoid burning judge budget on settled pairs).
+
+        Returns:
+            Snapshot of the pre-merge edge state (type/origin/weight/
+            confidence/metadata) when the upsert retyped an existing
+            non-supersedes edge, else None. The caller stamps it into the
+            merge action's details as ``prior_edge`` so undo/rollback can
+            RESTORE the original association instead of deleting the row.
         """
         if not winner or not loser:
-            return
+            return None
         from models.memory import EDGE_ORIGIN_SEMANTIC, EDGE_TYPE_SUPERSEDES
+
+        prior = await self.edge_repo.get_edge(
+            user_id, winner.id, loser.id, workspace_id, context_id
+        )
+        prior_edge: dict[str, Any] | None = None
+        if prior is not None and prior.edge_type != EDGE_TYPE_SUPERSEDES:
+            prior_edge = {
+                "edge_type": prior.edge_type,
+                "origin": prior.origin,
+                "weight": prior.weight,
+                "confidence": prior.confidence,
+                "edge_metadata": prior.edge_metadata,
+            }
 
         await self.edge_repo.create_or_update_edge(
             user_id=user_id,
@@ -939,7 +963,9 @@ class DedupMergePhase:
             "dedup_shadow_merge",
             winner_id=str(winner.id),
             loser_id=str(loser.id),
+            retyped_prior_edge=prior_edge is not None,
         )
+        return prior_edge
 
     async def _filter_already_superseded_pairs(
         self,

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -908,16 +908,22 @@ class DedupMergePhase:
         origin='semantic' — machine-inferred by the dedup judge, not
         user-asserted). The loser row, vector, tags and edges are all left
         untouched: recall shadows it out by the edge alone, so deleting the
-        edge restores full visibility. Idempotent via create_edge_if_absent —
-        re-judging the same pair on a later run is a no-op (and
-        already-superseded pairs are filtered out before judging to avoid
-        burning judge budget on settled pairs).
+        edge restores full visibility. Upserts via create_or_update_edge:
+        ``unique_edge`` is keyed on (user, src, dst) regardless of edge_type,
+        so a pre-existing edge between the pair (e.g. a Hebbian association
+        between near-duplicates — the common case) must be retyped to
+        ``supersedes``, not silently left as-is while the action is audited
+        as mode=shadow. A pre-existing origin='declared' row keeps its
+        origin (sticky-origin CASE in the upsert). Idempotent —
+        re-judging the same pair on a later run converges to the same row
+        (and already-superseded pairs are filtered out before judging to
+        avoid burning judge budget on settled pairs).
         """
         if not winner or not loser:
             return
         from models.memory import EDGE_ORIGIN_SEMANTIC, EDGE_TYPE_SUPERSEDES
 
-        await self.edge_repo.create_edge_if_absent(
+        await self.edge_repo.create_or_update_edge(
             user_id=user_id,
             src_id=winner.id,
             dst_id=loser.id,
@@ -927,6 +933,7 @@ class DedupMergePhase:
             workspace_id=workspace_id,
             context_id=context_id,
             origin=EDGE_ORIGIN_SEMANTIC,
+            return_fresh_edge=False,
         )
         logger.info(
             "dedup_shadow_merge",

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -22,9 +22,72 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import Memory
 from models.sleep import SleepAction, SleepReport
+from utils.datetime import utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+async def revert_shadow_merge_edge(
+    db: AsyncSession,
+    *,
+    user_id: str,
+    winner_id: UUID,
+    loser_id: UUID,
+    prior_edge: dict[str, Any] | None,
+) -> bool:
+    """Undo ONE shadow-mode merge's supersedes edge (#1208).
+
+    Shared by run-level rollback and per-merge undo so the two paths cannot
+    drift. The shadow merge upserted ``supersedes`` over whatever edge
+    existed between (winner, loser); undoing it means:
+
+    - ``prior_edge`` snapshot present → restore the pre-merge edge state
+      (type/origin/weight/confidence/metadata) with a direct UPDATE — an
+      upsert cannot do this because the sticky-origin CASE refuses to
+      downgrade a non-hebbian origin back to hebbian.
+    - no snapshot (the merge CREATED the edge) → delete it, but only after
+      verifying it still is a ``supersedes`` edge: ``unique_edge`` is keyed
+      on (user, src, dst) regardless of edge_type, so a blind delete could
+      remove an unrelated association written since.
+
+    Returns:
+        True if an edge was restored or deleted; False if nothing matched
+        (the shadow merge was already undone, or the edge was retyped by a
+        later writer).
+    """
+    from sqlalchemy import delete as sa_delete
+
+    from models.memory import EDGE_TYPE_SUPERSEDES, NeuralMemoryEdge
+
+    if prior_edge:
+        result = await db.execute(
+            sa_update(NeuralMemoryEdge)
+            .where(
+                NeuralMemoryEdge.user_id == user_id,
+                NeuralMemoryEdge.src_id == winner_id,
+                NeuralMemoryEdge.dst_id == loser_id,
+                NeuralMemoryEdge.edge_type == EDGE_TYPE_SUPERSEDES,
+            )
+            .values(
+                edge_type=prior_edge.get("edge_type") or "neural_association",
+                origin=prior_edge.get("origin") or "hebbian",
+                weight=prior_edge.get("weight", 0.0),
+                confidence=prior_edge.get("confidence", 1.0),
+                edge_metadata=prior_edge.get("edge_metadata"),
+                last_updated=utcnow(),
+            )
+        )
+    else:
+        result = await db.execute(
+            sa_delete(NeuralMemoryEdge).where(
+                NeuralMemoryEdge.user_id == user_id,
+                NeuralMemoryEdge.src_id == winner_id,
+                NeuralMemoryEdge.dst_id == loser_id,
+                NeuralMemoryEdge.edge_type == EDGE_TYPE_SUPERSEDES,
+            )
+        )
+    return (result.rowcount or 0) > 0
 
 
 class UndoMergeError(Exception):
@@ -155,6 +218,55 @@ async def undo_merge_action(
     winner_id = action.memory_id
     if loser_id is None:
         raise UndoMergeError("not_a_merge", f"Sleep action {action_id} records no merge loser.")
+
+    # #1208 shadow-mode merge: the loser was never deleted, so the restore
+    # path below (deleted_at checks + re-embed) does not apply — undo means
+    # reverting the supersedes edge (winner → loser) instead.
+    if (action.details or {}).get("mode") == "shadow":
+        if winner_id is None:
+            raise UndoMergeError(
+                "not_a_merge", f"Sleep action {action_id} records no shadow-merge winner."
+            )
+        reverted = await revert_shadow_merge_edge(
+            db,
+            user_id=report.user_id,
+            winner_id=winner_id,
+            loser_id=loser_id,
+            prior_edge=(action.details or {}).get("prior_edge"),
+        )
+        if not reverted:
+            raise UndoMergeError(
+                "already_restored",
+                f"No supersedes edge {winner_id} → {loser_id} exists — this shadow "
+                "merge was already undone, or the edge was since retyped.",
+            )
+        undo_action = SleepAction(
+            report_id=action.report_id,
+            phase="dedup_merge",
+            action_type="undo_merge",
+            memory_id=loser_id,
+            target_id=winner_id,
+            details={
+                "undone_action_id": action.id,
+                "undone_by": acting_user_id,
+                "mode": "shadow",
+            },
+        )
+        db.add(undo_action)
+        await db.commit()
+        logger.info(
+            "dedup_shadow_merge_undone",
+            action_id=action_id,
+            unshadowed_memory_id=str(loser_id),
+            winner_id=str(winner_id),
+            report_id=str(action.report_id),
+        )
+        return {
+            "restored_memory_id": str(loser_id),
+            "winner_id": str(winner_id),
+            "report_id": str(action.report_id),
+            "undone_action_id": action.id,
+        }
 
     mem_result = await db.execute(select(Memory).where(Memory.id == loser_id))
     loser = mem_result.scalar_one_or_none()

--- a/backend/tests/services/sleep/test_dedup_merge.py
+++ b/backend/tests/services/sleep/test_dedup_merge.py
@@ -110,6 +110,7 @@ def _make_config(dedup_enabled=True, threshold=0.92, provider="openai", model="g
     config = MagicMock()
     config.sleep_dedup_enabled = dedup_enabled
     config.sleep_dedup_similarity_threshold = threshold
+    config.sleep_dedup_supersede_enabled = False  # #1208: remove mode (default)
     config.sleep_llm_provider = provider
     config.sleep_llm_model = model
     return config

--- a/backend/tests/services/sleep/test_dedup_merge_coverage.py
+++ b/backend/tests/services/sleep/test_dedup_merge_coverage.py
@@ -61,6 +61,7 @@ def _make_config(dedup_enabled=True, threshold=0.92, provider="openai", model="g
     config = MagicMock()
     config.sleep_dedup_enabled = dedup_enabled
     config.sleep_dedup_similarity_threshold = threshold
+    config.sleep_dedup_supersede_enabled = False  # #1208: remove mode (default)
     config.sleep_llm_provider = provider
     config.sleep_llm_model = model
     config.sleep_max_memories_per_run = 500

--- a/backend/tests/services/sleep/test_undo_merge.py
+++ b/backend/tests/services/sleep/test_undo_merge.py
@@ -123,3 +123,92 @@ async def test_happy_path_restores_reembeds_and_audits() -> None:
     assert added.details["undone_action_id"] == 42
     assert added.details["undone_by"] == "admin-user"
     db.commit.assert_awaited_once()
+
+
+# ------------------------------------------------------------ shadow merges
+
+
+def _shadow_action(prior_edge=None) -> MagicMock:
+    action = _action()
+    action.details = {"mode": "shadow", "prior_edge": prior_edge}
+    return action
+
+
+def _shadow_db(first_row, revert_rowcount: int) -> AsyncMock:
+    """AsyncMock db: 1st execute -> (action, report) join, 2nd -> the edge
+    revert (UPDATE restore or verified DELETE) with the given rowcount."""
+    db = AsyncMock()
+    join_result = MagicMock()
+    join_result.first.return_value = first_row
+    revert_result = MagicMock()
+    revert_result.rowcount = revert_rowcount
+    db.execute.side_effect = [join_result, revert_result]
+    db.add = MagicMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_deletes_created_edge_and_audits() -> None:
+    """#1208: a shadow merge never deleted the loser — undo means removing
+    the supersedes edge, audited as undo_merge with mode=shadow."""
+    action = _shadow_action(prior_edge=None)
+    db = _shadow_db((action, _report()), revert_rowcount=1)
+
+    summary = await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert summary["restored_memory_id"] == str(action.target_id)
+    assert summary["undone_action_id"] == 42
+    added = db.add.call_args.args[0]
+    assert added.action_type == "undo_merge"
+    assert added.details["mode"] == "shadow"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_restores_prior_edge_state() -> None:
+    """When the shadow merge retyped a pre-existing edge, undo must issue an
+    UPDATE restoring the snapshot, not a DELETE (the association survives)."""
+    from sqlalchemy.sql.dml import Update
+
+    prior = {
+        "edge_type": "neural_association",
+        "origin": "hebbian",
+        "weight": 0.4,
+        "confidence": 0.9,
+        "edge_metadata": None,
+    }
+    action = _shadow_action(prior_edge=prior)
+    db = _shadow_db((action, _report()), revert_rowcount=1)
+
+    await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    revert_stmt = db.execute.call_args_list[1].args[0]
+    assert isinstance(revert_stmt, Update)
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_without_snapshot_deletes() -> None:
+    """No snapshot means the merge CREATED the edge — undo deletes it."""
+    from sqlalchemy.sql.dml import Delete
+
+    action = _shadow_action(prior_edge=None)
+    db = _shadow_db((action, _report()), revert_rowcount=1)
+
+    await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    revert_stmt = db.execute.call_args_list[1].args[0]
+    assert isinstance(revert_stmt, Delete)
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_gone_edge_is_already_restored() -> None:
+    """Edge already gone (or retyped by a later writer) → stable error,
+    nothing audited."""
+    action = _shadow_action(prior_edge=None)
+    db = _shadow_db((action, _report()), revert_rowcount=0)
+
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert exc.value.code == "already_restored"
+    db.add.assert_not_called()

--- a/backend/tests/services/test_graph_service_edge_types.py
+++ b/backend/tests/services/test_graph_service_edge_types.py
@@ -40,11 +40,13 @@ import pytest
 from models.memory import (
     EDGE_ORIGIN_DECLARED,
     EDGE_TYPE_CONTINUES_FROM,
+    EDGE_TYPE_CONTRADICTS,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SUPERSEDES,
 )
 from services.graph_service import GraphService
 
@@ -67,6 +69,9 @@ def test_edge_types_matches_constants() -> None:
             EDGE_TYPE_LEARNED_FROM,
             EDGE_TYPE_CONTINUES_FROM,
             EDGE_TYPE_REFERENCES_FILE,
+            # #1208: fact-succession relations.
+            EDGE_TYPE_SUPERSEDES,
+            EDGE_TYPE_CONTRADICTS,
         }
     )
 

--- a/backend/tests/services/test_supersede_shadowing.py
+++ b/backend/tests/services/test_supersede_shadowing.py
@@ -171,12 +171,14 @@ class TestShadowMergeMode:
     async def test_shadow_merge_creates_edge_and_mutates_nothing(self) -> None:
         phase = DedupMergePhase(MagicMock(), MagicMock())
         phase.edge_repo = MagicMock()
-        phase.edge_repo.create_edge_if_absent = AsyncMock()
+        # Upsert, not create-if-absent: a pre-existing edge between the pair
+        # (unique_edge ignores edge_type) must be retyped to supersedes.
+        phase.edge_repo.create_or_update_edge = AsyncMock()
         winner, loser = _mem(uuid4()), _mem(uuid4())
 
         await phase._execute_shadow_merge(winner, loser, "u", None, None)
 
-        kwargs = phase.edge_repo.create_edge_if_absent.await_args.kwargs
+        kwargs = phase.edge_repo.create_or_update_edge.await_args.kwargs
         assert kwargs["src_id"] == winner.id  # src = superseding (winner)
         assert kwargs["dst_id"] == loser.id  # dst = superseded (loser)
         assert kwargs["edge_type"] == "supersedes"

--- a/backend/tests/services/test_supersede_shadowing.py
+++ b/backend/tests/services/test_supersede_shadowing.py
@@ -1,0 +1,214 @@
+"""#1208: supersedes/contradicts relations + recall-time shadowing.
+
+Pins the non-destructive update path:
+
+1. **Shadow filter**: a candidate that is the dst of a LIVE supersedes edge
+   is removed from the pool before the top-k slice; ``include_superseded``
+   keeps it and the shadow map annotates it.
+2. **Self-healing**: the liveness JOIN means a deleted superseder stops
+   shadowing (simulated here by the query returning no rows for that edge).
+3. **contradicts never hides** — both sides are annotated, nothing is
+   filtered.
+4. **Over-supersede placebo (deterministic form)**: memories NOT linked by a
+   supersedes edge are never filtered — shadowing cannot leak onto distinct
+   facts that merely co-occur in the results.
+5. **Fail-open**: an edge-query error preserves the original results.
+6. Shadow-mode dedup merge records a supersedes edge and mutates nothing;
+   already-settled pairs are filtered before judging.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.memory_service import MemoryService
+from services.sleep.dedup_merge import DedupMergePhase
+
+
+def _mem(mid) -> MagicMock:
+    m = MagicMock()
+    m.id = mid
+    return m
+
+
+def _service_with_edges(supersede_rows, contradict_rows) -> MemoryService:
+    svc = MemoryService(MagicMock())
+    db = AsyncMock()
+    s_result = MagicMock()
+    s_result.all.return_value = supersede_rows
+    c_result = MagicMock()
+    c_result.all.return_value = contradict_rows
+    db.execute.side_effect = [s_result, c_result]
+    svc.db = db
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_shadowed_memory_filtered_out_by_default() -> None:
+    old_id, new_id, other_id = uuid4(), uuid4(), uuid4()
+    memories = {str(old_id): _mem(old_id), str(other_id): _mem(other_id)}
+    search_results = [
+        {"id": str(old_id), "score": 0.9},
+        {"id": str(other_id), "score": 0.8},
+    ]
+    svc = _service_with_edges([(old_id, new_id)], [])
+
+    shadow_map, contradiction_map = await svc._apply_supersede_shadowing(
+        search_results, memories, user_id="u", include_superseded=False
+    )
+
+    assert shadow_map == {old_id: new_id}
+    assert [r["id"] for r in search_results] == [str(other_id)]
+    assert contradiction_map == {}
+
+
+@pytest.mark.asyncio
+async def test_include_superseded_keeps_and_annotates() -> None:
+    old_id, new_id = uuid4(), uuid4()
+    memories = {str(old_id): _mem(old_id)}
+    search_results = [{"id": str(old_id), "score": 0.9}]
+    svc = _service_with_edges([(old_id, new_id)], [])
+
+    shadow_map, _ = await svc._apply_supersede_shadowing(
+        search_results, memories, user_id="u", include_superseded=True
+    )
+
+    assert shadow_map == {old_id: new_id}
+    assert len(search_results) == 1  # kept — annotation is the caller's job
+
+
+@pytest.mark.asyncio
+async def test_dead_superseder_stops_shadowing() -> None:
+    """Self-healing: the liveness JOIN yields no row when the superseding
+    memory was deleted — the previously shadowed memory surfaces again."""
+    old_id = uuid4()
+    memories = {str(old_id): _mem(old_id)}
+    search_results = [{"id": str(old_id), "score": 0.9}]
+    # JOIN against a deleted src returns nothing.
+    svc = _service_with_edges([], [])
+
+    shadow_map, _ = await svc._apply_supersede_shadowing(
+        search_results, memories, user_id="u", include_superseded=False
+    )
+
+    assert shadow_map == {}
+    assert len(search_results) == 1
+
+
+@pytest.mark.asyncio
+async def test_contradicts_never_hides_annotates_both_sides() -> None:
+    a_id, b_id = uuid4(), uuid4()
+    memories = {str(a_id): _mem(a_id), str(b_id): _mem(b_id)}
+    search_results = [
+        {"id": str(a_id), "score": 0.9},
+        {"id": str(b_id), "score": 0.8},
+    ]
+    svc = _service_with_edges([], [(a_id, b_id)])
+
+    shadow_map, contradiction_map = await svc._apply_supersede_shadowing(
+        search_results, memories, user_id="u", include_superseded=False
+    )
+
+    assert shadow_map == {}
+    assert len(search_results) == 2  # nothing hidden
+    assert contradiction_map[a_id] == [b_id]
+    assert contradiction_map[b_id] == [a_id]
+
+
+@pytest.mark.asyncio
+async def test_over_supersede_placebo_unlinked_memories_untouched() -> None:
+    """Distinct facts without a supersedes edge are NEVER filtered — the
+    deterministic form of the over-supersede placebo: shadowing cannot leak
+    beyond explicitly linked pairs."""
+    ids = [uuid4() for _ in range(4)]
+    memories = {str(i): _mem(i) for i in ids}
+    search_results = [{"id": str(i), "score": 0.9} for i in ids]
+    shadowed_id, superseder = ids[0], uuid4()
+    svc = _service_with_edges([(shadowed_id, superseder)], [])
+
+    shadow_map, _ = await svc._apply_supersede_shadowing(
+        search_results, memories, user_id="u", include_superseded=False
+    )
+
+    assert set(shadow_map) == {shadowed_id}
+    survivors = {r["id"] for r in search_results}
+    assert survivors == {str(i) for i in ids[1:]}  # only the linked dst dropped
+
+
+@pytest.mark.asyncio
+async def test_fail_open_on_query_error() -> None:
+    old_id = uuid4()
+    memories = {str(old_id): _mem(old_id)}
+    search_results = [{"id": str(old_id), "score": 0.9}]
+    svc = MemoryService(MagicMock())
+    db = AsyncMock()
+    db.execute.side_effect = RuntimeError("edge table on fire")
+    svc.db = db
+
+    shadow_map, contradiction_map = await svc._apply_supersede_shadowing(
+        search_results, memories, user_id="u", include_superseded=False
+    )
+
+    assert shadow_map == {} and contradiction_map == {}
+    assert len(search_results) == 1  # original results preserved
+
+
+@pytest.mark.asyncio
+async def test_empty_candidates_short_circuits() -> None:
+    svc = MemoryService(MagicMock())
+    svc.db = AsyncMock()
+    shadow_map, _ = await svc._apply_supersede_shadowing(
+        [], {}, user_id="u", include_superseded=False
+    )
+    assert shadow_map == {}
+    svc.db.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------- dedup mode
+
+
+class TestShadowMergeMode:
+    @pytest.mark.asyncio
+    async def test_shadow_merge_creates_edge_and_mutates_nothing(self) -> None:
+        phase = DedupMergePhase(MagicMock(), MagicMock())
+        phase.edge_repo = MagicMock()
+        phase.edge_repo.create_edge_if_absent = AsyncMock()
+        winner, loser = _mem(uuid4()), _mem(uuid4())
+
+        await phase._execute_shadow_merge(winner, loser, "u", None, None)
+
+        kwargs = phase.edge_repo.create_edge_if_absent.await_args.kwargs
+        assert kwargs["src_id"] == winner.id  # src = superseding (winner)
+        assert kwargs["dst_id"] == loser.id  # dst = superseded (loser)
+        assert kwargs["edge_type"] == "supersedes"
+        assert kwargs["origin"] == "semantic"  # machine-inferred, not declared
+
+    @pytest.mark.asyncio
+    async def test_settled_pairs_filtered_before_judging(self) -> None:
+        phase = DedupMergePhase(MagicMock(), MagicMock())
+        a, b, c, d = uuid4(), uuid4(), uuid4(), uuid4()
+        pairs = [(a, b, 0.95), (c, d, 0.94)]
+        db = AsyncMock()
+        rows = MagicMock()
+        rows.all.return_value = [(b, a)]  # (a, b) already settled, either direction
+        db.execute.return_value = rows
+        phase.db = db
+
+        remaining, skipped = await phase._filter_already_superseded_pairs(pairs, "u")
+
+        assert remaining == [(c, d, 0.94)]
+        assert skipped == 1
+
+    @pytest.mark.asyncio
+    async def test_no_settled_pairs_is_passthrough(self) -> None:
+        phase = DedupMergePhase(MagicMock(), MagicMock())
+        pairs = [(uuid4(), uuid4(), 0.95)]
+        db = AsyncMock()
+        rows = MagicMock()
+        rows.all.return_value = []
+        db.execute.return_value = rows
+        phase.db = db
+
+        remaining, skipped = await phase._filter_already_superseded_pairs(pairs, "u")
+        assert remaining == pairs and skipped == 0

--- a/backend/tests/services/test_supersede_shadowing.py
+++ b/backend/tests/services/test_supersede_shadowing.py
@@ -55,7 +55,7 @@ async def test_shadowed_memory_filtered_out_by_default() -> None:
     svc = _service_with_edges([(old_id, new_id)], [])
 
     shadow_map, contradiction_map = await svc._apply_supersede_shadowing(
-        search_results, memories, user_id="u", include_superseded=False
+        search_results, memories, include_superseded=False
     )
 
     assert shadow_map == {old_id: new_id}
@@ -71,7 +71,7 @@ async def test_include_superseded_keeps_and_annotates() -> None:
     svc = _service_with_edges([(old_id, new_id)], [])
 
     shadow_map, _ = await svc._apply_supersede_shadowing(
-        search_results, memories, user_id="u", include_superseded=True
+        search_results, memories, include_superseded=True
     )
 
     assert shadow_map == {old_id: new_id}
@@ -89,7 +89,7 @@ async def test_dead_superseder_stops_shadowing() -> None:
     svc = _service_with_edges([], [])
 
     shadow_map, _ = await svc._apply_supersede_shadowing(
-        search_results, memories, user_id="u", include_superseded=False
+        search_results, memories, include_superseded=False
     )
 
     assert shadow_map == {}
@@ -107,7 +107,7 @@ async def test_contradicts_never_hides_annotates_both_sides() -> None:
     svc = _service_with_edges([], [(a_id, b_id)])
 
     shadow_map, contradiction_map = await svc._apply_supersede_shadowing(
-        search_results, memories, user_id="u", include_superseded=False
+        search_results, memories, include_superseded=False
     )
 
     assert shadow_map == {}
@@ -128,7 +128,7 @@ async def test_over_supersede_placebo_unlinked_memories_untouched() -> None:
     svc = _service_with_edges([(shadowed_id, superseder)], [])
 
     shadow_map, _ = await svc._apply_supersede_shadowing(
-        search_results, memories, user_id="u", include_superseded=False
+        search_results, memories, include_superseded=False
     )
 
     assert set(shadow_map) == {shadowed_id}
@@ -147,7 +147,7 @@ async def test_fail_open_on_query_error() -> None:
     svc.db = db
 
     shadow_map, contradiction_map = await svc._apply_supersede_shadowing(
-        search_results, memories, user_id="u", include_superseded=False
+        search_results, memories, include_superseded=False
     )
 
     assert shadow_map == {} and contradiction_map == {}
@@ -158,9 +158,7 @@ async def test_fail_open_on_query_error() -> None:
 async def test_empty_candidates_short_circuits() -> None:
     svc = MemoryService(MagicMock())
     svc.db = AsyncMock()
-    shadow_map, _ = await svc._apply_supersede_shadowing(
-        [], {}, user_id="u", include_superseded=False
-    )
+    shadow_map, _ = await svc._apply_supersede_shadowing([], {}, include_superseded=False)
     assert shadow_map == {}
     svc.db.execute.assert_not_awaited()
 

--- a/backend/tests/services/test_supersede_shadowing.py
+++ b/backend/tests/services/test_supersede_shadowing.py
@@ -17,6 +17,7 @@ Pins the non-destructive update path:
    already-settled pairs are filtered before judging.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -173,16 +174,66 @@ class TestShadowMergeMode:
         phase.edge_repo = MagicMock()
         # Upsert, not create-if-absent: a pre-existing edge between the pair
         # (unique_edge ignores edge_type) must be retyped to supersedes.
+        phase.edge_repo.get_edge = AsyncMock(return_value=None)
         phase.edge_repo.create_or_update_edge = AsyncMock()
         winner, loser = _mem(uuid4()), _mem(uuid4())
 
-        await phase._execute_shadow_merge(winner, loser, "u", None, None)
+        prior = await phase._execute_shadow_merge(winner, loser, "u", None, None)
 
         kwargs = phase.edge_repo.create_or_update_edge.await_args.kwargs
         assert kwargs["src_id"] == winner.id  # src = superseding (winner)
         assert kwargs["dst_id"] == loser.id  # dst = superseded (loser)
         assert kwargs["edge_type"] == "supersedes"
         assert kwargs["origin"] == "semantic"  # machine-inferred, not declared
+        assert prior is None  # no pre-existing edge → nothing to snapshot
+
+    @pytest.mark.asyncio
+    async def test_shadow_merge_snapshots_retyped_prior_edge(self) -> None:
+        """The upsert retypes a pre-existing (e.g. Hebbian) edge — its
+        pre-merge state must come back as a snapshot so undo can RESTORE
+        the association instead of deleting the row."""
+        phase = DedupMergePhase(MagicMock(), MagicMock())
+        phase.edge_repo = MagicMock()
+        existing = SimpleNamespace(
+            edge_type="neural_association",
+            origin="hebbian",
+            weight=0.4,
+            confidence=0.9,
+            edge_metadata={"source": "tag_cooccurrence"},
+        )
+        phase.edge_repo.get_edge = AsyncMock(return_value=existing)
+        phase.edge_repo.create_or_update_edge = AsyncMock()
+
+        prior = await phase._execute_shadow_merge(_mem(uuid4()), _mem(uuid4()), "u", None, None)
+
+        assert prior == {
+            "edge_type": "neural_association",
+            "origin": "hebbian",
+            "weight": 0.4,
+            "confidence": 0.9,
+            "edge_metadata": {"source": "tag_cooccurrence"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_shadow_merge_existing_supersedes_not_snapshotted(self) -> None:
+        """Re-judging an already-shadowed pair must not snapshot the
+        supersedes edge itself as 'prior' (undo would then 'restore'
+        supersedes — a no-op disguised as a revert)."""
+        phase = DedupMergePhase(MagicMock(), MagicMock())
+        phase.edge_repo = MagicMock()
+        existing = SimpleNamespace(
+            edge_type="supersedes",
+            origin="semantic",
+            weight=1.0,
+            confidence=1.0,
+            edge_metadata=None,
+        )
+        phase.edge_repo.get_edge = AsyncMock(return_value=existing)
+        phase.edge_repo.create_or_update_edge = AsyncMock()
+
+        prior = await phase._execute_shadow_merge(_mem(uuid4()), _mem(uuid4()), "u", None, None)
+
+        assert prior is None
 
     @pytest.mark.asyncio
     async def test_settled_pairs_filtered_before_judging(self) -> None:

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -24,11 +24,13 @@ from mcp_server.tools.edge import VALID_EDGE_TYPES
 from models.memory import (
     _ALL_EDGE_TYPES,
     EDGE_TYPE_CONTINUES_FROM,
+    EDGE_TYPE_CONTRADICTS,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SUPERSEDES,
 )
 from services.graph_service import GraphService
 from services.sleep.edge_discovery import LLM_EMITTABLE_EDGE_TYPES
@@ -49,6 +51,8 @@ def test_valid_edge_types_matches_constants() -> None:
             EDGE_TYPE_LEARNED_FROM,
             EDGE_TYPE_CONTINUES_FROM,
             EDGE_TYPE_REFERENCES_FILE,
+            EDGE_TYPE_SUPERSEDES,
+            EDGE_TYPE_CONTRADICTS,
         }
     )
 
@@ -115,7 +119,8 @@ def test_valid_edge_type_check_constraint_matches_migration_literal() -> None:
 
     expected = (
         "edge_type IN ('neural_association', 'related_to', 'depends_on', "
-        "'learned_from', 'continues_from', 'references_file')"
+        "'learned_from', 'continues_from', 'references_file', "
+        "'supersedes', 'contradicts')"
     )
 
     valid_edge_type_check = next(

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -135,6 +135,32 @@ enable them per context with `update_search_config`
 monitoring telemetry. (Rare legacy contexts that never got a config row
 adopt the new default the first time the row is materialized.)
 
+## Fact Succession (supersedes / contradicts)
+
+When a fact changes, the worst thing a memory system can do is delete the old
+version (the truth is gone) or keep returning it (the truth is buried). Since
+#1208 Kagura models succession **non-destructively** with two typed relations:
+
+- **`supersedes`** — `src` is the newer memory, `dst` the outdated one it
+  replaces. A memory that is the dst of a live supersedes edge is
+  **shadowed**: default `recall()` demotes it out of results, but it is never
+  deleted — `recall(include_superseded=true)` returns it annotated with
+  `superseded_by`, `explore()` still reaches it, and deleting the edge (or
+  the superseding memory) restores full visibility. Create it by storing the
+  updated fact with `remember(..., supersedes=<old_memory_id>)`, or
+  explicitly with `create_edge(edge_type="supersedes")`.
+- **`contradicts`** — two memories disagree and neither is known to be
+  current. Contradiction **never hides** either side: both surface in recall
+  annotated with the opposing memory ids. Resolving a contradiction is an
+  arbitration decision (yours or a future judge's), not a deletion.
+
+Sleep's dedup phase can also record succession instead of removing
+duplicates: with `sleep_dedup_supersede_enabled` (default **off** —
+update-by-removal remains the default), a judged merge creates a
+`supersedes` edge (origin `semantic`) and leaves the loser
+alive-but-shadowed. Neither type is LLM-emittable by edge discovery — the
+sleep judge cannot invent supersession.
+
 ## Neural Memory
 
 **Neural Memory** creates automatic relationships between memories using brain-inspired algorithms.

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2749,6 +2749,7 @@
         "sleep_dedup_enabled": "Enable dedup/merge phase",
         "sleep_dedup_similarity_threshold": "Cosine similarity threshold for duplicate detection",
         "sleep_merge_retention_days": "Merge-loser purge window in days (0 = retain forever)",
+        "sleep_dedup_supersede_enabled": "Dedup shadow mode: record supersedes edges instead of deleting losers",
         "sleep_edge_discovery_enabled": "Enable edge discovery phase",
         "sleep_edge_discovery_sample_size": "Number of memories to sample per edge discovery run",
         "sleep_importance_reeval_enabled": "Enable importance re-evaluation phase"

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2749,6 +2749,7 @@
         "sleep_dedup_enabled": "重複排除/マージフェーズを有効化",
         "sleep_dedup_similarity_threshold": "重複検出のコサイン類似度しきい値",
         "sleep_merge_retention_days": "マージ敗者のパージ猶予日数（0 = 永久保持）",
+        "sleep_dedup_supersede_enabled": "dedupシャドウモード：敗者を削除せず supersedes エッジを記録",
         "sleep_edge_discovery_enabled": "エッジ発見フェーズを有効化",
         "sleep_edge_discovery_sample_size": "エッジ発見 1 回あたりのサンプルメモリ数",
         "sleep_importance_reeval_enabled": "重要度再評価フェーズを有効化"


### PR DESCRIPTION
Closes #1208

## Summary
- **Fact succession, modeled non-destructively**: `supersedes` + `contradicts` edge types (reusing the #722 typed-edge/origin machinery — no new tables). Direction convention: **src = superseding (newer), dst = superseded (older)**, consistent across constants, migration, MCP schemas, docs, and tests.
- **Recall shadowing**: memories that are the dst of a **live** supersedes edge are demoted out of the candidate pool before re-rank + top-k slice. `recall(include_superseded=true)` opts them back in annotated with `superseded_by`. The liveness JOIN is self-healing — a deleted superseder stops shadowing; deleting the edge restores full visibility. **`contradicts` never hides**: both sides surface annotated. Fail-open: a shadow-query error preserves results (never blank recall).
- **Shared contexts work**: shadow queries are deliberately not scoped to the calling user — member B's supersede shadows the stale fact for member A too (candidate ids are visibility-scoped upstream; edge creation validates endpoints in the creator's own context; UUIDs globally unique).
- **Write path**: `remember(..., supersedes=<memory_id>)` records succession at store time (origin `declared`, same-scope + active-target validated, best-effort like `linked_memory_ids`).
- **Sleep shadow mode**: `sleep_dedup_supersede_enabled` (default **OFF** — update-by-removal preserved byte-identically). ON: judged merges record a `supersedes` edge (origin `semantic`) and mutate **nothing**; already-settled pairs are filtered before judging (no judge budget burned on settled pairs); merge audit actions carry `mode`; `rollback_sleep_run` undoes a shadow merge by deleting the edge.
- **Over-supersede placebo (deterministic form)**: tests pin that shadowing cannot leak beyond explicitly linked pairs — unlinked distinct facts are never filtered.
- Not LLM-emittable: the sleep edge-discovery judge cannot invent supersession (structural over-supersede prevention).

## Implementation notes
- **⚠ Migration merge coordination (now 3 parallel)**: `e55` (#1215), `e56` (#1217), `e57` (this PR) all chain from `e54`. **Merge order decides**: each later-merging PR bumps its migration's `down_revision` to the then-current head (one line; noted in every migration docstring). `dedup_merge.py` is touched by both #1217 and this PR — the second squash merge will need a small conflict resolution in the merge loop.
- Constraint lock-step: `_ALL_EDGE_TYPES` (ORM CHECK f-string) + `e57` CHECK literal + MCP `VALID_EDGE_TYPES` + `GraphService.EDGE_TYPES` + both enum'd tool schemas + pinned literal test all updated together (the #461/#509 drift tests enforce this).
- Verified: 888-test battery green; e57 applied to a scratch DB (CHECK widened, config seed present); ruff/format clean. Acceptance criteria on frozen-corpus numbers are guaranteed **by construction** (the corpora contain no supersede edges — recall paths are byte-identical without edges); live re-measurement is owned by #1210's nightly gates.

## Pre-PR review summary
- gate2 mode: advisor-only / audit: skipped / binary_gate: (none)
- cso: green — 3-layer guard on the unscoped shadow query; malicious-member residual equals existing write-privilege trust, but auditable and reversible
- qa-lead: yellow — shared-context cross-owner shadowing + rollback shadow-merge branch lack DB-backed integration tests; frozen-metric invariance is constructional
- cto: green — minimal-invasive edge reuse; direction convention consistent across 5 surfaces; debt = 3-way migration coordination + dedup_merge conflict at second merge
- gate1: green via /ask (CTO lens — direction convention, self-healing JOIN, default-off sleep mode, LLM-emittable exclusion all incorporated)
- review provider: code-review — 2 findings applied (shared-context scoping was the critical one; shadow-merge rollback)

Follow-ups:
- DB-backed integration tests for cross-owner shadowing + shadow-merge rollback
- Shadowed-memory count as a #1211 memory-health metric (Qdrant candidate-slot occupancy)

Full reviews: ~/.claude/cache/gh-issue-driven/1208-feat-feat-api-supersedes-contradicts-relation.gate{1,2}.md

🤖 Generated via /gh-issue-driven:ship
