### PR TITLE
feat(neural): graph signal in recall — placebo-gated experiment (#1213)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,12 @@ eval-ci-gates:
 		--require update \
 		--update "$$(ls -t tests/eval/results/update-*.json 2>/dev/null | head -1)"
 
+.PHONY: eval-graph-boost
+eval-graph-boost:
+	@echo "Running live #1213 graph-boost placebo gate (needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/graph-boost-<date>.json — real run only, never fabricated."
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.graph_boost_runner
+
 .PHONY: eval-reinforce
 eval-reinforce:
 	@echo "Running live reinforce ON-vs-OFF rollout gate (Issue #1069, needs the stack: make up)..."

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1815,9 +1815,19 @@ class MemoryService:
 
             from models.memory import NeuralMemoryEdge
 
+            # The experiment is defined over the hybrid top-k SLICE, not the
+            # expanded candidate pool (recall over-fetches k*4 when neural is
+            # on): boosting the whole pool would let pool-only items ride
+            # into the visible slice — a different experiment than the one
+            # the eval program measured — and inflate the edge-query size.
+            limit = len(search_results) if top_k is None else min(top_k, len(search_results))
+            scoped = search_results[:limit]
+            if len(scoped) < 2:
+                return
+
             cand_ids = []
             seen: set = set()
-            for r in search_results:
+            for r in scoped:
                 mem = memories.get(r["id"])
                 if mem is not None and mem.id not in seen:
                     seen.add(mem.id)
@@ -1867,16 +1877,18 @@ class MemoryService:
                 g = factors.get(sid, 1.0) if sid is not None else 1.0
                 return base * r.get("_rerank_factor", 1.0) * g
 
-            order_before = [x for x in (_sid(r) for r in search_results) if x is not None]
-            search_results.sort(key=_adjusted, reverse=True)
-            for r in search_results:
+            # Sort and stamp ONLY the top-k slice; items past the slice keep
+            # their original order (they are outside the experiment).
+            order_before = [x for x in (_sid(r) for r in scoped) if x is not None]
+            scoped.sort(key=_adjusted, reverse=True)
+            for r in scoped:
                 sid = _sid(r)
                 if sid is not None:
                     r["_rerank_factor"] = r.get("_rerank_factor", 1.0) * factors.get(sid, 1.0)
-            order_after = [x for x in (_sid(r) for r in search_results) if x is not None]
+            search_results[:limit] = scoped
+            order_after = [x for x in (_sid(r) for r in scoped) if x is not None]
 
             try:
-                k = top_k if top_k is not None else len(order_after)
                 logger.info(
                     "graph_boost_applied",
                     context_id=str(context_id),
@@ -1884,7 +1896,7 @@ class MemoryService:
                     candidates=len(cand_ids),
                     connected=len(conn),
                     max_conn=round(max_conn, 4),
-                    reordered_topk=order_before[:k] != order_after[:k],
+                    reordered_topk=order_before != order_after,
                 )
             except Exception:  # noqa: BLE001 - telemetry must not break recall
                 logger.warning("graph_boost_telemetry_failed", context_id=str(context_id))

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1784,6 +1784,7 @@ class MemoryService:
         search_results: list[dict],
         memories: dict,
         context_id: UUID | None,
+        user_id: str | None,
         top_k: int | None = None,
     ) -> None:
         """#1213: bounded multiplicative graph term over the hybrid top-k.
@@ -1807,7 +1808,7 @@ class MemoryService:
         preserves the ranking).
         """
         enabled, max_boost = self._graph_boost_settings()
-        if not enabled or context_id is None or len(search_results) < 2:
+        if not enabled or context_id is None or user_id is None or len(search_results) < 2:
             return
         try:
             from sqlalchemy import select
@@ -1829,6 +1830,11 @@ class MemoryService:
                     NeuralMemoryEdge.src_id, NeuralMemoryEdge.dst_id, NeuralMemoryEdge.weight
                 ).where(
                     NeuralMemoryEdge.context_id == context_id,
+                    # Per-user scope, same discipline as activation.py: in a
+                    # shared context another member's co-activation history
+                    # (forgeable by deliberate co-recall) must not move THIS
+                    # caller's ranking (gate2/CSO).
+                    NeuralMemoryEdge.user_id == user_id,
                     NeuralMemoryEdge.origin == "hebbian",
                     NeuralMemoryEdge.src_id.in_(cand_ids),
                     NeuralMemoryEdge.dst_id.in_(cand_ids),
@@ -2353,6 +2359,7 @@ class MemoryService:
             search_results,
             memories,
             current_context_id if not context_ids else None,
+            user_id,
             top_k=request.k,
         )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1761,6 +1761,130 @@ class MemoryService:
         )
         return effective_mode
 
