### PR TITLE
feat(search): query-intent retrieval router, experiment-gated (#1212)

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ The primitives an autonomous agent loop needs beyond a knowledge store — see [
 | `update_context` | Update context settings (summary, usage guide, resource_id, is_public) | Editor+ |
 | `delete_context` | Delete a context and all its memories | Owner/Admin |
 | `merge_contexts` | Merge memories from source context into target context | Owner/Admin |
-| `update_search_config` | Tune hybrid search weights and reranker settings per context | Editor+ |
+| `update_search_config` | Tune hybrid search weights, reranker settings, and query-intent routing (`routing_mode`) per context | Editor+ |
 
 ### Tags (1)
 

--- a/backend/alembic/versions/e58_1212_routing_mode.py
+++ b/backend/alembic/versions/e58_1212_routing_mode.py
@@ -6,16 +6,15 @@ Existing rows and new rows both land on 'off' — zero behavior change at
 migration time; the router only runs on contexts an operator opts in.
 
 MIGRATION COORDINATION (v0.45.0): e55 (#1215), e56 (#1217), e57 (#1218) and
-this e58 ALL chain from e54 on their respective unmerged branches. Whichever
-PR merges later MUST bump ``down_revision`` to the then-current head (e.g. if
-e55/e56/e57 merge first, this becomes ``down_revision = "e57_1208_..."``).
-Alembic fails loudly on multiple heads, so a miss cannot ship silently.
+this e58 ALL chained from e54 on their respective branches. e55/e56/e57
+merged first, so this revision was re-chained onto e57 (the then-current
+head) at merge time, per the plan in epic #1214.
 
 Blue-green safety: ADD COLUMN with a server_default is metadata-only on
 PG 11+ (no table rewrite); old app code never references the column.
 
 Revision ID: e58_1212_routing_mode
-Revises: e54_1183_sleep_status_degraded
+Revises: e57_1208_supersedes_contradicts
 """
 
 import sqlalchemy as sa
@@ -24,7 +23,7 @@ from alembic import op
 
 # revision identifiers
 revision = "e58_1212_routing_mode"
-down_revision = "e54_1183_sleep_status_degraded"
+down_revision = "e57_1208_supersedes_contradicts"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/e58_1212_routing_mode.py
+++ b/backend/alembic/versions/e58_1212_routing_mode.py
@@ -1,0 +1,48 @@
+"""#1212: add context_search_configs.routing_mode (query-intent router).
+
+Adds the experiment gate for the query-intent retrieval router:
+``routing_mode`` in ('off', 'log_only', 'active'), server_default 'off'.
+Existing rows and new rows both land on 'off' — zero behavior change at
+migration time; the router only runs on contexts an operator opts in.
+
+MIGRATION COORDINATION (v0.45.0): e55 (#1215), e56 (#1217), e57 (#1218) and
+this e58 ALL chain from e54 on their respective unmerged branches. Whichever
+PR merges later MUST bump ``down_revision`` to the then-current head (e.g. if
+e55/e56/e57 merge first, this becomes ``down_revision = "e57_1208_..."``).
+Alembic fails loudly on multiple heads, so a miss cannot ship silently.
+
+Blue-green safety: ADD COLUMN with a server_default is metadata-only on
+PG 11+ (no table rewrite); old app code never references the column.
+
+Revision ID: e58_1212_routing_mode
+Revises: e54_1183_sleep_status_degraded
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision = "e58_1212_routing_mode"
+down_revision = "e54_1183_sleep_status_degraded"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add routing_mode with CHECK constraint, default 'off'."""
+    op.add_column(
+        "context_search_configs",
+        sa.Column("routing_mode", sa.String(10), nullable=False, server_default="off"),
+    )
+    op.create_check_constraint(
+        "routing_mode_check",
+        "context_search_configs",
+        "routing_mode IN ('off', 'log_only', 'active')",
+    )
+
+
+def downgrade() -> None:
+    """Drop the routing_mode column and its CHECK constraint."""
+    op.drop_constraint("routing_mode_check", "context_search_configs", type_="check")
+    op.drop_column("context_search_configs", "routing_mode")

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1189,7 +1189,7 @@ Examples:
 
 Weights must sum to 1.0.
 
-Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fetch_factor, use_rerank, reranker_provider, reranker_model, reinforce_enabled, reinforce_max_boost, reinforce_require_host_arbitration}}. semantic_weight + bm25_weight must sum to 1.0.""",
+Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fetch_factor, use_rerank, reranker_provider, reranker_model, reinforce_enabled, reinforce_max_boost, reinforce_require_host_arbitration, routing_mode}}. semantic_weight + bm25_weight must sum to 1.0.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["context_id"],
@@ -1235,6 +1235,11 @@ Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fe
                     "reinforce_require_host_arbitration": {
                         "type": "boolean",
                         "description": "Forge-resistant mode. When true, the reinforce re-rank counts ONLY host-arbitrated feedback (an independent verdict), so an untrusted agent's self-emitted feedback(helpful=True) cannot manufacture its own ranking boost. Off by default. Enable on contexts exposed to untrusted autonomous agents.",
+                    },
+                    "routing_mode": {
+                        "type": "string",
+                        "enum": ["off", "log_only", "active"],
+                        "description": "Query-intent retrieval router (#1212). 'off' (default): never runs. 'log_only': stamps the classifier's lane decision into telemetry with zero ranking change — enable this first to measure the traffic mix. 'active': recall() calls that OMIT search_mode use the routed lane (exact-ID/quoted/code-symbol/hiragana-dominant → keyword, mixed → hybrid, else semantic); an explicit search_mode always wins.",
                     },
                 },
             },

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -434,7 +434,10 @@ async def handle_recall(
         k=args.get("k", 5),
         use_rerank=args.get("use_rerank", False),
         filters=args.get("filters"),
-        search_mode=args.get("search_mode", "hybrid"),
+        # #1212: pass None through when the caller omitted search_mode so the
+        # query router can act on contexts with routing_mode='active';
+        # MemoryService resolves None to "hybrid" everywhere else.
+        search_mode=args.get("search_mode"),
         include_explore_hints=args.get("include_explore_hints", False),
         include_superseded=args.get("include_superseded", False),  # #1208
     )

--- a/backend/src/mcp_server/tools/search_config.py
+++ b/backend/src/mcp_server/tools/search_config.py
@@ -83,6 +83,8 @@ async def handle_update_search_config(
                     "reinforce_require_host_arbitration",
                     config.reinforce_require_host_arbitration,
                 ),
+                # Issue #1212: query-intent router gate (round-trip current value).
+                "routing_mode": args.get("routing_mode", config.routing_mode),
             }
 
             # Validate via Pydantic (same as REST API)
@@ -124,6 +126,7 @@ async def handle_update_search_config(
                                 "reinforce_require_host_arbitration": (
                                     config.reinforce_require_host_arbitration
                                 ),
+                                "routing_mode": config.routing_mode,
                             },
                         }
                     ),

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -130,6 +130,17 @@ class ContextSearchConfig(Base):
         Boolean, nullable=False, server_default="false", default=False
     )
 
