### PR TITLE
feat(api,frontend): consolidated memory-health report (#1211)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -493,6 +493,7 @@ for _exc_cls in (
 
 from api.routes import (  # noqa: E402
     admin,
+    admin_memory_health,  # Issue #1211: consolidated memory-health report
     admin_neural,  # Issue #406: Manual kNN calibration recalibrate trigger
     admin_plans,
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
@@ -608,6 +609,9 @@ app.include_router(analyses.router, prefix="/api/v1")
 
 # Admin Sleep trigger (Issue #247 - Manual Sleep Maintenance trigger)
 app.include_router(admin_sleep.router, prefix="/api/v1")
+
+# Consolidated memory-health report (Issue #1211)
+app.include_router(admin_memory_health.router, prefix="/api/v1")
 
 # Admin Neural calibrate trigger (Issue #406 Phase B - Manual kNN recalibration)
 app.include_router(admin_neural.router, prefix="/api/v1")

--- a/backend/src/api/routes/admin_memory_health.py
+++ b/backend/src/api/routes/admin_memory_health.py
@@ -1,0 +1,77 @@
+"""Consolidated memory-health report API (#1211).
+
+One endpoint answering "is this partition's memory healthy?" from the
+signals the system already emits (sleep reports, graph invariants, usage
+stats, config posture) — thresholded ok/warn/fail per section so a
+silent-judge-death class of failure (#1177) surfaces without an external
+eval program. Self-scoped like the manual sleep trigger (Phase 1).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import AdminUser
+from db.base import get_db
+from services.memory_health_service import MemoryHealthService
+from utils.exceptions import MemoryCloudException
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/admin/memory-health", tags=["admin-memory-health"])
+
+
+class MemoryHealthSection(BaseModel):
+    """One graded health section.
+
+    Attributes:
+        status: ok | warn | fail (fail only on deterministic facts).
+        metrics: Label-free numeric signals backing the grade.
+        notes: Human-readable explanations for every non-ok contribution.
+    """
+
+    status: str
+    metrics: dict[str, Any]
+    notes: list[str]
+
+
+class MemoryHealthResponse(BaseModel):
+    """200 response for GET /admin/memory-health."""
+
+    generated_at: str
+    overall_status: str
+    sections: dict[str, MemoryHealthSection]
+
+
+@router.get(
+    "",
+    response_model=MemoryHealthResponse,
+    summary="Consolidated memory-health report (self-diagnosis)",
+)
+async def get_memory_health(
+    admin: AdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> MemoryHealthResponse:
+    """Build the thresholded health document for the calling admin's data.
+
+    Sections: consolidation (judge health, merge audit, soft-delete
+    backlog), graph (edge composition, weight invariant, cold-graph
+    check), retrieval (usage volume, config posture). Label-free signals
+    only — gold-label rates (stale_only, P@k) live in the #1210 eval
+    gates, not here.
+    """
+    user_id = admin.get("user_id")
+    if not user_id:
+        raise MemoryCloudException(
+            message="Admin user id missing from session.",
+            status_code=500,
+            error_code="HEALTH-001",
+        )
+
+    report = await MemoryHealthService(db).build_report(user_id)
+    return MemoryHealthResponse(**report)

--- a/backend/src/api/routes/admin_memory_health.py
+++ b/backend/src/api/routes/admin_memory_health.py
@@ -9,7 +9,7 @@ eval program. Self-scoped like the manual sleep trigger (Phase 1).
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
@@ -26,6 +26,9 @@ logger = get_logger(__name__)
 router = APIRouter(prefix="/admin/memory-health", tags=["admin-memory-health"])
 
 
+HealthStatus = Literal["ok", "warn", "fail"]
+
+
 class MemoryHealthSection(BaseModel):
     """One graded health section.
 
@@ -35,7 +38,7 @@ class MemoryHealthSection(BaseModel):
         notes: Human-readable explanations for every non-ok contribution.
     """
 
-    status: str
+    status: HealthStatus
     metrics: dict[str, Any]
     notes: list[str]
 
@@ -44,7 +47,7 @@ class MemoryHealthResponse(BaseModel):
     """200 response for GET /admin/memory-health."""
 
     generated_at: str
-    overall_status: str
+    overall_status: HealthStatus
     sections: dict[str, MemoryHealthSection]
 
 

--- a/backend/src/services/memory_health_service.py
+++ b/backend/src/services/memory_health_service.py
@@ -1,0 +1,332 @@
+"""Consolidated memory-health report (#1211) — runtime self-diagnosis.
+
+The eval program's most transferable lesson: memory failures manifest as
+plausible successes (``sleep_summary.ok=true`` while every judge call failed,
+#1177). The system already emits the needed signals — ``llm_call_failures``
+(#1183), ``winner_overrides`` (#1198), merge counts and cluster stats, graph
+stats, soft-delete rows — but they are fragmented across the Sleep report,
+graph stats, memory stats and logs. This service assembles them into ONE
+thresholded document so a silent-judge-death class of failure surfaces as
+WARN/FAIL within one sleep cycle instead of via an external eval program.
+
+Scope rules (gate1/COO):
+
+- **Label-free only**: rates that need gold labels (``stale_only``, P@k)
+  belong to the eval harness / #1210 CI gates, not here.
+- **No log-derived metrics**: signals that exist only in structlog output
+  (e.g. ``reinforce_rerank_applied``) are excluded until they are persisted —
+  not rendered as "pending".
+- **Conservative thresholds**: FAIL only on deterministic facts (latest run
+  failed, invariant violated); WARN on degradation signals. A false FAIL
+  erodes dashboard trust (the eval-infra lesson).
+- **Self-scoped** (Phase-1, same discipline as the manual sleep trigger):
+  the report covers the calling admin's own data partition.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import Context, UsageStats
+from models.config import ContextSearchConfig
+from models.memory import Memory, NeuralMemoryEdge
+from models.sleep import SleepReport
+from utils.datetime import to_utc_iso, utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+STATUS_OK = "ok"
+STATUS_WARN = "warn"
+STATUS_FAIL = "fail"
+
+_STATUS_RANK = {STATUS_OK: 0, STATUS_WARN: 1, STATUS_FAIL: 2}
+
+# Sleep reports considered "the recent window" for consolidation grading.
+_REPORT_WINDOW = 20
+# Soft-deleted merge losers older than this warn (retention likely wanted).
+_BACKLOG_WARN_DAYS = 90
+# A graph with this many active memories and zero edges is suspiciously cold.
+_COLD_GRAPH_MIN_MEMORIES = 25
+# Retrieval activity window.
+_USAGE_WINDOW_DAYS = 7
+
+_EDGE_WEIGHT_MIN = 0.0
+_EDGE_WEIGHT_MAX = 3.0
+
+
+def _worst(statuses: list[str]) -> str:
+    return max(statuses, key=lambda s: _STATUS_RANK[s]) if statuses else STATUS_OK
+
+
+class MemoryHealthService:
+    """Builds the consolidated memory-health document for one user partition."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def build_report(self, user_id: str) -> dict[str, Any]:
+        """Assemble all sections and grade them.
+
+        Returns a JSON-shaped dict:
+        ``{generated_at, overall_status, sections: {name: {status, metrics,
+        notes}}}``.
+        """
+        consolidation = self._grade_consolidation(
+            await self._fetch_sleep_window(user_id),
+            await self._fetch_merge_backlog(user_id),
+        )
+        graph = self._grade_graph(await self._fetch_graph_stats(user_id))
+        retrieval = self._grade_retrieval(
+            await self._fetch_usage_counts(user_id),
+            await self._fetch_config_posture(user_id),
+            active_memories=graph["metrics"]["active_memories"],
+        )
+
+        sections = {
+            "consolidation": consolidation,
+            "graph": graph,
+            "retrieval": retrieval,
+        }
+        return {
+            "generated_at": to_utc_iso(utcnow()),
+            "overall_status": _worst([s["status"] for s in sections.values()]),
+            "sections": sections,
+        }
+
+    # ------------------------------------------------------------- fetchers
+
+    async def _fetch_sleep_window(self, user_id: str) -> list[dict[str, Any]]:
+        """Most recent sleep reports (newest first), flattened for grading."""
+        result = await self.db.execute(
+            select(SleepReport)
+            .where(SleepReport.user_id == user_id)
+            .order_by(SleepReport.started_at.desc())
+            .limit(_REPORT_WINDOW)
+        )
+        reports = list(result.scalars().all())
+        window: list[dict[str, Any]] = []
+        for r in reports:
+            dedup = r.dedup_result or {}
+            details = dedup.get("details") or {}
+            window.append(
+                {
+                    "status": r.status,
+                    "llm_call_failures": r.llm_call_failures or 0,
+                    "memories_merged": r.memories_merged or 0,
+                    "winner_overrides": details.get("winner_overrides", 0),
+                    "deferred_pairs": details.get("deferred_pairs", 0),
+                    "oversize_clusters": details.get("oversize_clusters", 0),
+                    "started_at": to_utc_iso(r.started_at) if r.started_at else None,
+                }
+            )
+        return window
+
+    async def _fetch_merge_backlog(self, user_id: str) -> dict[str, Any]:
+        """Soft-deleted merge losers: count + oldest age in days."""
+        result = await self.db.execute(
+            select(func.count(Memory.id), func.min(Memory.deleted_at)).where(
+                Memory.user_id == user_id,
+                Memory.deleted_by == "sleep_maintenance",
+                Memory.deleted_at.is_not(None),
+            )
+        )
+        count, oldest = result.one()
+        oldest_days = None
+        if oldest is not None:
+            oldest_days = max(0, (utcnow() - oldest).days)
+        return {"count": int(count or 0), "oldest_days": oldest_days}
+
+    async def _fetch_graph_stats(self, user_id: str) -> dict[str, Any]:
+        """Edge composition by origin, weight-invariant violations, density."""
+        origin_rows = await self.db.execute(
+            select(NeuralMemoryEdge.origin, func.count(NeuralMemoryEdge.id))
+            .where(NeuralMemoryEdge.user_id == user_id)
+            .group_by(NeuralMemoryEdge.origin)
+        )
+        edges_by_origin = {origin: int(count) for origin, count in origin_rows.all()}
+
+        violations = await self.db.execute(
+            select(func.count(NeuralMemoryEdge.id)).where(
+                NeuralMemoryEdge.user_id == user_id,
+                (NeuralMemoryEdge.weight < _EDGE_WEIGHT_MIN)
+                | (NeuralMemoryEdge.weight > _EDGE_WEIGHT_MAX),
+            )
+        )
+        weight_violations = int(violations.scalar_one() or 0)
+
+        memories = await self.db.execute(
+            select(func.count(Memory.id)).where(
+                Memory.user_id == user_id,
+                Memory.deleted_at.is_(None),
+            )
+        )
+        active_memories = int(memories.scalar_one() or 0)
+
+        total_edges = sum(edges_by_origin.values())
+        return {
+            "edges_by_origin": edges_by_origin,
+            "total_edges": total_edges,
+            "weight_violations": weight_violations,
+            "active_memories": active_memories,
+            "edges_per_memory": (
+                round(total_edges / active_memories, 4) if active_memories else 0.0
+            ),
+        }
+
+    async def _fetch_usage_counts(self, user_id: str) -> dict[str, int]:
+        """MCP tool call counts over the usage window, keyed by tool name."""
+        since = utcnow() - timedelta(days=_USAGE_WINDOW_DAYS)
+        rows = await self.db.execute(
+            select(UsageStats.endpoint, func.count(UsageStats.id))
+            .where(
+                UsageStats.user_id == user_id,
+                UsageStats.created_at >= since,
+                UsageStats.endpoint.in_(["mcp:recall", "mcp:remember", "mcp:explore"]),
+            )
+            .group_by(UsageStats.endpoint)
+        )
+        return {endpoint.removeprefix("mcp:"): int(count) for endpoint, count in rows.all()}
+
+    async def _fetch_config_posture(self, user_id: str) -> dict[str, int]:
+        """Search-config posture across the user's contexts."""
+        rows = await self.db.execute(
+            select(
+                func.count(ContextSearchConfig.id),
+                func.count(ContextSearchConfig.id).filter(
+                    ContextSearchConfig.reinforce_enabled.is_(True)
+                ),
+                func.count(ContextSearchConfig.id).filter(ContextSearchConfig.use_rerank.is_(True)),
+            )
+            .select_from(ContextSearchConfig)
+            .join(Context, Context.id == ContextSearchConfig.context_id)
+            .where(Context.created_by == user_id)
+        )
+        total, reinforce_on, rerank_on = rows.one()
+        return {
+            "contexts_with_config": int(total or 0),
+            "reinforce_enabled": int(reinforce_on or 0),
+            "use_rerank": int(rerank_on or 0),
+        }
+
+    # -------------------------------------------------------------- grading
+
+    @staticmethod
+    def _grade_consolidation(
+        window: list[dict[str, Any]], backlog: dict[str, Any]
+    ) -> dict[str, Any]:
+        """FAIL: latest run failed. WARN: degradation signals in the window."""
+        notes: list[str] = []
+        status = STATUS_OK
+
+        latest = window[0] if window else None
+        total_failures = sum(r["llm_call_failures"] for r in window)
+        degraded = sum(1 for r in window if r["status"] == "degraded")
+        failed = sum(1 for r in window if r["status"] == "failed")
+        overrides = sum(r["winner_overrides"] for r in window)
+        deferred = sum(r["deferred_pairs"] for r in window)
+
+        if latest and latest["status"] == "failed":
+            status = STATUS_FAIL
+            notes.append(
+                "latest sleep run FAILED (total judge failure — the #1177 class); "
+                "check the sleep LLM configuration"
+            )
+        elif total_failures > 0 or degraded > 0:
+            status = STATUS_WARN
+            notes.append(
+                f"judge failures in the window: {total_failures} across "
+                f"{degraded} degraded run(s) — a partially dead judge grades "
+                "'degraded', never silently 'completed' (#1183)"
+            )
+        if deferred > 0 and status == STATUS_OK:
+            status = STATUS_WARN
+            notes.append(
+                f"{deferred} candidate pair(s) deferred unjudged (cluster caps) — "
+                "dedup may be structurally behind (#1184 class)"
+            )
+        if (
+            backlog["oldest_days"] is not None
+            and backlog["oldest_days"] > _BACKLOG_WARN_DAYS
+            and status != STATUS_FAIL
+        ):
+            status = _worst([status, STATUS_WARN])
+            notes.append(
+                f"oldest merge loser is {backlog['oldest_days']}d old "
+                f"(> {_BACKLOG_WARN_DAYS}d) — consider a retention window "
+                "(sleep_merge_retention_days, #1209)"
+            )
+
+        return {
+            "status": status,
+            "metrics": {
+                "reports_in_window": len(window),
+                "latest_status": latest["status"] if latest else None,
+                "llm_call_failures": total_failures,
+                "degraded_runs": degraded,
+                "failed_runs": failed,
+                "winner_overrides": overrides,
+                "deferred_pairs": deferred,
+                "merge_backlog_count": backlog["count"],
+                "merge_backlog_oldest_days": backlog["oldest_days"],
+            },
+            "notes": notes,
+        }
+
+    @staticmethod
+    def _grade_graph(stats: dict[str, Any]) -> dict[str, Any]:
+        """FAIL: weight invariant violated. WARN: suspiciously cold graph."""
+        notes: list[str] = []
+        status = STATUS_OK
+
+        if stats["weight_violations"] > 0:
+            status = STATUS_FAIL
+            notes.append(
+                f"{stats['weight_violations']} edge(s) outside the weight bounds "
+                f"[{_EDGE_WEIGHT_MIN}, {_EDGE_WEIGHT_MAX}] — the #1197 class of "
+                "unclamped-accumulation bug"
+            )
+        elif stats["total_edges"] == 0 and stats["active_memories"] >= _COLD_GRAPH_MIN_MEMORIES:
+            status = STATUS_WARN
+            notes.append(
+                f"{stats['active_memories']} active memories but zero edges — "
+                "the graph never warmed (check edge-formation gates / sleep_mode)"
+            )
+
+        return {"status": status, "metrics": stats, "notes": notes}
+
+    @staticmethod
+    def _grade_retrieval(
+        usage: dict[str, int],
+        posture: dict[str, int],
+        *,
+        active_memories: int,
+    ) -> dict[str, Any]:
+        """Informational; WARN only when memory exists but nothing reads it."""
+        notes: list[str] = []
+        status = STATUS_OK
+        recalls = usage.get("recall", 0)
+
+        if recalls == 0 and active_memories > 0:
+            status = STATUS_WARN
+            notes.append(
+                f"no recall() calls in the last {_USAGE_WINDOW_DAYS}d despite "
+                f"{active_memories} active memories — the store is write-only "
+                "right now"
+            )
+
+        return {
+            "status": status,
+            "metrics": {
+                "window_days": _USAGE_WINDOW_DAYS,
+                "recall_calls": recalls,
+                "remember_calls": usage.get("remember", 0),
+                "explore_calls": usage.get("explore", 0),
+                **posture,
+            },
+            "notes": notes,
+        }

--- a/backend/src/services/memory_health_service.py
+++ b/backend/src/services/memory_health_service.py
@@ -186,7 +186,9 @@ class MemoryHealthService:
             .where(
                 UsageStats.user_id == user_id,
                 UsageStats.created_at >= since,
-                UsageStats.endpoint.in_(["mcp:recall", "mcp:remember", "mcp:explore"]),
+                UsageStats.endpoint.in_(
+                    ["mcp:recall", "mcp:recall_upcoming", "mcp:remember", "mcp:explore"]
+                ),
             )
             .group_by(UsageStats.endpoint)
         )
@@ -204,7 +206,7 @@ class MemoryHealthService:
             )
             .select_from(ContextSearchConfig)
             .join(Context, Context.id == ContextSearchConfig.context_id)
-            .where(Context.created_by == user_id)
+            .where(Context.created_by == user_id, Context.deleted_at.is_(None))
         )
         total, reinforce_on, rerank_on = rows.one()
         return {
@@ -250,8 +252,8 @@ class MemoryHealthService:
                     f"{failed} failed sleep run(s) in the window — the latest "
                     "run recovered, but recent instability is worth a look"
                 )
-        if deferred > 0 and status == STATUS_OK:
-            status = STATUS_WARN
+        if deferred > 0:
+            status = _worst([status, STATUS_WARN])
             notes.append(
                 f"{deferred} candidate pair(s) deferred unjudged (cluster caps) — "
                 "dedup may be structurally behind (#1184 class)"
@@ -317,8 +319,9 @@ class MemoryHealthService:
         notes: list[str] = []
         status = STATUS_OK
         recalls = usage.get("recall", 0)
+        recall_upcoming = usage.get("recall_upcoming", 0)
 
-        if recalls == 0 and active_memories > 0:
+        if recalls + recall_upcoming == 0 and active_memories > 0:
             status = STATUS_WARN
             notes.append(
                 f"no recall() calls in the last {_USAGE_WINDOW_DAYS}d despite "
@@ -331,6 +334,7 @@ class MemoryHealthService:
             "metrics": {
                 "window_days": _USAGE_WINDOW_DAYS,
                 "recall_calls": recalls,
+                "recall_upcoming_calls": recall_upcoming,
                 "remember_calls": usage.get("remember", 0),
                 "explore_calls": usage.get("explore", 0),
                 **posture,

--- a/backend/src/services/memory_health_service.py
+++ b/backend/src/services/memory_health_service.py
@@ -236,13 +236,20 @@ class MemoryHealthService:
                 "latest sleep run FAILED (total judge failure — the #1177 class); "
                 "check the sleep LLM configuration"
             )
-        elif total_failures > 0 or degraded > 0:
-            status = STATUS_WARN
-            notes.append(
-                f"judge failures in the window: {total_failures} across "
-                f"{degraded} degraded run(s) — a partially dead judge grades "
-                "'degraded', never silently 'completed' (#1183)"
-            )
+        else:
+            if total_failures > 0 or degraded > 0:
+                status = STATUS_WARN
+                notes.append(
+                    f"judge failures in the window: {total_failures} across "
+                    f"{degraded} degraded run(s) — a partially dead judge grades "
+                    "'degraded', never silently 'completed' (#1183)"
+                )
+            if failed > 0:
+                status = STATUS_WARN
+                notes.append(
+                    f"{failed} failed sleep run(s) in the window — the latest "
+                    "run recovered, but recent instability is worth a look"
+                )
         if deferred > 0 and status == STATUS_OK:
             status = STATUS_WARN
             notes.append(

--- a/backend/tests/api/test_admin_memory_health.py
+++ b/backend/tests/api/test_admin_memory_health.py
@@ -1,0 +1,87 @@
+"""Route-level tests for GET /api/v1/admin/memory-health (#1211).
+
+Covers the admin gate (403 for non-admin), the 200 response shape through
+FastAPI serialization (MemoryHealthResponse(**report) — the dict-to-model
+boundary the service unit tests can't see), and the HEALTH-001 guard.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import get_current_user, require_admin
+from db.base import get_db
+
+_CANNED_REPORT = {
+    "generated_at": "2026-07-08T00:00:00Z",
+    "overall_status": "warn",
+    "sections": {
+        "consolidation": {
+            "status": "warn",
+            "metrics": {"reports_in_window": 3, "llm_call_failures": 2},
+            "notes": ["judge failures in the window: 2"],
+        },
+        "graph": {"status": "ok", "metrics": {"total_edges": 5}, "notes": []},
+        "retrieval": {"status": "ok", "metrics": {"recall_calls": 7}, "notes": []},
+    },
+}
+
+
+def _admin_user() -> dict:
+    return {"user_id": "admin_user_1", "email": "admin@test.com", "role": "admin"}
+
+
+async def _mock_get_db():
+    yield AsyncMock()
+
+
+@pytest.fixture
+def client():
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestAdminMemoryHealthRoute:
+    def test_non_admin_gets_403(self, client) -> None:
+        async def member_user():
+            return {"user_id": "u1", "email": "member@test.com", "role": "member"}
+
+        app.dependency_overrides[get_current_user] = member_user
+        app.dependency_overrides[get_db] = _mock_get_db
+
+        resp = client.get("/api/v1/admin/memory-health")
+        assert resp.status_code == 403
+
+    def test_admin_gets_200_report_shape(self, client) -> None:
+        async def admin():
+            return _admin_user()
+
+        app.dependency_overrides[require_admin] = admin
+        app.dependency_overrides[get_db] = _mock_get_db
+
+        with patch(
+            "api.routes.admin_memory_health.MemoryHealthService.build_report",
+            new=AsyncMock(return_value=_CANNED_REPORT),
+        ):
+            resp = client.get("/api/v1/admin/memory-health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["overall_status"] == "warn"
+        assert body["generated_at"] == "2026-07-08T00:00:00Z"
+        assert set(body["sections"]) == {"consolidation", "graph", "retrieval"}
+        assert body["sections"]["consolidation"]["notes"] == ["judge failures in the window: 2"]
+        assert body["sections"]["graph"]["metrics"]["total_edges"] == 5
+
+    def test_missing_user_id_yields_health_001(self, client) -> None:
+        async def admin_without_id():
+            return {"email": "admin@test.com", "role": "admin"}
+
+        app.dependency_overrides[require_admin] = admin_without_id
+        app.dependency_overrides[get_db] = _mock_get_db
+
+        resp = client.get("/api/v1/admin/memory-health")
+        assert resp.status_code == 500
+        assert "HEALTH-001" in resp.text

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -7,7 +7,8 @@ class), and healthy inputs grade ok. FAIL fires only on deterministic facts;
 degradation signals produce WARN (a false FAIL erodes dashboard trust).
 """
 
-from unittest.mock import AsyncMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -153,6 +154,40 @@ class TestRetrievalGrading:
             active_memories=0,
         )
         assert section["status"] == STATUS_OK
+
+
+class TestFetchSleepWindowDefaults:
+    @pytest.mark.asyncio
+    async def test_pre_existing_reports_without_detail_keys_default_to_zero(self) -> None:
+        """Reports written before #1198/#1184 added the detail keys (or with
+        dedup_result=None) must flatten to zeros, not raise."""
+        legacy_none = SimpleNamespace(
+            status="completed",
+            llm_call_failures=None,
+            memories_merged=None,
+            dedup_result=None,
+            started_at=None,
+        )
+        legacy_no_details = SimpleNamespace(
+            status="completed",
+            llm_call_failures=0,
+            memories_merged=1,
+            dedup_result={"merged": 1},
+            started_at=None,
+        )
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [legacy_none, legacy_no_details]
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=result)
+
+        window = await MemoryHealthService(db)._fetch_sleep_window("u1")
+
+        assert len(window) == 2
+        for row in window:
+            assert row["llm_call_failures"] == 0
+            assert row["winner_overrides"] == 0
+            assert row["deferred_pairs"] == 0
+            assert row["oversize_clusters"] == 0
 
 
 class TestBuildReport:

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -67,6 +67,23 @@ class TestConsolidationGrading:
         )
         assert section["status"] == STATUS_WARN
 
+    def test_latest_degraded_is_warn_not_fail(self) -> None:
+        """A degraded LATEST run is partial judge death — WARN, never FAIL."""
+        section = MemoryHealthService._grade_consolidation(
+            [_report(status="degraded", failures=1), _report()],
+            {"count": 0, "oldest_days": None},
+        )
+        assert section["status"] == STATUS_WARN
+
+    def test_backlog_at_threshold_is_ok_just_over_warns(self) -> None:
+        """The 90-day backlog threshold is strict (>): 90d ok, 91d warn."""
+        at = MemoryHealthService._grade_consolidation([_report()], {"count": 10, "oldest_days": 90})
+        over = MemoryHealthService._grade_consolidation(
+            [_report()], {"count": 10, "oldest_days": 91}
+        )
+        assert at["status"] == STATUS_OK
+        assert over["status"] == STATUS_WARN
+
     def test_deferred_pairs_warn(self) -> None:
         section = MemoryHealthService._grade_consolidation(
             [_report(deferred=12)], {"count": 0, "oldest_days": None}

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -106,6 +106,17 @@ class TestConsolidationGrading:
         assert section["status"] == STATUS_WARN
         assert any("#1184" in n for n in section["notes"])
 
+    def test_deferred_note_survives_coexisting_warn(self) -> None:
+        """Every non-ok contribution gets a note — a judge-failure WARN must
+        not swallow the orthogonal deferred-pairs (#1184) explanation."""
+        section = MemoryHealthService._grade_consolidation(
+            [_report(status="degraded", failures=2, deferred=12)],
+            {"count": 0, "oldest_days": None},
+        )
+        assert section["status"] == STATUS_WARN
+        assert any("#1183" in n for n in section["notes"])
+        assert any("#1184" in n for n in section["notes"])
+
     def test_old_merge_backlog_warns_and_names_retention(self) -> None:
         section = MemoryHealthService._grade_consolidation(
             [_report()], {"count": 500, "oldest_days": 120}

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -76,6 +76,20 @@ class TestConsolidationGrading:
         )
         assert section["status"] == STATUS_WARN
 
+    def test_past_failed_run_with_recovered_latest_is_warn(self) -> None:
+        """A failed run in the window must not hide behind a recovered latest.
+
+        No llm_call_failures and no degraded runs on the failed row (total
+        judge death records status only) — the failed status itself carries
+        the WARN.
+        """
+        section = MemoryHealthService._grade_consolidation(
+            [_report(), _report(status="failed")],
+            {"count": 0, "oldest_days": None},
+        )
+        assert section["status"] == STATUS_WARN
+        assert any("failed sleep run" in n for n in section["notes"])
+
     def test_backlog_at_threshold_is_ok_just_over_warns(self) -> None:
         """The 90-day backlog threshold is strict (>): 90d ok, 91d warn."""
         at = MemoryHealthService._grade_consolidation([_report()], {"count": 10, "oldest_days": 90})

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -1,0 +1,178 @@
+"""#1211: consolidated memory-health report grading.
+
+Pins the acceptance contract: a simulated judge death flips the
+consolidation section to warn/fail (the #1177 class of plausible success can
+no longer hide), the graph weight invariant fails deterministically (#1197
+class), and healthy inputs grade ok. FAIL fires only on deterministic facts;
+degradation signals produce WARN (a false FAIL erodes dashboard trust).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from services.memory_health_service import (
+    STATUS_FAIL,
+    STATUS_OK,
+    STATUS_WARN,
+    MemoryHealthService,
+)
+
+
+def _report(status="completed", failures=0, overrides=0, deferred=0):
+    return {
+        "status": status,
+        "llm_call_failures": failures,
+        "memories_merged": 0,
+        "winner_overrides": overrides,
+        "deferred_pairs": deferred,
+        "oversize_clusters": 0,
+        "started_at": "2026-07-08T00:00:00Z",
+    }
+
+
+def _healthy_graph(**over):
+    stats = {
+        "edges_by_origin": {"hebbian": 10, "semantic": 5},
+        "total_edges": 15,
+        "weight_violations": 0,
+        "active_memories": 40,
+        "edges_per_memory": 0.375,
+    }
+    stats.update(over)
+    return stats
+
+
+class TestConsolidationGrading:
+    def test_healthy_window_is_ok(self) -> None:
+        section = MemoryHealthService._grade_consolidation(
+            [_report(), _report()], {"count": 0, "oldest_days": None}
+        )
+        assert section["status"] == STATUS_OK
+        assert section["notes"] == []
+
+    def test_latest_failed_run_is_fail(self) -> None:
+        """Total judge death (#1177 class) must be a hard FAIL."""
+        section = MemoryHealthService._grade_consolidation(
+            [_report(status="failed", failures=5), _report()],
+            {"count": 0, "oldest_days": None},
+        )
+        assert section["status"] == STATUS_FAIL
+        assert any("#1177" in n for n in section["notes"])
+
+    def test_degraded_run_in_window_is_warn(self) -> None:
+        section = MemoryHealthService._grade_consolidation(
+            [_report(), _report(status="degraded", failures=2)],
+            {"count": 0, "oldest_days": None},
+        )
+        assert section["status"] == STATUS_WARN
+
+    def test_deferred_pairs_warn(self) -> None:
+        section = MemoryHealthService._grade_consolidation(
+            [_report(deferred=12)], {"count": 0, "oldest_days": None}
+        )
+        assert section["status"] == STATUS_WARN
+        assert any("#1184" in n for n in section["notes"])
+
+    def test_old_merge_backlog_warns_and_names_retention(self) -> None:
+        section = MemoryHealthService._grade_consolidation(
+            [_report()], {"count": 500, "oldest_days": 120}
+        )
+        assert section["status"] == STATUS_WARN
+        assert any("sleep_merge_retention_days" in n for n in section["notes"])
+
+    def test_empty_window_is_ok(self) -> None:
+        """No sleep runs yet is not a failure — sleep is opt-in (#558)."""
+        section = MemoryHealthService._grade_consolidation([], {"count": 0, "oldest_days": None})
+        assert section["status"] == STATUS_OK
+
+
+class TestGraphGrading:
+    def test_healthy_graph_is_ok(self) -> None:
+        assert MemoryHealthService._grade_graph(_healthy_graph())["status"] == STATUS_OK
+
+    def test_weight_violation_is_fail(self) -> None:
+        """Out-of-bounds edge weights are the #1197 unclamped-accumulation
+        class — a deterministic invariant violation, hard FAIL."""
+        section = MemoryHealthService._grade_graph(_healthy_graph(weight_violations=3))
+        assert section["status"] == STATUS_FAIL
+        assert any("#1197" in n for n in section["notes"])
+
+    def test_cold_graph_with_many_memories_warns(self) -> None:
+        section = MemoryHealthService._grade_graph(
+            _healthy_graph(total_edges=0, edges_by_origin={}, active_memories=100)
+        )
+        assert section["status"] == STATUS_WARN
+
+    def test_small_cold_store_is_ok(self) -> None:
+        section = MemoryHealthService._grade_graph(
+            _healthy_graph(total_edges=0, edges_by_origin={}, active_memories=3)
+        )
+        assert section["status"] == STATUS_OK
+
+
+class TestRetrievalGrading:
+    def test_active_usage_is_ok(self) -> None:
+        section = MemoryHealthService._grade_retrieval(
+            {"recall": 42, "remember": 10},
+            {"contexts_with_config": 3, "reinforce_enabled": 2, "use_rerank": 0},
+            active_memories=100,
+        )
+        assert section["status"] == STATUS_OK
+        assert section["metrics"]["recall_calls"] == 42
+
+    def test_write_only_store_warns(self) -> None:
+        section = MemoryHealthService._grade_retrieval(
+            {"remember": 5},
+            {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
+            active_memories=50,
+        )
+        assert section["status"] == STATUS_WARN
+
+    def test_empty_store_is_ok(self) -> None:
+        section = MemoryHealthService._grade_retrieval(
+            {},
+            {"contexts_with_config": 0, "reinforce_enabled": 0, "use_rerank": 0},
+            active_memories=0,
+        )
+        assert section["status"] == STATUS_OK
+
+
+class TestBuildReport:
+    @pytest.mark.asyncio
+    async def test_overall_is_worst_section(self) -> None:
+        """Judge death anywhere makes the OVERALL document non-ok — the
+        acceptance criterion: a broken judge flips health within one cycle."""
+        svc = MemoryHealthService(AsyncMock())
+        with (
+            patch.object(
+                svc,
+                "_fetch_sleep_window",
+                new=AsyncMock(return_value=[_report(status="failed", failures=5)]),
+            ),
+            patch.object(
+                svc,
+                "_fetch_merge_backlog",
+                new=AsyncMock(return_value={"count": 0, "oldest_days": None}),
+            ),
+            patch.object(svc, "_fetch_graph_stats", new=AsyncMock(return_value=_healthy_graph())),
+            patch.object(svc, "_fetch_usage_counts", new=AsyncMock(return_value={"recall": 1})),
+            patch.object(
+                svc,
+                "_fetch_config_posture",
+                new=AsyncMock(
+                    return_value={
+                        "contexts_with_config": 1,
+                        "reinforce_enabled": 1,
+                        "use_rerank": 0,
+                    }
+                ),
+            ),
+        ):
+            report = await svc.build_report("admin-user")
+
+        assert report["overall_status"] == STATUS_FAIL
+        assert report["sections"]["consolidation"]["status"] == STATUS_FAIL
+        assert report["sections"]["graph"]["status"] == STATUS_OK
+        assert set(report["sections"]) == {"consolidation", "graph", "retrieval"}
+        assert report["generated_at"]

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -934,6 +934,14 @@ Admin endpoints require `system_admin` or `workspace_admin` role.
 
 See [Sleep Maintenance](sleep-maintenance.md) for the full Sleep cycle design, `sleep_mode`, and rollback semantics.
 
+### Memory Health
+
+| Endpoint                          | Purpose                                                       |
+|-----------------------------------|---------------------------------------------------------------|
+| `GET /api/v1/admin/memory-health` | Consolidated self-diagnosis report — consolidation / graph / retrieval sections graded `ok`/`warn`/`fail` from Sleep telemetry, graph invariants, and usage stats. Self-scoped (the calling admin's data partition). |
+
+See [Memory Health Report](ops/memory-health-report.md) for every metric and threshold.
+
 ### Neural Config
 
 Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, reranker weights) are persisted in `neural_config` and exposed under `/api/v1/admin/neural-config`. The fields are editable from the admin UI's Neural Config page.

--- a/docs/ops/memory-health-report.md
+++ b/docs/ops/memory-health-report.md
@@ -1,0 +1,70 @@
+# Memory Health Report (#1211)
+
+`GET /api/v1/admin/memory-health` assembles the signals the system already
+emits — Sleep reports, graph invariants, usage stats, search-config posture —
+into one thresholded self-diagnosis document. The motivating failure class:
+memory bugs that manifest as *plausible successes* (`sleep_summary.ok=true`
+while every judge call failed, #1177). Each section grades `ok | warn | fail`;
+`overall_status` is the worst section.
+
+Scope (Phase 1): self-scoped — the report covers the calling admin's own data
+partition, same discipline as the manual sleep trigger. Label-free signals
+only; gold-label rates (`stale_only`, P@k) belong to the eval CI gates
+([eval README](../../backend/tests/eval/README.md), #1210).
+
+Web UI: **Admin → Memory Health** renders the same document.
+
+## Grading philosophy
+
+- **FAIL** fires only on deterministic facts (latest run failed, invariant
+  violated). A false FAIL erodes dashboard trust.
+- **WARN** covers degradation signals worth a look but not proof of breakage.
+- Signals that exist only in logs (e.g. `reinforce_rerank_applied`) are
+  excluded until persisted — never rendered as "pending".
+
+## Sections, metrics, thresholds
+
+### consolidation
+
+Window: the 20 most recent Sleep reports for the user.
+
+| Condition | Grade | Rationale |
+|---|---|---|
+| Latest sleep run `status=failed` | **fail** | Total judge death — the #1177 class. |
+| Any `llm_call_failures > 0` or `degraded` run in the window | warn | Partial judge death grades `degraded`, never a silent `completed` (#1183). |
+| `deferred_pairs > 0` in the window | warn | Cluster caps deferring candidate pairs unjudged — dedup may be structurally behind (#1184 class). |
+| Oldest `sleep_maintenance` soft-deleted merge loser > 90 days | warn | Backlog suggests a retention window is wanted (`sleep_merge_retention_days`, #1209). |
+| No sleep runs at all | ok | Sleep is opt-in (#558); absence is not failure. |
+
+Metrics: `reports_in_window`, `latest_status`, `llm_call_failures`,
+`degraded_runs`, `failed_runs`, `winner_overrides`, `deferred_pairs`,
+`merge_backlog_count`, `merge_backlog_oldest_days`.
+
+### graph
+
+| Condition | Grade | Rationale |
+|---|---|---|
+| Any edge weight outside `[0.0, 3.0]` | **fail** | Deterministic invariant violation — the #1197 unclamped-accumulation class. |
+| Zero edges with ≥ 25 active memories | warn | The graph never warmed; check edge-formation gates / `sleep_mode`. |
+
+Metrics: `edges_by_origin` (hebbian / semantic / declared), `total_edges`,
+`weight_violations`, `active_memories`, `edges_per_memory`.
+
+### retrieval
+
+Window: 7 days of `mcp:recall` / `mcp:remember` / `mcp:explore` usage.
+
+| Condition | Grade | Rationale |
+|---|---|---|
+| Zero `recall()` calls with > 0 active memories | warn | The store is write-only — memory exists but nothing reads it. |
+
+Metrics: `recall_calls`, `remember_calls`, `explore_calls`, `window_days`,
+plus config posture (`contexts_with_config`, `reinforce_enabled`,
+`use_rerank`).
+
+## Relationship to the eval CI gates (#1210)
+
+This report is the *runtime* half of the post-eval hardening pair: it grades
+what production emits, continuously and label-free. The nightly eval workflow
+grades what a frozen labeled corpus proves (update-correctness, placebo
+compounding). A regression can trip either first; neither replaces the other.

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -125,7 +125,7 @@ export default function AdminMemoryHealthPage() {
                 {section.notes.length > 0 && (
                   <ul className="mb-3 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
                     {section.notes.map((note, i) => (
-                      <li key={`${i}-${note.slice(0, 24)}`}>{note}</li>
+                      <li key={i}>{note}</li>
                     ))}
                   </ul>
                 )}

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -32,7 +32,21 @@ const STATUS_STYLES: Record<string, string> = {
   fail: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
 };
 
+const STATUS_LABEL_KEYS: Record<string, string> = {
+  ok: "status.ok",
+  warn: "status.warn",
+  fail: "status.fail",
+};
+
+const SECTION_LABEL_KEYS: Record<string, string> = {
+  consolidation: "sections.consolidation",
+  graph: "sections.graph",
+  retrieval: "sections.retrieval",
+};
+
 function StatusBadge({ status }: { status: string }) {
+  const t = useTranslations("admin.memoryHealth");
+  const labelKey = STATUS_LABEL_KEYS[status];
   return (
     <span
       className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase ${
@@ -40,7 +54,7 @@ function StatusBadge({ status }: { status: string }) {
       }`}
       data-testid={`status-${status}`}
     >
-      {status}
+      {labelKey ? t(labelKey) : status}
     </span>
   );
 }
@@ -103,13 +117,15 @@ export default function AdminMemoryHealthPage() {
             {Object.entries(report.sections).map(([name, section]) => (
               <div key={name} className="rounded-lg border p-4">
                 <div className="mb-2 flex items-center justify-between">
-                  <h2 className="font-semibold capitalize">{name}</h2>
+                  <h2 className="font-semibold capitalize">
+                    {SECTION_LABEL_KEYS[name] ? t(SECTION_LABEL_KEYS[name]) : name}
+                  </h2>
                   <StatusBadge status={section.status} />
                 </div>
                 {section.notes.length > 0 && (
                   <ul className="mb-3 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
-                    {section.notes.map((note) => (
-                      <li key={note}>{note}</li>
+                    {section.notes.map((note, i) => (
+                      <li key={`${i}-${note.slice(0, 24)}`}>{note}</li>
                     ))}
                   </ul>
                 )}
@@ -122,7 +138,7 @@ export default function AdminMemoryHealthPage() {
                         </td>
                         <td className="py-1 text-right font-mono">
                           {value === null
-                            ? "—"
+                            ? t("emptyValue")
                             : typeof value === "object"
                               ? JSON.stringify(value)
                               : String(value)}

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * Admin Memory Health Page (#1211)
+ *
+ * Renders the consolidated memory-health report — the label-free runtime
+ * self-diagnosis document (consolidation / graph / retrieval sections with
+ * ok / warn / fail grading). Admin-only, self-scoped (Phase 1).
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { CardLoadingState } from "@/components/common/LoadingState";
+import { apiClient } from "@/lib/api";
+
+type HealthSection = {
+  status: "ok" | "warn" | "fail";
+  metrics: Record<string, unknown>;
+  notes: string[];
+};
+
+type MemoryHealthResponse = {
+  generated_at: string;
+  overall_status: "ok" | "warn" | "fail";
+  sections: Record<string, HealthSection>;
+};
+
+const STATUS_STYLES: Record<string, string> = {
+  ok: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+  warn: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+  fail: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+};
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={`inline-block rounded px-2 py-0.5 text-xs font-semibold uppercase ${
+        STATUS_STYLES[status] ?? ""
+      }`}
+      data-testid={`status-${status}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default function AdminMemoryHealthPage() {
+  const t = useTranslations("admin.memoryHealth");
+  const [report, setReport] = useState<MemoryHealthResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<MemoryHealthResponse>(
+        "/api/v1/admin/memory-health",
+      );
+      setReport(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{t("title")}</h1>
+          <p className="text-sm text-muted-foreground">{t("description")}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="rounded border px-3 py-1 text-sm hover:bg-accent"
+        >
+          {t("refresh")}
+        </button>
+      </div>
+
+      {loading && <CardLoadingState count={3} />}
+      <ErrorBanner error={error} />
+
+      {!loading && report && (
+        <>
+          <div className="flex items-center gap-3">
+            <span className="text-sm font-medium">{t("overall")}</span>
+            <StatusBadge status={report.overall_status} />
+            <span className="text-xs text-muted-foreground">
+              {report.generated_at}
+            </span>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            {Object.entries(report.sections).map(([name, section]) => (
+              <div key={name} className="rounded-lg border p-4">
+                <div className="mb-2 flex items-center justify-between">
+                  <h2 className="font-semibold capitalize">{name}</h2>
+                  <StatusBadge status={section.status} />
+                </div>
+                {section.notes.length > 0 && (
+                  <ul className="mb-3 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+                    {section.notes.map((note) => (
+                      <li key={note}>{note}</li>
+                    ))}
+                  </ul>
+                )}
+                <table className="w-full text-xs">
+                  <tbody>
+                    {Object.entries(section.metrics).map(([key, value]) => (
+                      <tr key={key} className="border-t">
+                        <td className="py-1 pr-2 font-mono text-muted-foreground">
+                          {key}
+                        </td>
+                        <td className="py-1 text-right font-mono">
+                          {value === null
+                            ? "—"
+                            : typeof value === "object"
+                              ? JSON.stringify(value)
+                              : String(value)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -45,6 +45,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
+  Activity,
   Brain,
   Key,
   Settings,
@@ -253,6 +254,13 @@ const navigationGroups: NavGroup[] = [
         nameKey: "sleepReports",
         href: "/admin/sleep-reports",
         icon: Moon,
+        requiredRole: Role.ADMIN,
+      },
+      {
+        // Issue #1211: consolidated memory-health report
+        nameKey: "memoryHealth",
+        href: "/admin/memory-health",
+        icon: Activity,
         requiredRole: Role.ADMIN,
       },
       {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2812,7 +2812,18 @@
       "title": "Memory Health",
       "description": "Consolidated self-diagnosis: consolidation, graph, and retrieval signals with ok/warn/fail grading",
       "refresh": "Refresh",
-      "overall": "Overall"
+      "overall": "Overall",
+      "emptyValue": "—",
+      "status": {
+        "ok": "OK",
+        "warn": "Warn",
+        "fail": "Fail"
+      },
+      "sections": {
+        "consolidation": "Consolidation",
+        "graph": "Graph",
+        "retrieval": "Retrieval"
+      }
     },
     "sleepReports": {
       "title": "Sleep Reports",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -147,6 +147,7 @@
     "quotas": "Quotas & Limits",
     "neuralConfig": "Neural Config",
     "sleepReports": "Sleep Reports",
+    "memoryHealth": "Memory Health",
     "cost": "Cost",
     "environment": "Environment",
     "systemAdmin": "System Admin",
@@ -2806,6 +2807,12 @@
         "noWorkspaceSelected": "No workspace is currently selected. Create or select a workspace to view its cost aggregation.",
         "unknown": "Unknown error while loading cost aggregation."
       }
+    },
+    "memoryHealth": {
+      "title": "Memory Health",
+      "description": "Consolidated self-diagnosis: consolidation, graph, and retrieval signals with ok/warn/fail grading",
+      "refresh": "Refresh",
+      "overall": "Overall"
     },
     "sleepReports": {
       "title": "Sleep Reports",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2812,7 +2812,18 @@
       "title": "メモリーヘルス",
       "description": "統合セルフ診断：consolidation / graph / retrieval のシグナルを ok/warn/fail で判定",
       "refresh": "更新",
-      "overall": "総合"
+      "overall": "総合",
+      "emptyValue": "—",
+      "status": {
+        "ok": "正常",
+        "warn": "警告",
+        "fail": "異常"
+      },
+      "sections": {
+        "consolidation": "統合（consolidation）",
+        "graph": "グラフ（graph）",
+        "retrieval": "検索（retrieval）"
+      }
     },
     "sleepReports": {
       "title": "Sleep レポート",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -147,6 +147,7 @@
     "quotas": "クォータ・制限",
     "neuralConfig": "ニューラル設定",
     "sleepReports": "Sleep レポート",
+    "memoryHealth": "メモリーヘルス",
     "cost": "コスト",
     "environment": "環境設定",
     "systemAdmin": "システム管理",
@@ -2806,6 +2807,12 @@
         "noWorkspaceSelected": "workspace が選択されていません。workspace を作成または選択してからコスト集計を確認してください。",
         "unknown": "コスト集計の読み込み中に不明なエラーが発生しました。"
       }
+    },
+    "memoryHealth": {
+      "title": "メモリーヘルス",
+      "description": "統合セルフ診断：consolidation / graph / retrieval のシグナルを ok/warn/fail で判定",
+      "refresh": "更新",
+      "overall": "総合"
     },
     "sleepReports": {
       "title": "Sleep レポート",


### PR DESCRIPTION
Closes #1211

## What

One admin endpoint — `GET /api/v1/admin/memory-health` — plus an admin UI page (**Admin → Memory Health**) that assembles the signals the system already emits into a single thresholded `ok | warn | fail` self-diagnosis document:

- **consolidation** — last 20 Sleep reports (`llm_call_failures`, `degraded`/`failed` runs, `winner_overrides`, `deferred_pairs`) + soft-deleted merge-loser backlog
- **graph** — edge composition by origin, weight-invariant check (`[0.0, 3.0]`), cold-graph detection
- **retrieval** — 7-day `mcp:recall`/`remember`/`explore` volume + search-config posture

`overall_status` is the worst section. Full metric + threshold table: `docs/ops/memory-health-report.md`.

## Why

The eval program's most transferable lesson: memory failures manifest as **plausible successes** — `sleep_summary.ok=true` while every judge call failed (#1177), unclamped edge weights (#1197), dedup mega-clusters (#1184). The signals to catch these already exist but are fragmented across Sleep reports, graph stats, and logs. This report makes a judge death flip health to FAIL within one sleep cycle, without an external eval program.

## Design decisions (gate1)

- **FAIL only on deterministic facts** (latest run `failed`, weight invariant violated); WARN on degradation signals — a false FAIL erodes dashboard trust.
- **Label-free only**: gold-label rates (`stale_only`, P@k) stay in the #1210 eval CI gates; this is the runtime half of the pair.
- **No log-derived metrics**: signals that exist only in structlog output are excluded until persisted, not rendered as "pending".
- **Self-scoped Phase 1**: the report covers the calling admin's own data partition — same discipline as the manual sleep trigger.

## Tests

- `backend/tests/services/test_memory_health_service.py` — 14 tests, incl. the gate1 acceptance criterion (simulated judge death → consolidation FAIL → overall FAIL) and the #1197 weight-violation class.
- In-container: new tests 14/14; `tests/api` 904 passed (7 known OAuth-template staging artifacts of the `/tmp/wt` harness — verified failing identically on unmodified code).
- Frontend: `tsc --noEmit` clean; Vitest 750/751 (1 known live-`:8080` flake + 1 recharts ESM file failure — both reproduce on unmodified `main`).

## Notes

- No DB migration — read-only aggregation over existing tables.
- The consolidation fetcher reads `dedup_result["details"]` keys written by `services/sleep/reporter.py`; absent keys (pre-existing reports) default to 0 — fails soft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