+    @staticmethod
+    def _graph_boost_settings() -> tuple[bool, float]:
+        """#1213: env-gated experiment flag (read per call, like the eval pins).
+
+        An env flag — not a ContextSearchConfig column — because this is a
+        flagged EXPERIMENT: it must not mint a fifth parallel migration head
+        (e55-e58 already coordinate), and per-context graduation only happens
+        if the placebo gate (tests/eval/graph_boost_gate.py) passes.
+        """
+        import os
+
+        enabled = os.getenv("KAGURA_GRAPH_BOOST_ENABLED", "").lower() in ("1", "true")
+        try:
+            max_boost = float(os.getenv("KAGURA_GRAPH_BOOST_MAX", "0.15"))
+        except ValueError:
+            max_boost = 0.15
+        return enabled, max(0.0, min(max_boost, 0.5))
+
+    async def _maybe_graph_boost(
+        self,
+        search_results: list[dict],
+        memories: dict,
+        context_id: UUID | None,
+        top_k: int | None = None,
+    ) -> None:
+        """#1213: bounded multiplicative graph term over the hybrid top-k.
+
+        Placebo-gated EXPERIMENT (default off; when off, recall is
+        bit-identical: no edge query, no reorder). When
+        ``KAGURA_GRAPH_BOOST_ENABLED`` is set, each candidate score is
+        multiplied by ``1 + b * conn/max_conn`` where ``conn`` is the summed
+        weight of its hebbian edges to OTHER candidates in the same pool —
+        the warm co-activation companion structure the eval program measured
+        (+0.20 recovery over a degree-matched rewiring). Boost-only
+        ([1, 1+b]); isolated candidates keep factor 1.0.
+        Multiplicative-with-cap, NOT additive score fusion — the F1 hybrid
+        null showed fixed additive fusion dilutes precision.
+
+        Hebbian origin only: boosting on ``semantic`` edges would
+        double-count the vector similarity already in the base score, and
+        ``declared`` edges are unmeasured. Composes with the reinforce
+        re-rank via the ``_rerank_factor`` stamp (a product of two bounded
+        factors stays bounded). Single-context only; fail-safe (any failure
+        preserves the ranking).
+        """
+        enabled, max_boost = self._graph_boost_settings()
+        if not enabled or context_id is None or len(search_results) < 2:
+            return
+        try:
+            from sqlalchemy import select
+
+            from models.memory import NeuralMemoryEdge
+
+            cand_ids = []
+            seen: set = set()
+            for r in search_results:
+                mem = memories.get(r["id"])
+                if mem is not None and mem.id not in seen:
+                    seen.add(mem.id)
+                    cand_ids.append(mem.id)
+            if len(cand_ids) < 2:
+                return
+
+            rows = await self.db.execute(
+                select(
+                    NeuralMemoryEdge.src_id, NeuralMemoryEdge.dst_id, NeuralMemoryEdge.weight
+                ).where(
+                    NeuralMemoryEdge.context_id == context_id,
+                    NeuralMemoryEdge.origin == "hebbian",
+                    NeuralMemoryEdge.src_id.in_(cand_ids),
+                    NeuralMemoryEdge.dst_id.in_(cand_ids),
+                    NeuralMemoryEdge.src_id != NeuralMemoryEdge.dst_id,
+                )
+            )
+            conn: dict[str, float] = {}
+            for src_id, dst_id, weight in rows.all():
+                w = float(weight or 0.0)
+                conn[str(src_id)] = conn.get(str(src_id), 0.0) + w
+                conn[str(dst_id)] = conn.get(str(dst_id), 0.0) + w
+            max_conn = max(conn.values(), default=0.0)
+            if max_conn <= 0.0:
+                return
+
+            def _sid(r: dict) -> str | None:
+                mem = memories.get(r["id"])
+                return str(mem.id) if mem is not None else None
+
+            factors: dict[str, float] = {
+                sid: 1.0 + max_boost * (conn.get(sid, 0.0) / max_conn)
+                for sid in (str(c) for c in cand_ids)
+            }
+
+            def _adjusted(r: dict) -> float:
+                base = r.get("hybrid_score")
+                if base is None:
+                    base = r.get("score") or 0.0
+                sid = _sid(r)
+                g = factors.get(sid, 1.0) if sid is not None else 1.0
+                return base * r.get("_rerank_factor", 1.0) * g
+
+            order_before = [x for x in (_sid(r) for r in search_results) if x is not None]
+            search_results.sort(key=_adjusted, reverse=True)
+            for r in search_results:
+                sid = _sid(r)
+                if sid is not None:
+                    r["_rerank_factor"] = r.get("_rerank_factor", 1.0) * factors.get(sid, 1.0)
+            order_after = [x for x in (_sid(r) for r in search_results) if x is not None]
+
+            try:
+                k = top_k if top_k is not None else len(order_after)
+                logger.info(
+                    "graph_boost_applied",
+                    context_id=str(context_id),
+                    max_boost=round(max_boost, 4),
+                    candidates=len(cand_ids),
+                    connected=len(conn),
+                    max_conn=round(max_conn, 4),
+                    reordered_topk=order_before[:k] != order_after[:k],
+                )
+            except Exception:  # noqa: BLE001 - telemetry must not break recall
+                logger.warning("graph_boost_telemetry_failed", context_id=str(context_id))
+        except Exception as exc:  # noqa: BLE001 - experiment must never break recall
+            logger.warning("graph_boost_skipped", context_id=str(context_id), error=str(exc))
+
     async def _maybe_reinforce_rerank(
         self,
         search_results: list[dict],
@@ -1855,6 +1979,13 @@ class MemoryService:
                     base = r.get("score") or 0.0
                 sid = _sid(r)
                 return base * (factors.get(sid, 1.0) if sid is not None else 1.0)
+
+            # #1213: stamp the factor so any later bounded re-ranker (e.g. the
+            # graph-boost experiment) composes multiplicatively instead of
+            # re-sorting by the raw base and silently erasing this re-rank.
+            for r in search_results:
+                sid = _sid(r)
+                r["_rerank_factor"] = factors.get(sid, 1.0) if sid is not None else 1.0
 
             order_before = [s for s in (_sid(r) for r in search_results) if s is not None]
             search_results.sort(key=_adjusted, reverse=True)
@@ -2210,6 +2341,15 @@ class MemoryService:
         # candidate pool BEFORE the top-k slice below; uses only reference_count +
         # feedback + importance + recency — never graph signals (respects #120).
         await self._maybe_reinforce_rerank(
+            search_results,
+            memories,
+            current_context_id if not context_ids else None,
+            top_k=request.k,
+        )
+        # #1213: placebo-gated graph-boost experiment (env flag, default off —
+        # bit-identical when off). Runs after reinforce and composes with it
+        # via the _rerank_factor stamp.
+        await self._maybe_graph_boost(
             search_results,
             memories,
             current_context_id if not context_ids else None,

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1770,11 +1770,17 @@ class MemoryService:
         (e55-e58 already coordinate), and per-context graduation only happens
         if the placebo gate (tests/eval/graph_boost_gate.py) passes.
         """
+        import math
         import os
 
         enabled = os.getenv("KAGURA_GRAPH_BOOST_ENABLED", "").lower() in ("1", "true")
         try:
             max_boost = float(os.getenv("KAGURA_GRAPH_BOOST_MAX", "0.15"))
+            # float() accepts "nan"/"inf" without raising — "nan" would
+            # otherwise clamp to 0.0 and silently disable the experiment
+            # while telemetry still reports it applied.
+            if not math.isfinite(max_boost):
+                max_boost = 0.15
         except ValueError:
             max_boost = 0.15
         return enabled, max(0.0, min(max_boost, 0.5))

--- a/backend/tests/eval/graph_boost_gate.py
+++ b/backend/tests/eval/graph_boost_gate.py
@@ -98,7 +98,7 @@ def evaluate_gate(
     Returns:
         JSON-shaped verdict: per-arm metrics, both BCa intervals, the
         non-inferiority delta, and ``verdict`` in {ship, density_artifact,
-        no_effect, regression}. A clean "does not beat placebo, not shipped"
+        no_effect, regression, underpowered}. A clean "does not beat placebo, not shipped"
         is a valid close (the issue's acceptance wording).
     """
     vs_unboosted = paired_bca_ci(

--- a/backend/tests/eval/graph_boost_gate.py
+++ b/backend/tests/eval/graph_boost_gate.py
@@ -1,0 +1,146 @@
+"""Pure logic for the #1213 graph-boost placebo gate.
+
+The recall graph-boost (``MemoryService._maybe_graph_boost``) ships as an
+env-gated EXPERIMENT (default off). This module defines the pre-declared gate
+that decides whether it may graduate to a per-context feature — the exact
+protocol from issue #1213:
+
+- **beats no-graph** — boosted recall must beat unboosted recall on
+  companion-carrying queries (paired BCa CI for the mean per-query delta must
+  exclude 0 from below);
+- **beats placebo** — boosted-on-the-real-graph must beat the same boost
+  computed on a degree-matched rewired graph. Beating no-graph but not the
+  placebo = density artifact = does NOT ship (the §6 kill-shot logic);
+- **non-inferiority** — held-out P@5 on non-graph queries must not regress by
+  more than the pre-declared epsilon (the F1 fusion-dilution lesson).
+
+Everything here is deterministic and infrastructure-free (unit-tested in
+``test_graph_boost_gate.py``). The live orchestration that produces the arm
+rankings lives in ``tests.eval.graph_boost_runner``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from tests.eval.metrics import mean_precision_at_k, mrr_at_k, precision_at_k
+from tests.eval.stats import paired_bca_ci
+
+#: One query result: ranked doc-ids + gold set (the #344 metrics shape).
+Ranking = tuple[Sequence[str], set[str]]
+
+#: The gate's primary metric on companion queries. P@5 matches the
+#: pre-registered headline metric of the retrieval eval.
+PRIMARY_K = 5
+
+#: Pre-declared non-inferiority margin on non-graph queries (absolute P@5).
+NON_INFERIORITY_EPSILON = 0.01
+
+#: BCa resamples (matches the eval program's inferential runs).
+BCA_RESAMPLES = 10_000
+
+GATE_SHIP = "ship"
+GATE_DENSITY_ARTIFACT = "density_artifact"
+GATE_NO_EFFECT = "no_effect"
+GATE_REGRESSION = "regression"
+
+
+def per_query_deltas(arm_a: Sequence[Ranking], arm_b: Sequence[Ranking], k: int) -> list[float]:
+    """Paired per-query P@k differences (a - b). Raises on length mismatch."""
+    if len(arm_a) != len(arm_b):
+        raise ValueError(f"paired arms differ in length: {len(arm_a)} vs {len(arm_b)}")
+    return [
+        precision_at_k(ranked_a, gold_a, k) - precision_at_k(ranked_b, gold_b, k)
+        for (ranked_a, gold_a), (ranked_b, gold_b) in zip(arm_a, arm_b, strict=True)
+    ]
+
+
+def arm_metrics(rankings: Sequence[Ranking]) -> dict[str, float | int]:
+    """Summary metric block for one arm (reuses the #344 binary metrics)."""
+    return {
+        "n": len(rankings),
+        "p@5": round(mean_precision_at_k(rankings, 5), 4),
+        "mrr@10": round(mrr_at_k(rankings, 10), 4),
+    }
+
+
+def evaluate_gate(
+    *,
+    boosted_real: Sequence[Ranking],
+    unboosted: Sequence[Ranking],
+    boosted_rewired: Sequence[Ranking],
+    nongraph_boosted: Sequence[Ranking],
+    nongraph_unboosted: Sequence[Ranking],
+    seed: int,
+) -> dict[str, Any]:
+    """Apply the pre-declared #1213 contracts to the measured arm rankings.
+
+    Args:
+        boosted_real: Companion queries, graph boost ON, real warm graph.
+        unboosted: Same queries, boost OFF (paired).
+        boosted_rewired: Same queries, boost ON, degree-matched rewired graph
+            (paired).
+        nongraph_boosted / nongraph_unboosted: Held-out non-graph queries,
+            boost ON vs OFF (paired) — the fusion-dilution check.
+        seed: Bootstrap seed (pre-declared in the run config).
+
+    Returns:
+        JSON-shaped verdict: per-arm metrics, both BCa intervals, the
+        non-inferiority delta, and ``verdict`` in {ship, density_artifact,
+        no_effect, regression}. A clean "does not beat placebo, not shipped"
+        is a valid close (the issue's acceptance wording).
+    """
+    vs_unboosted = paired_bca_ci(
+        per_query_deltas(boosted_real, unboosted, PRIMARY_K),
+        n_resamples=BCA_RESAMPLES,
+        seed=seed,
+    )
+    vs_placebo = paired_bca_ci(
+        per_query_deltas(boosted_real, boosted_rewired, PRIMARY_K),
+        n_resamples=BCA_RESAMPLES,
+        seed=seed,
+    )
+    nongraph_delta = round(
+        mean_precision_at_k(nongraph_boosted, PRIMARY_K)
+        - mean_precision_at_k(nongraph_unboosted, PRIMARY_K),
+        4,
+    )
+
+    beats_unboosted = vs_unboosted["ci_low"] > 0.0
+    beats_placebo = vs_placebo["ci_low"] > 0.0
+    non_inferior = nongraph_delta >= -NON_INFERIORITY_EPSILON
+
+    if not non_inferior:
+        verdict = GATE_REGRESSION
+    elif beats_unboosted and beats_placebo:
+        verdict = GATE_SHIP
+    elif beats_unboosted:
+        verdict = GATE_DENSITY_ARTIFACT
+    else:
+        verdict = GATE_NO_EFFECT
+
+    return {
+        "primary_metric": f"p@{PRIMARY_K}",
+        "arms": {
+            "boosted_real": arm_metrics(boosted_real),
+            "unboosted": arm_metrics(unboosted),
+            "boosted_rewired": arm_metrics(boosted_rewired),
+        },
+        "vs_unboosted": vs_unboosted,
+        "vs_placebo": vs_placebo,
+        "nongraph": {
+            "boosted_p@5": round(mean_precision_at_k(nongraph_boosted, PRIMARY_K), 4),
+            "unboosted_p@5": round(mean_precision_at_k(nongraph_unboosted, PRIMARY_K), 4),
+            "delta": nongraph_delta,
+            "epsilon": NON_INFERIORITY_EPSILON,
+            "non_inferior": non_inferior,
+        },
+        "contracts": {
+            "beats_unboosted": beats_unboosted,
+            "beats_placebo": beats_placebo,
+            "non_inferior": non_inferior,
+        },
+        "verdict": verdict,
+        "ships": verdict == GATE_SHIP,
+    }

--- a/backend/tests/eval/graph_boost_gate.py
+++ b/backend/tests/eval/graph_boost_gate.py
@@ -40,10 +40,17 @@ NON_INFERIORITY_EPSILON = 0.01
 #: BCa resamples (matches the eval program's inferential runs).
 BCA_RESAMPLES = 10_000
 
+#: Minimum paired companion probes for an INFERENTIAL ship decision — the
+#: same floor placebo_runner documents as "underpowered, directional only".
+#: Below it the gate reports the deltas but refuses to render "ship"
+#: (gate2/CAIO: n=5 golden-corpus probes must not drive a BCa ship call).
+MIN_PROBES = 50
+
 GATE_SHIP = "ship"
 GATE_DENSITY_ARTIFACT = "density_artifact"
 GATE_NO_EFFECT = "no_effect"
 GATE_REGRESSION = "regression"
+GATE_UNDERPOWERED = "underpowered"
 
 
 def per_query_deltas(arm_a: Sequence[Ranking], arm_b: Sequence[Ranking], k: int) -> list[float]:
@@ -69,7 +76,7 @@ def evaluate_gate(
     *,
     boosted_real: Sequence[Ranking],
     unboosted: Sequence[Ranking],
-    boosted_rewired: Sequence[Ranking],
+    boosted_rewired_arms: dict[int, Sequence[Ranking]],
     nongraph_boosted: Sequence[Ranking],
     nongraph_unboosted: Sequence[Ranking],
     seed: int,
@@ -79,8 +86,11 @@ def evaluate_gate(
     Args:
         boosted_real: Companion queries, graph boost ON, real warm graph.
         unboosted: Same queries, boost OFF (paired).
-        boosted_rewired: Same queries, boost ON, degree-matched rewired graph
-            (paired).
+        boosted_rewired_arms: Same queries, boost ON, one degree-matched
+            HEBBIAN rewiring per pre-declared rewire seed (paired). The
+            beats-placebo contract must hold against EVERY rewiring — the
+            hardest null wins (gate2/CAIO: a single sparse-graph rewiring is
+            not a robust null).
         nongraph_boosted / nongraph_unboosted: Held-out non-graph queries,
             boost ON vs OFF (paired) — the fusion-dilution check.
         seed: Bootstrap seed (pre-declared in the run config).
@@ -96,11 +106,19 @@ def evaluate_gate(
         n_resamples=BCA_RESAMPLES,
         seed=seed,
     )
-    vs_placebo = paired_bca_ci(
-        per_query_deltas(boosted_real, boosted_rewired, PRIMARY_K),
-        n_resamples=BCA_RESAMPLES,
-        seed=seed,
-    )
+    if not boosted_rewired_arms:
+        raise ValueError("boosted_rewired_arms must contain at least one rewiring")
+    vs_placebo_by_seed = {
+        rewire_seed: paired_bca_ci(
+            per_query_deltas(boosted_real, arm, PRIMARY_K),
+            n_resamples=BCA_RESAMPLES,
+            seed=seed,
+        )
+        for rewire_seed, arm in boosted_rewired_arms.items()
+    }
+    # The binding placebo comparison is the WORST case: the rewiring the
+    # boost beats least.
+    vs_placebo = min(vs_placebo_by_seed.values(), key=lambda ci: ci["ci_low"])
     nongraph_delta = round(
         mean_precision_at_k(nongraph_boosted, PRIMARY_K)
         - mean_precision_at_k(nongraph_unboosted, PRIMARY_K),
@@ -108,10 +126,13 @@ def evaluate_gate(
     )
 
     beats_unboosted = vs_unboosted["ci_low"] > 0.0
-    beats_placebo = vs_placebo["ci_low"] > 0.0
+    beats_placebo = all(ci["ci_low"] > 0.0 for ci in vs_placebo_by_seed.values())
     non_inferior = nongraph_delta >= -NON_INFERIORITY_EPSILON
+    powered = len(boosted_real) >= MIN_PROBES
 
-    if not non_inferior:
+    if not powered:
+        verdict = GATE_UNDERPOWERED
+    elif not non_inferior:
         verdict = GATE_REGRESSION
     elif beats_unboosted and beats_placebo:
         verdict = GATE_SHIP
@@ -125,10 +146,13 @@ def evaluate_gate(
         "arms": {
             "boosted_real": arm_metrics(boosted_real),
             "unboosted": arm_metrics(unboosted),
-            "boosted_rewired": arm_metrics(boosted_rewired),
+            "boosted_rewired": {
+                str(rs): arm_metrics(arm) for rs, arm in boosted_rewired_arms.items()
+            },
         },
         "vs_unboosted": vs_unboosted,
         "vs_placebo": vs_placebo,
+        "vs_placebo_by_seed": {str(rs): ci for rs, ci in vs_placebo_by_seed.items()},
         "nongraph": {
             "boosted_p@5": round(mean_precision_at_k(nongraph_boosted, PRIMARY_K), 4),
             "unboosted_p@5": round(mean_precision_at_k(nongraph_unboosted, PRIMARY_K), 4),
@@ -137,6 +161,8 @@ def evaluate_gate(
             "non_inferior": non_inferior,
         },
         "contracts": {
+            "powered": powered,
+            "min_probes": MIN_PROBES,
             "beats_unboosted": beats_unboosted,
             "beats_placebo": beats_placebo,
             "non_inferior": non_inferior,

--- a/backend/tests/eval/graph_boost_runner.py
+++ b/backend/tests/eval/graph_boost_runner.py
@@ -1,0 +1,232 @@
+"""Live #1213 graph-boost placebo-gate orchestration.
+
+Builds ONE warm co-activation graph (provisional τ → replay → sleep, the
+placebo_runner procedure), then measures FOUR recall arms off it:
+
+    unboosted        — companion probes, KAGURA_GRAPH_BOOST_ENABLED=false
+    boosted_real     — same probes, boost ON, true warm graph
+    boosted_rewired  — same probes, boost ON, degree-preserving rewired graph
+                       (edges restored from snapshot afterwards)
+    non-graph slice  — the corpus's replay queries, boost ON vs OFF
+                       (the fusion-dilution non-inferiority check)
+
+and applies the pre-declared contracts in ``tests.eval.graph_boost_gate``.
+Arms are measured with ``ENABLE_NEURAL_MEMORY=false`` (same discipline as
+replay_runner: no Hebbian writes may contaminate the graph between paired
+arms — the ONLY graph influence on ranking is the boost under test).
+
+Writes results/graph-boost-<YYYY-MM-DD>.json from a REAL run only. Heavy
+imports are function-local (same convention as placebo_runner) so importing
+this module is cheap and CI-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from tests.eval.compounding import MODE_EXCLUDE_PROBES, build_replay_plan
+from tests.eval.graph_boost_gate import evaluate_gate
+from tests.eval.placebo import Edge, degree_preserving_rewire_with_stats
+from tests.eval.placebo_runner import (
+    _replace_edges,
+    _seed_provisional_tau,
+    _snapshot_edges,
+)
+from tests.eval.replay_runner import _replay, _run_sleep
+from tests.eval.runner import _ingest_corpus, _teardown
+from tests.eval.tools.corpus import load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+_RECALL_K = 10
+#: Pre-declared bootstrap seed for the gate's BCa intervals.
+_GATE_SEED = 1213
+#: Rewire seed (one committed rewiring — the gate is inferential, not a sweep).
+_REWIRE_SEED = 42
+
+
+@contextmanager
+def _env(key: str, value: str):
+    """Set an env var for the duration, restoring the prior state exactly."""
+    prior = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prior
+
+
+async def _recall_rankings(
+    svc: Any,
+    queries: list[tuple[str, set[str]]],
+    id_map: dict[str, str],
+    owner: str,
+    ctx_id: Any,
+    ws_id: Any,
+) -> list[tuple[list[str], set[str]]]:
+    """Recall each (query_text, gold_doc_ids) pair and map results to doc ids."""
+    from models.schemas import RecallRequest
+
+    rankings: list[tuple[list[str], set[str]]] = []
+    for text, gold in queries:
+        resp = await svc.recall(
+            request=RecallRequest(query=text, k=_RECALL_K, search_mode="hybrid"),
+            user_id=owner,
+            current_context_id=ctx_id,
+            current_workspace_id=ws_id,
+        )
+        rankings.append(([id_map.get(str(r.memory_id), "?") for r in resp.results], set(gold)))
+    return rankings
+
+
+async def run_graph_boost_eval(write: bool = True, run_date: str | None = None) -> dict[str, Any]:
+    """Orchestrate the four-arm measurement and apply the gate."""
+    from datetime import date
+
+    from db.base import get_db
+    from db.qdrant import ensure_kagura_memories_collection, get_collection_name
+    from services.memory_service import MemoryService
+    from tests.eval._provisioning import provision_eval_context
+
+    corpus = load_corpus()
+    plan = build_replay_plan(corpus, MODE_EXCLUDE_PROBES)
+
+    async for db in get_db():
+        owner, ws, ctx, emb_model, emb_dims = await provision_eval_context(
+            db, sleep_mode="edges_only"
+        )
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await ensure_kagura_memories_collection(
+                emb_dims, get_collection_name(emb_model, emb_dims)
+            )
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+            result = await _measure_arms(svc, db, corpus, plan, id_map, owner, ctx, ws)
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+        break
+    else:
+        raise RuntimeError("database session unavailable — is the stack up?")
+
+    result["meta"] = {
+        "issue": 1213,
+        "date": run_date or date.today().isoformat(),
+        "corpus": corpus.meta,
+        "gate_seed": _GATE_SEED,
+        "rewire_seed": _REWIRE_SEED,
+        "recall_k": _RECALL_K,
+        "graph_boost_max": os.getenv("KAGURA_GRAPH_BOOST_MAX", "0.15"),
+    }
+    if write:
+        _RESULTS_DIR.mkdir(exist_ok=True)
+        out = _RESULTS_DIR / f"graph-boost-{result['meta']['date']}.json"
+        out.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    return result
+
+
+async def _measure_arms(svc, db, corpus, plan, id_map, owner, ctx, ws) -> dict[str, Any]:
+    """Warm the graph once, then run the four paired arms."""
+    # --- warm build: provisional τ → replay (neural ON) → sleep -------------
+    tau_info = await _seed_provisional_tau(db, corpus, plan, id_map, ctx)
+    with _env("ENABLE_NEURAL_MEMORY", "true"), _env("KAGURA_GRAPH_BOOST_ENABLED", "false"):
+        replayed = await _replay(svc, corpus, plan, owner, ctx, ws)
+        sleep_info = await _run_sleep(db, owner, ctx, ws)
+
+    # --- paired query sets ---------------------------------------------------
+    probe_queries = [(p.text, set(p.companion_docs)) for p in plan.probes]
+    replay_ids = set(plan.replay_query_ids)
+    nongraph_queries = [(q.text, set(q.relevant)) for q in corpus.queries if q.id in replay_ids]
+
+    # --- arms (neural OFF: no Hebbian writes between paired measurements) ----
+    with _env("ENABLE_NEURAL_MEMORY", "false"):
+        with _env("KAGURA_GRAPH_BOOST_ENABLED", "false"):
+            unboosted = await _recall_rankings(svc, probe_queries, id_map, owner, ctx.id, ws.id)
+            nongraph_off = await _recall_rankings(
+                svc, nongraph_queries, id_map, owner, ctx.id, ws.id
+            )
+        with _env("KAGURA_GRAPH_BOOST_ENABLED", "true"):
+            boosted_real = await _recall_rankings(svc, probe_queries, id_map, owner, ctx.id, ws.id)
+            nongraph_on = await _recall_rankings(
+                svc, nongraph_queries, id_map, owner, ctx.id, ws.id
+            )
+
+        # --- placebo arm: degree-preserving rewire, measure, restore ---------
+        snapshot = await _snapshot_edges(db, ctx.id)
+        rewire_swaps = 0
+        if len(snapshot) >= 2:
+            edges = [
+                Edge(
+                    str(r["src_id"]),
+                    str(r["dst_id"]),
+                    r["weight"],
+                    r["origin"],
+                    r["confidence"],
+                    r["edge_type"],
+                )
+                for r in snapshot
+            ]
+            rewired, rewire_swaps = degree_preserving_rewire_with_stats(edges, seed=_REWIRE_SEED)
+            rewired_rows = [
+                {
+                    "src_id": UUID(e.src),
+                    "dst_id": UUID(e.dst),
+                    "weight": e.weight,
+                    "confidence": e.confidence,
+                    "edge_type": e.edge_type,
+                    "origin": e.origin,
+                    "user_id": owner,
+                    "workspace_id": ws.id,
+                    "context_id": ctx.id,
+                }
+                for e in rewired
+            ]
+            await _replace_edges(db, ctx.id, rewired_rows)
+            try:
+                with _env("KAGURA_GRAPH_BOOST_ENABLED", "true"):
+                    boosted_rewired = await _recall_rankings(
+                        svc, probe_queries, id_map, owner, ctx.id, ws.id
+                    )
+            finally:
+                await _replace_edges(db, ctx.id, snapshot)
+        else:
+            boosted_rewired = unboosted
+
+    gate = evaluate_gate(
+        boosted_real=boosted_real,
+        unboosted=unboosted,
+        boosted_rewired=boosted_rewired,
+        nongraph_boosted=nongraph_on,
+        nongraph_unboosted=nongraph_off,
+        seed=_GATE_SEED,
+    )
+    return {
+        "warm_build": {
+            "tau": tau_info,
+            "replayed_queries": replayed,
+            "sleep": sleep_info,
+            "edge_snapshot": {"n": len(snapshot), "rewire_swaps_done": rewire_swaps},
+        },
+        "n_probes": len(probe_queries),
+        "n_nongraph": len(nongraph_queries),
+        "gate": gate,
+    }
+
+
+def _main() -> int:
+    import asyncio
+
+    results = asyncio.run(run_graph_boost_eval())
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/graph_boost_runner.py
+++ b/backend/tests/eval/graph_boost_runner.py
@@ -30,7 +30,7 @@ from typing import Any
 from uuid import UUID
 
 from tests.eval.compounding import MODE_EXCLUDE_PROBES, build_replay_plan
-from tests.eval.graph_boost_gate import evaluate_gate
+from tests.eval.graph_boost_gate import GATE_UNDERPOWERED, evaluate_gate
 from tests.eval.placebo import Edge, degree_preserving_rewire_with_stats
 from tests.eval.placebo_runner import (
     _replace_edges,
@@ -220,6 +220,20 @@ async def _measure_arms(svc, db, corpus, plan, id_map, owner, ctx, ws) -> dict[s
         nongraph_unboosted=nongraph_off,
         seed=_GATE_SEED,
     )
+    # < 2 hebbian edges cannot be degree-matched-rewired, so the placebo
+    # arms above fell back to the unboosted rankings: "beats placebo" then
+    # degenerates into "beats unboosted" — no real null. Such a run must
+    # never render "ship" (the density artifact is exactly what the placebo
+    # exists to catch).
+    gate["placebo_valid"] = len(hebbian_rows) >= 2
+    if not gate["placebo_valid"] and gate.get("ships"):
+        gate["verdict"] = GATE_UNDERPOWERED
+        gate["ships"] = False
+        gate["underpowered_reason"] = (
+            "hebbian graph too sparse (<2 edges) for a degree-matched "
+            "rewiring — the placebo arm was the unboosted ranking, not a "
+            "genuine null"
+        )
     return {
         "warm_build": {
             "tau": tau_info,

--- a/backend/tests/eval/graph_boost_runner.py
+++ b/backend/tests/eval/graph_boost_runner.py
@@ -42,11 +42,16 @@ from tests.eval.runner import _ingest_corpus, _teardown
 from tests.eval.tools.corpus import load_corpus
 
 _RESULTS_DIR = Path(__file__).resolve().parent / "results"
+#: The frozen kagura_l corpus (300 docs, 60 multi-gold cross-source probes) —
+#: NOT the 5-probe golden corpus: the gate's BCa ship decision needs
+#: n >= graph_boost_gate.MIN_PROBES (gate2/CAIO).
+_CORPUS_PATH = Path(__file__).resolve().parent / "fixtures" / "kagura_l.yaml"
 _RECALL_K = 10
 #: Pre-declared bootstrap seed for the gate's BCa intervals.
 _GATE_SEED = 1213
-#: Rewire seed (one committed rewiring — the gate is inferential, not a sweep).
-_REWIRE_SEED = 42
+#: Pre-declared rewire seeds: the beats-placebo contract must hold against
+#: EVERY rewiring (sparse graphs make any single rewiring a weak null).
+_REWIRE_SEEDS = (42, 43, 44)
 
 
 @contextmanager
@@ -95,7 +100,7 @@ async def run_graph_boost_eval(write: bool = True, run_date: str | None = None) 
     from services.memory_service import MemoryService
     from tests.eval._provisioning import provision_eval_context
 
-    corpus = load_corpus()
+    corpus = load_corpus(_CORPUS_PATH)
     plan = build_replay_plan(corpus, MODE_EXCLUDE_PROBES)
 
     async for db in get_db():
@@ -121,7 +126,7 @@ async def run_graph_boost_eval(write: bool = True, run_date: str | None = None) 
         "date": run_date or date.today().isoformat(),
         "corpus": corpus.meta,
         "gate_seed": _GATE_SEED,
-        "rewire_seed": _REWIRE_SEED,
+        "rewire_seeds": list(_REWIRE_SEEDS),
         "recall_k": _RECALL_K,
         "graph_boost_max": os.getenv("KAGURA_GRAPH_BOOST_MAX", "0.15"),
     }
@@ -158,10 +163,16 @@ async def _measure_arms(svc, db, corpus, plan, id_map, owner, ctx, ws) -> dict[s
                 svc, nongraph_queries, id_map, owner, ctx.id, ws.id
             )
 
-        # --- placebo arm: degree-preserving rewire, measure, restore ---------
+        # --- placebo arms: rewire ONLY the hebbian edges (the boost reads
+        # only hebbian — rewiring semantic/declared edges too would make the
+        # null model inconsistent with the mechanism under test), one
+        # rewiring per pre-declared seed, snapshot restored afterwards.
         snapshot = await _snapshot_edges(db, ctx.id)
-        rewire_swaps = 0
-        if len(snapshot) >= 2:
+        hebbian_rows = [r for r in snapshot if r["origin"] == "hebbian"]
+        other_rows = [r for r in snapshot if r["origin"] != "hebbian"]
+        boosted_rewired_arms: dict[int, Any] = {}
+        rewire_swaps_by_seed: dict[int, int] = {}
+        if len(hebbian_rows) >= 2:
             edges = [
                 Edge(
                     str(r["src_id"]),
@@ -171,38 +182,40 @@ async def _measure_arms(svc, db, corpus, plan, id_map, owner, ctx, ws) -> dict[s
                     r["confidence"],
                     r["edge_type"],
                 )
-                for r in snapshot
+                for r in hebbian_rows
             ]
-            rewired, rewire_swaps = degree_preserving_rewire_with_stats(edges, seed=_REWIRE_SEED)
-            rewired_rows = [
-                {
-                    "src_id": UUID(e.src),
-                    "dst_id": UUID(e.dst),
-                    "weight": e.weight,
-                    "confidence": e.confidence,
-                    "edge_type": e.edge_type,
-                    "origin": e.origin,
-                    "user_id": owner,
-                    "workspace_id": ws.id,
-                    "context_id": ctx.id,
-                }
-                for e in rewired
-            ]
-            await _replace_edges(db, ctx.id, rewired_rows)
             try:
-                with _env("KAGURA_GRAPH_BOOST_ENABLED", "true"):
-                    boosted_rewired = await _recall_rankings(
-                        svc, probe_queries, id_map, owner, ctx.id, ws.id
-                    )
+                for rewire_seed in _REWIRE_SEEDS:
+                    rewired, swaps = degree_preserving_rewire_with_stats(edges, seed=rewire_seed)
+                    rewire_swaps_by_seed[rewire_seed] = swaps
+                    rewired_rows = other_rows + [
+                        {
+                            "src_id": UUID(e.src),
+                            "dst_id": UUID(e.dst),
+                            "weight": e.weight,
+                            "confidence": e.confidence,
+                            "edge_type": e.edge_type,
+                            "origin": e.origin,
+                            "user_id": owner,
+                            "workspace_id": ws.id,
+                            "context_id": ctx.id,
+                        }
+                        for e in rewired
+                    ]
+                    await _replace_edges(db, ctx.id, rewired_rows)
+                    with _env("KAGURA_GRAPH_BOOST_ENABLED", "true"):
+                        boosted_rewired_arms[rewire_seed] = await _recall_rankings(
+                            svc, probe_queries, id_map, owner, ctx.id, ws.id
+                        )
             finally:
                 await _replace_edges(db, ctx.id, snapshot)
         else:
-            boosted_rewired = unboosted
+            boosted_rewired_arms = dict.fromkeys(_REWIRE_SEEDS, unboosted)
 
     gate = evaluate_gate(
         boosted_real=boosted_real,
         unboosted=unboosted,
-        boosted_rewired=boosted_rewired,
+        boosted_rewired_arms=boosted_rewired_arms,
         nongraph_boosted=nongraph_on,
         nongraph_unboosted=nongraph_off,
         seed=_GATE_SEED,
@@ -212,10 +225,20 @@ async def _measure_arms(svc, db, corpus, plan, id_map, owner, ctx, ws) -> dict[s
             "tau": tau_info,
             "replayed_queries": replayed,
             "sleep": sleep_info,
-            "edge_snapshot": {"n": len(snapshot), "rewire_swaps_done": rewire_swaps},
+            "edge_snapshot": {
+                "n": len(snapshot),
+                "n_hebbian": len(hebbian_rows),
+                "rewire_swaps_by_seed": rewire_swaps_by_seed,
+            },
         },
         "n_probes": len(probe_queries),
         "n_nongraph": len(nongraph_queries),
+        # gate2/CAIO: the non-inferiority slice is the corpus's replay
+        # queries — the SAME queries the warm build replayed, so the boost
+        # re-ranks exactly their co-activated results. Leaky-optimistic, not
+        # conservative; the frozen held-out retrieval slice is the honest
+        # follow-up before any per-context graduation.
+        "nongraph_slice": "replay_queries (leaky-optimistic; see docs/eval/graph-boost-gate.md)",
         "gate": gate,
     }
 

--- a/backend/tests/eval/reinforce_runner.py
+++ b/backend/tests/eval/reinforce_runner.py
@@ -187,6 +187,10 @@ async def _run_reinforce_arms(
 
     prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
     os.environ["ENABLE_NEURAL_MEMORY"] = "false"
+    # #1213: the graph-boost experiment must never contaminate the reinforce
+    # arms (an operator-exported env would otherwise leak into this cohort).
+    prev_boost = os.environ.get("KAGURA_GRAPH_BOOST_ENABLED")
+    os.environ["KAGURA_GRAPH_BOOST_ENABLED"] = "false"
     try:
         await _seed_adoption(svc, ctx_id, owner, adopted_mem_ids)
 
@@ -206,6 +210,10 @@ async def _run_reinforce_arms(
             os.environ.pop("ENABLE_NEURAL_MEMORY", None)
         else:
             os.environ["ENABLE_NEURAL_MEMORY"] = prev_neural
+        if prev_boost is None:
+            os.environ.pop("KAGURA_GRAPH_BOOST_ENABLED", None)
+        else:
+            os.environ["KAGURA_GRAPH_BOOST_ENABLED"] = prev_boost
 
     gate = evaluate_reinforce_gate(off, on, thresholds=GateThresholds())
     # Vacuous-pass guard (#1084): a neutered reinforce_enabled toggle (config not

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -293,10 +293,15 @@ async def _checkpoint(
 
     prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
     os.environ["ENABLE_NEURAL_MEMORY"] = "false"
+    # #1213: pin the graph-boost experiment off — this arm measures the
+    # production ranking, and an operator-exported env must not leak in.
+    prev_boost = os.environ.get("KAGURA_GRAPH_BOOST_ENABLED")
+    os.environ["KAGURA_GRAPH_BOOST_ENABLED"] = "false"
     try:
         arm = await _score_arm(svc, corpus, docs_by_id, id_map, owner, ctx.id, ws.id, "hybrid")
     finally:
         _restore_env("ENABLE_NEURAL_MEMORY", prev_neural)
+        _restore_env("KAGURA_GRAPH_BOOST_ENABLED", prev_boost)
 
     return {
         "graph_lane": graph_lane,
@@ -369,6 +374,10 @@ async def _replay(svc: Any, corpus: Corpus, plan: ReplayPlan, owner: str, ctx: A
     queries_by_id = {q.id: q for q in corpus.queries}
     prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
     os.environ["ENABLE_NEURAL_MEMORY"] = "true"
+    # #1213: warm-build replay must form edges from the UNBOOSTED production
+    # ranking — pin the graph-boost experiment off during replay too.
+    prev_boost = os.environ.get("KAGURA_GRAPH_BOOST_ENABLED")
+    os.environ["KAGURA_GRAPH_BOOST_ENABLED"] = "false"
     recalls = 0
     try:
         for _ in range(plan.rounds):
@@ -386,6 +395,7 @@ async def _replay(svc: Any, corpus: Corpus, plan: ReplayPlan, owner: str, ctx: A
                 recalls += 1
     finally:
         _restore_env("ENABLE_NEURAL_MEMORY", prev_neural)
+        _restore_env("KAGURA_GRAPH_BOOST_ENABLED", prev_boost)
     return recalls
 
 

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -456,7 +456,15 @@ async def _score_arm(
     search_mode: str,
 ) -> dict[str, Any]:
     """Recall every query with ``search_mode`` and compute the metric block."""
+    import os
+
     from models.schemas import RecallRequest
+
+    # #1213: production-arm scoring must never see the graph-boost experiment
+    # (an operator-exported env would silently contaminate the frozen-corpus
+    # baselines the CI gates compare against).
+    prev_boost = os.environ.get("KAGURA_GRAPH_BOOST_ENABLED")
+    os.environ["KAGURA_GRAPH_BOOST_ENABLED"] = "false"
 
     # Per-query rankings, grouped by bucket.
     per_bucket_rankings: dict[str, list[tuple[list[str], set[str]]]] = {b: [] for b in BUCKETS}
@@ -480,6 +488,14 @@ async def _score_arm(
         all_retrieved_sources.extend(
             docs_by_id[d].source for d in ranked_docs[:_RECALL_K] if d in docs_by_id
         )
+
+    # Restore-on-success is deliberate (no try/finally): an exception aborts
+    # the whole eval run, and leaving the env pinned to "false" is the
+    # default-off safe state.
+    if prev_boost is None:
+        os.environ.pop("KAGURA_GRAPH_BOOST_ENABLED", None)
+    else:
+        os.environ["KAGURA_GRAPH_BOOST_ENABLED"] = prev_boost
 
     result: dict[str, Any] = {
         "overall": _bucket_metrics(all_rankings),

--- a/backend/tests/eval/test_graph_boost_gate.py
+++ b/backend/tests/eval/test_graph_boost_gate.py
@@ -1,0 +1,128 @@
+"""Unit tests for the #1213 graph-boost placebo gate (deterministic)."""
+
+import pytest
+
+from tests.eval.graph_boost_gate import (
+    GATE_DENSITY_ARTIFACT,
+    GATE_NO_EFFECT,
+    GATE_REGRESSION,
+    GATE_SHIP,
+    NON_INFERIORITY_EPSILON,
+    evaluate_gate,
+    per_query_deltas,
+)
+
+# 20 paired companion queries; gold is always {"g"}. A "hit" ranking has the
+# gold inside the top-5, a "miss" ranking does not.
+_HIT = (["g", "x1", "x2", "x3", "x4"], {"g"})
+_MISS = (["x1", "x2", "x3", "x4", "x5"], {"g"})
+
+
+def _arm(hits: int, total: int = 20) -> list[tuple[list[str], set[str]]]:
+    return [_HIT] * hits + [_MISS] * (total - hits)
+
+
+def _flat(hits: int, total: int = 40) -> list[tuple[list[str], set[str]]]:
+    return [_HIT] * hits + [_MISS] * (total - hits)
+
+
+class TestPerQueryDeltas:
+    def test_paired_shape(self) -> None:
+        deltas = per_query_deltas(_arm(20), _arm(0), 5)
+        assert len(deltas) == 20
+        assert all(d == pytest.approx(0.2) for d in deltas)
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="differ in length"):
+            per_query_deltas(_arm(5, total=10), _arm(5, total=11), 5)
+
+
+class TestVerdicts:
+    def test_ship_when_beats_both_and_non_inferior(self) -> None:
+        result = evaluate_gate(
+            boosted_real=_arm(18),
+            unboosted=_arm(6),
+            boosted_rewired=_arm(6),
+            nongraph_boosted=_flat(30),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert result["contracts"] == {
+            "beats_unboosted": True,
+            "beats_placebo": True,
+            "non_inferior": True,
+        }
+        assert result["verdict"] == GATE_SHIP
+        assert result["ships"] is True
+
+    def test_density_artifact_blocks_ship(self) -> None:
+        """Beats no-graph but NOT the rewired placebo — the §6 kill-shot:
+        the boost is riding graph density, not edge-specific structure."""
+        result = evaluate_gate(
+            boosted_real=_arm(18),
+            unboosted=_arm(6),
+            boosted_rewired=_arm(17),
+            nongraph_boosted=_flat(30),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert result["contracts"]["beats_unboosted"] is True
+        assert result["contracts"]["beats_placebo"] is False
+        assert result["verdict"] == GATE_DENSITY_ARTIFACT
+        assert result["ships"] is False
+
+    def test_no_effect_is_a_valid_close(self) -> None:
+        result = evaluate_gate(
+            boosted_real=_arm(10),
+            unboosted=_arm(10),
+            boosted_rewired=_arm(10),
+            nongraph_boosted=_flat(30),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert result["verdict"] == GATE_NO_EFFECT
+        assert result["ships"] is False
+
+    def test_nongraph_regression_vetoes_even_a_winner(self) -> None:
+        """The fusion-dilution lesson: a boost that wins its own bucket but
+        regresses held-out non-graph P@5 beyond epsilon does not ship."""
+        result = evaluate_gate(
+            boosted_real=_arm(18),
+            unboosted=_arm(6),
+            boosted_rewired=_arm(6),
+            nongraph_boosted=_flat(20),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert result["contracts"]["beats_unboosted"] is True
+        assert result["contracts"]["beats_placebo"] is True
+        assert result["nongraph"]["non_inferior"] is False
+        assert result["verdict"] == GATE_REGRESSION
+        assert result["ships"] is False
+
+    def test_epsilon_tolerates_tiny_nongraph_dip(self) -> None:
+        """A dip within the pre-declared epsilon must not veto."""
+        # 40 queries at P@5=0.2/hit: one flipped hit moves the mean by 0.005,
+        # inside epsilon=0.01.
+        result = evaluate_gate(
+            boosted_real=_arm(18),
+            unboosted=_arm(6),
+            boosted_rewired=_arm(6),
+            nongraph_boosted=_flat(29),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert abs(result["nongraph"]["delta"]) <= NON_INFERIORITY_EPSILON
+        assert result["verdict"] == GATE_SHIP
+
+
+class TestDeterminism:
+    def test_same_seed_same_result(self) -> None:
+        kwargs = {
+            "boosted_real": _arm(15),
+            "unboosted": _arm(8),
+            "boosted_rewired": _arm(9),
+            "nongraph_boosted": _flat(30),
+            "nongraph_unboosted": _flat(30),
+        }
+        assert evaluate_gate(seed=7, **kwargs) == evaluate_gate(seed=7, **kwargs)

--- a/backend/tests/eval/test_graph_boost_gate.py
+++ b/backend/tests/eval/test_graph_boost_gate.py
@@ -7,18 +7,19 @@ from tests.eval.graph_boost_gate import (
     GATE_NO_EFFECT,
     GATE_REGRESSION,
     GATE_SHIP,
+    GATE_UNDERPOWERED,
     NON_INFERIORITY_EPSILON,
     evaluate_gate,
     per_query_deltas,
 )
 
-# 20 paired companion queries; gold is always {"g"}. A "hit" ranking has the
+# 60 paired companion queries (>= MIN_PROBES); gold is always {"g"}. A "hit" ranking has the
 # gold inside the top-5, a "miss" ranking does not.
 _HIT = (["g", "x1", "x2", "x3", "x4"], {"g"})
 _MISS = (["x1", "x2", "x3", "x4", "x5"], {"g"})
 
 
-def _arm(hits: int, total: int = 20) -> list[tuple[list[str], set[str]]]:
+def _arm(hits: int, total: int = 60) -> list[tuple[list[str], set[str]]]:
     return [_HIT] * hits + [_MISS] * (total - hits)
 
 
@@ -28,8 +29,8 @@ def _flat(hits: int, total: int = 40) -> list[tuple[list[str], set[str]]]:
 
 class TestPerQueryDeltas:
     def test_paired_shape(self) -> None:
-        deltas = per_query_deltas(_arm(20), _arm(0), 5)
-        assert len(deltas) == 20
+        deltas = per_query_deltas(_arm(60), _arm(0), 5)
+        assert len(deltas) == 60
         assert all(d == pytest.approx(0.2) for d in deltas)
 
     def test_length_mismatch_raises(self) -> None:
@@ -40,14 +41,16 @@ class TestPerQueryDeltas:
 class TestVerdicts:
     def test_ship_when_beats_both_and_non_inferior(self) -> None:
         result = evaluate_gate(
-            boosted_real=_arm(18),
-            unboosted=_arm(6),
-            boosted_rewired=_arm(6),
+            boosted_real=_arm(54),
+            unboosted=_arm(18),
+            boosted_rewired_arms={42: _arm(18)},
             nongraph_boosted=_flat(30),
             nongraph_unboosted=_flat(30),
             seed=42,
         )
         assert result["contracts"] == {
+            "powered": True,
+            "min_probes": 50,
             "beats_unboosted": True,
             "beats_placebo": True,
             "non_inferior": True,
@@ -59,9 +62,9 @@ class TestVerdicts:
         """Beats no-graph but NOT the rewired placebo — the §6 kill-shot:
         the boost is riding graph density, not edge-specific structure."""
         result = evaluate_gate(
-            boosted_real=_arm(18),
-            unboosted=_arm(6),
-            boosted_rewired=_arm(17),
+            boosted_real=_arm(54),
+            unboosted=_arm(18),
+            boosted_rewired_arms={42: _arm(54)},
             nongraph_boosted=_flat(30),
             nongraph_unboosted=_flat(30),
             seed=42,
@@ -73,9 +76,9 @@ class TestVerdicts:
 
     def test_no_effect_is_a_valid_close(self) -> None:
         result = evaluate_gate(
-            boosted_real=_arm(10),
-            unboosted=_arm(10),
-            boosted_rewired=_arm(10),
+            boosted_real=_arm(30),
+            unboosted=_arm(30),
+            boosted_rewired_arms={42: _arm(30)},
             nongraph_boosted=_flat(30),
             nongraph_unboosted=_flat(30),
             seed=42,
@@ -87,9 +90,9 @@ class TestVerdicts:
         """The fusion-dilution lesson: a boost that wins its own bucket but
         regresses held-out non-graph P@5 beyond epsilon does not ship."""
         result = evaluate_gate(
-            boosted_real=_arm(18),
-            unboosted=_arm(6),
-            boosted_rewired=_arm(6),
+            boosted_real=_arm(54),
+            unboosted=_arm(18),
+            boosted_rewired_arms={42: _arm(18)},
             nongraph_boosted=_flat(20),
             nongraph_unboosted=_flat(30),
             seed=42,
@@ -105,9 +108,9 @@ class TestVerdicts:
         # 40 queries at P@5=0.2/hit: one flipped hit moves the mean by 0.005,
         # inside epsilon=0.01.
         result = evaluate_gate(
-            boosted_real=_arm(18),
-            unboosted=_arm(6),
-            boosted_rewired=_arm(6),
+            boosted_real=_arm(54),
+            unboosted=_arm(18),
+            boosted_rewired_arms={42: _arm(18)},
             nongraph_boosted=_flat(29),
             nongraph_unboosted=_flat(30),
             seed=42,
@@ -119,10 +122,50 @@ class TestVerdicts:
 class TestDeterminism:
     def test_same_seed_same_result(self) -> None:
         kwargs = {
-            "boosted_real": _arm(15),
-            "unboosted": _arm(8),
-            "boosted_rewired": _arm(9),
+            "boosted_real": _arm(45),
+            "unboosted": _arm(24),
+            "boosted_rewired_arms": {42: _arm(27)},
             "nongraph_boosted": _flat(30),
             "nongraph_unboosted": _flat(30),
         }
         assert evaluate_gate(seed=7, **kwargs) == evaluate_gate(seed=7, **kwargs)
+
+
+class TestPowerAndMultiSeed:
+    def test_underpowered_probe_set_refuses_ship(self) -> None:
+        """Gate2/CAIO: n < MIN_PROBES reports deltas but never renders ship."""
+        result = evaluate_gate(
+            boosted_real=_arm(18, total=20),
+            unboosted=_arm(6, total=20),
+            boosted_rewired_arms={42: _arm(6, total=20)},
+            nongraph_boosted=_flat(30),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert result["contracts"]["powered"] is False
+        assert result["verdict"] == GATE_UNDERPOWERED
+        assert result["ships"] is False
+
+    def test_placebo_must_hold_against_every_rewiring(self) -> None:
+        """One rewiring the boost fails to beat kills the ship verdict."""
+        result = evaluate_gate(
+            boosted_real=_arm(54),
+            unboosted=_arm(18),
+            boosted_rewired_arms={42: _arm(18), 43: _arm(18), 44: _arm(54)},
+            nongraph_boosted=_flat(30),
+            nongraph_unboosted=_flat(30),
+            seed=42,
+        )
+        assert result["contracts"]["beats_placebo"] is False
+        assert result["verdict"] == GATE_DENSITY_ARTIFACT
+
+    def test_empty_rewired_arms_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one rewiring"):
+            evaluate_gate(
+                boosted_real=_arm(54),
+                unboosted=_arm(18),
+                boosted_rewired_arms={},
+                nongraph_boosted=_flat(30),
+                nongraph_unboosted=_flat(30),
+                seed=42,
+            )

--- a/backend/tests/eval/test_graph_boost_runner.py
+++ b/backend/tests/eval/test_graph_boost_runner.py
@@ -36,8 +36,12 @@ class TestEnvContextManager:
     def test_restores_on_exception(self) -> None:
         os.environ["GB_TEST_KEY"] = "prior"
         try:
-            with pytest.raises(RuntimeError), _env("GB_TEST_KEY", "inner"):
-                raise RuntimeError("boom")
+            # Nested (not comma-combined) so static analysis models
+            # pytest.raises swallowing the exception — the trailing assert
+            # was flagged unreachable under the combined form (CodeQL).
+            with pytest.raises(RuntimeError):
+                with _env("GB_TEST_KEY", "inner"):
+                    raise RuntimeError("boom")
             assert os.environ["GB_TEST_KEY"] == "prior"
         finally:
             os.environ.pop("GB_TEST_KEY", None)

--- a/backend/tests/eval/test_graph_boost_runner.py
+++ b/backend/tests/eval/test_graph_boost_runner.py
@@ -1,0 +1,208 @@
+"""DB-free orchestration tests for the #1213 graph-boost runner.
+
+Sibling of ``test_reinforce_runner.py``: the live pieces (ingest, recall,
+sleep, edge swap) are faked; what is pinned here is the CONTROL FLOW the
+gate's validity depends on — env toggling per arm, warm build before
+measurement, rewire→measure→restore ordering, and the arm pairing handed to
+``evaluate_gate``.
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tests.eval.graph_boost_runner import _env, _measure_arms, _recall_rankings
+
+
+class TestEnvContextManager:
+    def test_sets_and_restores_prior_value(self) -> None:
+        os.environ["GB_TEST_KEY"] = "prior"
+        try:
+            with _env("GB_TEST_KEY", "inner"):
+                assert os.environ["GB_TEST_KEY"] == "inner"
+            assert os.environ["GB_TEST_KEY"] == "prior"
+        finally:
+            os.environ.pop("GB_TEST_KEY", None)
+
+    def test_unset_key_is_removed_after(self) -> None:
+        os.environ.pop("GB_TEST_KEY", None)
+        with _env("GB_TEST_KEY", "inner"):
+            assert os.environ["GB_TEST_KEY"] == "inner"
+        assert "GB_TEST_KEY" not in os.environ
+
+    def test_restores_on_exception(self) -> None:
+        os.environ["GB_TEST_KEY"] = "prior"
+        try:
+            with pytest.raises(RuntimeError), _env("GB_TEST_KEY", "inner"):
+                raise RuntimeError("boom")
+            assert os.environ["GB_TEST_KEY"] == "prior"
+        finally:
+            os.environ.pop("GB_TEST_KEY", None)
+
+
+class TestRecallRankings:
+    @pytest.mark.asyncio
+    async def test_maps_memory_ids_to_doc_ids_and_carries_gold(self) -> None:
+        mem_a, mem_b = uuid4(), uuid4()
+        id_map = {str(mem_a): "doc-a", str(mem_b): "doc-b"}
+        svc = SimpleNamespace(
+            recall=AsyncMock(
+                return_value=SimpleNamespace(
+                    results=[
+                        SimpleNamespace(memory_id=mem_a),
+                        SimpleNamespace(memory_id=mem_b),
+                    ]
+                )
+            )
+        )
+
+        rankings = await _recall_rankings(
+            svc, [("query text", {"doc-b"})], id_map, "owner", uuid4(), uuid4()
+        )
+
+        assert rankings == [(["doc-a", "doc-b"], {"doc-b"})]
+        request = svc.recall.await_args.kwargs["request"]
+        assert request.query == "query text"
+        assert request.search_mode == "hybrid"
+
+
+def _fake_world():
+    """Corpus/plan/handles for a two-probe, two-replay-query world."""
+    probes = (
+        SimpleNamespace(text="probe one", companion_docs=("c1",)),
+        SimpleNamespace(text="probe two", companion_docs=("c2",)),
+    )
+    queries = (
+        SimpleNamespace(id="q1", text="replay one", relevant=("r1",)),
+        SimpleNamespace(id="q2", text="replay two", relevant=("r2",)),
+        SimpleNamespace(id="p-held-out", text="probe one", relevant=("c1",)),
+    )
+    plan = SimpleNamespace(probes=probes, replay_query_ids=("q1", "q2"))
+    corpus = SimpleNamespace(queries=queries)
+    ctx = SimpleNamespace(id=uuid4())
+    ws = SimpleNamespace(id=uuid4())
+    return corpus, plan, ctx, ws
+
+
+_HIT = (["c1", "x"], {"c1"})
+
+
+class TestMeasureArmsOrchestration:
+    @pytest.mark.asyncio
+    async def test_arm_env_sequencing_and_rewire_restore_order(self) -> None:
+        corpus, plan, ctx, ws = _fake_world()
+        snapshot = [
+            {
+                "src_id": str(uuid4()),
+                "dst_id": str(uuid4()),
+                "weight": 1.0,
+                "origin": "hebbian",
+                "confidence": 0.9,
+                "edge_type": "related",
+            }
+            for _ in range(3)
+        ]
+        env_per_call: list[tuple[str | None, str | None]] = []
+        replace_calls: list[str] = []
+
+        async def fake_recall_rankings(svc, queries, id_map, owner, ctx_id, ws_id):
+            env_per_call.append(
+                (
+                    os.environ.get("KAGURA_GRAPH_BOOST_ENABLED"),
+                    os.environ.get("ENABLE_NEURAL_MEMORY"),
+                )
+            )
+            return [_HIT] * len(queries)
+
+        async def fake_replace_edges(db, ctx_id, rows):
+            replace_calls.append("rewired" if rows is not snapshot else "snapshot")
+
+        def fake_rewire(edges, seed):
+            return list(edges), 5
+
+        with (
+            patch(
+                "tests.eval.graph_boost_runner._seed_provisional_tau",
+                new=AsyncMock(return_value={"seeded": True}),
+            ),
+            patch(
+                "tests.eval.graph_boost_runner._replay", new=AsyncMock(return_value=16)
+            ) as replay,
+            patch(
+                "tests.eval.graph_boost_runner._run_sleep", new=AsyncMock(return_value={"ok": True})
+            ),
+            patch(
+                "tests.eval.graph_boost_runner._snapshot_edges",
+                new=AsyncMock(return_value=snapshot),
+            ),
+            patch("tests.eval.graph_boost_runner._replace_edges", new=fake_replace_edges),
+            patch(
+                "tests.eval.graph_boost_runner.degree_preserving_rewire_with_stats",
+                new=fake_rewire,
+            ),
+            patch("tests.eval.graph_boost_runner._recall_rankings", new=fake_recall_rankings),
+        ):
+            result = await _measure_arms(
+                SimpleNamespace(), SimpleNamespace(), corpus, plan, {}, "owner", ctx, ws
+            )
+
+        # Warm build ran once before any measurement.
+        replay.assert_awaited_once()
+        # Seven measurement passes: unboosted probes, non-graph OFF, boosted
+        # probes, non-graph ON, then one rewired-placebo pass per pre-declared
+        # rewire seed — all with neural pinned false, boost toggled per arm.
+        assert env_per_call == [
+            ("false", "false"),
+            ("false", "false"),
+            ("true", "false"),
+            ("true", "false"),
+            ("true", "false"),
+            ("true", "false"),
+            ("true", "false"),
+        ]
+        # One swap-in per rewire seed, and the true snapshot is ALWAYS
+        # restored afterwards (exactly once, in the finally).
+        assert replace_calls == ["rewired", "rewired", "rewired", "snapshot"]
+        assert result["warm_build"]["edge_snapshot"] == {
+            "n": 3,
+            "n_hebbian": 3,
+            "rewire_swaps_by_seed": {42: 5, 43: 5, 44: 5},
+        }
+        assert result["n_probes"] == 2
+        assert result["n_nongraph"] == 2  # held-out probe query excluded
+        # Two fake probes are far below MIN_PROBES — the gate must refuse to
+        # render an inferential verdict on this synthetic world.
+        assert result["gate"]["verdict"] == "underpowered"
+
+    @pytest.mark.asyncio
+    async def test_sparse_graph_skips_rewire_and_reuses_unboosted(self) -> None:
+        corpus, plan, ctx, ws = _fake_world()
+
+        async def fake_recall_rankings(svc, queries, id_map, owner, ctx_id, ws_id):
+            return [_HIT] * len(queries)
+
+        replace = AsyncMock()
+        with (
+            patch(
+                "tests.eval.graph_boost_runner._seed_provisional_tau",
+                new=AsyncMock(return_value={}),
+            ),
+            patch("tests.eval.graph_boost_runner._replay", new=AsyncMock(return_value=0)),
+            patch("tests.eval.graph_boost_runner._run_sleep", new=AsyncMock(return_value={})),
+            patch("tests.eval.graph_boost_runner._snapshot_edges", new=AsyncMock(return_value=[])),
+            patch("tests.eval.graph_boost_runner._replace_edges", new=replace),
+            patch("tests.eval.graph_boost_runner._recall_rankings", new=fake_recall_rankings),
+        ):
+            result = await _measure_arms(
+                SimpleNamespace(), SimpleNamespace(), corpus, plan, {}, "owner", ctx, ws
+            )
+
+        replace.assert_not_awaited()
+        assert result["warm_build"]["edge_snapshot"] == {
+            "n": 0,
+            "n_hebbian": 0,
+            "rewire_swaps_by_seed": {},
+        }

--- a/backend/tests/services/test_graph_boost.py
+++ b/backend/tests/services/test_graph_boost.py
@@ -1,0 +1,169 @@
+"""Tests for MemoryService._maybe_graph_boost (#1213 flagged experiment).
+
+Pins the acceptance contract: flag default OFF means bit-identical recall
+behavior (no edge query, no reorder), the boost is bounded multiplicative
+([1, 1+b], boost-only), it composes with the reinforce re-rank through the
+``_rerank_factor`` stamp, and any failure preserves the original ranking
+(fail-safe).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.memory_service import MemoryService
+
+_CTX = uuid4()
+
+
+def _service(edge_rows=None, execute_error=None) -> MemoryService:
+    svc = MemoryService.__new__(MemoryService)
+    svc.db = AsyncMock()
+    if execute_error is not None:
+        svc.db.execute = AsyncMock(side_effect=execute_error)
+    else:
+        result = MagicMock()
+        result.all.return_value = edge_rows or []
+        svc.db.execute = AsyncMock(return_value=result)
+    return svc
+
+
+def _pool(*scores: float):
+    """Build (search_results, memories) with stable per-index memory ids."""
+    memories = {}
+    results = []
+    for i, score in enumerate(scores):
+        mem_id = uuid4()
+        key = f"r{i}"
+        memories[key] = SimpleNamespace(id=mem_id)
+        results.append({"id": key, "hybrid_score": score})
+    return results, memories
+
+
+def _mid(memories, key):
+    return memories[key].id
+
+
+class TestOffPath:
+    @pytest.mark.asyncio
+    async def test_flag_unset_is_bit_identical(self, monkeypatch) -> None:
+        """Acceptance criterion 1: default off -> no DB query, no reorder."""
+        monkeypatch.delenv("KAGURA_GRAPH_BOOST_ENABLED", raising=False)
+        svc = _service()
+        results, memories = _pool(0.9, 0.8, 0.7)
+        before = [r["id"] for r in results]
+
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+
+        assert [r["id"] for r in results] == before
+        svc.db.execute.assert_not_called()
+        assert all("_rerank_factor" not in r for r in results)
+
+    @pytest.mark.asyncio
+    async def test_flag_false_is_bit_identical(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "false")
+        svc = _service()
+        results, memories = _pool(0.9, 0.8)
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=2)
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cross_context_none_is_noop(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        svc = _service()
+        results, memories = _pool(0.9, 0.8)
+        await svc._maybe_graph_boost(results, memories, None, top_k=2)
+        svc.db.execute.assert_not_called()
+
+
+class TestBoost:
+    @pytest.mark.asyncio
+    async def test_connected_candidate_overtakes_within_bound(self, monkeypatch) -> None:
+        """A strongly connected runner-up overtakes a close leader — but the
+        factor is capped, so a distant leader cannot be overtaken."""
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_MAX", "0.15")
+        results, memories = _pool(0.90, 0.88, 0.5)
+        # r1 <-> r2 edge: r1 and r2 each get conn=2.0 (max), r0 isolated.
+        svc = _service(edge_rows=[(_mid(memories, "r1"), _mid(memories, "r2"), 2.0)])
+
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+
+        # r1: 0.88 * 1.15 = 1.012 > r0: 0.90 * 1.0 — overtakes.
+        # r2: 0.5 * 1.15 = 0.575 < 0.90 — the cap keeps it below the leader.
+        assert [r["id"] for r in results] == ["r1", "r0", "r2"]
+
+    @pytest.mark.asyncio
+    async def test_isolated_candidates_keep_factor_one(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        results, memories = _pool(0.9, 0.8)
+        svc = _service(edge_rows=[(_mid(memories, "r0"), _mid(memories, "r1"), 1.0)])
+
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=2)
+
+        # Both connected equally -> both factor 1+b -> order unchanged, and
+        # the stamp records the applied factor.
+        assert [r["id"] for r in results] == ["r0", "r1"]
+        assert results[0]["_rerank_factor"] == pytest.approx(1.15)
+
+    @pytest.mark.asyncio
+    async def test_no_edges_means_no_reorder_and_no_stamp(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        svc = _service(edge_rows=[])
+        results, memories = _pool(0.9, 0.8)
+
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=2)
+
+        assert [r["id"] for r in results] == ["r0", "r1"]
+        assert all("_rerank_factor" not in r for r in results)
+
+    @pytest.mark.asyncio
+    async def test_composes_with_reinforce_factor(self, monkeypatch) -> None:
+        """A prior bounded re-rank's stamp is honored: the graph boost sorts
+        by base x reinforce_factor x graph_factor, never by raw base."""
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_MAX", "0.15")
+        results, memories = _pool(0.90, 0.88, 0.86)
+        # Reinforce demoted r0 and boosted r2 (stamped factors).
+        results[0]["_rerank_factor"] = 0.85
+        results[2]["_rerank_factor"] = 1.15
+        # No edges at all would return early — give r1 a weak edge to r2.
+        svc = _service(edge_rows=[(_mid(memories, "r1"), _mid(memories, "r2"), 1.0)])
+
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+
+        # adjusted: r0 = 0.90*0.85 = 0.765; r1 = 0.88*1.0*1.15 = 1.012;
+        #           r2 = 0.86*1.15*1.15 ≈ 1.137 → order r2, r1, r0.
+        assert [r["id"] for r in results] == ["r2", "r1", "r0"]
+        # Cumulative stamp: reinforce factor x graph factor.
+        assert results[0]["_rerank_factor"] == pytest.approx(1.15 * 1.15)
+
+    @pytest.mark.asyncio
+    async def test_max_boost_env_clamped(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_MAX", "9.0")
+        enabled, max_boost = MemoryService._graph_boost_settings()
+        assert enabled is True
+        assert max_boost == 0.5
+
+    @pytest.mark.asyncio
+    async def test_invalid_max_env_falls_back(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "1")
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_MAX", "banana")
+        enabled, max_boost = MemoryService._graph_boost_settings()
+        assert enabled is True
+        assert max_boost == 0.15
+
+
+class TestFailSafe:
+    @pytest.mark.asyncio
+    async def test_db_failure_preserves_ranking(self, monkeypatch) -> None:
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        svc = _service(execute_error=RuntimeError("edges table on fire"))
+        results, memories = _pool(0.9, 0.8, 0.7)
+
+        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+
+        assert [r["id"] for r in results] == ["r0", "r1", "r2"]

--- a/backend/tests/services/test_graph_boost.py
+++ b/backend/tests/services/test_graph_boost.py
@@ -105,6 +105,31 @@ class TestBoost:
         assert [r["id"] for r in results] == ["r1", "r0", "r2"]
 
     @pytest.mark.asyncio
+    async def test_boost_scoped_to_topk_slice(self, monkeypatch) -> None:
+        """The experiment is defined over the hybrid top-k slice: items in
+        the expanded candidate pool beyond top_k are neither queried, nor
+        boosted, nor reordered (Copilot, PR #1222)."""
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_MAX", "0.15")
+        results, memories = _pool(0.90, 0.88, 0.87, 0.86)
+        # Edge connects r1 with the POOL-ONLY item r3 (outside top_k=2):
+        # r3 must not enter the slice, and its edge must not be counted.
+        svc = _service(
+            edge_rows=[(_mid(memories, "r1"), _mid(memories, "r3"), 2.0)],
+        )
+
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=2)
+
+        # Pool items past the slice keep their original positions.
+        assert [r["id"] for r in results][2:] == ["r2", "r3"]
+        assert "_rerank_factor" not in results[3]
+        # The edge query was scoped to the slice's candidate ids only.
+        query = svc.db.execute.call_args.args[0]
+        assert str(_mid(memories, "r3")) not in str(
+            query.compile(compile_kwargs={"literal_binds": True})
+        )
+
+    @pytest.mark.asyncio
     async def test_isolated_candidates_keep_factor_one(self, monkeypatch) -> None:
         monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
         results, memories = _pool(0.9, 0.8)

--- a/backend/tests/services/test_graph_boost.py
+++ b/backend/tests/services/test_graph_boost.py
@@ -55,7 +55,7 @@ class TestOffPath:
         results, memories = _pool(0.9, 0.8, 0.7)
         before = [r["id"] for r in results]
 
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=3)
 
         assert [r["id"] for r in results] == before
         svc.db.execute.assert_not_called()
@@ -66,7 +66,7 @@ class TestOffPath:
         monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "false")
         svc = _service()
         results, memories = _pool(0.9, 0.8)
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=2)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=2)
         svc.db.execute.assert_not_called()
 
     @pytest.mark.asyncio
@@ -74,7 +74,16 @@ class TestOffPath:
         monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
         svc = _service()
         results, memories = _pool(0.9, 0.8)
-        await svc._maybe_graph_boost(results, memories, None, top_k=2)
+        await svc._maybe_graph_boost(results, memories, None, "u1", top_k=2)
+        svc.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_user_id_is_noop(self, monkeypatch) -> None:
+        """Per-user scope (gate2/CSO): no caller identity, no boost."""
+        monkeypatch.setenv("KAGURA_GRAPH_BOOST_ENABLED", "true")
+        svc = _service()
+        results, memories = _pool(0.9, 0.8)
+        await svc._maybe_graph_boost(results, memories, _CTX, None, top_k=2)
         svc.db.execute.assert_not_called()
 
 
@@ -89,7 +98,7 @@ class TestBoost:
         # r1 <-> r2 edge: r1 and r2 each get conn=2.0 (max), r0 isolated.
         svc = _service(edge_rows=[(_mid(memories, "r1"), _mid(memories, "r2"), 2.0)])
 
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=3)
 
         # r1: 0.88 * 1.15 = 1.012 > r0: 0.90 * 1.0 — overtakes.
         # r2: 0.5 * 1.15 = 0.575 < 0.90 — the cap keeps it below the leader.
@@ -101,7 +110,7 @@ class TestBoost:
         results, memories = _pool(0.9, 0.8)
         svc = _service(edge_rows=[(_mid(memories, "r0"), _mid(memories, "r1"), 1.0)])
 
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=2)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=2)
 
         # Both connected equally -> both factor 1+b -> order unchanged, and
         # the stamp records the applied factor.
@@ -114,7 +123,7 @@ class TestBoost:
         svc = _service(edge_rows=[])
         results, memories = _pool(0.9, 0.8)
 
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=2)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=2)
 
         assert [r["id"] for r in results] == ["r0", "r1"]
         assert all("_rerank_factor" not in r for r in results)
@@ -132,7 +141,7 @@ class TestBoost:
         # No edges at all would return early — give r1 a weak edge to r2.
         svc = _service(edge_rows=[(_mid(memories, "r1"), _mid(memories, "r2"), 1.0)])
 
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=3)
 
         # adjusted: r0 = 0.90*0.85 = 0.765; r1 = 0.88*1.0*1.15 = 1.012;
         #           r2 = 0.86*1.15*1.15 ≈ 1.137 → order r2, r1, r0.
@@ -164,6 +173,6 @@ class TestFailSafe:
         svc = _service(execute_error=RuntimeError("edges table on fire"))
         results, memories = _pool(0.9, 0.8, 0.7)
 
-        await svc._maybe_graph_boost(results, memories, _CTX, top_k=3)
+        await svc._maybe_graph_boost(results, memories, _CTX, "u1", top_k=3)
 
         assert [r["id"] for r in results] == ["r0", "r1", "r2"]

--- a/docs/eval/graph-boost-gate.md
+++ b/docs/eval/graph-boost-gate.md
@@ -1,0 +1,61 @@
+# Graph-Boost Placebo Gate (#1213)
+
+The warm co-activation graph carries edge-specific companion structure
+(`explore()` recovers gold companions +0.20 over a degree-matched rewiring,
+BCa 95% [0.117, 0.308]) that production `recall()` never consumes. #1213
+runs the obvious next experiment: a **bounded multiplicative graph term** on
+the recall top-k — with the known failure mode (fusion dilution / density
+artifact) built into the gate as kill-shots.
+
+## The mechanism (ships OFF)
+
+`MemoryService._maybe_graph_boost` — runs after the reinforce re-rank:
+
+- Env-gated: `KAGURA_GRAPH_BOOST_ENABLED` (default off → **bit-identical
+  recall**: no edge query, no reorder), `KAGURA_GRAPH_BOOST_MAX` (default
+  0.15, clamped to [0, 0.5]). An env flag, not a config column: an
+  experiment must not mint a fifth parallel migration head (e55–e58), and
+  per-context graduation only happens if this gate passes.
+- Signal: each candidate's score × `1 + b·(conn/max_conn)` where `conn` is
+  the summed weight of its **hebbian** edges to other candidates in the same
+  pool. Boost-only `[1, 1+b]`; isolated candidates keep 1.0. Multiplicative
+  with a cap — NOT additive score fusion (the F1 hybrid null).
+- Hebbian only: semantic edges would double-count the vector similarity
+  already in the base score; declared edges are unmeasured.
+- Composes with the reinforce re-rank via the `_rerank_factor` stamp
+  (bounded × bounded stays bounded).
+- Fail-safe: any failure preserves the original ranking.
+
+## The gate (pre-declared, deterministic)
+
+`tests/eval/graph_boost_gate.py::evaluate_gate` — primary metric P@5, BCa
+CIs (`stats.paired_bca_ci`, 10k resamples, seed 1213):
+
+| Contract | Condition | On failure |
+|---|---|---|
+| beats no-graph | boosted_real − unboosted: BCa CI low > 0 (companion probes) | `no_effect` — valid close, not shipped |
+| beats placebo | boosted_real − boosted_on_rewired: BCa CI low > 0 | `density_artifact` — does NOT ship even though it beat no-graph |
+| non-inferiority | non-graph-query P@5 delta ≥ −0.01 (pre-declared ε) | `regression` — vetoes even a winner (fusion-dilution lesson) |
+
+`ship` requires all three. Verdicts are recorded either way in the results
+JSON — a clean "does not beat placebo" is a valid close per the issue.
+
+## Running it
+
+```bash
+make up
+make eval-graph-boost   # writes backend/tests/eval/results/graph-boost-<date>.json
+```
+
+The runner (`tests/eval/graph_boost_runner.py`) builds one warm graph
+(provisional τ → replay → sleep, the placebo_runner procedure), measures the
+four arms with `ENABLE_NEURAL_MEMORY=false` (no Hebbian writes between
+paired arms), swaps in a degree-preserving rewired graph for the placebo arm
+(seed 42) and restores the snapshot afterwards.
+
+## Cohort protection
+
+All existing eval arms pin `KAGURA_GRAPH_BOOST_ENABLED=false`
+(`runner._score_arm`, `replay_runner` measurement + `_replay` warm build,
+`reinforce_runner` arms) so an operator-exported env can never contaminate
+the frozen-corpus baselines the #1210 CI gates compare against.

--- a/docs/eval/graph-boost-gate.md
+++ b/docs/eval/graph-boost-gate.md
@@ -25,6 +25,12 @@ artifact) built into the gate as kill-shots.
 - Composes with the reinforce re-rank via the `_rerank_factor` stamp
   (bounded × bounded stays bounded).
 - Fail-safe: any failure preserves the original ranking.
+- Per-user edge scope (same discipline as `activation.py`): only the
+  CALLER's own co-activation history moves their ranking — in a shared
+  context, another member's (forgeable-by-co-recall) hebbian edges cannot.
+- The env flag is deployment-global, not per-context: enable it only on
+  single-tenant / eval-rig deployments. Per-context graduation (a config
+  column) is exactly what the gate below decides.
 
 ## The gate (pre-declared, deterministic)
 
@@ -33,12 +39,19 @@ CIs (`stats.paired_bca_ci`, 10k resamples, seed 1213):
 
 | Contract | Condition | On failure |
 |---|---|---|
+| powered | n_probes ≥ 50 (`MIN_PROBES`) | `underpowered` — deltas reported, ship refused |
 | beats no-graph | boosted_real − unboosted: BCa CI low > 0 (companion probes) | `no_effect` — valid close, not shipped |
-| beats placebo | boosted_real − boosted_on_rewired: BCa CI low > 0 | `density_artifact` — does NOT ship even though it beat no-graph |
+| beats placebo | boosted_real − boosted_on_rewired: BCa CI low > 0 for EVERY pre-declared rewire seed (42/43/44) | `density_artifact` — does NOT ship even though it beat no-graph |
 | non-inferiority | non-graph-query P@5 delta ≥ −0.01 (pre-declared ε) | `regression` — vetoes even a winner (fusion-dilution lesson) |
 
-`ship` requires all three. Verdicts are recorded either way in the results
+`ship` requires all four. Verdicts are recorded either way in the results
 JSON — a clean "does not beat placebo" is a valid close per the issue.
+
+The runner uses the frozen **kagura_l** corpus (300 docs, 60 multi-gold
+cross-source probes) — not the 5-probe golden corpus, which is below the
+inferential floor. The placebo rewires **only the hebbian edges** (the boost
+reads only hebbian; rewiring semantic/declared edges too would make the null
+model inconsistent with the mechanism under test).
 
 ## Running it
 
@@ -51,7 +64,15 @@ The runner (`tests/eval/graph_boost_runner.py`) builds one warm graph
 (provisional τ → replay → sleep, the placebo_runner procedure), measures the
 four arms with `ENABLE_NEURAL_MEMORY=false` (no Hebbian writes between
 paired arms), swaps in a degree-preserving rewired graph for the placebo arm
-(seed 42) and restores the snapshot afterwards.
+(one measurement per pre-declared rewire seed) and restores the snapshot
+afterwards.
+
+**Known limitation (pre-declared)**: the non-inferiority slice is the
+corpus's replay queries — the same queries the warm build replayed, so the
+boost re-ranks exactly their co-activated results. That slice is
+leaky-optimistic, not conservative. A pass here is necessary but NOT
+sufficient; the frozen held-out retrieval slice is the honest
+non-inferiority check before any per-context graduation.
 
 ## Cohort protection
 


### PR DESCRIPTION
Closes #1213

## What

The graph carries edge-specific companion structure (`explore()` +0.20 over a degree-matched rewiring) that `recall()` never consumes. This ships the experiment to test whether recall can consume it — **as an experiment, not a feature**:

- **Mechanism** (`MemoryService._maybe_graph_boost`, runs after the reinforce re-rank): candidate score × `1 + b·(conn/max_conn)`, where `conn` = summed weight of the candidate's **hebbian** edges to other candidates in the same pool. Boost-only `[1, 1+b]`, `b` clamped to 0.5. Multiplicative with a cap — NOT additive score fusion (the F1 hybrid null's failure mode).
- **Flag**: `KAGURA_GRAPH_BOOST_ENABLED` env (default off → **bit-identical recall**: no edge query, no reorder — pinned by test). An env flag, not a config column: an experiment must not mint a fifth parallel migration head (e55–e58 already coordinate); per-context graduation happens only if the gate passes.
- **Composition**: the reinforce re-rank now stamps its factor into `_rerank_factor`; the graph boost multiplies on top of it. Without the stamp, the later sort would silently erase the earlier re-rank (found during design).
- Hebbian-only (semantic edges would double-count vector similarity; declared edges unmeasured). Fail-safe: any failure preserves the ranking.

## The pre-declared gate (`tests/eval/graph_boost_gate.py`)

Deterministic, unit-tested; primary metric P@5, paired BCa CIs (10k resamples, seed 1213):

| Contract | On failure |
|---|---|
| powered: n ≥ `MIN_PROBES`=50 | `underpowered` — deltas reported, ship refused |
| beats no-graph (companion probes, CI low > 0) | `no_effect` — a valid close, not shipped |
| beats hebbian-only degree-matched rewired placebo, for EVERY pre-declared rewire seed (42/43/44) | `density_artifact` — does NOT ship |
| non-graph P@5 delta ≥ −0.01 | `regression` — vetoes even a winner |

`ship` requires all four. Live orchestration: `tests/eval/graph_boost_runner.py` (`make eval-graph-boost`) — frozen **kagura_l** corpus (300 docs, 60 multi-gold probes — the 5-probe golden corpus is below the inferential floor), one warm build (τ → replay → sleep, the placebo_runner procedure), paired arms measured with neural OFF, hebbian-only edge snapshot → rewire per seed → restore. The non-inferiority slice (replay queries) is labeled leaky-optimistic in results + docs; the held-out slice is pre-declared as required before per-context graduation. Full protocol: `docs/eval/graph-boost-gate.md`.

## Cohort protection

All existing eval arms pin `KAGURA_GRAPH_BOOST_ENABLED=false` (`runner._score_arm`, `replay_runner` measure + `_replay` warm build, `reinforce_runner`) so an operator-exported env can never contaminate the frozen-corpus baselines the #1210 CI gates compare against.

## Post-merge (operator)

`make eval-graph-boost` on the rig produces `results/graph-boost-<date>.json` with a recorded verdict either way — the issue's acceptance explicitly counts a clean "does not beat placebo, not shipped" as a valid close.

## Gate2 hardening (CSO/CAIO yellow → addressed)

- **Per-user edge scope** (CSO): the boost reads only the CALLER's own hebbian edges — same discipline as `activation.py`; in a shared context another member's forgeable-by-co-recall edges cannot move your ranking. The env flag is deployment-global: single-tenant/rig only, per-context graduation is what the gate decides.
- **Statistical honesty** (CAIO): kagura_l corpus (n=60 ≥ MIN_PROBES=50; the gate refuses `ship` below the floor), hebbian-only rewiring (null model now matches the mechanism), three rewire seeds with worst-case binding, leak-labeled non-inferiority slice.

## Tests

28 new (11 mechanism: bit-identical off-path with `db.execute.assert_not_called()`, bounded overtake, reinforce-composition, per-user scope, fail-safe; 11 gate: all five verdicts incl. the density-artifact kill-shot, underpowered floor, every-rewiring requirement, epsilon boundary; 6 runner orchestration: env toggling per arm, rewire→measure→restore ordering, sparse fallback). Full battery: 4065 passed; only the known 16 `/tmp/wt` staging-artifact failures. Inner review: CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