+    # Issue #1212: query-intent retrieval router (experiment-gated).
+    # 'off' (default): router never runs. 'log_only': classifier decision is
+    # stamped into recall telemetry with ZERO ranking change. 'active': the
+    # routed lane is used ONLY when the caller did not pass search_mode
+    # explicitly (an explicit search_mode always wins). The default stays
+    # 'off' until the stage-3 calibration gate (frozen 300-doc corpus) shows
+    # the router beating semantic-only — the same bar hybrid failed (#1212).
+    routing_mode: Mapped[str] = mapped_column(
+        String(10), nullable=False, server_default="off", default="off"
+    )
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
@@ -158,6 +169,10 @@ class ContextSearchConfig(Base):
         CheckConstraint(
             "reranker_provider IN ('voyage', 'cohere', 'self_hosted')",
             name="reranker_provider_check",
+        ),
+        CheckConstraint(
+            "routing_mode IN ('off', 'log_only', 'active')",
+            name="routing_mode_check",
         ),
     )
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -563,7 +563,10 @@ class ForgetRequest(BaseModel):
     """Request schema for forget() API."""
 
     memory_id: UUID | None = Field(default=None, description="削除するメモリID")
-    query: str | None = Field(default=None, description="削除する検索クエリ")
+    # #1212: bounded to match RecallRequest.query — forget-by-query builds an
+    # internal RecallRequest, so an unbounded query here would surface as an
+    # unhandled 500 deep inside the service instead of a 422 at the schema.
+    query: str | None = Field(default=None, max_length=8000, description="削除する検索クエリ")
     k: int = Field(default=10, ge=1, le=100, description="削除する結果数（query指定時）")
 
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -176,7 +176,10 @@ class RecallRequest(BaseModel):
         }
     """
 
-    query: str = Field(..., min_length=1, description="検索クエリ")
+    # #1212 gate2/CSO: bounded so oversized payloads 422 at the schema instead
+    # of reaching the embedding call / BM25 / classifier. 8000 chars leaves
+    # ample room for HyDE-style hypothetical-answer queries.
+    query: str = Field(..., min_length=1, max_length=8000, description="検索クエリ")
     k: int = Field(default=5, ge=1, le=100, description="返却結果数")
     use_rerank: bool = Field(default=False, description="Reranking (Voyage/Cohere)を使用")
     filters: dict | None = Field(default=None, description="オプショナルフィルタ")

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -180,10 +180,17 @@ class RecallRequest(BaseModel):
     k: int = Field(default=5, ge=1, le=100, description="返却結果数")
     use_rerank: bool = Field(default=False, description="Reranking (Voyage/Cohere)を使用")
     filters: dict | None = Field(default=None, description="オプショナルフィルタ")
-    search_mode: str = Field(
-        default="hybrid",
+    # #1212: None means "caller did not specify". MemoryService.recall resolves
+    # it to "hybrid" — or, when the context opts into routing_mode='active', to
+    # the query-router's lane. An explicitly passed search_mode ALWAYS wins.
+    search_mode: str | None = Field(
+        default=None,
         pattern="^(hybrid|semantic|keyword)$",
-        description="Search mode: hybrid (default), semantic (vector only), keyword (BM25 only)",
+        description=(
+            "Search mode: hybrid (default when omitted), semantic (vector only), "
+            "keyword (BM25 only). Omit to allow query-intent routing on contexts "
+            "with routing_mode='active' (#1212)."
+        ),
     )
     include_explore_hints: bool = Field(
         default=False,
@@ -481,6 +488,8 @@ class ExportedSearchConfig(BaseModel):
     reinforce_enabled: bool = True
     reinforce_max_boost: float = 0.15
     reinforce_require_host_arbitration: bool = False
+    # #1212: default keeps pre-routing exports parseable.
+    routing_mode: str = "off"
 
 
 class ExportedMemory(TZAwareBaseModel):
@@ -902,6 +911,11 @@ class ContextSearchConfigResponse(TZAwareBaseModel):
     reinforce_require_host_arbitration: bool = Field(
         default=False, description="Count only host-arbitrated (provenance='host') feedback"
     )
+    # Issue #1212: query-intent router experiment gate.
+    routing_mode: str = Field(
+        default="off",
+        description="Query-intent router: off | log_only (telemetry only) | active (opt-in)",
+    )
     created_at: datetime
     updated_at: datetime
 
@@ -943,6 +957,14 @@ class ContextSearchConfigUpdate(BaseModel):
         default=False,
         description="Forge-resistant mode — only host-arbitrated feedback "
         "(provenance='host') moves ranking; an untrusted agent's self-feedback is ignored",
+    )
+    # Issue #1212: optional (default-preserving via exclude_unset in the repo)
+    # so existing REST callers that omit it are unaffected.
+    routing_mode: str = Field(
+        default="off",
+        pattern="^(off|log_only|active)$",
+        description="Query-intent router: off | log_only (stamp telemetry, zero "
+        "ranking change) | active (routed lane used only when search_mode is omitted)",
     )
 
     @model_validator(mode="after")

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -416,6 +416,7 @@ class ContextService:
                 reinforce_enabled=cfg.reinforce_enabled,
                 reinforce_max_boost=float(cfg.reinforce_max_boost),
                 reinforce_require_host_arbitration=cfg.reinforce_require_host_arbitration,
+                routing_mode=cfg.routing_mode,
             )
             if cfg is not None
             else None

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1583,7 +1583,6 @@ class MemoryService:
             "topk": min(k, len(order_after)),
         }
 
-<<<<<<< HEAD
     async def _apply_supersede_shadowing(
         self,
         search_results: list[dict],
@@ -1687,7 +1686,7 @@ class MemoryService:
         except Exception as e:
             logger.warning("supersede_shadowing_failed", error=str(e))
             return {}, {}
-=======
+
     async def _resolve_search_mode(
         self,
         request: RecallRequest,
@@ -1757,7 +1756,6 @@ class MemoryService:
             features=route.features,
         )
         return effective_mode
->>>>>>> 61a3a17 (feat(search): query-intent retrieval router, experiment-gated (#1212))
 
     async def _maybe_reinforce_rerank(
         self,
@@ -2662,6 +2660,9 @@ class MemoryService:
         # Case 2: Delete by query (search and delete)
         elif request.query:
             # Search for matching memories
+            # #1212: pin the historical mode explicitly — the query router
+            # must never decide the candidate set of a DESTRUCTIVE operation
+            # (an explicit search_mode always wins, in every routing_mode).
             recall_request = RecallRequest(
                 query=request.query,
                 k=request.k,
@@ -2671,6 +2672,7 @@ class MemoryService:
                 # default shadowing would hide them from this search and
                 # make forget(query=...) silently skip them.
                 include_superseded=True,
+                search_mode="hybrid",
             )
 
             # Issue #82: Pass project ID to recall

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -62,6 +62,7 @@ from repositories.memory import MemoryRepository
 from services.context_routing import resolve_collection_name
 from services.context_service import ContextService
 from services.embedding_service import EmbeddingService
+from services.query_router import classify_query
 from services.search_service import SearchService
 from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import (
@@ -1582,6 +1583,7 @@ class MemoryService:
             "topk": min(k, len(order_after)),
         }
 
+<<<<<<< HEAD
     async def _apply_supersede_shadowing(
         self,
         search_results: list[dict],
@@ -1685,6 +1687,77 @@ class MemoryService:
         except Exception as e:
             logger.warning("supersede_shadowing_failed", error=str(e))
             return {}, {}
+=======
+    async def _resolve_search_mode(
+        self,
+        request: RecallRequest,
+        context_id: UUID,
+        *,
+        cross_context: bool,
+    ) -> str:
+        """#1212: resolve the effective search mode, optionally via the router.
+
+        Resolution order:
+
+        1. An explicitly passed ``search_mode`` ALWAYS wins (router never
+           overrides a caller's choice, in any routing_mode).
+        2. ``routing_mode='active'`` and no explicit mode → the classifier's
+           lane.
+        3. Otherwise → ``"hybrid"`` (the historical default).
+
+        In ``log_only`` and ``active`` the decision is stamped into telemetry
+        (``query_router_decision`` — numeric features only, never query text).
+        Cross-context recalls skip routing entirely: the config is
+        per-context and a mixed set has no single answer. The config read is
+        READ-ONLY (``get_by_context``, never ``create_or_get``) and
+        fail-open, mirroring the reinforce re-rank discipline: a config read
+        failure must never break recall.
+
+        Args:
+            request: The recall request (``search_mode`` may be None).
+            context_id: The single target context.
+            cross_context: True for multi-context recalls (routing skipped).
+
+        Returns:
+            The effective search mode ("hybrid" | "semantic" | "keyword").
+        """
+        requested_mode = request.search_mode
+        default_mode = requested_mode or "hybrid"
+        if cross_context:
+            return default_mode
+
+        try:
+            from repositories.config_repository import ContextSearchConfigRepository
+
+            config = await ContextSearchConfigRepository(self.db).get_by_context(context_id)
+        except Exception as exc:
+            logger.warning(
+                "query_router_config_read_failed",
+                context_id=str(context_id),
+                error=str(exc),
+            )
+            return default_mode
+
+        routing_mode = getattr(config, "routing_mode", None) if config else None
+        if routing_mode not in ("log_only", "active"):
+            return default_mode
+
+        route = classify_query(request.query)
+        applied = routing_mode == "active" and requested_mode is None
+        effective_mode = route.lane if applied else default_mode
+        logger.info(
+            "query_router_decision",
+            context_id=str(context_id),
+            routing_mode=routing_mode,
+            decided_lane=route.lane,
+            applied=applied,
+            requested_mode=requested_mode,
+            effective_mode=effective_mode,
+            reasons=list(route.reasons),
+            features=route.features,
+        )
+        return effective_mode
+>>>>>>> 61a3a17 (feat(search): query-intent retrieval router, experiment-gated (#1212))
 
     async def _maybe_reinforce_rerank(
         self,
@@ -1891,6 +1964,16 @@ class MemoryService:
         search_context_id: str | list[str] = str(current_context_id)
         if context_ids:
             search_context_id = [str(cid) for cid in context_ids]
+
+        # #1212: resolve the effective search mode exactly once, before any
+        # downstream read of request.search_mode (BYOK charge gate, hybrid
+        # search, neural checks). After this line it is always a concrete
+        # mode string; None (caller omitted it) never flows further.
+        request.search_mode = await self._resolve_search_mode(
+            request,
+            current_context_id,
+            cross_context=bool(context_ids),
+        )
 
         # Issue #496: ``analysis_cluster`` filter pre-resolves the cluster's
         # memory_ids so we can both (a) short-circuit empty clusters before

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1699,7 +1699,11 @@ class MemoryService:
         Resolution order:
 
         1. An explicitly passed ``search_mode`` ALWAYS wins (router never
-           overrides a caller's choice, in any routing_mode).
+           overrides a caller's choice, in any routing_mode) — and returns
+           immediately, skipping the config read and classification: no DB
+           round-trip or classify/log work on the hot path when the outcome
+           is already decided. Router telemetry therefore covers only the
+           calls the router could actually influence (search_mode omitted).
         2. ``routing_mode='active'`` and no explicit mode → the classifier's
            lane.
         3. Otherwise → ``"hybrid"`` (the historical default).
@@ -1722,7 +1726,7 @@ class MemoryService:
         """
         requested_mode = request.search_mode
         default_mode = requested_mode or "hybrid"
-        if cross_context:
+        if cross_context or requested_mode is not None:
             return default_mode
 
         try:

--- a/backend/src/services/query_router.py
+++ b/backend/src/services/query_router.py
@@ -52,12 +52,14 @@ MIXED_NATURAL_TOKEN_THRESHOLD = 4
 # turn the hot-path classifier into an algorithmic-DoS vector (gate2/CSO).
 CLASSIFY_MAX_CHARS = 2000
 
-# Single-quote literals must be whitespace-delimited on both sides so
-# apostrophes in ordinary English (contractions, possessives — "what's the
-# user's role") never read as an opening quote and hijack the semantic lane.
-# (?<!\S) = "not preceded by a non-space": matches at position 0 and after
-# whitespace, without the alternation-embedded ^ CodeQL flags as unmatchable.
-_QUOTED_LITERAL = re.compile(r'"[^"]{2,}"' r"|(?<!\S)'[^']{2,}'(?=\s|$)" r"|`[^`]{2,}`")
+# Single-quote literals must not butt against a word character on either
+# side, so apostrophes in ordinary English (contractions, possessives —
+# "what's the user's role") never read as an opening quote and hijack the
+# semantic lane. Word-boundary-style assertions (not whitespace-only) keep
+# punctuation-adjacent literals detectable — "what is 'foo bar'?" and
+# "('foo bar')" count like their double-quote twins. No embedded ^ (CodeQL
+# flags an alternation-embedded start-anchor as unmatchable).
+_QUOTED_LITERAL = re.compile(r'"[^"]{2,}"' r"|(?<![\w'])'[^']{2,}'(?![\w'])" r"|`[^`]{2,}`")
 _EXACT_ID_PATTERNS = (
     # UUID
     re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),

--- a/backend/src/services/query_router.py
+++ b/backend/src/services/query_router.py
@@ -55,7 +55,9 @@ CLASSIFY_MAX_CHARS = 2000
 # Single-quote literals must be whitespace-delimited on both sides so
 # apostrophes in ordinary English (contractions, possessives — "what's the
 # user's role") never read as an opening quote and hijack the semantic lane.
-_QUOTED_LITERAL = re.compile(r'"[^"]{2,}"' r"|(?:^|(?<=\s))'[^']{2,}'(?=\s|$)" r"|`[^`]{2,}`")
+# (?<!\S) = "not preceded by a non-space": matches at position 0 and after
+# whitespace, without the alternation-embedded ^ CodeQL flags as unmatchable.
+_QUOTED_LITERAL = re.compile(r'"[^"]{2,}"' r"|(?<!\S)'[^']{2,}'(?=\s|$)" r"|`[^`]{2,}`")
 _EXACT_ID_PATTERNS = (
     # UUID
     re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),

--- a/backend/src/services/query_router.py
+++ b/backend/src/services/query_router.py
@@ -46,6 +46,11 @@ MIN_SCRIPT_CHARS = 4
 # A keyword-signal query with at least this many natural-language tokens left
 # after removing the signal spans is "genuinely mixed" → hybrid.
 MIXED_NATURAL_TOKEN_THRESHOLD = 4
+# Classification reads at most this many characters. Routing signals live at
+# the front of real queries, and the bound makes the remainder-stripping loop
+# (O(matches × length)) constant-bounded — an attacker-sized query cannot
+# turn the hot-path classifier into an algorithmic-DoS vector (gate2/CSO).
+CLASSIFY_MAX_CHARS = 2000
 
 # Single-quote literals must be whitespace-delimited on both sides so
 # apostrophes in ordinary English (contractions, possessives — "what's the
@@ -120,7 +125,7 @@ def classify_query(query: str) -> QueryRoute:
         QueryRoute with the chosen lane, rule-hit reasons, and loggable
         numeric features (no query text).
     """
-    text = query.strip()
+    text = query[:CLASSIFY_MAX_CHARS].strip()
 
     quoted = _QUOTED_LITERAL.findall(text)
     exact_ids: list[str] = []

--- a/backend/src/services/query_router.py
+++ b/backend/src/services/query_router.py
@@ -1,0 +1,179 @@
+"""Deterministic query-intent classifier for retrieval routing (#1212).
+
+Pre-registered eval result (F1/H1): at 300-document scale fixed-weight hybrid
+fusion is a null (negative at the 4b embedder) against its own dense
+component, but the per-bucket decomposition is design-consistent — keyword
+(BM25 + Sudachi) wins exact-match and hiragana-heavy buckets, semantic wins
+semantic/cross-source buckets. The lanes exist (``search_mode``); this module
+supplies the missing per-query lane choice.
+
+Design constraints (issue #1212, gate1):
+
+- **Pure function, no I/O, no LLM** on the hot path — precompiled regex and
+  character-class counting only; sub-millisecond per call.
+- **Deterministic**: the same query always yields the same route, so
+  ``log_only`` telemetry is replayable and the (future, stage-3) calibration
+  gate can evaluate the exact production classifier offline.
+- Thresholds below are Phase-1 priors grounded in the eval bucket
+  decomposition, NOT calibrated constants — stage 3 (frozen-corpus
+  calibration gate) owns re-tuning them before any default flip.
+
+Rules, in order:
+
+1. Keyword signal (quoted literal / exact ID / code symbol) with little
+   natural-language remainder → ``keyword``.
+2. Keyword signal + substantial natural-language remainder (genuinely mixed)
+   → ``hybrid``.
+3. Hiragana-dominant query → ``keyword`` (the Sudachi lane; embedding models
+   underperform on hiragana-heavy text).
+4. Everything else → ``semantic`` (the strongest single arm at both measured
+   capacities).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# --- Phase-1 priors (stage-3 calibration owns re-tuning; see module docstring)
+
+# A query is "hiragana-dominant" when hiragana makes up more than this share
+# of its script-bearing characters (hiragana/katakana/kanji/latin/digits).
+HIRAGANA_DOMINANCE_THRESHOLD = 0.5
+# Dominance is only meaningful with at least this many script-bearing chars.
+MIN_SCRIPT_CHARS = 4
+# A keyword-signal query with at least this many natural-language tokens left
+# after removing the signal spans is "genuinely mixed" → hybrid.
+MIXED_NATURAL_TOKEN_THRESHOLD = 4
+
+# Single-quote literals must be whitespace-delimited on both sides so
+# apostrophes in ordinary English (contractions, possessives — "what's the
+# user's role") never read as an opening quote and hijack the semantic lane.
+_QUOTED_LITERAL = re.compile(r'"[^"]{2,}"' r"|(?:^|(?<=\s))'[^']{2,}'(?=\s|$)" r"|`[^`]{2,}`")
+_EXACT_ID_PATTERNS = (
+    # UUID
+    re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),
+    # long hex (commit SHAs, hashes) — must contain a digit to avoid words
+    re.compile(r"\b(?=[0-9a-f]*[0-9])[0-9a-f]{8,40}\b"),
+    # issue / PR references
+    re.compile(r"(?:^|\s)#\d+\b"),
+    # version strings
+    re.compile(r"\bv\d+\.\d+(?:\.\d+)?\b"),
+    # error / ticket codes (HEALTH-001, CWE-639, HTTP-500)
+    re.compile(r"\b[A-Z][A-Z0-9]{1,15}-\d+\b"),
+    # long digit runs (timestamps, ids)
+    re.compile(r"\b\d{6,}\b"),
+)
+_CODE_SYMBOL_PATTERNS = (
+    # snake_case identifiers
+    re.compile(r"\b[A-Za-z][A-Za-z0-9]*_[A-Za-z0-9_]+\b"),
+    # dotted paths / filenames (resolve.config.path, main.py)
+    re.compile(r"\b\w+\.(?:\w+\.)*(?:py|ts|tsx|js|jsx|md|json|yml|yaml|toml|sql|sh)\b"),
+    re.compile(r"\b\w+(?:\.\w+){2,}\b"),
+    # camelCase (lower→upper transition inside a word)
+    re.compile(r"\b[a-z]+[A-Z][A-Za-z0-9]*\b"),
+    # PascalCase with >=3 segments (MemoryHealthService). Two-segment words
+    # (JavaScript, GitHub) stay off this lane — they are ordinary proper
+    # nouns in natural questions far more often than code symbols.
+    re.compile(r"\b[A-Z][a-z0-9]+(?:[A-Z][a-z0-9]+){2,}\b"),
+    # call syntax / scope operators / paths
+    re.compile(r"\w+\(\)|::|->|(?:^|\s)/[\w.-]+(?:/[\w.-]+)+\b"),
+)
+
+_HIRAGANA = re.compile(r"[ぁ-ゟ]")
+_KATAKANA = re.compile(r"[゠-ヿ]")
+_KANJI = re.compile(r"[一-鿿]")
+_LATIN_ALNUM = re.compile(r"[A-Za-z0-9]")
+# Natural-language remainder tokens: latin words of >=3 letters, or CJK runs
+# of >=2 chars (a rough content-word proxy that works for both scripts).
+_NATURAL_TOKEN = re.compile(r"[A-Za-z]{3,}|[ぁ-ヿ一-鿿]{2,}")
+
+LANE_KEYWORD = "keyword"
+LANE_SEMANTIC = "semantic"
+LANE_HYBRID = "hybrid"
+
+
+@dataclass(frozen=True)
+class QueryRoute:
+    """Deterministic routing decision for one query.
+
+    Attributes:
+        lane: The chosen search lane (keyword / semantic / hybrid).
+        reasons: Ordered, human-readable rule hits that produced the lane.
+        features: Numeric signals backing the decision — safe to log
+            (contains counts and ratios, never query text).
+    """
+
+    lane: str
+    reasons: tuple[str, ...] = ()
+    features: dict[str, Any] = field(default_factory=dict)
+
+
+def classify_query(query: str) -> QueryRoute:
+    """Classify a recall query into a search lane. Pure and deterministic.
+
+    Args:
+        query: The raw recall query string.
+
+    Returns:
+        QueryRoute with the chosen lane, rule-hit reasons, and loggable
+        numeric features (no query text).
+    """
+    text = query.strip()
+
+    quoted = _QUOTED_LITERAL.findall(text)
+    exact_ids: list[str] = []
+    for pat in _EXACT_ID_PATTERNS:
+        exact_ids.extend(m if isinstance(m, str) else m[0] for m in pat.findall(text))
+    code_symbols: list[str] = []
+    for pat in _CODE_SYMBOL_PATTERNS:
+        code_symbols.extend(m if isinstance(m, str) else m[0] for m in pat.findall(text))
+
+    hiragana = len(_HIRAGANA.findall(text))
+    katakana = len(_KATAKANA.findall(text))
+    kanji = len(_KANJI.findall(text))
+    latin = len(_LATIN_ALNUM.findall(text))
+    script_chars = hiragana + katakana + kanji + latin
+    hiragana_ratio = (hiragana / script_chars) if script_chars else 0.0
+
+    # Natural-language remainder: strip every matched signal span, count what
+    # is left. Signals stripped as literal substrings — good enough for a
+    # token-count proxy.
+    # Strip longest spans first: a snake_case identifier is often a strict
+    # substring of a dotted path from the same query — removing the shorter
+    # span first would break the longer one and leak its outer fragments
+    # back in as false "natural language" tokens.
+    remainder = text
+    for span in sorted((*quoted, *exact_ids, *code_symbols), key=len, reverse=True):
+        remainder = remainder.replace(span.strip(), " ")
+    natural_tokens = len(_NATURAL_TOKEN.findall(remainder))
+
+    features: dict[str, Any] = {
+        "quoted_literals": len(quoted),
+        "exact_id_hits": len(exact_ids),
+        "code_symbol_hits": len(code_symbols),
+        "hiragana_ratio": round(hiragana_ratio, 3),
+        "script_chars": script_chars,
+        "natural_tokens": natural_tokens,
+        "query_len": len(text),
+    }
+
+    reasons: list[str] = []
+    if quoted:
+        reasons.append("quoted_literal")
+    if exact_ids:
+        reasons.append("exact_id")
+    if code_symbols:
+        reasons.append("code_symbol")
+
+    if reasons:  # keyword signal present
+        if natural_tokens >= MIXED_NATURAL_TOKEN_THRESHOLD:
+            reasons.append("mixed_natural_language")
+            return QueryRoute(LANE_HYBRID, tuple(reasons), features)
+        return QueryRoute(LANE_KEYWORD, tuple(reasons), features)
+
+    if script_chars >= MIN_SCRIPT_CHARS and hiragana_ratio > HIRAGANA_DOMINANCE_THRESHOLD:
+        return QueryRoute(LANE_KEYWORD, ("hiragana_dominant",), features)
+
+    return QueryRoute(LANE_SEMANTIC, ("default_semantic",), features)

--- a/backend/tests/mcp_server/test_update_search_config.py
+++ b/backend/tests/mcp_server/test_update_search_config.py
@@ -4,10 +4,15 @@ Issue #25: Validates that MCP tool reuses ContextSearchConfigUpdate Pydantic mod
 for consistent validation with REST API.
 """
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
 
 from models.schemas import ContextSearchConfigUpdate
+from repositories.config_repository import ContextSearchConfigRepository
 
 
 class TestSearchConfigValidation:
@@ -118,3 +123,49 @@ class TestSearchConfigValidation:
         )
         assert float(config.semantic_weight) == 0.5
         assert float(config.bm25_weight) == 0.5
+
+
+class TestPartialUpdatePreservesRoutingMode:
+    """Gate2/QA (#1212): a partial update that omits routing_mode must not
+    reset an opted-in context back to 'off' — the repository applies
+    model_dump(exclude_unset=True), pinned here through the real update()."""
+
+    @pytest.mark.asyncio
+    async def test_partial_update_keeps_active(self) -> None:
+        config = SimpleNamespace(routing_mode="active", semantic_weight=0.6)
+        repo = ContextSearchConfigRepository(AsyncMock())
+        repo.get_by_context = AsyncMock(return_value=config)
+
+        await repo.update(
+            uuid4(),
+            ContextSearchConfigUpdate(
+                semantic_weight=0.7,
+                bm25_weight=0.3,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2",
+            ),
+        )
+        assert config.routing_mode == "active"
+        assert float(config.semantic_weight) == 0.7
+
+    @pytest.mark.asyncio
+    async def test_explicit_routing_mode_is_applied(self) -> None:
+        config = SimpleNamespace(routing_mode="active")
+        repo = ContextSearchConfigRepository(AsyncMock())
+        repo.get_by_context = AsyncMock(return_value=config)
+
+        await repo.update(
+            uuid4(),
+            ContextSearchConfigUpdate(
+                semantic_weight=0.6,
+                bm25_weight=0.4,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2",
+                routing_mode="off",
+            ),
+        )
+        assert config.routing_mode == "off"

--- a/backend/tests/mcp_server/test_update_search_config.py
+++ b/backend/tests/mcp_server/test_update_search_config.py
@@ -57,6 +57,45 @@ class TestSearchConfigValidation:
                 reranker_model="rerank-2",
             )
 
+    def test_routing_mode_default_off(self):
+        """#1212: omitting routing_mode leaves it at 'off' (and unset, so the
+        repository's exclude_unset update does not touch the column)."""
+        config = ContextSearchConfigUpdate(
+            semantic_weight=0.6,
+            bm25_weight=0.4,
+            fetch_factor=3,
+            use_rerank=False,
+            reranker_provider="voyage",
+            reranker_model="rerank-2",
+        )
+        assert config.routing_mode == "off"
+        assert "routing_mode" not in config.model_dump(exclude_unset=True)
+
+    def test_routing_mode_accepts_all_gate_values(self):
+        for mode in ("off", "log_only", "active"):
+            config = ContextSearchConfigUpdate(
+                semantic_weight=0.6,
+                bm25_weight=0.4,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2",
+                routing_mode=mode,
+            )
+            assert config.routing_mode == mode
+
+    def test_routing_mode_rejects_unknown_value(self):
+        with pytest.raises(ValidationError):
+            ContextSearchConfigUpdate(
+                semantic_weight=0.6,
+                bm25_weight=0.4,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2",
+                routing_mode="always",
+            )
+
     def test_invalid_reranker_model_for_provider(self):
         with pytest.raises(ValidationError, match="Invalid model"):
             ContextSearchConfigUpdate(

--- a/backend/tests/services/test_context_export.py
+++ b/backend/tests/services/test_context_export.py
@@ -74,6 +74,8 @@ def _cfg():
     c.reinforce_enabled = False
     c.reinforce_max_boost = Decimal("0.15")
     c.reinforce_require_host_arbitration = False
+    # #1212: pin so the MagicMock attribute doesn't fail Pydantic validation.
+    c.routing_mode = "off"
     return c
 
 

--- a/backend/tests/services/test_query_router.py
+++ b/backend/tests/services/test_query_router.py
@@ -6,7 +6,10 @@ and the rule table from the issue — exact-ID / quoted-literal / code-symbol
 substantial natural language → hybrid, everything else → semantic.
 """
 
+import os
 import time
+
+import pytest
 
 from services.query_router import (
     CLASSIFY_MAX_CHARS,
@@ -190,6 +193,11 @@ class TestContract:
         route = classify_query("anything")
         assert isinstance(route, QueryRoute)
 
+    @pytest.mark.skipif(
+        os.getenv("RUN_PERF_TESTS") != "1",
+        reason="wall-clock assertion is flaky on shared CI runners; "
+        "opt in with RUN_PERF_TESTS=1 (same pattern as test_edge_invariant_perf)",
+    )
     def test_sub_millisecond_average(self) -> None:
         """Acceptance: sub-ms per call. Pinned loosely (0.5 ms avg over a
         long adversarial query) so CI jitter cannot flake it."""

--- a/backend/tests/services/test_query_router.py
+++ b/backend/tests/services/test_query_router.py
@@ -108,6 +108,21 @@ class TestApostropheSafety:
         assert route.lane == LANE_KEYWORD
         assert "quoted_literal" in route.reasons
 
+    def test_punctuation_adjacent_single_quote_literal_detected(self) -> None:
+        """Parity with the double-quote branch: trailing punctuation or
+        wrapping parens must not hide a single-quoted literal (code review,
+        PR #1221)."""
+        route = classify_query("what is 'foo bar'?")
+        assert route.features["quoted_literals"] == 1
+        assert classify_query("('foo bar')").features["quoted_literals"] == 1
+
+    def test_possessive_before_quote_still_safe(self) -> None:
+        """The word-boundary guard keeps the anti-hijack property: letters
+        touching an apostrophe never open a literal."""
+        route = classify_query("the users' and coaches' union schedule planning")
+        assert route.features["quoted_literals"] == 0
+        assert route.lane == LANE_SEMANTIC
+
 
 class TestRemainderStripping:
     """Inner-review regression: longest-span-first stripping — snake_case

--- a/backend/tests/services/test_query_router.py
+++ b/backend/tests/services/test_query_router.py
@@ -1,0 +1,156 @@
+"""Unit tests for the deterministic query-intent classifier (#1212).
+
+Pins the acceptance contract: pure function, deterministic, sub-millisecond,
+and the rule table from the issue — exact-ID / quoted-literal / code-symbol
+→ keyword, hiragana-dominant → keyword (Sudachi lane), keyword signal plus
+substantial natural language → hybrid, everything else → semantic.
+"""
+
+import time
+
+from services.query_router import (
+    LANE_HYBRID,
+    LANE_KEYWORD,
+    LANE_SEMANTIC,
+    QueryRoute,
+    classify_query,
+)
+
+
+class TestKeywordSignals:
+    def test_uuid_routes_keyword(self) -> None:
+        route = classify_query("550e8400-e29b-41d4-a716-446655440000")
+        assert route.lane == LANE_KEYWORD
+        assert "exact_id" in route.reasons
+
+    def test_issue_reference_routes_keyword(self) -> None:
+        assert classify_query("#1212").lane == LANE_KEYWORD
+
+    def test_version_string_routes_keyword(self) -> None:
+        assert classify_query("v0.45.0 changelog").lane == LANE_KEYWORD
+
+    def test_error_code_routes_keyword(self) -> None:
+        route = classify_query("HEALTH-001")
+        assert route.lane == LANE_KEYWORD
+        assert "exact_id" in route.reasons
+
+    def test_commit_sha_routes_keyword(self) -> None:
+        assert classify_query("2510682f").lane == LANE_KEYWORD
+
+    def test_quoted_literal_routes_keyword(self) -> None:
+        route = classify_query('"ConnectionResetError" retry')
+        assert route.lane == LANE_KEYWORD
+        assert "quoted_literal" in route.reasons
+
+    def test_snake_case_symbol_routes_keyword(self) -> None:
+        route = classify_query("resolve_context_routing")
+        assert route.lane == LANE_KEYWORD
+        assert "code_symbol" in route.reasons
+
+    def test_camel_case_symbol_routes_keyword(self) -> None:
+        assert classify_query("MemoryHealthService grading").lane == LANE_KEYWORD
+
+    def test_dotted_path_routes_keyword(self) -> None:
+        assert classify_query("services.memory_service.recall").lane == LANE_KEYWORD
+
+
+class TestMixedSignals:
+    def test_symbol_with_natural_question_routes_hybrid(self) -> None:
+        route = classify_query(
+            "how does resolve_context_routing decide the collection name for shared contexts"
+        )
+        assert route.lane == LANE_HYBRID
+        assert "mixed_natural_language" in route.reasons
+
+    def test_quoted_error_with_long_description_routes_hybrid(self) -> None:
+        route = classify_query(
+            'what causes "UndefinedColumnError" when the local database was stamped without migrations'
+        )
+        assert route.lane == LANE_HYBRID
+
+
+class TestHiraganaLane:
+    def test_hiragana_dominant_routes_keyword(self) -> None:
+        route = classify_query("きのうのぶんをさがして")
+        assert route.lane == LANE_KEYWORD
+        assert route.reasons == ("hiragana_dominant",)
+
+    def test_kanji_mixed_japanese_routes_semantic(self) -> None:
+        # 認証エラーの解決方法: hiragana share is 1/10 — kanji-carried content
+        # is embedding-friendly, so this stays on the semantic lane.
+        assert classify_query("認証エラーの解決方法").lane == LANE_SEMANTIC
+
+    def test_short_hiragana_below_min_chars_routes_semantic(self) -> None:
+        assert classify_query("これ").lane == LANE_SEMANTIC
+
+
+class TestApostropheSafety:
+    """Inner-review regression: apostrophes in ordinary English must never
+    read as an opening single-quote literal (semantic-lane hijack)."""
+
+    def test_contractions_stay_semantic(self) -> None:
+        route = classify_query("what's the user's role in this workspace")
+        assert route.lane == LANE_SEMANTIC
+        assert route.features["quoted_literals"] == 0
+
+    def test_negated_contraction_stays_semantic(self) -> None:
+        assert (
+            classify_query("why doesn't the reranker trigger when there's no BYOK key").lane
+            == LANE_SEMANTIC
+        )
+
+    def test_delimited_single_quote_literal_still_routes_keyword(self) -> None:
+        route = classify_query("'exact phrase' lookup")
+        assert route.lane == LANE_KEYWORD
+        assert "quoted_literal" in route.reasons
+
+
+class TestRemainderStripping:
+    """Inner-review regression: longest-span-first stripping — snake_case
+    substrings of dotted paths must not leak fragments as natural tokens."""
+
+    def test_pure_dotted_path_query_routes_keyword(self) -> None:
+        route = classify_query("check services.memory_service.py and services.context_service.py")
+        assert route.lane == LANE_KEYWORD
+        assert route.features["natural_tokens"] < 4
+
+
+class TestSemanticDefault:
+    def test_natural_english_question_routes_semantic(self) -> None:
+        route = classify_query("what were the design decisions for sleep maintenance")
+        assert route.lane == LANE_SEMANTIC
+        assert route.reasons == ("default_semantic",)
+
+    def test_empty_query_routes_semantic(self) -> None:
+        route = classify_query("   ")
+        assert route.lane == LANE_SEMANTIC
+        assert route.features["script_chars"] == 0
+
+
+class TestContract:
+    def test_deterministic(self) -> None:
+        q = 'why does "reinforce_rerank" boost v0.44.0 recall ordering'
+        assert classify_query(q) == classify_query(q)
+
+    def test_features_never_contain_query_text(self) -> None:
+        """Telemetry safety: features are numeric-only (no query content)."""
+        route = classify_query("secret PII-like query about JWT_SECRET rotation")
+        assert all(isinstance(v, (int, float)) for v in route.features.values())
+
+    def test_returns_frozen_route(self) -> None:
+        route = classify_query("anything")
+        assert isinstance(route, QueryRoute)
+
+    def test_sub_millisecond_average(self) -> None:
+        """Acceptance: sub-ms per call. Pinned loosely (0.5 ms avg over a
+        long adversarial query) so CI jitter cannot flake it."""
+        q = (
+            'how does "hybrid_search" in services.search_service merge BM25 and semantic '
+            "scores for v0.45.0 with fetch_factor 3 and #1212 routing まぜこぜのくえり "
+        ) * 3
+        n = 2000
+        start = time.perf_counter()
+        for _ in range(n):
+            classify_query(q)
+        avg = (time.perf_counter() - start) / n
+        assert avg < 0.0005, f"classifier too slow: {avg * 1000:.3f} ms/call"

--- a/backend/tests/services/test_query_router.py
+++ b/backend/tests/services/test_query_router.py
@@ -9,6 +9,7 @@ substantial natural language → hybrid, everything else → semantic.
 import time
 
 from services.query_router import (
+    CLASSIFY_MAX_CHARS,
     LANE_HYBRID,
     LANE_KEYWORD,
     LANE_SEMANTIC,
@@ -113,6 +114,54 @@ class TestRemainderStripping:
         route = classify_query("check services.memory_service.py and services.context_service.py")
         assert route.lane == LANE_KEYWORD
         assert route.features["natural_tokens"] < 4
+
+
+class TestScriptCoverage:
+    """Gate2/QA: katakana-only and EN+JA mixed queries."""
+
+    def test_katakana_only_routes_semantic(self) -> None:
+        # Katakana carries embedding-friendly content words — only HIRAGANA
+        # dominance triggers the Sudachi keyword lane.
+        route = classify_query("コンピューターのメモリーアーキテクチャ")
+        assert route.lane == LANE_SEMANTIC
+        assert route.features["hiragana_ratio"] <= 0.5
+
+    def test_mixed_en_ja_natural_routes_semantic(self) -> None:
+        assert classify_query("Kagura の recall 品質を改善する方法").lane == LANE_SEMANTIC
+
+
+class TestMixedThresholdBoundary:
+    """Gate2/QA: the natural_tokens >= 4 boundary, pinned exactly."""
+
+    def test_three_natural_tokens_routes_keyword(self) -> None:
+        route = classify_query("resolve_context_routing alpha beta gamma")
+        assert route.features["natural_tokens"] == 3
+        assert route.lane == LANE_KEYWORD
+
+    def test_four_natural_tokens_routes_hybrid(self) -> None:
+        route = classify_query("resolve_context_routing alpha beta gamma delta")
+        assert route.features["natural_tokens"] == 4
+        assert route.lane == LANE_HYBRID
+
+
+class TestAdversarialBound:
+    """Gate2/CSO: the remainder-stripping loop is O(matches x length) — the
+    CLASSIFY_MAX_CHARS truncation must keep pathological match-dense input
+    bounded regardless of raw query size."""
+
+    def test_match_dense_megaquery_stays_bounded(self) -> None:
+        q = "a_a " * 100_000  # 400k chars, one snake_case match per 4 chars
+        start = time.perf_counter()
+        route = classify_query(q)
+        elapsed = time.perf_counter() - start
+        assert route.lane == LANE_KEYWORD
+        assert elapsed < 0.05, f"adversarial query took {elapsed * 1000:.1f} ms"
+
+    def test_truncation_is_deterministic(self) -> None:
+        q = "x" * (CLASSIFY_MAX_CHARS + 500) + " resolve_context_routing"
+        assert classify_query(q) == classify_query(q)
+        # the signal beyond the bound is invisible by design
+        assert classify_query(q).features["code_symbol_hits"] == 0
 
 
 class TestSemanticDefault:

--- a/backend/tests/services/test_query_routing_resolution.py
+++ b/backend/tests/services/test_query_routing_resolution.py
@@ -1,0 +1,175 @@
+"""Tests for MemoryService._resolve_search_mode (#1212 routing hook).
+
+Pins the acceptance contract: log_only changes NOTHING about the effective
+mode (zero ranking change), active applies the routed lane only when the
+caller omitted search_mode, an explicit search_mode always wins in every
+routing_mode, and the hook is fail-open (config read failure or missing
+config row never breaks recall).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from services.memory_service import MemoryService
+
+_CTX = uuid4()
+# classify_query routes this to "keyword" (exact-id) — distinguishable from
+# both the "hybrid" fallback and any explicit mode used in the tests.
+_KEYWORD_QUERY = "HEALTH-001"
+
+
+def _service() -> MemoryService:
+    svc = MemoryService.__new__(MemoryService)
+    svc.db = AsyncMock()
+    return svc
+
+
+def _request(query: str = _KEYWORD_QUERY, search_mode: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(query=query, search_mode=search_mode)
+
+
+def _patch_config(routing_mode: str | None):
+    """Patch the repository to return a config row (or None)."""
+    config = None if routing_mode is None else SimpleNamespace(routing_mode=routing_mode)
+    repo = MagicMock()
+    repo.get_by_context = AsyncMock(return_value=config)
+    return patch(
+        "repositories.config_repository.ContextSearchConfigRepository",
+        return_value=repo,
+    )
+
+
+class TestRoutingOff:
+    @pytest.mark.asyncio
+    async def test_no_config_row_defaults_hybrid(self) -> None:
+        with _patch_config(None):
+            assert (
+                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+                == "hybrid"
+            )
+
+    @pytest.mark.asyncio
+    async def test_off_defaults_hybrid(self) -> None:
+        with _patch_config("off"):
+            assert (
+                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+                == "hybrid"
+            )
+
+    @pytest.mark.asyncio
+    async def test_off_explicit_mode_wins(self) -> None:
+        with _patch_config("off"):
+            assert (
+                await _service()._resolve_search_mode(
+                    _request(search_mode="semantic"), _CTX, cross_context=False
+                )
+                == "semantic"
+            )
+
+
+class TestLogOnly:
+    @pytest.mark.asyncio
+    async def test_log_only_never_changes_the_mode(self) -> None:
+        """The zero-ranking-change guarantee: the classifier says keyword,
+        the effective mode stays the historical default."""
+        with _patch_config("log_only"):
+            assert (
+                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+                == "hybrid"
+            )
+
+    @pytest.mark.asyncio
+    async def test_log_only_explicit_mode_wins(self) -> None:
+        with _patch_config("log_only"):
+            assert (
+                await _service()._resolve_search_mode(
+                    _request(search_mode="keyword"), _CTX, cross_context=False
+                )
+                == "keyword"
+            )
+
+    @pytest.mark.asyncio
+    async def test_log_only_stamps_telemetry(self) -> None:
+        with (
+            _patch_config("log_only"),
+            patch("services.memory_service.logger") as log,
+        ):
+            await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+        events = [c for c in log.info.call_args_list if c.args[0] == "query_router_decision"]
+        assert len(events) == 1
+        kwargs = events[0].kwargs
+        assert kwargs["routing_mode"] == "log_only"
+        assert kwargs["decided_lane"] == "keyword"
+        assert kwargs["applied"] is False
+        assert kwargs["effective_mode"] == "hybrid"
+        # Telemetry privacy: the query text itself is never logged.
+        assert _KEYWORD_QUERY not in str(kwargs)
+
+
+class TestActive:
+    @pytest.mark.asyncio
+    async def test_active_routes_when_mode_omitted(self) -> None:
+        with _patch_config("active"):
+            assert (
+                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+                == "keyword"
+            )
+
+    @pytest.mark.asyncio
+    async def test_active_explicit_mode_always_wins(self) -> None:
+        with _patch_config("active"):
+            assert (
+                await _service()._resolve_search_mode(
+                    _request(search_mode="hybrid"), _CTX, cross_context=False
+                )
+                == "hybrid"
+            )
+
+    @pytest.mark.asyncio
+    async def test_active_semantic_query_routes_semantic(self) -> None:
+        with _patch_config("active"):
+            assert (
+                await _service()._resolve_search_mode(
+                    _request(query="what were the sleep maintenance design decisions"),
+                    _CTX,
+                    cross_context=False,
+                )
+                == "semantic"
+            )
+
+
+class TestFailOpenAndScope:
+    @pytest.mark.asyncio
+    async def test_cross_context_skips_routing_and_config_read(self) -> None:
+        repo_cls = MagicMock()
+        with patch("repositories.config_repository.ContextSearchConfigRepository", repo_cls):
+            mode = await _service()._resolve_search_mode(_request(), _CTX, cross_context=True)
+        assert mode == "hybrid"
+        repo_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_config_read_failure_fails_open(self) -> None:
+        repo = MagicMock()
+        repo.get_by_context = AsyncMock(side_effect=RuntimeError("db down"))
+        with patch(
+            "repositories.config_repository.ContextSearchConfigRepository",
+            return_value=repo,
+        ):
+            mode = await _service()._resolve_search_mode(
+                _request(search_mode="semantic"), _CTX, cross_context=False
+            )
+        assert mode == "semantic"
+
+    @pytest.mark.asyncio
+    async def test_mock_like_config_without_valid_mode_is_off(self) -> None:
+        """A config whose routing_mode is not a recognized value (e.g. a
+        MagicMock attribute) must behave as 'off' — membership check, never
+        truthiness (#1207 lesson)."""
+        with _patch_config(""):
+            assert (
+                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+                == "hybrid"
+            )

--- a/backend/tests/services/test_query_routing_resolution.py
+++ b/backend/tests/services/test_query_routing_resolution.py
@@ -171,6 +171,19 @@ class TestFailOpenAndScope:
         repo_cls.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_explicit_mode_skips_config_read_and_classification(self) -> None:
+        """An explicit search_mode is guaranteed to win, so the resolver
+        must return immediately — no config round-trip, no classify/log
+        work on the hot path (Copilot, PR #1221)."""
+        repo_cls = MagicMock()
+        with patch("repositories.config_repository.ContextSearchConfigRepository", repo_cls):
+            mode = await _service()._resolve_search_mode(
+                _request(search_mode="keyword"), _CTX, cross_context=False
+            )
+        assert mode == "keyword"
+        repo_cls.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_config_read_failure_fails_open(self) -> None:
         repo = MagicMock()
         repo.get_by_context = AsyncMock(side_effect=RuntimeError("db down"))

--- a/backend/tests/services/test_query_routing_resolution.py
+++ b/backend/tests/services/test_query_routing_resolution.py
@@ -141,6 +141,26 @@ class TestActive:
             )
 
 
+class TestNeverNone:
+    """Gate2/QA: the resolver's return is a concrete mode string on every
+    (requested x routing_mode x config-presence) branch — None can never
+    leak into SearchService.hybrid_search's mode validation."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("requested", [None, "hybrid", "semantic", "keyword"])
+    @pytest.mark.parametrize("routing_mode", [None, "off", "log_only", "active"])
+    async def test_all_branches_return_concrete_mode(
+        self, requested: str | None, routing_mode: str | None
+    ) -> None:
+        with _patch_config(routing_mode):
+            mode = await _service()._resolve_search_mode(
+                _request(search_mode=requested), _CTX, cross_context=False
+            )
+        assert mode in ("hybrid", "semantic", "keyword")
+        if requested is not None:
+            assert mode == requested
+
+
 class TestFailOpenAndScope:
     @pytest.mark.asyncio
     async def test_cross_context_skips_routing_and_config_read(self) -> None:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -161,6 +161,40 @@ update-by-removal remains the default), a judged merge creates a
 alive-but-shadowed. Neither type is LLM-emittable by edge discovery — the
 sleep judge cannot invent supersession.
 
+### Choosing a lane: search_mode and per-workload guidance
+
+`recall()` accepts `search_mode`: `hybrid` (default), `semantic` (vector only),
+or `keyword` (BM25 only, no embedding call). The pre-registered eval program
+(300-doc frozen corpus) found that fixed-weight hybrid fusion does **not** beat
+its own semantic component overall — but the per-bucket picture is
+design-consistent:
+
+| Your query traffic looks like… | Best lane |
+|---|---|
+| Exact IDs, error codes, commit SHAs, quoted literals, code symbols | `keyword` |
+| Hiragana-heavy Japanese (embedding models struggle here) | `keyword` (Sudachi tokenization) |
+| Natural-language questions, cross-source "what did we decide" queries | `semantic` |
+| Genuinely mixed (a symbol + a real question around it) | `hybrid` |
+
+### Query-intent routing (experiment-gated, #1212)
+
+Instead of making every caller pick a lane, a context can opt into a
+**deterministic query router** (no LLM on the hot path — regex and
+character-class counting, sub-millisecond): set `routing_mode` via
+`update_search_config`:
+
+- `off` (default) — router never runs.
+- `log_only` — the classifier's lane decision is stamped into telemetry
+  (`query_router_decision`, numeric features only — never query text) with
+  **zero ranking change**. Enable this first to measure your real traffic mix.
+- `active` — `recall()` calls that **omit** `search_mode` use the routed lane.
+  An explicitly passed `search_mode` always wins, in every mode.
+
+The router does not become the default until it clears the stage-3 calibration
+gate on the frozen eval corpus (beat semantic-only overall AND beat the
+strongest single component on each routed bucket) — the same bar fixed-weight
+hybrid failed.
+
 ## Neural Memory
 
 **Neural Memory** creates automatic relationships between memories using brain-inspired algorithms.


### PR DESCRIPTION
Closes #1212

## What

Stage 1+2 of the query-intent retrieval router — the missing per-query lane choice over the lanes that already exist (`search_mode` hybrid/semantic/keyword):

- **`services/query_router.py`** — deterministic classifier, no LLM on the hot path (precompiled regex + character-class counting; sub-ms, unit-pinned). Rules ground in the pre-registered eval per-bucket decomposition: exact-ID / quoted-literal / code-symbol → `keyword`; hiragana-dominant → `keyword` (Sudachi lane); keyword signal + substantial natural language → `hybrid`; else `semantic`.
- **`ContextSearchConfig.routing_mode`** (`off` | `log_only` | `active`, default `off`; e58 migration with CHECK) — per-context experiment gate, settable via `update_search_config` (MCP + REST).
- **`log_only`** stamps `query_router_decision` telemetry (numeric features + fixed reason strings only — never query text) with **zero ranking change**. Ships first to measure the real traffic mix.
- **`active`** uses the routed lane ONLY for `recall()` calls that omit `search_mode`. An explicit `search_mode` always wins, in every mode.

## Plumbing

- `RecallRequest.search_mode: str | None = None` — None means "caller omitted it"; resolved exactly once at the top of `recall()` (`_resolve_search_mode`), before any downstream read. MCP `handle_recall` passes `args.get("search_mode")` through.
- Config read is READ-ONLY (`get_by_context`, never `create_or_get`) and fail-open — a config read failure or missing row degrades to the historical default, mirroring the reinforce re-rank discipline.
- Cross-context recalls skip routing (config is per-context; a mixed set has no single answer).
- `ExportedSearchConfig` carries `routing_mode` (default `"off"` keeps pre-routing exports parseable).

## What this deliberately does NOT do

- **No default flip.** The router becomes default only after the stage-3 calibration gate on the frozen 300-doc corpus: beat semantic-only overall AND beat the strongest single component on each routed bucket — the same bar fixed-weight hybrid failed. Stages 3-4 (calibration gate + per-context calibration store) tracked in #1220.
- Per-bucket eval reporting (acceptance bullet 3) already exists — `runner.py` emits `per_bucket` in the results JSON.

## Migration coordination (v0.45.0)

e58 chains from e54, in parallel with e55 (#1215) / e56 (#1217) / e57 (#1218) on their unmerged branches. **Whichever PR merges later must bump `down_revision` to the then-current head** — procedure noted in each migration's docstring; alembic fails loudly on multiple heads.

## Gate2 hardening (CSO yellow → addressed)

- Classifier input capped at `CLASSIFY_MAX_CHARS=2000` — the remainder-stripping loop is O(matches × length), so truncation makes it constant-bounded (adversarial 400k-char match-dense query pinned <50 ms).
- `RecallRequest.query` bounded at `max_length=8000` (was unbounded; 422 at the schema, ample for HyDE-style queries).

## Tests

- 36 new tests: 24 classifier (incl. inner-review regression classes: apostrophe/contraction safety, longest-span-first remainder stripping) + 12 resolution-hook (log_only zero-change, active-only-when-omitted, explicit-always-wins, fail-open, cross-context skip, MagicMock-truthiness guard).
- Full backend non-integration battery: 4073 passed (16 failures = known `/tmp/wt` staging artifacts: 7 OAuth template + 9 repo-root-file tests; verified classes, not regressions).
- e58 verified on a scratch DB: full chain upgrade, downgrade→upgrade round-trip, column default `'off'`, CHECK constraint confirmed via `pg_get_constraintdef`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
