### PR TITLE
feat(search): router calibration gate + per-context calibration store (#1220)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,13 @@ eval-graph-boost:
 	@echo "Writes backend/tests/eval/results/graph-boost-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.graph_boost_runner
 
+.PHONY: eval-router-gate
+eval-router-gate:
+	@echo "Running live #1220 router calibration gate (needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/router-calibration-<date>.json and persists"
+	@echo "fleet-default rows to router_calibrations — real run only, never fabricated."
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.router_gate_runner
+
 .PHONY: eval-reinforce
 eval-reinforce:
 	@echo "Running live reinforce ON-vs-OFF rollout gate (Issue #1069, needs the stack: make up)..."

--- a/backend/alembic/versions/e59_1220_router_calibrations.py
+++ b/backend/alembic/versions/e59_1220_router_calibrations.py
@@ -1,0 +1,103 @@
+"""#1220: add router_calibrations (per-context router arm performance).
+
+Stage 4 of the #1212 query-intent router: persist per-bucket arm
+performance so managed-cloud tuning can diverge from self-host defaults.
+Rows with ``context_id IS NULL`` are the fleet defaults measured on the
+frozen eval corpus (written by ``tests.eval.router_gate_runner``); rows
+with a ``context_id`` come from live-traffic measurements. Keying mirrors
+``embedding_calibrations``: partial-unique indexes split on NULL context
+because Postgres unique constraints treat NULLs as distinct.
+
+Blue-green safety: pure CREATE TABLE — no existing table or app code is
+touched; old app code never references the table.
+
+Revision ID: e59_1220_router_calibrations
+Revises: e58_1212_routing_mode
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers
+revision = "e59_1220_router_calibrations"
+down_revision = "e58_1212_routing_mode"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the router_calibrations table + partial-unique indexes."""
+    op.create_table(
+        "router_calibrations",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "context_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("bucket", sa.String(16), nullable=False),
+        sa.Column("arm", sa.String(16), nullable=False),
+        sa.Column("p_at_5", sa.Float, nullable=False),
+        sa.Column("mrr_at_10", sa.Float, nullable=False),
+        sa.Column("n_queries", sa.Integer, nullable=False),
+        sa.Column("source", sa.String(20), nullable=False, server_default="frozen_corpus"),
+        # No server_default: the measurement timestamp is always supplied by
+        # the writer (a defaulted "now" would fake a sampling time).
+        sa.Column("sampled_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "bucket IN ('keyword', 'semantic', 'hybrid')",
+            name="router_calibrations_bucket_check",
+        ),
+        sa.CheckConstraint(
+            "arm IN ('keyword', 'semantic', 'hybrid', 'routed')",
+            name="router_calibrations_arm_check",
+        ),
+        sa.CheckConstraint(
+            "source IN ('frozen_corpus', 'live_traffic')",
+            name="router_calibrations_source_check",
+        ),
+        sa.CheckConstraint(
+            "p_at_5 >= 0.0 AND p_at_5 <= 1.0",
+            name="router_calibrations_p_at_5_range",
+        ),
+        sa.CheckConstraint(
+            "mrr_at_10 >= 0.0 AND mrr_at_10 <= 1.0",
+            name="router_calibrations_mrr_range",
+        ),
+        sa.CheckConstraint("n_queries >= 0", name="router_calibrations_nonneg_n"),
+    )
+    op.create_index(
+        "ix_router_calibrations_context_id",
+        "router_calibrations",
+        ["context_id"],
+    )
+    op.create_index(
+        "uq_router_calibration_global",
+        "router_calibrations",
+        ["bucket", "arm", "source"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NULL"),
+    )
+    op.create_index(
+        "uq_router_calibration_context",
+        "router_calibrations",
+        ["context_id", "bucket", "arm", "source"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the router_calibrations table."""
+    op.drop_index("uq_router_calibration_context", table_name="router_calibrations")
+    op.drop_index("uq_router_calibration_global", table_name="router_calibrations")
+    op.drop_index("ix_router_calibrations_context_id", table_name="router_calibrations")
+    op.drop_table("router_calibrations")

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -15,15 +15,25 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
+    Float,
     ForeignKey,
+    Index,
     Integer,
     String,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from db.base import Base
+
+# Router calibration vocabulary (#1220). Buckets are the classifier's lane
+# decisions; arms are the retrieval strategies measured against each bucket.
+ROUTER_CALIBRATION_BUCKETS = ("keyword", "semantic", "hybrid")
+ROUTER_CALIBRATION_ARMS = ("keyword", "semantic", "hybrid", "routed")
+ROUTER_CALIBRATION_SOURCE_FROZEN = "frozen_corpus"
+ROUTER_CALIBRATION_SOURCE_LIVE = "live_traffic"
 
 
 class ConfigOverride(Base):
@@ -187,5 +197,111 @@ class ContextSearchConfig(Base):
             f"use_rerank={self.use_rerank}, "
             f"provider={self.reranker_provider}, "
             f"model={self.reranker_model}"
+            f")>"
+        )
+
+
+class RouterCalibration(Base):
+    """Per-bucket router arm performance (#1220 stage 4).
+
+    One row = one (bucket, arm) measurement: how one retrieval strategy
+    performed on the queries the classifier routes to one lane. Rows with
+    ``context_id IS NULL`` are the fleet defaults measured on the frozen
+    eval corpus (written by ``tests.eval.router_gate_runner``); rows with a
+    ``context_id`` let managed-cloud tuning diverge per context from
+    live-traffic measurements without touching the self-host defaults —
+    the same NULL-vs-non-NULL keying as ``embedding_calibrations``.
+
+    Attributes:
+        id: Primary key.
+        context_id: Context scope; NULL = fleet default (frozen corpus).
+        bucket: Classifier lane the measured queries were routed to.
+        arm: Retrieval strategy measured on that bucket.
+        p_at_5: Mean P@5 of the arm on the bucket.
+        mrr_at_10: MRR@10 of the arm on the bucket.
+        n_queries: Number of queries behind the measurement.
+        source: Where the measurement came from (frozen_corpus | live_traffic).
+        sampled_at: When the measurement was taken.
+    """
+
+    __tablename__ = "router_calibrations"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=text("gen_random_uuid()")
+    )
+    context_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+    )
+    bucket: Mapped[str] = mapped_column(String(16), nullable=False)
+    arm: Mapped[str] = mapped_column(String(16), nullable=False)
+    p_at_5: Mapped[float] = mapped_column(Float, nullable=False)
+    mrr_at_10: Mapped[float] = mapped_column(Float, nullable=False)
+    n_queries: Mapped[int] = mapped_column(Integer, nullable=False)
+    source: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=ROUTER_CALIBRATION_SOURCE_FROZEN
+    )
+    sampled_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "bucket IN ('keyword', 'semantic', 'hybrid')",
+            name="router_calibrations_bucket_check",
+        ),
+        CheckConstraint(
+            "arm IN ('keyword', 'semantic', 'hybrid', 'routed')",
+            name="router_calibrations_arm_check",
+        ),
+        CheckConstraint(
+            "source IN ('frozen_corpus', 'live_traffic')",
+            name="router_calibrations_source_check",
+        ),
+        CheckConstraint(
+            "p_at_5 >= 0.0 AND p_at_5 <= 1.0",
+            name="router_calibrations_p_at_5_range",
+        ),
+        CheckConstraint(
+            "mrr_at_10 >= 0.0 AND mrr_at_10 <= 1.0",
+            name="router_calibrations_mrr_range",
+        ),
+        CheckConstraint(
+            "n_queries >= 0",
+            name="router_calibrations_nonneg_n",
+        ),
+        # One measurement per (scope, bucket, arm, source): partial-unique
+        # split on NULL context (the embedding_calibrations pattern —
+        # Postgres unique treats NULLs as distinct, so the global scope
+        # needs its own predicate index).
+        Index(
+            "uq_router_calibration_global",
+            "bucket",
+            "arm",
+            "source",
+            unique=True,
+            postgresql_where=text("context_id IS NULL"),
+        ),
+        Index(
+            "uq_router_calibration_context",
+            "context_id",
+            "bucket",
+            "arm",
+            "source",
+            unique=True,
+            postgresql_where=text("context_id IS NOT NULL"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            f"<RouterCalibration("
+            f"context_id={self.context_id}, "
+            f"bucket={self.bucket}, "
+            f"arm={self.arm}, "
+            f"p@5={self.p_at_5}, "
+            f"n={self.n_queries}, "
+            f"source={self.source}"
             f")>"
         )

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -44,6 +44,7 @@ DERIVED_MOAT_TABLES: frozenset[str] = frozenset(
         "neural_memory_edges",  # Hebbian/semantic edge weights + origin
         "graph_memory",  # legacy NetworkX graph JSON storage
         "embedding_calibrations",  # similarity percentile calibration (p25–p99)
+        "router_calibrations",  # per-bucket router arm performance (#1220)
         "neural_config",  # neural tuning parameters
         "sleep_reports",  # Sleep consolidation phase results
         "sleep_actions",  # individual consolidation decisions

--- a/backend/src/repositories/config_repository.py
+++ b/backend/src/repositories/config_repository.py
@@ -2,14 +2,21 @@
 
 This module provides database access for context-level search and reranker settings.
 Issue #130: Context-scoped Search & Reranker Settings UI
+Issue #1220: Per-context router calibration store (stage 4)
 """
 
+from datetime import datetime  # noqa: TC003 - runtime annotation in upsert()
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.config import ContextSearchConfig
+from models.config import (
+    ROUTER_CALIBRATION_SOURCE_FROZEN,
+    ContextSearchConfig,
+    RouterCalibration,
+)
 from models.schemas import ContextSearchConfigUpdate
 from utils.logger import get_logger
 
@@ -189,3 +196,101 @@ class ContextSearchConfigRepository:
 
         logger.info("config_deleted", context_id=str(context_id))
         return True
+
+
+class RouterCalibrationRepository:
+    """Repository for per-bucket router arm performance (#1220 stage 4).
+
+    Rows with ``context_id IS NULL`` are the fleet defaults (frozen-corpus
+    gate runs); per-context rows let managed-cloud tuning diverge without
+    touching the self-host defaults.
+    """
+
+    def __init__(self, db: AsyncSession):
+        """Initialize repository with database session.
+
+        Args:
+            db: Async SQLAlchemy session
+        """
+        self.db = db
+
+    async def upsert(
+        self,
+        *,
+        bucket: str,
+        arm: str,
+        p_at_5: float,
+        mrr_at_10: float,
+        n_queries: int,
+        sampled_at: datetime,
+        context_id: UUID | None = None,
+        source: str = ROUTER_CALIBRATION_SOURCE_FROZEN,
+    ) -> RouterCalibration:
+        """Insert or refresh one (scope, bucket, arm, source) measurement.
+
+        ON CONFLICT targets the partial-unique index matching the scope
+        (global vs per-context), so re-running a gate refreshes the row
+        instead of failing or duplicating.
+
+        Returns:
+            The stored RouterCalibration row.
+        """
+        stmt = (
+            pg_insert(RouterCalibration)
+            .values(
+                context_id=context_id,
+                bucket=bucket,
+                arm=arm,
+                p_at_5=p_at_5,
+                mrr_at_10=mrr_at_10,
+                n_queries=n_queries,
+                source=source,
+                sampled_at=sampled_at,
+            )
+            .on_conflict_do_update(
+                index_elements=(
+                    ["bucket", "arm", "source"]
+                    if context_id is None
+                    else ["context_id", "bucket", "arm", "source"]
+                ),
+                index_where=text(
+                    "context_id IS NULL" if context_id is None else "context_id IS NOT NULL"
+                ),
+                set_={
+                    "p_at_5": p_at_5,
+                    "mrr_at_10": mrr_at_10,
+                    "n_queries": n_queries,
+                    "sampled_at": sampled_at,
+                },
+            )
+            .returning(RouterCalibration)
+        )
+        result = await self.db.execute(stmt)
+        row = result.scalar_one()
+        logger.debug(
+            "router_calibration_upserted",
+            context_id=str(context_id) if context_id else None,
+            bucket=bucket,
+            arm=arm,
+            source=source,
+        )
+        return row
+
+    async def get_for_context(self, context_id: UUID | None) -> list[RouterCalibration]:
+        """Calibration rows for a context, falling back to the fleet defaults.
+
+        Returns the context's own rows when any exist, else the global
+        (``context_id IS NULL``) rows. Never mixes scopes — a partially
+        calibrated context should read as its own coherent measurement set.
+        """
+        if context_id is not None:
+            result = await self.db.execute(
+                select(RouterCalibration).where(RouterCalibration.context_id == context_id)
+            )
+            rows = list(result.scalars().all())
+            if rows:
+                return rows
+        result = await self.db.execute(
+            select(RouterCalibration).where(RouterCalibration.context_id.is_(None))
+        )
+        return list(result.scalars().all())

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -13,6 +13,7 @@ import hashlib
 import math
 import statistics
 from datetime import datetime
+from typing import Any
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, or_, select
@@ -1693,6 +1694,7 @@ class MemoryService:
         context_id: UUID,
         *,
         cross_context: bool,
+        config: Any = None,
     ) -> str:
         """#1212: resolve the effective search mode, optionally via the router.
 
@@ -1700,10 +1702,10 @@ class MemoryService:
 
         1. An explicitly passed ``search_mode`` ALWAYS wins (router never
            overrides a caller's choice, in any routing_mode) — and returns
-           immediately, skipping the config read and classification: no DB
-           round-trip or classify/log work on the hot path when the outcome
-           is already decided. Router telemetry therefore covers only the
-           calls the router could actually influence (search_mode omitted).
+           immediately, skipping classification: no classify/log work on the
+           hot path when the outcome is already decided. Router telemetry
+           therefore covers only the calls the router could actually
+           influence (search_mode omitted).
         2. ``routing_mode='active'`` and no explicit mode → the classifier's
            lane.
         3. Otherwise → ``"hybrid"`` (the historical default).
@@ -1711,15 +1713,17 @@ class MemoryService:
         In ``log_only`` and ``active`` the decision is stamped into telemetry
         (``query_router_decision`` — numeric features only, never query text).
         Cross-context recalls skip routing entirely: the config is
-        per-context and a mixed set has no single answer. The config read is
-        READ-ONLY (``get_by_context``, never ``create_or_get``) and
-        fail-open, mirroring the reinforce re-rank discipline: a config read
-        failure must never break recall.
+        per-context and a mixed set has no single answer. This method issues
+        NO DB read (#1220 advisor rec): ``recall()`` prefetches the config
+        row once (read-only, fail-open) and threads it here and into the
+        reinforce re-rank — a missing/unfetched row simply means routing
+        off, exactly the pre-prefetch behavior.
 
         Args:
             request: The recall request (``search_mode`` may be None).
             context_id: The single target context.
             cross_context: True for multi-context recalls (routing skipped).
+            config: The prefetched ContextSearchConfig row (or None).
 
         Returns:
             The effective search mode ("hybrid" | "semantic" | "keyword").
@@ -1727,18 +1731,6 @@ class MemoryService:
         requested_mode = request.search_mode
         default_mode = requested_mode or "hybrid"
         if cross_context or requested_mode is not None:
-            return default_mode
-
-        try:
-            from repositories.config_repository import ContextSearchConfigRepository
-
-            config = await ContextSearchConfigRepository(self.db).get_by_context(context_id)
-        except Exception as exc:
-            logger.warning(
-                "query_router_config_read_failed",
-                context_id=str(context_id),
-                error=str(exc),
-            )
             return default_mode
 
         routing_mode = getattr(config, "routing_mode", None) if config else None
@@ -1915,6 +1907,7 @@ class MemoryService:
         memories: dict,
         context_id: UUID | None,
         top_k: int | None = None,
+        config: Any = None,
     ) -> None:
         """Issue #1048: bounded, config-gated recall re-rank by adoption + feedback.
 
@@ -1931,6 +1924,13 @@ class MemoryService:
         staged rollout is monitorable. ``top_k`` is the user-visible slice the
         telemetry measures the zero-adoption surfacing rate over (the caller passes
         ``request.k``); ``None`` falls back to the whole candidate pool.
+
+        #1220 (advisor rec): ``config`` is the row ``recall()`` prefetched at
+        the top of the call — passing it skips this helper's own SELECT.
+        ``None`` falls back to a local read: the prefetch happens BEFORE
+        hybrid_search's ``create_or_get`` materializes a fresh context's row,
+        so a row-less-at-prefetch context must be re-read here to keep the
+        first-ever recall's re-rank behavior unchanged.
         """
         if context_id is None or len(search_results) < 2:
             return
@@ -1939,15 +1939,17 @@ class MemoryService:
         # original hybrid ranking is preserved (fail-safe, mirrors the spend-cap
         # fail-open philosophy).
         try:
-            from repositories.config_repository import ContextSearchConfigRepository
+            cfg = config
+            if cfg is None:
+                from repositories.config_repository import ContextSearchConfigRepository
 
-            # READ-ONLY lookup — this helper must not create/commit a config row
-            # (create_or_get would INSERT+COMMIT, adding a side effect here). In
-            # practice hybrid_search's _get_search_config has usually materialized
-            # the row earlier in this same recall (with the #1207 default), so the
-            # cfg-None branch is a fail-safe for genuinely row-less states (e.g.
-            # that materialization failed), not a legacy-context opt-out.
-            cfg = await ContextSearchConfigRepository(self.db).get_by_context(context_id)
+                # READ-ONLY lookup — this helper must not create/commit a config
+                # row (create_or_get would INSERT+COMMIT, adding a side effect
+                # here). In practice hybrid_search's _get_search_config has
+                # usually materialized the row earlier in this same recall (with
+                # the #1207 default), so the cfg-None branch is a fail-safe for
+                # genuinely row-less states, not a legacy-context opt-out.
+                cfg = await ContextSearchConfigRepository(self.db).get_by_context(context_id)
             if cfg is None or not getattr(cfg, "reinforce_enabled", False):
                 return
             max_boost = float(cfg.reinforce_max_boost)
@@ -2122,14 +2124,42 @@ class MemoryService:
         if context_ids:
             search_context_id = [str(cid) for cid in context_ids]
 
+        # #1220 (advisor rec): ONE read-only config fetch threads into both
+        # the router below and the reinforce re-rank later — previously each
+        # issued its own get_by_context SELECT per recall (the #341 class of
+        # duplicated hot-path reads). Fail-open: a config read failure must
+        # never break recall (None = routing off; reinforce re-reads).
+        search_config = None
+        if not context_ids:
+            try:
+                from repositories.config_repository import ContextSearchConfigRepository
+
+                search_config = await ContextSearchConfigRepository(self.db).get_by_context(
+                    current_context_id
+                )
+            except Exception as exc:
+                logger.warning(
+                    "search_config_prefetch_failed",
+                    context_id=str(current_context_id),
+                    error=str(exc),
+                )
+
         # #1212: resolve the effective search mode exactly once, before any
         # downstream read of request.search_mode (BYOK charge gate, hybrid
         # search, neural checks). After this line it is always a concrete
         # mode string; None (caller omitted it) never flows further.
-        request.search_mode = await self._resolve_search_mode(
-            request,
-            current_context_id,
-            cross_context=bool(context_ids),
+        # #1220 (advisor rec): model_copy instead of in-place mutation — a
+        # caller that reuses one RecallRequest across calls must never see
+        # its search_mode silently rewritten.
+        request = request.model_copy(
+            update={
+                "search_mode": await self._resolve_search_mode(
+                    request,
+                    current_context_id,
+                    cross_context=bool(context_ids),
+                    config=search_config,
+                )
+            }
         )
 
         # Issue #496: ``analysis_cluster`` filter pre-resolves the cluster's
@@ -2369,6 +2399,10 @@ class MemoryService:
             memories,
             current_context_id if not context_ids else None,
             top_k=request.k,
+            # #1220: the row prefetched at the top of recall(); None (fresh
+            # context — materialized by hybrid_search after the prefetch)
+            # falls back to the helper's own read.
+            config=search_config,
         )
         # #1213: placebo-gated graph-boost experiment (env flag, default off —
         # bit-identical when off). Runs after reinforce and composes with it

--- a/backend/tests/eval/router_gate.py
+++ b/backend/tests/eval/router_gate.py
@@ -1,0 +1,209 @@
+"""Pure logic for the #1220 router calibration gate (stage 3 of #1212).
+
+The query-intent router (#1212) ships experiment-gated: ``routing_mode``
+stays ``off`` by default until the router clears THIS gate on the frozen
+corpus — the same bar fixed-weight hybrid failed. The pre-declared contracts:
+
+- **beats semantic overall** — routed recall must beat semantic-only recall
+  on held-out P@5 AND MRR@10 (each paired BCa CI for the mean per-query
+  delta must exclude 0 from below);
+- **each routed lane wins its bucket** — on the queries the classifier
+  routes to lane L, the routed arm must be at least as good as the strongest
+  SINGLE component (semantic-only / keyword-only) on that bucket. Ties are a
+  pass: on a bucket routed to a component lane the routed rankings ARE that
+  component's rankings, so "beat" degenerates to "the router picked the
+  winning component". Hybrid is a fusion, not a single component, so it sets
+  no bar here (it already failed the overall bar in the eval program);
+- **powered** — the overall decision needs ``MIN_QUERIES`` paired queries,
+  and every non-empty bucket needs ``MIN_BUCKET_QUERIES`` before the gate
+  will render a flip-ready verdict (a lane the router uses on real traffic
+  must not graduate unmeasured).
+
+Everything here is deterministic and infrastructure-free (unit-tested in
+``test_router_gate.py``). The live orchestration that produces the arm
+rankings lives in ``tests.eval.router_gate_runner``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from tests.eval.metrics import (
+    mean_precision_at_k,
+    mrr_at_k,
+    precision_at_k,
+    reciprocal_rank_at_k,
+)
+from tests.eval.stats import paired_bca_ci
+
+#: One query result: ranked doc-ids + gold set (the #344 metrics shape).
+Ranking = tuple[Sequence[str], set[str]]
+
+#: Primary metric (matches the pre-registered headline metric).
+PRIMARY_K = 5
+#: Secondary metric depth.
+MRR_K = 10
+
+#: BCa resamples (matches the eval program's inferential runs).
+BCA_RESAMPLES = 10_000
+
+#: Minimum paired queries for the overall inferential decision (same floor
+#: as graph_boost_gate.MIN_PROBES — n=5 golden-corpus probes must not drive
+#: a BCa flip call).
+MIN_QUERIES = 50
+
+#: Minimum queries per non-empty lane bucket before its component
+#: comparison is considered measured rather than anecdotal.
+MIN_BUCKET_QUERIES = 10
+
+#: Single retrieval components a routed lane must not lose to on its own
+#: bucket. Hybrid is a fusion of these two, not a single component.
+COMPONENT_ARMS = ("semantic", "keyword")
+
+GATE_FLIP_READY = "flip_ready"
+GATE_NO_EFFECT = "no_effect"
+GATE_REGRESSION = "regression"
+GATE_BUCKET_REGRESSION = "bucket_regression"
+GATE_UNDERPOWERED = "underpowered"
+
+
+def per_query_deltas(
+    arm_a: Sequence[Ranking], arm_b: Sequence[Ranking], k: int, *, metric: str = "p"
+) -> list[float]:
+    """Paired per-query deltas (a - b) on P@k or RR@k. Raises on length mismatch."""
+    if len(arm_a) != len(arm_b):
+        raise ValueError(f"paired arms differ in length: {len(arm_a)} vs {len(arm_b)}")
+    score = precision_at_k if metric == "p" else reciprocal_rank_at_k
+    return [
+        score(ranked_a, gold_a, k) - score(ranked_b, gold_b, k)
+        for (ranked_a, gold_a), (ranked_b, gold_b) in zip(arm_a, arm_b, strict=True)
+    ]
+
+
+def arm_metrics(rankings: Sequence[Ranking]) -> dict[str, float | int]:
+    """Summary metric block for one arm (reuses the #344 binary metrics)."""
+    return {
+        "n": len(rankings),
+        "p@5": round(mean_precision_at_k(rankings, PRIMARY_K), 4),
+        "mrr@10": round(mrr_at_k(rankings, MRR_K), 4),
+    }
+
+
+def bucket_indices(lanes: Sequence[str]) -> dict[str, list[int]]:
+    """Group query indices by the classifier's lane decision."""
+    buckets: dict[str, list[int]] = {}
+    for i, lane in enumerate(lanes):
+        buckets.setdefault(lane, []).append(i)
+    return buckets
+
+
+def _slice(arm: Sequence[Ranking], indices: Sequence[int]) -> list[Ranking]:
+    return [arm[i] for i in indices]
+
+
+def evaluate_router_gate(
+    *,
+    routed: Sequence[Ranking],
+    components: dict[str, Sequence[Ranking]],
+    lanes: Sequence[str],
+    seed: int,
+) -> dict[str, Any]:
+    """Apply the pre-declared #1220 contracts to the measured arm rankings.
+
+    Args:
+        routed: Per-query rankings under the router's lane decisions
+            (query i answered with ``components[lanes[i]][i]`` — the router
+            is deterministic, so the routed arm is constructed, not
+            re-measured).
+        components: Full paired arms keyed by search mode. MUST contain
+            ``semantic`` and ``keyword`` (the single components); ``hybrid``
+            is included in the report when present.
+        lanes: The classifier's lane per query, parallel to ``routed``.
+        seed: Bootstrap seed (pre-declared in the run config).
+
+    Returns:
+        JSON-shaped verdict: per-arm metrics, both overall BCa intervals,
+        per-bucket component comparisons, and ``verdict`` in {flip_ready,
+        bucket_regression, no_effect, regression, underpowered}. A clean
+        "does not beat semantic, stays opt-in" is a valid close.
+    """
+    for required in COMPONENT_ARMS:
+        if required not in components:
+            raise ValueError(f"components must include the '{required}' arm")
+    if len(lanes) != len(routed):
+        raise ValueError(f"lanes and routed differ in length: {len(lanes)} vs {len(routed)}")
+    semantic = components["semantic"]
+
+    vs_semantic_p = paired_bca_ci(
+        per_query_deltas(routed, semantic, PRIMARY_K, metric="p"),
+        n_resamples=BCA_RESAMPLES,
+        seed=seed,
+    )
+    vs_semantic_mrr = paired_bca_ci(
+        per_query_deltas(routed, semantic, MRR_K, metric="rr"),
+        n_resamples=BCA_RESAMPLES,
+        seed=seed,
+    )
+
+    buckets_report: dict[str, dict[str, Any]] = {}
+    all_buckets_measured = True
+    all_buckets_won = True
+    for lane, indices in sorted(bucket_indices(lanes).items()):
+        routed_slice = _slice(routed, indices)
+        routed_mean = round(mean_precision_at_k(routed_slice, PRIMARY_K), 4)
+        component_means = {
+            arm: round(mean_precision_at_k(_slice(components[arm], indices), PRIMARY_K), 4)
+            for arm in COMPONENT_ARMS
+        }
+        strongest_arm = max(component_means, key=lambda a: component_means[a])
+        measured = len(indices) >= MIN_BUCKET_QUERIES
+        # Ties pass: on a component-lane bucket the routed slice IS that
+        # component's slice, so ">=" asks "did the router pick the winner".
+        won = routed_mean >= component_means[strongest_arm]
+        all_buckets_measured &= measured
+        all_buckets_won &= won or not measured
+        buckets_report[lane] = {
+            "n": len(indices),
+            "measured": measured,
+            "routed_p@5": routed_mean,
+            "components_p@5": component_means,
+            "strongest_component": strongest_arm,
+            "beats_strongest_component": won,
+        }
+
+    beats_semantic = vs_semantic_p["ci_low"] > 0.0 and vs_semantic_mrr["ci_low"] > 0.0
+    regressed = vs_semantic_p["ci_high"] < 0.0 or vs_semantic_mrr["ci_high"] < 0.0
+    powered = len(routed) >= MIN_QUERIES and all_buckets_measured
+
+    if not powered:
+        verdict = GATE_UNDERPOWERED
+    elif regressed:
+        verdict = GATE_REGRESSION
+    elif beats_semantic and all_buckets_won:
+        verdict = GATE_FLIP_READY
+    elif beats_semantic:
+        verdict = GATE_BUCKET_REGRESSION
+    else:
+        verdict = GATE_NO_EFFECT
+
+    arms_report = {"routed": arm_metrics(routed)}
+    for arm, rankings in components.items():
+        arms_report[arm] = arm_metrics(rankings)
+
+    return {
+        "primary_metric": f"p@{PRIMARY_K}",
+        "secondary_metric": f"mrr@{MRR_K}",
+        "arms": arms_report,
+        "vs_semantic": {"p@5": vs_semantic_p, "mrr@10": vs_semantic_mrr},
+        "buckets": buckets_report,
+        "contracts": {
+            "powered": powered,
+            "min_queries": MIN_QUERIES,
+            "min_bucket_queries": MIN_BUCKET_QUERIES,
+            "beats_semantic_overall": beats_semantic,
+            "all_buckets_beat_strongest_component": all_buckets_won,
+        },
+        "verdict": verdict,
+        "flip_ready": verdict == GATE_FLIP_READY,
+    }

--- a/backend/tests/eval/router_gate_runner.py
+++ b/backend/tests/eval/router_gate_runner.py
@@ -1,0 +1,203 @@
+"""Live #1220 router-calibration-gate orchestration (stage 3 + 4 of #1212).
+
+Ingests the frozen corpus once, then measures THREE paired lane arms over
+ALL corpus queries — semantic-only, keyword-only, hybrid — each pinned via
+an explicit ``search_mode`` (an explicit mode always wins, so no config
+flip is needed). The ROUTED arm is then constructed, not re-measured: the
+classifier is deterministic, so query *i*'s routed ranking IS
+``arms[classify_query(q_i).lane][i]``. The pre-declared contracts live in
+``tests.eval.router_gate``; a per-bucket breakdown of every arm is
+persisted to the ``router_calibrations`` store (stage 4, fleet-default
+scope ``context_id IS NULL``).
+
+Arms are measured with ``ENABLE_NEURAL_MEMORY=false`` and
+``KAGURA_GRAPH_BOOST_ENABLED=false`` (same discipline as replay_runner: the
+ONLY variable between paired arms is the retrieval lane).
+
+Writes results/router-calibration-<YYYY-MM-DD>.json from a REAL run only.
+Heavy imports are function-local (same convention as placebo_runner) so
+importing this module is cheap and CI-safe.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from tests.eval.router_gate import (
+    COMPONENT_ARMS,
+    arm_metrics,
+    bucket_indices,
+    evaluate_router_gate,
+)
+from tests.eval.runner import _ingest_corpus, _teardown
+from tests.eval.tools.corpus import load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+#: The frozen kagura_l corpus (300 docs, multi-gold probes) — NOT the
+#: 5-probe golden corpus: the gate's BCa flip decision needs
+#: n >= router_gate.MIN_QUERIES (gate2/CAIO).
+_CORPUS_PATH = Path(__file__).resolve().parent / "fixtures" / "kagura_l.yaml"
+_RECALL_K = 10
+#: Pre-declared bootstrap seed for the gate's BCa intervals.
+_GATE_SEED = 1220
+#: The lane arms measured live; "routed" is constructed from these.
+_LANE_ARMS = ("semantic", "keyword", "hybrid")
+
+
+@contextmanager
+def _env(key: str, value: str):
+    """Set an env var for the duration, restoring the prior state exactly."""
+    prior = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if prior is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = prior
+
+
+async def _lane_rankings(
+    svc: Any,
+    queries: list[tuple[str, set[str]]],
+    id_map: dict[str, str],
+    owner: str,
+    ctx_id: Any,
+    ws_id: Any,
+    search_mode: str,
+) -> list[tuple[list[str], set[str]]]:
+    """Recall each (query_text, gold_doc_ids) pair under ONE explicit lane."""
+    from models.schemas import RecallRequest
+
+    rankings: list[tuple[list[str], set[str]]] = []
+    for text, gold in queries:
+        resp = await svc.recall(
+            request=RecallRequest(query=text, k=_RECALL_K, search_mode=search_mode),
+            user_id=owner,
+            current_context_id=ctx_id,
+            current_workspace_id=ws_id,
+        )
+        rankings.append(([id_map.get(str(r.memory_id), "?") for r in resp.results], set(gold)))
+    return rankings
+
+
+async def _persist_calibrations(
+    db: Any,
+    components: dict[str, list[tuple[list[str], set[str]]]],
+    routed: list[tuple[list[str], set[str]]],
+    lanes: list[str],
+) -> int:
+    """Stage 4: upsert per-bucket arm performance as fleet defaults."""
+    from datetime import UTC, datetime
+
+    from repositories.config_repository import RouterCalibrationRepository
+
+    repo = RouterCalibrationRepository(db)
+    sampled_at = datetime.now(UTC)
+    all_arms: dict[str, list[tuple[list[str], set[str]]]] = {**components, "routed": routed}
+    written = 0
+    for bucket, indices in sorted(bucket_indices(lanes).items()):
+        for arm, rankings in all_arms.items():
+            stats = arm_metrics([rankings[i] for i in indices])
+            await repo.upsert(
+                bucket=bucket,
+                arm=arm,
+                p_at_5=float(stats["p@5"]),
+                mrr_at_10=float(stats["mrr@10"]),
+                n_queries=int(stats["n"]),
+                sampled_at=sampled_at,
+                context_id=None,
+            )
+            written += 1
+    await db.commit()
+    return written
+
+
+async def run_router_calibration_eval(
+    write: bool = True, persist: bool = True, run_date: str | None = None
+) -> dict[str, Any]:
+    """Orchestrate the lane-arm measurement, apply the gate, persist store rows."""
+    from datetime import date
+
+    from db.base import get_db
+    from db.qdrant import ensure_kagura_memories_collection, get_collection_name
+    from services.memory_service import MemoryService
+    from services.query_router import classify_query
+    from tests.eval._provisioning import provision_eval_context
+
+    corpus = load_corpus(_CORPUS_PATH)
+    queries = [(q.text, set(q.relevant)) for q in corpus.queries]
+    lanes = [classify_query(text).lane for text, _ in queries]
+
+    async for db in get_db():
+        owner, ws, ctx, emb_model, emb_dims = await provision_eval_context(db)
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await ensure_kagura_memories_collection(
+                emb_dims, get_collection_name(emb_model, emb_dims)
+            )
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+
+            # Paired lane arms: the ONLY variable is search_mode.
+            components: dict[str, list[tuple[list[str], set[str]]]] = {}
+            with _env("ENABLE_NEURAL_MEMORY", "false"):
+                with _env("KAGURA_GRAPH_BOOST_ENABLED", "false"):
+                    for mode in _LANE_ARMS:
+                        components[mode] = await _lane_rankings(
+                            svc, queries, id_map, owner, ctx.id, ws.id, mode
+                        )
+
+            # The router is deterministic → the routed arm is constructed.
+            routed = [components[lane][i] for i, lane in enumerate(lanes)]
+            gate = evaluate_router_gate(
+                routed=routed,
+                components=components,
+                lanes=lanes,
+                seed=_GATE_SEED,
+            )
+            calibrations_written = (
+                await _persist_calibrations(db, components, routed, lanes) if persist else 0
+            )
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+        break
+    else:
+        raise RuntimeError("database session unavailable — is the stack up?")
+
+    result: dict[str, Any] = {
+        "n_queries": len(queries),
+        "lane_mix": {lane: len(idx) for lane, idx in sorted(bucket_indices(lanes).items())},
+        "gate": gate,
+        "calibrations_written": calibrations_written,
+        "meta": {
+            "issue": 1220,
+            "date": run_date or date.today().isoformat(),
+            "corpus": corpus.meta,
+            "gate_seed": _GATE_SEED,
+            "recall_k": _RECALL_K,
+            "component_arms": list(COMPONENT_ARMS),
+        },
+    }
+    if write:
+        _RESULTS_DIR.mkdir(exist_ok=True)
+        out = _RESULTS_DIR / f"router-calibration-{result['meta']['date']}.json"
+        out.write_text(json.dumps(result, indent=2, ensure_ascii=False), encoding="utf-8")
+    return result
+
+
+def _main() -> int:
+    import asyncio
+
+    results = asyncio.run(run_router_calibration_eval())
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/test_router_gate.py
+++ b/backend/tests/eval/test_router_gate.py
@@ -1,0 +1,166 @@
+"""Unit tests for the #1220 router calibration gate (deterministic)."""
+
+import pytest
+
+from tests.eval.router_gate import (
+    GATE_BUCKET_REGRESSION,
+    GATE_FLIP_READY,
+    GATE_NO_EFFECT,
+    GATE_REGRESSION,
+    GATE_UNDERPOWERED,
+    MIN_BUCKET_QUERIES,
+    MIN_QUERIES,
+    bucket_indices,
+    evaluate_router_gate,
+    per_query_deltas,
+)
+
+# A "hit" ranking has the single gold doc at rank 1 (P@5 = 0.2, RR@10 = 1.0);
+# a "miss" ranking does not contain it at all.
+_HIT = (["g", "x1", "x2", "x3", "x4"], {"g"})
+_MISS = (["x1", "x2", "x3", "x4", "x5"], {"g"})
+
+
+def _arm(hits_by_index: dict[int, bool], total: int) -> list[tuple[list[str], set[str]]]:
+    """Build one arm from an index → hit? map (missing indices miss)."""
+    return [_HIT if hits_by_index.get(i, False) else _MISS for i in range(total)]
+
+
+def _uniform(hits: int, total: int) -> list[tuple[list[str], set[str]]]:
+    return [_HIT] * hits + [_MISS] * (total - hits)
+
+
+def _routed(components: dict[str, list], lanes: list[str]) -> list[tuple[list[str], set[str]]]:
+    """The runner's construction: query i is answered by its lane's arm."""
+    return [components[lane][i] for i, lane in enumerate(lanes)]
+
+
+class TestPerQueryDeltas:
+    def test_precision_deltas(self) -> None:
+        deltas = per_query_deltas(_uniform(60, 60), _uniform(0, 60), 5)
+        assert len(deltas) == 60
+        assert all(d == pytest.approx(0.2) for d in deltas)
+
+    def test_reciprocal_rank_deltas(self) -> None:
+        deltas = per_query_deltas(_uniform(60, 60), _uniform(0, 60), 10, metric="rr")
+        assert all(d == pytest.approx(1.0) for d in deltas)
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="differ in length"):
+            per_query_deltas(_uniform(5, 10), _uniform(5, 11), 5)
+
+
+class TestBucketIndices:
+    def test_groups_by_lane(self) -> None:
+        assert bucket_indices(["keyword", "semantic", "keyword"]) == {
+            "keyword": [0, 2],
+            "semantic": [1],
+        }
+
+
+class TestVerdicts:
+    def test_flip_ready_when_router_picks_winners(self) -> None:
+        """Keyword bucket: keyword component wins; semantic bucket: tie by
+        construction (routed IS semantic there). Overall routed >> semantic."""
+        total = 60
+        lanes = ["keyword"] * 30 + ["semantic"] * 30
+        semantic = _arm(dict.fromkeys(range(30, 60), True), total)  # 6/30 → 0 on kw bucket
+        keyword = _arm(dict.fromkeys(range(30), True), total)
+        components = {"semantic": semantic, "keyword": keyword}
+        routed = _routed(components, lanes)
+
+        result = evaluate_router_gate(routed=routed, components=components, lanes=lanes, seed=42)
+
+        assert result["contracts"]["powered"] is True
+        assert result["contracts"]["beats_semantic_overall"] is True
+        assert result["contracts"]["all_buckets_beat_strongest_component"] is True
+        assert result["verdict"] == GATE_FLIP_READY
+        assert result["flip_ready"] is True
+        assert result["buckets"]["semantic"]["beats_strongest_component"] is True  # tie passes
+
+    def test_bucket_regression_when_hybrid_lane_loses_to_a_component(self) -> None:
+        """Hybrid bucket: hybrid beats semantic (overall win) but loses to
+        keyword (the strongest single component) → bucket_regression."""
+        total = 60
+        lanes = ["hybrid"] * 30 + ["semantic"] * 30
+        semantic = _arm(dict.fromkeys(range(30, 60), True), total)  # 0 hits on hybrid bucket
+        keyword = _arm(dict.fromkeys(range(25), True), total)  # 25/30 on hybrid bucket
+        hybrid = _arm(dict.fromkeys(range(15), True) | dict.fromkeys(range(30, 60), True), total)
+        components = {"semantic": semantic, "keyword": keyword, "hybrid": hybrid}
+        routed = _routed(components, lanes)
+
+        result = evaluate_router_gate(routed=routed, components=components, lanes=lanes, seed=42)
+
+        assert result["contracts"]["beats_semantic_overall"] is True
+        bucket = result["buckets"]["hybrid"]
+        assert bucket["strongest_component"] == "keyword"
+        assert bucket["beats_strongest_component"] is False
+        assert result["verdict"] == GATE_BUCKET_REGRESSION
+        assert result["flip_ready"] is False
+
+    def test_no_effect_when_router_always_picks_semantic(self) -> None:
+        total = 60
+        lanes = ["semantic"] * total
+        semantic = _uniform(30, total)
+        components = {"semantic": semantic, "keyword": _uniform(0, total)}
+        routed = _routed(components, lanes)
+
+        result = evaluate_router_gate(routed=routed, components=components, lanes=lanes, seed=42)
+
+        assert result["contracts"]["beats_semantic_overall"] is False
+        assert result["verdict"] == GATE_NO_EFFECT
+
+    def test_regression_when_routed_loses_overall(self) -> None:
+        total = 60
+        lanes = ["keyword"] * total
+        semantic = _uniform(40, total)
+        keyword = _uniform(10, total)
+        components = {"semantic": semantic, "keyword": keyword}
+        routed = _routed(components, lanes)
+
+        result = evaluate_router_gate(routed=routed, components=components, lanes=lanes, seed=42)
+
+        assert result["verdict"] == GATE_REGRESSION
+
+    def test_underpowered_overall(self) -> None:
+        total = MIN_QUERIES - 1
+        lanes = ["semantic"] * total
+        components = {"semantic": _uniform(10, total), "keyword": _uniform(0, total)}
+        routed = _routed(components, lanes)
+
+        result = evaluate_router_gate(routed=routed, components=components, lanes=lanes, seed=42)
+
+        assert result["verdict"] == GATE_UNDERPOWERED
+
+    def test_underpowered_when_a_used_bucket_is_unmeasured(self) -> None:
+        """A lane the router actually uses must not graduate on n < floor."""
+        total = 60
+        thin = MIN_BUCKET_QUERIES - 1
+        lanes = ["keyword"] * thin + ["semantic"] * (total - thin)
+        semantic = _arm(dict.fromkeys(range(thin, total), True), total)
+        keyword = _arm(dict.fromkeys(range(thin), True), total)
+        components = {"semantic": semantic, "keyword": keyword}
+        routed = _routed(components, lanes)
+
+        result = evaluate_router_gate(routed=routed, components=components, lanes=lanes, seed=42)
+
+        assert result["buckets"]["keyword"]["measured"] is False
+        assert result["verdict"] == GATE_UNDERPOWERED
+
+    def test_missing_component_arm_raises(self) -> None:
+        with pytest.raises(ValueError, match="keyword"):
+            evaluate_router_gate(
+                routed=_uniform(5, 60),
+                components={"semantic": _uniform(5, 60)},
+                lanes=["semantic"] * 60,
+                seed=42,
+            )
+
+    def test_lane_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="lanes and routed"):
+            evaluate_router_gate(
+                routed=_uniform(5, 60),
+                components={"semantic": _uniform(5, 60), "keyword": _uniform(5, 60)},
+                lanes=["semantic"] * 59,
+                seed=42,
+            )

--- a/backend/tests/eval/test_router_gate_runner.py
+++ b/backend/tests/eval/test_router_gate_runner.py
@@ -1,0 +1,105 @@
+"""DB-free control-flow tests for the #1220 router-gate runner.
+
+Pins the runner's mechanics without a live stack: the env pins around arm
+measurement, the explicit search_mode per lane arm, the routed-arm
+construction (routed[i] == components[lane_i][i]), and the stage-4
+persistence fan-out (one upsert per bucket × arm, fleet-default scope).
+The live end-to-end run is `make eval-router-gate` (KAGURA_EVAL_LIVE=1).
+"""
+
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tests.eval.router_gate_runner import (
+    _env,
+    _lane_rankings,
+    _persist_calibrations,
+)
+
+
+class TestEnvPin:
+    def test_sets_and_restores(self) -> None:
+        os.environ["RG_TEST_KEY"] = "prior"
+        try:
+            with _env("RG_TEST_KEY", "inner"):
+                assert os.environ["RG_TEST_KEY"] == "inner"
+            assert os.environ["RG_TEST_KEY"] == "prior"
+        finally:
+            os.environ.pop("RG_TEST_KEY", None)
+
+    def test_unset_key_is_removed_after(self) -> None:
+        os.environ.pop("RG_TEST_KEY", None)
+        with _env("RG_TEST_KEY", "inner"):
+            assert os.environ["RG_TEST_KEY"] == "inner"
+        assert "RG_TEST_KEY" not in os.environ
+
+
+class TestLaneRankings:
+    @pytest.mark.asyncio
+    async def test_passes_explicit_search_mode_and_maps_doc_ids(self) -> None:
+        mem_a, mem_b = uuid4(), uuid4()
+        id_map = {str(mem_a): "doc-a", str(mem_b): "doc-b"}
+        svc = SimpleNamespace(
+            recall=AsyncMock(
+                return_value=SimpleNamespace(
+                    results=[
+                        SimpleNamespace(memory_id=mem_a),
+                        SimpleNamespace(memory_id=mem_b),
+                    ]
+                )
+            )
+        )
+
+        rankings = await _lane_rankings(
+            svc, [("find the doc", {"doc-a"})], id_map, "u", uuid4(), uuid4(), "keyword"
+        )
+
+        assert rankings == [(["doc-a", "doc-b"], {"doc-a"})]
+        request = svc.recall.await_args.kwargs["request"]
+        assert request.search_mode == "keyword"  # the lane pin IS the arm
+
+
+class TestPersistCalibrations:
+    @pytest.mark.asyncio
+    async def test_one_upsert_per_bucket_arm_at_fleet_scope(self) -> None:
+        hit = (["g", "x1", "x2", "x3", "x4"], {"g"})
+        miss = (["x1", "x2", "x3", "x4", "x5"], {"g"})
+        components = {
+            "semantic": [miss, hit],
+            "keyword": [hit, miss],
+            "hybrid": [hit, hit],
+        }
+        lanes = ["keyword", "semantic"]
+        routed = [components[lane][i] for i, lane in enumerate(lanes)]
+        repo = MagicMock()
+        repo.upsert = AsyncMock()
+        db = AsyncMock()
+
+        with patch("repositories.config_repository.RouterCalibrationRepository", return_value=repo):
+            written = await _persist_calibrations(db, components, routed, lanes)
+
+        # 2 buckets x 4 arms (semantic/keyword/hybrid/routed).
+        assert written == 8
+        assert repo.upsert.await_count == 8
+        for call in repo.upsert.await_args_list:
+            assert call.kwargs["context_id"] is None  # fleet-default scope
+            assert call.kwargs["n_queries"] == 1
+            assert call.kwargs["bucket"] in ("keyword", "semantic")
+            assert call.kwargs["arm"] in ("semantic", "keyword", "hybrid", "routed")
+        # The routed arm on the keyword bucket is the keyword arm's ranking.
+        routed_kw = next(
+            c.kwargs
+            for c in repo.upsert.await_args_list
+            if c.kwargs["arm"] == "routed" and c.kwargs["bucket"] == "keyword"
+        )
+        keyword_kw = next(
+            c.kwargs
+            for c in repo.upsert.await_args_list
+            if c.kwargs["arm"] == "keyword" and c.kwargs["bucket"] == "keyword"
+        )
+        assert routed_kw["p_at_5"] == keyword_kw["p_at_5"]
+        db.commit.assert_awaited_once()

--- a/backend/tests/repositories/test_router_calibration_repository.py
+++ b/backend/tests/repositories/test_router_calibration_repository.py
@@ -1,0 +1,127 @@
+"""Unit tests for RouterCalibrationRepository (#1220 stage 4, mock-only).
+
+Pins the store's contract without a DB: the upsert targets the
+partial-unique index matching the scope (global vs per-context — Postgres
+unique constraints treat NULLs as distinct, so each scope has its own
+predicate index), and reads never mix scopes (a context's own rows win;
+the fleet defaults are the fallback, not a merge source).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from repositories.config_repository import RouterCalibrationRepository
+
+_SAMPLED = datetime(2026, 7, 12, tzinfo=UTC)
+
+
+def _repo() -> tuple[RouterCalibrationRepository, AsyncMock]:
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one.return_value = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    return RouterCalibrationRepository(db), db
+
+
+def _compiled(db: AsyncMock) -> str:
+    from sqlalchemy.dialects import postgresql
+
+    stmt = db.execute.await_args.args[0]
+    return str(stmt.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}))
+
+
+class TestUpsertScopeTargeting:
+    @pytest.mark.asyncio
+    async def test_global_scope_targets_null_partial_index(self) -> None:
+        repo, db = _repo()
+        await repo.upsert(
+            bucket="keyword",
+            arm="routed",
+            p_at_5=0.4,
+            mrr_at_10=0.6,
+            n_queries=30,
+            sampled_at=_SAMPLED,
+            context_id=None,
+        )
+        sql = _compiled(db)
+        assert "ON CONFLICT (bucket, arm, source)" in sql
+        assert "context_id IS NULL" in sql
+
+    @pytest.mark.asyncio
+    async def test_context_scope_targets_nonnull_partial_index(self) -> None:
+        repo, db = _repo()
+        await repo.upsert(
+            bucket="semantic",
+            arm="semantic",
+            p_at_5=0.5,
+            mrr_at_10=0.7,
+            n_queries=40,
+            sampled_at=_SAMPLED,
+            context_id=uuid4(),
+            source="live_traffic",
+        )
+        sql = _compiled(db)
+        assert "ON CONFLICT (context_id, bucket, arm, source)" in sql
+        assert "context_id IS NOT NULL" in sql
+
+    @pytest.mark.asyncio
+    async def test_conflict_refreshes_measurement_fields(self) -> None:
+        repo, db = _repo()
+        await repo.upsert(
+            bucket="hybrid",
+            arm="hybrid",
+            p_at_5=0.3,
+            mrr_at_10=0.5,
+            n_queries=20,
+            sampled_at=_SAMPLED,
+        )
+        sql = _compiled(db)
+        assert "DO UPDATE SET" in sql
+        for field in ("p_at_5", "mrr_at_10", "n_queries", "sampled_at"):
+            assert field in sql.split("DO UPDATE SET")[1]
+
+
+class TestGetForContext:
+    @pytest.mark.asyncio
+    async def test_context_rows_win_without_mixing(self) -> None:
+        repo, db = _repo()
+        own_rows = [MagicMock(), MagicMock()]
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = own_rows
+        db.execute = AsyncMock(return_value=result)
+
+        rows = await repo.get_for_context(uuid4())
+
+        assert rows == own_rows
+        assert db.execute.await_count == 1  # no second (global) query
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_fleet_defaults(self) -> None:
+        repo, db = _repo()
+        empty = MagicMock()
+        empty.scalars.return_value.all.return_value = []
+        globals_result = MagicMock()
+        fleet_rows = [MagicMock()]
+        globals_result.scalars.return_value.all.return_value = fleet_rows
+        db.execute = AsyncMock(side_effect=[empty, globals_result])
+
+        rows = await repo.get_for_context(uuid4())
+
+        assert rows == fleet_rows
+        assert db.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_none_context_reads_fleet_defaults_directly(self) -> None:
+        repo, db = _repo()
+        globals_result = MagicMock()
+        fleet_rows = [MagicMock()]
+        globals_result.scalars.return_value.all.return_value = fleet_rows
+        db.execute = AsyncMock(return_value=globals_result)
+
+        rows = await repo.get_for_context(None)
+
+        assert rows == fleet_rows
+        assert db.execute.await_count == 1

--- a/backend/tests/services/test_query_routing_resolution.py
+++ b/backend/tests/services/test_query_routing_resolution.py
@@ -3,8 +3,12 @@
 Pins the acceptance contract: log_only changes NOTHING about the effective
 mode (zero ranking change), active applies the routed lane only when the
 caller omitted search_mode, an explicit search_mode always wins in every
-routing_mode, and the hook is fail-open (config read failure or missing
-config row never breaks recall).
+routing_mode, and the resolver is total (a concrete mode on every branch).
+
+#1220 (advisor rec): the resolver no longer reads the DB — ``recall()``
+prefetches the ContextSearchConfig row once and threads it in via the
+``config`` parameter (None = row missing / prefetch failed = routing off).
+These tests therefore pass the config directly.
 """
 
 from types import SimpleNamespace
@@ -31,43 +35,38 @@ def _request(query: str = _KEYWORD_QUERY, search_mode: str | None = None) -> Sim
     return SimpleNamespace(query=query, search_mode=search_mode)
 
 
-def _patch_config(routing_mode: str | None):
-    """Patch the repository to return a config row (or None)."""
-    config = None if routing_mode is None else SimpleNamespace(routing_mode=routing_mode)
-    repo = MagicMock()
-    repo.get_by_context = AsyncMock(return_value=config)
-    return patch(
-        "repositories.config_repository.ContextSearchConfigRepository",
-        return_value=repo,
+def _config(routing_mode: str | None) -> SimpleNamespace | None:
+    """The prefetched config row (or None for a row-less context)."""
+    return None if routing_mode is None else SimpleNamespace(routing_mode=routing_mode)
+
+
+async def _resolve(
+    routing_mode: str | None,
+    *,
+    search_mode: str | None = None,
+    query: str = _KEYWORD_QUERY,
+    cross_context: bool = False,
+) -> str:
+    return await _service()._resolve_search_mode(
+        _request(query=query, search_mode=search_mode),
+        _CTX,
+        cross_context=cross_context,
+        config=_config(routing_mode),
     )
 
 
 class TestRoutingOff:
     @pytest.mark.asyncio
     async def test_no_config_row_defaults_hybrid(self) -> None:
-        with _patch_config(None):
-            assert (
-                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
-                == "hybrid"
-            )
+        assert await _resolve(None) == "hybrid"
 
     @pytest.mark.asyncio
     async def test_off_defaults_hybrid(self) -> None:
-        with _patch_config("off"):
-            assert (
-                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
-                == "hybrid"
-            )
+        assert await _resolve("off") == "hybrid"
 
     @pytest.mark.asyncio
     async def test_off_explicit_mode_wins(self) -> None:
-        with _patch_config("off"):
-            assert (
-                await _service()._resolve_search_mode(
-                    _request(search_mode="semantic"), _CTX, cross_context=False
-                )
-                == "semantic"
-            )
+        assert await _resolve("off", search_mode="semantic") == "semantic"
 
 
 class TestLogOnly:
@@ -75,29 +74,18 @@ class TestLogOnly:
     async def test_log_only_never_changes_the_mode(self) -> None:
         """The zero-ranking-change guarantee: the classifier says keyword,
         the effective mode stays the historical default."""
-        with _patch_config("log_only"):
-            assert (
-                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
-                == "hybrid"
-            )
+        assert await _resolve("log_only") == "hybrid"
 
     @pytest.mark.asyncio
     async def test_log_only_explicit_mode_wins(self) -> None:
-        with _patch_config("log_only"):
-            assert (
-                await _service()._resolve_search_mode(
-                    _request(search_mode="keyword"), _CTX, cross_context=False
-                )
-                == "keyword"
-            )
+        assert await _resolve("log_only", search_mode="keyword") == "keyword"
 
     @pytest.mark.asyncio
     async def test_log_only_stamps_telemetry(self) -> None:
-        with (
-            _patch_config("log_only"),
-            patch("services.memory_service.logger") as log,
-        ):
-            await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
+        with patch("services.memory_service.logger") as log:
+            await _service()._resolve_search_mode(
+                _request(), _CTX, cross_context=False, config=_config("log_only")
+            )
         events = [c for c in log.info.call_args_list if c.args[0] == "query_router_decision"]
         assert len(events) == 1
         kwargs = events[0].kwargs
@@ -112,33 +100,18 @@ class TestLogOnly:
 class TestActive:
     @pytest.mark.asyncio
     async def test_active_routes_when_mode_omitted(self) -> None:
-        with _patch_config("active"):
-            assert (
-                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
-                == "keyword"
-            )
+        assert await _resolve("active") == "keyword"
 
     @pytest.mark.asyncio
     async def test_active_explicit_mode_always_wins(self) -> None:
-        with _patch_config("active"):
-            assert (
-                await _service()._resolve_search_mode(
-                    _request(search_mode="hybrid"), _CTX, cross_context=False
-                )
-                == "hybrid"
-            )
+        assert await _resolve("active", search_mode="hybrid") == "hybrid"
 
     @pytest.mark.asyncio
     async def test_active_semantic_query_routes_semantic(self) -> None:
-        with _patch_config("active"):
-            assert (
-                await _service()._resolve_search_mode(
-                    _request(query="what were the sleep maintenance design decisions"),
-                    _CTX,
-                    cross_context=False,
-                )
-                == "semantic"
-            )
+        assert (
+            await _resolve("active", query="what were the sleep maintenance design decisions")
+            == "semantic"
+        )
 
 
 class TestNeverNone:
@@ -152,57 +125,63 @@ class TestNeverNone:
     async def test_all_branches_return_concrete_mode(
         self, requested: str | None, routing_mode: str | None
     ) -> None:
-        with _patch_config(routing_mode):
-            mode = await _service()._resolve_search_mode(
-                _request(search_mode=requested), _CTX, cross_context=False
-            )
+        mode = await _resolve(routing_mode, search_mode=requested)
         assert mode in ("hybrid", "semantic", "keyword")
         if requested is not None:
             assert mode == requested
 
 
-class TestFailOpenAndScope:
+class TestNoDbReadAndScope:
     @pytest.mark.asyncio
-    async def test_cross_context_skips_routing_and_config_read(self) -> None:
-        repo_cls = MagicMock()
-        with patch("repositories.config_repository.ContextSearchConfigRepository", repo_cls):
-            mode = await _service()._resolve_search_mode(_request(), _CTX, cross_context=True)
-        assert mode == "hybrid"
-        repo_cls.assert_not_called()
+    async def test_resolver_never_touches_the_db(self) -> None:
+        """#1220: the config is prefetched by recall() — the resolver itself
+        must issue no read, in any routing_mode."""
+        svc = _service()
+        for routing_mode in (None, "off", "log_only", "active"):
+            await svc._resolve_search_mode(
+                _request(), _CTX, cross_context=False, config=_config(routing_mode)
+            )
+        svc.db.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_explicit_mode_skips_config_read_and_classification(self) -> None:
-        """An explicit search_mode is guaranteed to win, so the resolver
-        must return immediately — no config round-trip, no classify/log
-        work on the hot path (Copilot, PR #1221)."""
-        repo_cls = MagicMock()
-        with patch("repositories.config_repository.ContextSearchConfigRepository", repo_cls):
-            mode = await _service()._resolve_search_mode(
-                _request(search_mode="keyword"), _CTX, cross_context=False
-            )
-        assert mode == "keyword"
-        repo_cls.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_config_read_failure_fails_open(self) -> None:
-        repo = MagicMock()
-        repo.get_by_context = AsyncMock(side_effect=RuntimeError("db down"))
-        with patch(
-            "repositories.config_repository.ContextSearchConfigRepository",
-            return_value=repo,
-        ):
-            mode = await _service()._resolve_search_mode(
-                _request(search_mode="semantic"), _CTX, cross_context=False
-            )
-        assert mode == "semantic"
+    async def test_cross_context_skips_routing(self) -> None:
+        assert await _resolve("active", cross_context=True) == "hybrid"
 
     @pytest.mark.asyncio
     async def test_mock_like_config_without_valid_mode_is_off(self) -> None:
         """A config whose routing_mode is not a recognized value (e.g. a
         MagicMock attribute) must behave as 'off' — membership check, never
         truthiness (#1207 lesson)."""
-        with _patch_config(""):
-            assert (
-                await _service()._resolve_search_mode(_request(), _CTX, cross_context=False)
-                == "hybrid"
+        mode = await _service()._resolve_search_mode(
+            _request(), _CTX, cross_context=False, config=MagicMock()
+        )
+        assert mode == "hybrid"
+
+
+class TestReinforcePrefetchThreading:
+    @pytest.mark.asyncio
+    async def test_passed_config_skips_the_reinforce_config_read(self) -> None:
+        """#1220: when recall() threads the prefetched row in, the reinforce
+        re-rank must not issue its own get_by_context SELECT."""
+        svc = _service()
+        cfg = SimpleNamespace(reinforce_enabled=False)
+        repo_cls = MagicMock()
+        with patch("repositories.config_repository.ContextSearchConfigRepository", repo_cls):
+            await svc._maybe_reinforce_rerank(
+                [{"id": "a"}, {"id": "b"}], {}, _CTX, top_k=5, config=cfg
             )
+        repo_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_prefetch_falls_back_to_local_read(self) -> None:
+        """A fresh context's row is materialized by hybrid_search AFTER the
+        prefetch — config=None must re-read so the first-ever recall keeps
+        its re-rank behavior."""
+        svc = _service()
+        repo = MagicMock()
+        repo.get_by_context = AsyncMock(return_value=SimpleNamespace(reinforce_enabled=False))
+        with patch(
+            "repositories.config_repository.ContextSearchConfigRepository", return_value=repo
+        ):
+            await svc._maybe_reinforce_rerank([{"id": "a"}, {"id": "b"}], {}, _CTX, top_k=5)
+        repo.get_by_context.assert_awaited_once_with(_CTX)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -193,7 +193,10 @@ character-class counting, sub-millisecond): set `routing_mode` via
 The router does not become the default until it clears the stage-3 calibration
 gate on the frozen eval corpus (beat semantic-only overall AND beat the
 strongest single component on each routed bucket) — the same bar fixed-weight
-hybrid failed.
+hybrid failed. The gate is runnable: `make eval-router-gate` measures the
+lane arms, applies the pre-declared contracts, and persists per-bucket arm
+performance to the `router_calibrations` store (see
+`docs/eval/router-calibration-gate.md`, #1220).
 
 ## Neural Memory
 

--- a/docs/derived-layer-boundary.md
+++ b/docs/derived-layer-boundary.md
@@ -65,6 +65,7 @@ link topology and its user-set initial weight are user-authored data.
 | `neural_memory_edges` | Hebbian (`origin='hebbian'`) and semantic (`origin='semantic'`) edge `weight`, `origin`, `confidence`, `edge_metadata` | Strengthened by co-recall, decayed nightly; encodes how *this* context is actually used |
 | `graph_memory` | Legacy NetworkX graph JSON | Same learned graph, earlier storage format |
 | `embedding_calibrations` | Top-k similarity percentiles (`p25`–`p99`), sample size, TTL | Recalibrated as the corpus grows; tunes seeding thresholds per workspace |
+| `router_calibrations` | Per-bucket router arm performance (P@5, MRR@10 per lane × strategy, #1220) | Re-measured per gate run / live traffic; lets per-context routing tuning diverge from fleet defaults |
 | `neural_config` | Neural tuning parameters | Operator/learned tuning of the learning loop itself |
 | `sleep_reports` | Per-phase Sleep results (`edge_discovery_result`, `dedup_result`, `importance_result`, `consolidation_result`, `reindex_result`) | Consolidation history; each run builds on prior structure |
 | `sleep_actions` | Individual consolidation decisions (merges, promotions, flags) | Same |

--- a/docs/eval/router-calibration-gate.md
+++ b/docs/eval/router-calibration-gate.md
@@ -1,0 +1,41 @@
+# Router calibration gate (#1220 — stage 3-4 of #1212)
+
+The query-intent router (#1212) ships experiment-gated: `routing_mode`
+defaults to `off` and may only become a default after clearing this gate —
+the same bar fixed-weight hybrid failed in the eval program.
+
+## Running the gate
+
+```bash
+make up                # the gate needs the live stack
+make eval-router-gate  # writes backend/tests/eval/results/router-calibration-<date>.json
+```
+
+The runner (`tests.eval.router_gate_runner`) ingests the frozen `kagura_l`
+corpus once, measures three paired lane arms over ALL corpus queries —
+`semantic`, `keyword`, `hybrid`, each pinned via an explicit `search_mode` —
+and **constructs** the routed arm: the classifier is deterministic, so query
+*i*'s routed ranking is `arms[classify_query(q_i).lane][i]`. No config flip
+is needed and no fourth live arm is measured.
+
+## Contracts (pre-declared, `tests.eval.router_gate`)
+
+| Contract | Definition |
+|---|---|
+| beats semantic overall | paired BCa 95% CI of the per-query routed−semantic delta excludes 0 from below, on **both** P@5 and MRR@10 |
+| every bucket wins | on the queries routed to lane L, the routed arm is at least as good (mean P@5) as the strongest single component (`semantic` / `keyword`). Ties pass — on a component-lane bucket the routed rankings ARE that component's rankings, so the contract reads "the router picked the winning component" |
+| powered | ≥ 50 paired queries overall AND ≥ 10 queries in every non-empty bucket |
+
+Verdicts: `flip_ready` / `bucket_regression` / `no_effect` / `regression` /
+`underpowered`. Only `flip_ready` permits changing the `routing_mode`
+default — and per the issue, real-traffic `log_only` telemetry
+(`query_router_decision`) should corroborate the corpus lane mix first.
+
+## Stage 4 — calibration store
+
+Each gate run upserts per-bucket arm performance into the
+`router_calibrations` table at fleet-default scope (`context_id IS NULL`).
+Per-context rows (from live-traffic measurement, `source='live_traffic'`)
+let managed-cloud tuning diverge from self-host defaults; reads via
+`RouterCalibrationRepository.get_for_context` never mix scopes — a
+context's own rows win, else the fleet defaults.


### PR DESCRIPTION
Closes #1220 — stages 3-4 of the #1212 query-intent router.

## Stage 3 — calibration gate (blocks any default flip)

- `tests/eval/router_gate.py` (pure, unit-tested): the pre-declared contracts —
  - **beats semantic overall**: paired BCa 95% CI of the per-query routed−semantic delta must exclude 0 from below on **both** P@5 and MRR@10;
  - **every bucket wins**: on the queries the classifier routes to lane L, the routed arm must be ≥ the strongest single component (semantic/keyword) on that bucket. Ties pass — on a component-lane bucket the routed rankings ARE that component's rankings, so the contract reads "the router picked the winning component";
  - **powered**: ≥50 paired queries overall, ≥10 per non-empty bucket.
  - Verdicts: `flip_ready` / `bucket_regression` / `no_effect` / `regression` / `underpowered`.
- `tests/eval/router_gate_runner.py` + `make eval-router-gate`: measures the three lane arms over the frozen corpus via explicit `search_mode`; the **routed arm is constructed** (the classifier is deterministic: query i's routed ranking is `arms[classify_query(q_i).lane][i]`) — no config flip, no fourth live arm.
- The live gate run is an operator action (needs the stack); per the issue, real-traffic `log_only` telemetry should corroborate the corpus lane mix before any default flip.

## Stage 4 — per-context calibration store

- `router_calibrations` table (migration **e59**, chains from e58): per-bucket arm performance rows. `context_id IS NULL` = fleet defaults (frozen-corpus runs); per-context rows let managed-cloud tuning diverge from self-host defaults. Keying mirrors `embedding_calibrations` (partial-unique split on NULL).
- `RouterCalibrationRepository`: scope-targeted upsert (ON CONFLICT against the matching partial index) + never-mix reads (a context's own rows win, else fleet defaults).
- Each gate run upserts the fleet-default rows.

## Carried advisor recs (gate2, #1212)

- `recall()` prefetches the `ContextSearchConfig` row **once** (read-only, fail-open) and threads it into both `_resolve_search_mode` and `_maybe_reinforce_rerank` — kills the double `get_by_context` SELECT (the #341 class). Fresh-context fallback preserved: reinforce re-reads when the prefetch found no row (materialized later by hybrid_search).
- `request.model_copy(update=...)` replaces the in-place `search_mode` mutation, so a caller-reused `RecallRequest` is never mutated.

## Tests

- 12 gate-math tests, 3 runner control-flow tests, 6 repository tests (upsert scope targeting compiled against the postgresql dialect), routing-resolution suite reworked to the config-param contract (+ threading regression tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)