### PR TITLE
chore(release): v0.45.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "Kagura Memory Cloud plugin — restore session context, recall & save durable project knowledge, setup help, and an MCP smoke test",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.44.0"
+version = "0.45.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.44.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.45.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.44.0"
+APP_VERSION = "0.45.0"
 
 # ============================================================================
 # Context Field Limits (#1193)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
## What's Changed

**Theme: eval-driven memory OS follow-ups — two measured wins, two honestly-null experiments.**

### Enhancements
- feat(api,frontend): surface per-user identity in Sleep reports list (#1201)
- feat(neural): enable the cold-start recency re-rank by default (#1207)
- feat(api): supersedes/contradicts relations + recall shadowing (#1208)
- feat(sleep): reversible, auditable dedup merges + retention policy (#1209)
- feat(eval): scheduled update-correctness + placebo CI gates (#1210)
- feat(api): consolidated memory-health report (self-diagnosis) (#1211)
- feat(search): query-intent retrieval router (experiment-gated) (#1212)
- feat(neural): graph signal in recall — placebo-gated experiment (#1213)
- feat(search): router calibration gate + per-context calibration store (#1220)
- Epic: eval-driven memory OS follow-ups (two wins, two nulls) (#1214)

### Documentation
- chore: unify 'Memory Analysis' terminology (remove deprecated 'broadlistening') (#1202)

### Highlights
- **Update-correctness by default** — the cold-start recency re-rank (measured +0.36 update-correctness lift over vanilla RAG, BCa 95% [0.24, 0.50]) is now ON for new contexts (#1207), backed by non-destructive fact succession (#1208) and reversible dedup (#1209).
- **Self-diagnosis** — a consolidated memory-health report surfaces silent-judge-death within one sleep cycle (#1211), guarded by CI gates on the measured wins (#1210).
- **Honest experiments** — the query-intent router (#1212/#1220) and graph-boost (#1213) ship OFF by default, each gated behind a pre-declared calibration/placebo bar on the frozen corpus.

Schema: migrations e55–e59 (all additive).

**Full Changelog**: https://github.com/kagura-ai/memory-cloud/compare/v0.44.0...v0.45.0
