### PR TITLE
feat(api,frontend): per-context memory-health report (#1225)

### DIFF
--- a/backend/src/api/routes/admin_memory_health.py
+++ b/backend/src/api/routes/admin_memory_health.py
@@ -19,7 +19,7 @@ Phase 3.
 from __future__ import annotations
 
 import uuid
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -112,15 +112,17 @@ class MemoryHealthDetailResponse(BaseModel):
 )
 async def get_memory_health(
     admin: AdminUser,
-    context_id: str | None = Query(
-        default=None,
-        description=(
-            "Omit for the per-context breakdown. Pass a context UUID for that "
-            "context's 3-section detail (must be owned by the caller — "
-            "otherwise 404), or the sentinel 'unattributed' for signals "
-            "recorded without a context."
+    context_id: Annotated[
+        uuid.UUID | Literal["unattributed"] | None,
+        Query(
+            description=(
+                "Omit for the per-context breakdown. Pass a context UUID for "
+                "that context's 3-section detail (must be owned by the caller "
+                "— otherwise 404), or the sentinel 'unattributed' for signals "
+                "recorded without a context."
+            ),
         ),
-    ),
+    ] = None,
     db: AsyncSession = Depends(get_db),
 ) -> MemoryHealthBreakdownResponse | MemoryHealthDetailResponse:
     """Build the thresholded health document(s) for the calling admin.
@@ -145,17 +147,9 @@ async def get_memory_health(
         breakdown = await service.build_breakdown(user_id)
         return MemoryHealthBreakdownResponse(**breakdown)
 
-    scope: uuid.UUID | None
-    if context_id == UNATTRIBUTED_SCOPE:
-        scope = None
-    else:
-        try:
-            scope = uuid.UUID(context_id)
-        except ValueError as exc:
-            raise HTTPException(
-                status_code=422,
-                detail="context_id must be a UUID or 'unattributed'",
-            ) from exc
+    # FastAPI already validated the param shape (UUID | 'unattributed'):
+    # anything else got the standard 422 body before reaching here.
+    scope = None if context_id == UNATTRIBUTED_SCOPE else context_id
 
     report = await service.build_context_report(user_id, scope)
     if report is None:

--- a/backend/src/api/routes/admin_memory_health.py
+++ b/backend/src/api/routes/admin_memory_health.py
@@ -1,18 +1,28 @@
-"""Consolidated memory-health report API (#1211).
+"""Per-context memory-health report API (#1211 Phase 1, #1225 Phase 2).
 
 One endpoint answering "is this partition's memory healthy?" from the
 signals the system already emits (sleep reports, graph invariants, usage
 stats, config posture) — thresholded ok/warn/fail per section so a
 silent-judge-death class of failure (#1177) surfaces without an external
-eval program. Self-scoped like the manual sleep trigger (Phase 1).
+eval program.
+
+Without ``context_id`` the endpoint returns the per-context breakdown (one
+graded entry per owned context; the page-level overall is the worst entry).
+With ``context_id=<uuid>`` it returns the 3-section detailed document for
+that single context (ownership validated — un-owned or unknown → uniform
+404). The sentinel ``context_id=unattributed`` targets signals recorded
+without a context (account-wide sleep runs, cross-context recalls, legacy
+rows). Self-scoped like the manual sleep trigger; workspace rollup is
+Phase 3.
 """
 
 from __future__ import annotations
 
+import uuid
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import AdminUser
@@ -28,6 +38,23 @@ router = APIRouter(prefix="/admin/memory-health", tags=["admin-memory-health"])
 
 HealthStatus = Literal["ok", "warn", "fail"]
 
+# Query-param sentinel selecting the context-less signal bucket.
+UNATTRIBUTED_SCOPE = "unattributed"
+
+
+class MemoryHealthNote(BaseModel):
+    """One structured section note (#1225).
+
+    Attributes:
+        code: Stable note code the frontend maps to a localized string
+            (the code → rationale mapping lives in
+            docs/ops/memory-health-report.md).
+        params: Interpolation values for the localized message.
+    """
+
+    code: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
 
 class MemoryHealthSection(BaseModel):
     """One graded health section.
@@ -35,32 +62,68 @@ class MemoryHealthSection(BaseModel):
     Attributes:
         status: ok | warn | fail (fail only on deterministic facts).
         metrics: Label-free numeric signals backing the grade.
-        notes: Human-readable explanations for every non-ok contribution.
+        notes: Structured explanations for every non-ok contribution.
     """
 
     status: HealthStatus
     metrics: dict[str, Any]
-    notes: list[str]
+    notes: list[MemoryHealthNote]
 
 
-class MemoryHealthResponse(BaseModel):
-    """200 response for GET /admin/memory-health."""
+class MemoryHealthContextEntry(BaseModel):
+    """One breakdown row: a single context's graded statuses.
+
+    Attributes:
+        context_id: The context UUID, or null for the unattributed bucket
+            (signals recorded without a context).
+        name: Context display name; null for the unattributed bucket.
+        overall_status: Worst section status for this context.
+        sections: Per-section status only — metrics live in the detail view.
+    """
+
+    context_id: str | None
+    name: str | None
+    overall_status: HealthStatus
+    sections: dict[str, HealthStatus]
+
+
+class MemoryHealthBreakdownResponse(BaseModel):
+    """200 response for GET /admin/memory-health (no context_id)."""
 
     generated_at: str
+    overall_status: HealthStatus
+    contexts: list[MemoryHealthContextEntry]
+
+
+class MemoryHealthDetailResponse(BaseModel):
+    """200 response for GET /admin/memory-health?context_id=..."""
+
+    generated_at: str
+    context_id: str | None
+    context_name: str | None
     overall_status: HealthStatus
     sections: dict[str, MemoryHealthSection]
 
 
 @router.get(
     "",
-    response_model=MemoryHealthResponse,
-    summary="Consolidated memory-health report (self-diagnosis)",
+    response_model=MemoryHealthBreakdownResponse | MemoryHealthDetailResponse,
+    summary="Per-context memory-health report (self-diagnosis)",
 )
 async def get_memory_health(
     admin: AdminUser,
+    context_id: str | None = Query(
+        default=None,
+        description=(
+            "Omit for the per-context breakdown. Pass a context UUID for that "
+            "context's 3-section detail (must be owned by the caller — "
+            "otherwise 404), or the sentinel 'unattributed' for signals "
+            "recorded without a context."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
-) -> MemoryHealthResponse:
-    """Build the thresholded health document for the calling admin's data.
+) -> MemoryHealthBreakdownResponse | MemoryHealthDetailResponse:
+    """Build the thresholded health document(s) for the calling admin.
 
     Sections: consolidation (judge health, merge audit, soft-delete
     backlog), graph (edge composition, weight invariant, cold-graph
@@ -76,5 +139,27 @@ async def get_memory_health(
             error_code="HEALTH-001",
         )
 
-    report = await MemoryHealthService(db).build_report(user_id)
-    return MemoryHealthResponse(**report)
+    service = MemoryHealthService(db)
+
+    if context_id is None:
+        breakdown = await service.build_breakdown(user_id)
+        return MemoryHealthBreakdownResponse(**breakdown)
+
+    scope: uuid.UUID | None
+    if context_id == UNATTRIBUTED_SCOPE:
+        scope = None
+    else:
+        try:
+            scope = uuid.UUID(context_id)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail="context_id must be a UUID or 'unattributed'",
+            ) from exc
+
+    report = await service.build_context_report(user_id, scope)
+    if report is None:
+        # Uniform 404: no distinction between "does not exist" and
+        # "not owned by the caller" (CWE-639 discipline).
+        raise HTTPException(status_code=404, detail="Context not found")
+    return MemoryHealthDetailResponse(**report)

--- a/backend/src/services/memory_health_service.py
+++ b/backend/src/services/memory_health_service.py
@@ -1,15 +1,15 @@
-"""Consolidated memory-health report (#1211) — runtime self-diagnosis.
+"""Per-context memory-health report (#1211 Phase 1, #1225 Phase 2).
 
 The eval program's most transferable lesson: memory failures manifest as
 plausible successes (``sleep_summary.ok=true`` while every judge call failed,
 #1177). The system already emits the needed signals — ``llm_call_failures``
 (#1183), ``winner_overrides`` (#1198), merge counts and cluster stats, graph
 stats, soft-delete rows — but they are fragmented across the Sleep report,
-graph stats, memory stats and logs. This service assembles them into ONE
-thresholded document so a silent-judge-death class of failure surfaces as
+graph stats, memory stats and logs. This service assembles them into
+thresholded documents so a silent-judge-death class of failure surfaces as
 WARN/FAIL within one sleep cycle instead of via an external eval program.
 
-Scope rules (gate1/COO):
+Scope rules (gate1/COO, #1211; per-context leaf scoping added by #1225):
 
 - **Label-free only**: rates that need gold labels (``stale_only``, P@k)
   belong to the eval harness / #1210 CI gates, not here.
@@ -19,12 +19,25 @@ Scope rules (gate1/COO):
 - **Conservative thresholds**: FAIL only on deterministic facts (latest run
   failed, invariant violated); WARN on degradation signals. A false FAIL
   erodes dashboard trust (the eval-infra lesson).
-- **Self-scoped** (Phase-1, same discipline as the manual sleep trigger):
-  the report covers the calling admin's own data partition.
+- **Self-scoped**: reports cover the calling admin's own data partition,
+  broken down per owned context (#1225). Signals recorded without a
+  ``context_id`` (account-wide sleep runs, cross-context recalls, legacy
+  rows) surface as one explicit *unattributed* entry rather than being
+  silently dropped — dropping them would hide Phase-1 WARNs behind the
+  new grouping (the same plausible-success shape this report exists to
+  prevent).
+- Workspace-level rollup across members is deliberately Phase 3
+  (needs ``PermissionService.check_workspace_access()`` semantics).
+
+Notes are structured ``{code, params}`` records (#1225); the frontend maps
+codes to localized strings. Issue references stay in code comments and
+``docs/ops/memory-health-report.md`` — never in the payload.
 """
 
 from __future__ import annotations
 
+import uuid
+from collections import defaultdict
 from datetime import timedelta
 from typing import Any
 
@@ -58,131 +71,303 @@ _USAGE_WINDOW_DAYS = 7
 _EDGE_WEIGHT_MIN = 0.0
 _EDGE_WEIGHT_MAX = 3.0
 
+# Scope key for signals recorded without a context_id. NeuralMemoryEdge
+# rows always carry a context (NOT NULL CHECK), but SleepReport, Memory and
+# UsageStats are nullable.
+_UNATTRIBUTED: uuid.UUID | None = None
+
+_EMPTY_BACKLOG: dict[str, Any] = {"count": 0, "oldest_days": None}
+_EMPTY_POSTURE: dict[str, int] = {
+    "contexts_with_config": 0,
+    "reinforce_enabled": 0,
+    "use_rerank": 0,
+}
+
 
 def _worst(statuses: list[str]) -> str:
     return max(statuses, key=lambda s: _STATUS_RANK[s]) if statuses else STATUS_OK
 
 
+def _note(code: str, **params: Any) -> dict[str, Any]:
+    """One structured section note. Codes are a stable contract with the
+    frontend message catalogs and docs/ops/memory-health-report.md."""
+    return {"code": code, "params": params}
+
+
+def _empty_graph_stats() -> dict[str, Any]:
+    return {
+        "edges_by_origin": {},
+        "total_edges": 0,
+        "weight_violations": 0,
+        "active_memories": 0,
+        "edges_per_memory": 0.0,
+    }
+
+
 class MemoryHealthService:
-    """Builds the consolidated memory-health document for one user partition."""
+    """Builds per-context memory-health documents for one user partition."""
 
     def __init__(self, db: AsyncSession):
         self.db = db
 
-    async def build_report(self, user_id: str) -> dict[str, Any]:
-        """Assemble all sections and grade them.
+    # ------------------------------------------------------------- builders
 
-        Returns a JSON-shaped dict:
-        ``{generated_at, overall_status, sections: {name: {status, metrics,
-        notes}}}``.
+    async def build_breakdown(self, user_id: str) -> dict[str, Any]:
+        """One graded entry per owned context, plus an unattributed entry
+        when context-less signals exist.
+
+        Returns ``{generated_at, overall_status, contexts: [{context_id,
+        name, overall_status, sections: {name: status}}]}``. No metric is
+        summed across contexts; the page-level overall is the worst entry.
+        A user with zero contexts and no unattributed signals gets an ok
+        overall with an empty list.
         """
-        consolidation = self._grade_consolidation(
-            await self._fetch_sleep_window(user_id),
-            await self._fetch_merge_backlog(user_id),
-        )
-        graph = self._grade_graph(await self._fetch_graph_stats(user_id))
-        retrieval = self._grade_retrieval(
-            await self._fetch_usage_counts(user_id),
-            await self._fetch_config_posture(user_id),
-            active_memories=graph["metrics"]["active_memories"],
-        )
+        contexts = await self._fetch_owned_contexts(user_id)
+        signals = await self._fetch_signals(user_id)
 
-        sections = {
-            "consolidation": consolidation,
-            "graph": graph,
-            "retrieval": retrieval,
-        }
+        scopes: list[tuple[uuid.UUID | None, str | None]] = list(contexts)
+        if self._has_unattributed_signals(signals):
+            scopes.append((_UNATTRIBUTED, None))
+
+        entries: list[dict[str, Any]] = []
+        for context_id, name in scopes:
+            sections = self._grade_scope(signals, context_id)
+            entries.append(
+                {
+                    "context_id": str(context_id) if context_id else None,
+                    "name": name,
+                    "overall_status": _worst([s["status"] for s in sections.values()]),
+                    "sections": {k: v["status"] for k, v in sections.items()},
+                }
+            )
+
         return {
             "generated_at": to_utc_iso(utcnow()),
+            "overall_status": _worst([e["overall_status"] for e in entries]),
+            "contexts": entries,
+        }
+
+    async def build_context_report(
+        self, user_id: str, context_scope: uuid.UUID | None
+    ) -> dict[str, Any] | None:
+        """The 3-section detailed document for a single scope.
+
+        ``context_scope=None`` targets the unattributed bucket (signals
+        recorded without a context). A UUID scope is validated against the
+        caller's owned, non-deleted contexts; returns ``None`` when not
+        owned (the route maps that to a uniform 404 — no existence
+        disclosure).
+        """
+        context_name: str | None = None
+        if context_scope is not None:
+            owned = dict(await self._fetch_owned_contexts(user_id))
+            if context_scope not in owned:
+                return None
+            context_name = owned[context_scope]
+
+        signals = await self._fetch_signals(user_id)
+        sections = self._grade_scope(signals, context_scope)
+        return {
+            "generated_at": to_utc_iso(utcnow()),
+            "context_id": str(context_scope) if context_scope else None,
+            "context_name": context_name,
             "overall_status": _worst([s["status"] for s in sections.values()]),
             "sections": sections,
         }
 
+    # -------------------------------------------------------------- scoping
+
+    async def _fetch_signals(self, user_id: str) -> dict[str, Any]:
+        """All grouped signal maps, one query per signal (no per-context
+        fan-out — the gate1 N+1 concern)."""
+        return {
+            "windows": await self._fetch_sleep_windows(user_id),
+            "backlogs": await self._fetch_merge_backlogs(user_id),
+            "graphs": await self._fetch_graph_stats(user_id),
+            "usage": await self._fetch_usage_counts(user_id),
+            "postures": await self._fetch_config_postures(user_id),
+        }
+
+    @staticmethod
+    def _has_unattributed_signals(signals: dict[str, Any]) -> bool:
+        graphs = signals["graphs"].get(_UNATTRIBUTED) or _empty_graph_stats()
+        return bool(
+            signals["windows"].get(_UNATTRIBUTED)
+            or signals["backlogs"].get(_UNATTRIBUTED, _EMPTY_BACKLOG)["count"]
+            or graphs["active_memories"]
+            or signals["usage"].get(_UNATTRIBUTED)
+        )
+
+    def _grade_scope(self, signals: dict[str, Any], context_id: uuid.UUID | None) -> dict[str, Any]:
+        """Grade the 3 sections from one scope's slice of the signal maps.
+
+        The isolation contract (#1225): only rows recorded under this
+        ``context_id`` contribute — a WARN-producing signal in context A
+        cannot change context B's grade.
+        """
+        graph_stats = signals["graphs"].get(context_id) or _empty_graph_stats()
+        # The unattributed bucket skips the heuristic checks that assume a
+        # real context partition: edges always carry a context (NOT NULL),
+        # so legacy context-less memories would always look "cold", and
+        # cross-context recalls land here making write-only checks noise.
+        # False WARNs erode dashboard trust more than a missing heuristic.
+        heuristics = context_id is not None
+        return {
+            "consolidation": self._grade_consolidation(
+                signals["windows"].get(context_id, []),
+                signals["backlogs"].get(context_id, _EMPTY_BACKLOG),
+            ),
+            "graph": self._grade_graph(graph_stats, cold_check=heuristics),
+            "retrieval": self._grade_retrieval(
+                signals["usage"].get(context_id, {}),
+                signals["postures"].get(context_id, _EMPTY_POSTURE),
+                active_memories=graph_stats["active_memories"],
+                write_only_check=heuristics,
+            ),
+        }
+
     # ------------------------------------------------------------- fetchers
 
-    async def _fetch_sleep_window(self, user_id: str) -> list[dict[str, Any]]:
-        """Most recent sleep reports (newest first), flattened for grading."""
-        result = await self.db.execute(
-            select(SleepReport)
-            .where(SleepReport.user_id == user_id)
-            .order_by(SleepReport.started_at.desc())
-            .limit(_REPORT_WINDOW)
+    async def _fetch_owned_contexts(self, user_id: str) -> list[tuple[uuid.UUID, str]]:
+        """Owned, non-deleted contexts — the Phase-1 self-scope predicate
+        (same as the config-posture join); workspace semantics are Phase 3."""
+        rows = await self.db.execute(
+            select(Context.id, Context.name, Context.display_name)
+            .where(Context.created_by == user_id, Context.deleted_at.is_(None))
+            .order_by(Context.name)
         )
-        reports = list(result.scalars().all())
-        window: list[dict[str, Any]] = []
-        for r in reports:
-            dedup = r.dedup_result or {}
+        return [(cid, display_name or name) for cid, name, display_name in rows.all()]
+
+    async def _fetch_sleep_windows(
+        self, user_id: str
+    ) -> dict[uuid.UUID | None, list[dict[str, Any]]]:
+        """Most recent sleep reports per context (newest first), flattened.
+
+        One query: row_number() partitioned by context_id caps every scope
+        at the same window the Phase-1 report used.
+        """
+        rn = (
+            func.row_number()
+            .over(
+                partition_by=SleepReport.context_id,
+                order_by=SleepReport.started_at.desc(),
+            )
+            .label("rn")
+        )
+        subq = (
+            select(
+                SleepReport.context_id,
+                SleepReport.status,
+                SleepReport.llm_call_failures,
+                SleepReport.memories_merged,
+                SleepReport.dedup_result,
+                SleepReport.started_at,
+                rn,
+            )
+            .where(SleepReport.user_id == user_id)
+            .subquery()
+        )
+        result = await self.db.execute(
+            select(subq)
+            .where(subq.c.rn <= _REPORT_WINDOW)
+            .order_by(subq.c.context_id, subq.c.started_at.desc())
+        )
+        windows: dict[uuid.UUID | None, list[dict[str, Any]]] = defaultdict(list)
+        for row in result.all():
+            dedup = row.dedup_result or {}
             details = dedup.get("details") or {}
-            window.append(
+            windows[row.context_id].append(
                 {
-                    "status": r.status,
-                    "llm_call_failures": r.llm_call_failures or 0,
-                    "memories_merged": r.memories_merged or 0,
+                    "status": row.status,
+                    "llm_call_failures": row.llm_call_failures or 0,
+                    "memories_merged": row.memories_merged or 0,
                     "winner_overrides": details.get("winner_overrides", 0),
                     "deferred_pairs": details.get("deferred_pairs", 0),
                     "oversize_clusters": details.get("oversize_clusters", 0),
-                    "started_at": to_utc_iso(r.started_at) if r.started_at else None,
+                    "started_at": to_utc_iso(row.started_at) if row.started_at else None,
                 }
             )
-        return window
+        return dict(windows)
 
-    async def _fetch_merge_backlog(self, user_id: str) -> dict[str, Any]:
-        """Soft-deleted merge losers: count + oldest age in days."""
-        result = await self.db.execute(
-            select(func.count(Memory.id), func.min(Memory.deleted_at)).where(
+    async def _fetch_merge_backlogs(self, user_id: str) -> dict[uuid.UUID | None, dict[str, Any]]:
+        """Soft-deleted merge losers per context: count + oldest age (days)."""
+        rows = await self.db.execute(
+            select(
+                Memory.context_id,
+                func.count(Memory.id),
+                func.min(Memory.deleted_at),
+            )
+            .where(
                 Memory.user_id == user_id,
                 Memory.deleted_by == "sleep_maintenance",
                 Memory.deleted_at.is_not(None),
             )
+            .group_by(Memory.context_id)
         )
-        count, oldest = result.one()
-        oldest_days = None
-        if oldest is not None:
-            oldest_days = max(0, (utcnow() - oldest).days)
-        return {"count": int(count or 0), "oldest_days": oldest_days}
+        now = utcnow()
+        backlogs: dict[uuid.UUID | None, dict[str, Any]] = {}
+        for context_id, count, oldest in rows.all():
+            oldest_days = max(0, (now - oldest).days) if oldest is not None else None
+            backlogs[context_id] = {"count": int(count or 0), "oldest_days": oldest_days}
+        return backlogs
 
-    async def _fetch_graph_stats(self, user_id: str) -> dict[str, Any]:
-        """Edge composition by origin, weight-invariant violations, density."""
+    async def _fetch_graph_stats(self, user_id: str) -> dict[uuid.UUID | None, dict[str, Any]]:
+        """Edge composition, weight-invariant violations and density, per
+        context. Edges always carry a context; active memories may not."""
         origin_rows = await self.db.execute(
-            select(NeuralMemoryEdge.origin, func.count(NeuralMemoryEdge.id))
+            select(
+                NeuralMemoryEdge.context_id,
+                NeuralMemoryEdge.origin,
+                func.count(NeuralMemoryEdge.id),
+            )
             .where(NeuralMemoryEdge.user_id == user_id)
-            .group_by(NeuralMemoryEdge.origin)
+            .group_by(NeuralMemoryEdge.context_id, NeuralMemoryEdge.origin)
         )
-        edges_by_origin = {origin: int(count) for origin, count in origin_rows.all()}
+        edges_by_scope: dict[uuid.UUID | None, dict[str, int]] = defaultdict(dict)
+        for context_id, origin, count in origin_rows.all():
+            edges_by_scope[context_id][origin] = int(count)
 
-        violations = await self.db.execute(
-            select(func.count(NeuralMemoryEdge.id)).where(
+        violation_rows = await self.db.execute(
+            select(NeuralMemoryEdge.context_id, func.count(NeuralMemoryEdge.id))
+            .where(
                 NeuralMemoryEdge.user_id == user_id,
                 (NeuralMemoryEdge.weight < _EDGE_WEIGHT_MIN)
                 | (NeuralMemoryEdge.weight > _EDGE_WEIGHT_MAX),
             )
+            .group_by(NeuralMemoryEdge.context_id)
         )
-        weight_violations = int(violations.scalar_one() or 0)
+        violations = {cid: int(count or 0) for cid, count in violation_rows.all()}
 
-        memories = await self.db.execute(
-            select(func.count(Memory.id)).where(
-                Memory.user_id == user_id,
-                Memory.deleted_at.is_(None),
-            )
+        memory_rows = await self.db.execute(
+            select(Memory.context_id, func.count(Memory.id))
+            .where(Memory.user_id == user_id, Memory.deleted_at.is_(None))
+            .group_by(Memory.context_id)
         )
-        active_memories = int(memories.scalar_one() or 0)
+        memories = {cid: int(count or 0) for cid, count in memory_rows.all()}
 
-        total_edges = sum(edges_by_origin.values())
-        return {
-            "edges_by_origin": edges_by_origin,
-            "total_edges": total_edges,
-            "weight_violations": weight_violations,
-            "active_memories": active_memories,
-            "edges_per_memory": (
-                round(total_edges / active_memories, 4) if active_memories else 0.0
-            ),
-        }
+        stats: dict[uuid.UUID | None, dict[str, Any]] = {}
+        for scope in set(edges_by_scope) | set(violations) | set(memories):
+            edges_by_origin = edges_by_scope.get(scope, {})
+            total_edges = sum(edges_by_origin.values())
+            active = memories.get(scope, 0)
+            stats[scope] = {
+                "edges_by_origin": edges_by_origin,
+                "total_edges": total_edges,
+                "weight_violations": violations.get(scope, 0),
+                "active_memories": active,
+                "edges_per_memory": round(total_edges / active, 4) if active else 0.0,
+            }
+        return stats
 
-    async def _fetch_usage_counts(self, user_id: str) -> dict[str, int]:
-        """MCP tool call counts over the usage window, keyed by tool name."""
+    async def _fetch_usage_counts(self, user_id: str) -> dict[uuid.UUID | None, dict[str, int]]:
+        """MCP tool call counts per context over the usage window."""
         since = utcnow() - timedelta(days=_USAGE_WINDOW_DAYS)
         rows = await self.db.execute(
-            select(UsageStats.endpoint, func.count(UsageStats.id))
+            select(
+                UsageStats.context_id,
+                UsageStats.endpoint,
+                func.count(UsageStats.id),
+            )
             .where(
                 UsageStats.user_id == user_id,
                 UsageStats.created_at >= since,
@@ -190,30 +375,32 @@ class MemoryHealthService:
                     ["mcp:recall", "mcp:recall_upcoming", "mcp:remember", "mcp:explore"]
                 ),
             )
-            .group_by(UsageStats.endpoint)
+            .group_by(UsageStats.context_id, UsageStats.endpoint)
         )
-        return {endpoint.removeprefix("mcp:"): int(count) for endpoint, count in rows.all()}
+        usage: dict[uuid.UUID | None, dict[str, int]] = defaultdict(dict)
+        for context_id, endpoint, count in rows.all():
+            usage[context_id][endpoint.removeprefix("mcp:")] = int(count)
+        return dict(usage)
 
-    async def _fetch_config_posture(self, user_id: str) -> dict[str, int]:
-        """Search-config posture across the user's contexts."""
+    async def _fetch_config_postures(self, user_id: str) -> dict[uuid.UUID | None, dict[str, int]]:
+        """Search-config posture per owned context (0/1 flags per context)."""
         rows = await self.db.execute(
             select(
-                func.count(ContextSearchConfig.id),
-                func.count(ContextSearchConfig.id).filter(
-                    ContextSearchConfig.reinforce_enabled.is_(True)
-                ),
-                func.count(ContextSearchConfig.id).filter(ContextSearchConfig.use_rerank.is_(True)),
+                ContextSearchConfig.context_id,
+                ContextSearchConfig.reinforce_enabled,
+                ContextSearchConfig.use_rerank,
             )
-            .select_from(ContextSearchConfig)
             .join(Context, Context.id == ContextSearchConfig.context_id)
             .where(Context.created_by == user_id, Context.deleted_at.is_(None))
         )
-        total, reinforce_on, rerank_on = rows.one()
-        return {
-            "contexts_with_config": int(total or 0),
-            "reinforce_enabled": int(reinforce_on or 0),
-            "use_rerank": int(rerank_on or 0),
-        }
+        postures: dict[uuid.UUID | None, dict[str, int]] = {}
+        for context_id, reinforce_on, rerank_on in rows.all():
+            postures[context_id] = {
+                "contexts_with_config": 1,
+                "reinforce_enabled": int(bool(reinforce_on)),
+                "use_rerank": int(bool(rerank_on)),
+            }
+        return postures
 
     # -------------------------------------------------------------- grading
 
@@ -222,7 +409,7 @@ class MemoryHealthService:
         window: list[dict[str, Any]], backlog: dict[str, Any]
     ) -> dict[str, Any]:
         """FAIL: latest run failed. WARN: degradation signals in the window."""
-        notes: list[str] = []
+        notes: list[dict[str, Any]] = []
         status = STATUS_OK
 
         latest = window[0] if window else None
@@ -233,41 +420,37 @@ class MemoryHealthService:
         deferred = sum(r["deferred_pairs"] for r in window)
 
         if latest and latest["status"] == "failed":
+            # Total judge failure — the #1177 class; check the sleep LLM config.
             status = STATUS_FAIL
-            notes.append(
-                "latest sleep run FAILED (total judge failure — the #1177 class); "
-                "check the sleep LLM configuration"
-            )
+            notes.append(_note("latest_sleep_failed"))
         else:
             if total_failures > 0 or degraded > 0:
+                # A partially dead judge grades 'degraded', never silently
+                # 'completed' (#1183).
                 status = STATUS_WARN
-                notes.append(
-                    f"judge failures in the window: {total_failures} across "
-                    f"{degraded} degraded run(s) — a partially dead judge grades "
-                    "'degraded', never silently 'completed' (#1183)"
-                )
+                notes.append(_note("judge_failures", count=total_failures, degraded_runs=degraded))
             if failed > 0:
+                # The latest run recovered, but recent instability is worth a look.
                 status = STATUS_WARN
-                notes.append(
-                    f"{failed} failed sleep run(s) in the window — the latest "
-                    "run recovered, but recent instability is worth a look"
-                )
+                notes.append(_note("failed_runs_recovered", count=failed))
         if deferred > 0:
+            # Cluster caps deferring pairs unjudged — dedup may be
+            # structurally behind (the #1184 class).
             status = _worst([status, STATUS_WARN])
-            notes.append(
-                f"{deferred} candidate pair(s) deferred unjudged (cluster caps) — "
-                "dedup may be structurally behind (#1184 class)"
-            )
+            notes.append(_note("deferred_pairs", count=deferred))
         if (
             backlog["oldest_days"] is not None
             and backlog["oldest_days"] > _BACKLOG_WARN_DAYS
             and status != STATUS_FAIL
         ):
+            # A retention window is likely wanted (sleep_merge_retention_days, #1209).
             status = _worst([status, STATUS_WARN])
             notes.append(
-                f"oldest merge loser is {backlog['oldest_days']}d old "
-                f"(> {_BACKLOG_WARN_DAYS}d) — consider a retention window "
-                "(sleep_merge_retention_days, #1209)"
+                _note(
+                    "merge_backlog_old",
+                    oldest_days=backlog["oldest_days"],
+                    threshold_days=_BACKLOG_WARN_DAYS,
+                )
             )
 
         return {
@@ -287,24 +470,30 @@ class MemoryHealthService:
         }
 
     @staticmethod
-    def _grade_graph(stats: dict[str, Any]) -> dict[str, Any]:
+    def _grade_graph(stats: dict[str, Any], *, cold_check: bool = True) -> dict[str, Any]:
         """FAIL: weight invariant violated. WARN: suspiciously cold graph."""
-        notes: list[str] = []
+        notes: list[dict[str, Any]] = []
         status = STATUS_OK
 
         if stats["weight_violations"] > 0:
+            # The #1197 class of unclamped-accumulation bug.
             status = STATUS_FAIL
             notes.append(
-                f"{stats['weight_violations']} edge(s) outside the weight bounds "
-                f"[{_EDGE_WEIGHT_MIN}, {_EDGE_WEIGHT_MAX}] — the #1197 class of "
-                "unclamped-accumulation bug"
+                _note(
+                    "edge_weight_violations",
+                    count=stats["weight_violations"],
+                    min=_EDGE_WEIGHT_MIN,
+                    max=_EDGE_WEIGHT_MAX,
+                )
             )
-        elif stats["total_edges"] == 0 and stats["active_memories"] >= _COLD_GRAPH_MIN_MEMORIES:
+        elif (
+            cold_check
+            and stats["total_edges"] == 0
+            and stats["active_memories"] >= _COLD_GRAPH_MIN_MEMORIES
+        ):
+            # The graph never warmed — check edge-formation gates / sleep_mode.
             status = STATUS_WARN
-            notes.append(
-                f"{stats['active_memories']} active memories but zero edges — "
-                "the graph never warmed (check edge-formation gates / sleep_mode)"
-            )
+            notes.append(_note("cold_graph", active_memories=stats["active_memories"]))
 
         return {"status": status, "metrics": stats, "notes": notes}
 
@@ -314,19 +503,22 @@ class MemoryHealthService:
         posture: dict[str, int],
         *,
         active_memories: int,
+        write_only_check: bool = True,
     ) -> dict[str, Any]:
         """Informational; WARN only when memory exists but nothing reads it."""
-        notes: list[str] = []
+        notes: list[dict[str, Any]] = []
         status = STATUS_OK
         recalls = usage.get("recall", 0)
         recall_upcoming = usage.get("recall_upcoming", 0)
 
-        if recalls + recall_upcoming == 0 and active_memories > 0:
+        if write_only_check and recalls + recall_upcoming == 0 and active_memories > 0:
             status = STATUS_WARN
             notes.append(
-                f"no recall() calls in the last {_USAGE_WINDOW_DAYS}d despite "
-                f"{active_memories} active memories — the store is write-only "
-                "right now"
+                _note(
+                    "write_only_store",
+                    window_days=_USAGE_WINDOW_DAYS,
+                    active_memories=active_memories,
+                )
             )
 
         return {

--- a/backend/src/services/memory_health_service.py
+++ b/backend/src/services/memory_health_service.py
@@ -20,12 +20,13 @@ Scope rules (gate1/COO, #1211; per-context leaf scoping added by #1225):
   failed, invariant violated); WARN on degradation signals. A false FAIL
   erodes dashboard trust (the eval-infra lesson).
 - **Self-scoped**: reports cover the calling admin's own data partition,
-  broken down per owned context (#1225). Signals recorded without a
-  ``context_id`` (account-wide sleep runs, cross-context recalls, legacy
-  rows) surface as one explicit *unattributed* entry rather than being
-  silently dropped — dropping them would hide Phase-1 WARNs behind the
-  new grouping (the same plausible-success shape this report exists to
-  prevent).
+  broken down per owned context (#1225). Signals that do not belong to an
+  owned, live context — recorded without a ``context_id`` (account-wide
+  sleep runs, legacy rows), or under a soft-deleted context, or under a
+  shared context created by another member — fold into one explicit
+  *unattributed* entry rather than being silently dropped. Dropping them
+  would hide Phase-1 WARN/FAILs behind the new grouping — the same
+  plausible-success shape this report exists to prevent.
 - Workspace-level rollup across members is deliberately Phase 3
   (needs ``PermissionService.check_workspace_access()`` semantics).
 
@@ -61,6 +62,11 @@ _STATUS_RANK = {STATUS_OK: 0, STATUS_WARN: 1, STATUS_FAIL: 2}
 
 # Sleep reports considered "the recent window" for consolidation grading.
 _REPORT_WINDOW = 20
+# Hard recency bound on the window: reports older than this never grade.
+# Keeps the window scan bounded as history grows, and stops ancient failures
+# in sparse contexts from resurfacing as eternal WARNs under per-context
+# scoping (the Phase-1 account-wide window had already aged them out).
+_WINDOW_LOOKBACK_DAYS = 180
 # Soft-deleted merge losers older than this warn (retention likely wanted).
 _BACKLOG_WARN_DAYS = 90
 # A graph with this many active memories and zero edges is suspiciously cold.
@@ -71,17 +77,23 @@ _USAGE_WINDOW_DAYS = 7
 _EDGE_WEIGHT_MIN = 0.0
 _EDGE_WEIGHT_MAX = 3.0
 
-# Scope key for signals recorded without a context_id. NeuralMemoryEdge
-# rows always carry a context (NOT NULL CHECK), but SleepReport, Memory and
-# UsageStats are nullable.
+# Scope key for the unattributed bucket: signals recorded without a
+# context_id, plus signals folded in from non-owned scopes (see
+# _fold_orphan_scopes). NeuralMemoryEdge rows always carry a context
+# (NOT NULL CHECK), but SleepReport, Memory and UsageStats are nullable.
 _UNATTRIBUTED: uuid.UUID | None = None
 
+# Fetcher scope sentinel: no per-context WHERE filter (breakdown path).
+_ALL: Any = object()
+
 _EMPTY_BACKLOG: dict[str, Any] = {"count": 0, "oldest_days": None}
-_EMPTY_POSTURE: dict[str, int] = {
-    "contexts_with_config": 0,
-    "reinforce_enabled": 0,
-    "use_rerank": 0,
+_EMPTY_POSTURE: dict[str, bool] = {
+    "has_config": False,
+    "reinforce_enabled": False,
+    "use_rerank": False,
 }
+
+_SIGNAL_KEYS = ("windows", "backlogs", "graphs", "usage")
 
 
 def _worst(statuses: list[str]) -> str:
@@ -114,7 +126,7 @@ class MemoryHealthService:
 
     async def build_breakdown(self, user_id: str) -> dict[str, Any]:
         """One graded entry per owned context, plus an unattributed entry
-        when context-less signals exist.
+        when signals exist outside the owned scopes.
 
         Returns ``{generated_at, overall_status, contexts: [{context_id,
         name, overall_status, sections: {name: status}}]}``. No metric is
@@ -123,10 +135,11 @@ class MemoryHealthService:
         overall with an empty list.
         """
         contexts = await self._fetch_owned_contexts(user_id)
-        signals = await self._fetch_signals(user_id)
+        owned_ids = {context_id for context_id, _ in contexts}
+        signals = self._fold_orphan_scopes(await self._fetch_signals(user_id), owned_ids)
 
         scopes: list[tuple[uuid.UUID | None, str | None]] = list(contexts)
-        if self._has_unattributed_signals(signals):
+        if any(_UNATTRIBUTED in signals[key] for key in _SIGNAL_KEYS):
             scopes.append((_UNATTRIBUTED, None))
 
         entries: list[dict[str, Any]] = []
@@ -152,20 +165,23 @@ class MemoryHealthService:
     ) -> dict[str, Any] | None:
         """The 3-section detailed document for a single scope.
 
-        ``context_scope=None`` targets the unattributed bucket (signals
-        recorded without a context). A UUID scope is validated against the
-        caller's owned, non-deleted contexts; returns ``None`` when not
-        owned (the route maps that to a uniform 404 — no existence
-        disclosure).
+        ``context_scope=None`` targets the unattributed bucket. A UUID scope
+        is validated against the caller's owned, non-deleted contexts;
+        returns ``None`` when not owned (the route maps that to a uniform
+        404 — no existence disclosure).
         """
-        context_name: str | None = None
         if context_scope is not None:
-            owned = dict(await self._fetch_owned_contexts(user_id))
-            if context_scope not in owned:
+            context_name = await self._resolve_owned_context(user_id, context_scope)
+            if context_name is None:
                 return None
-            context_name = owned[context_scope]
+            # Scoped fetch: single-partition WHERE instead of grouping the
+            # caller's entire partition to read one key.
+            signals = await self._fetch_signals(user_id, scope=context_scope)
+        else:
+            context_name = None
+            owned_ids = {cid for cid, _ in await self._fetch_owned_contexts(user_id)}
+            signals = self._fold_orphan_scopes(await self._fetch_signals(user_id), owned_ids)
 
-        signals = await self._fetch_signals(user_id)
         sections = self._grade_scope(signals, context_scope)
         return {
             "generated_at": to_utc_iso(utcnow()),
@@ -177,26 +193,88 @@ class MemoryHealthService:
 
     # -------------------------------------------------------------- scoping
 
-    async def _fetch_signals(self, user_id: str) -> dict[str, Any]:
+    @staticmethod
+    def _owned_context_filter(user_id: str) -> tuple[Any, ...]:
+        """The Phase-1 self-scope predicate, defined once. Phase 3 replaces
+        this with workspace semantics — every consumer updates together."""
+        return (Context.created_by == user_id, Context.deleted_at.is_(None))
+
+    async def _fetch_signals(self, user_id: str, scope: Any = _ALL) -> dict[str, Any]:
         """All grouped signal maps, one query per signal (no per-context
-        fan-out — the gate1 N+1 concern)."""
+        fan-out — the gate1 N+1 concern). ``scope`` (a context UUID) narrows
+        every query to one partition for the detail path."""
         return {
-            "windows": await self._fetch_sleep_windows(user_id),
-            "backlogs": await self._fetch_merge_backlogs(user_id),
-            "graphs": await self._fetch_graph_stats(user_id),
-            "usage": await self._fetch_usage_counts(user_id),
-            "postures": await self._fetch_config_postures(user_id),
+            "windows": await self._fetch_sleep_windows(user_id, scope),
+            "backlogs": await self._fetch_merge_backlogs(user_id, scope),
+            "graphs": await self._fetch_graph_stats(user_id, scope),
+            "usage": await self._fetch_usage_counts(user_id, scope),
+            "postures": await self._fetch_config_postures(user_id, scope),
         }
 
     @staticmethod
-    def _has_unattributed_signals(signals: dict[str, Any]) -> bool:
-        graphs = signals["graphs"].get(_UNATTRIBUTED) or _empty_graph_stats()
-        return bool(
-            signals["windows"].get(_UNATTRIBUTED)
-            or signals["backlogs"].get(_UNATTRIBUTED, _EMPTY_BACKLOG)["count"]
-            or graphs["active_memories"]
-            or signals["usage"].get(_UNATTRIBUTED)
-        )
+    def _fold_orphan_scopes(signals: dict[str, Any], owned_ids: set[uuid.UUID]) -> dict[str, Any]:
+        """Re-key signals whose scope is not an owned, live context into the
+        unattributed bucket.
+
+        Orphan scopes are real: SleepReport / Memory / UsageStats rows
+        survive a context soft-delete, and a user's rows in a shared context
+        created by another member group under that context's UUID. Without
+        the fold those signals would appear in NO entry (not owned, not
+        NULL) — a failed sleep run or an edge-weight violation would vanish
+        from the report entirely.
+        """
+
+        def bucket(key: uuid.UUID | None) -> uuid.UUID | None:
+            return key if key in owned_ids else _UNATTRIBUTED
+
+        windows: dict[uuid.UUID | None, list[dict[str, Any]]] = {}
+        for key, window in signals["windows"].items():
+            windows.setdefault(bucket(key), []).extend(window)
+        if _UNATTRIBUTED in windows:
+            windows[_UNATTRIBUTED] = sorted(
+                windows[_UNATTRIBUTED], key=lambda r: r["started_at"] or "", reverse=True
+            )[:_REPORT_WINDOW]
+
+        backlogs: dict[uuid.UUID | None, dict[str, Any]] = {}
+        for key, backlog in signals["backlogs"].items():
+            target = backlogs.get(bucket(key))
+            if target is None:
+                backlogs[bucket(key)] = dict(backlog)
+                continue
+            target["count"] += backlog["count"]
+            ages = [d for d in (target["oldest_days"], backlog["oldest_days"]) if d is not None]
+            target["oldest_days"] = max(ages) if ages else None
+
+        graphs: dict[uuid.UUID | None, dict[str, Any]] = {}
+        for key, stats in signals["graphs"].items():
+            target = graphs.get(bucket(key))
+            if target is None:
+                graphs[bucket(key)] = {**stats, "edges_by_origin": dict(stats["edges_by_origin"])}
+                continue
+            for origin, count in stats["edges_by_origin"].items():
+                target["edges_by_origin"][origin] = target["edges_by_origin"].get(origin, 0) + count
+            target["weight_violations"] += stats["weight_violations"]
+            target["active_memories"] += stats["active_memories"]
+        for stats in graphs.values():
+            total_edges = sum(stats["edges_by_origin"].values())
+            active = stats["active_memories"]
+            stats["total_edges"] = total_edges
+            stats["edges_per_memory"] = round(total_edges / active, 4) if active else 0.0
+
+        usage: dict[uuid.UUID | None, dict[str, int]] = {}
+        for key, counts in signals["usage"].items():
+            target = usage.setdefault(bucket(key), {})
+            for tool, count in counts.items():
+                target[tool] = target.get(tool, 0) + count
+
+        # Postures come from a join on owned contexts — no orphans possible.
+        return {
+            "windows": windows,
+            "backlogs": backlogs,
+            "graphs": graphs,
+            "usage": usage,
+            "postures": signals["postures"],
+        }
 
     def _grade_scope(self, signals: dict[str, Any], context_id: uuid.UUID | None) -> dict[str, Any]:
         """Grade the 3 sections from one scope's slice of the signal maps.
@@ -208,43 +286,54 @@ class MemoryHealthService:
         graph_stats = signals["graphs"].get(context_id) or _empty_graph_stats()
         # The unattributed bucket skips the heuristic checks that assume a
         # real context partition: edges always carry a context (NOT NULL),
-        # so legacy context-less memories would always look "cold", and
-        # cross-context recalls land here making write-only checks noise.
-        # False WARNs erode dashboard trust more than a missing heuristic.
+        # so folded context-less memories would always look "cold", and the
+        # bucket mixes scopes so read/write ratios are noise. False WARNs
+        # erode dashboard trust more than a missing heuristic. Deterministic
+        # facts (failed runs, weight violations) still grade.
         heuristics = context_id is not None
         return {
             "consolidation": self._grade_consolidation(
                 signals["windows"].get(context_id, []),
                 signals["backlogs"].get(context_id, _EMPTY_BACKLOG),
             ),
-            "graph": self._grade_graph(graph_stats, cold_check=heuristics),
+            "graph": self._grade_graph(graph_stats, heuristics=heuristics),
             "retrieval": self._grade_retrieval(
                 signals["usage"].get(context_id, {}),
                 signals["postures"].get(context_id, _EMPTY_POSTURE),
                 active_memories=graph_stats["active_memories"],
-                write_only_check=heuristics,
+                heuristics=heuristics,
             ),
         }
 
     # ------------------------------------------------------------- fetchers
 
     async def _fetch_owned_contexts(self, user_id: str) -> list[tuple[uuid.UUID, str]]:
-        """Owned, non-deleted contexts — the Phase-1 self-scope predicate
-        (same as the config-posture join); workspace semantics are Phase 3."""
+        """Owned, non-deleted contexts — the Phase-1 self-scope."""
         rows = await self.db.execute(
             select(Context.id, Context.name, Context.display_name)
-            .where(Context.created_by == user_id, Context.deleted_at.is_(None))
+            .where(*self._owned_context_filter(user_id))
             .order_by(Context.name)
         )
         return [(cid, display_name or name) for cid, name, display_name in rows.all()]
 
+    async def _resolve_owned_context(self, user_id: str, context_id: uuid.UUID) -> str | None:
+        """Display name of one owned context, or None (single indexed row)."""
+        rows = await self.db.execute(
+            select(Context.name, Context.display_name).where(
+                Context.id == context_id, *self._owned_context_filter(user_id)
+            )
+        )
+        row = rows.one_or_none()
+        return (row.display_name or row.name) if row else None
+
     async def _fetch_sleep_windows(
-        self, user_id: str
+        self, user_id: str, scope: Any = _ALL
     ) -> dict[uuid.UUID | None, list[dict[str, Any]]]:
         """Most recent sleep reports per context (newest first), flattened.
 
         One query: row_number() partitioned by context_id caps every scope
-        at the same window the Phase-1 report used.
+        at the same window the Phase-1 report used, bounded to the lookback
+        horizon so the scan does not grow with total history.
         """
         rn = (
             func.row_number()
@@ -254,6 +343,12 @@ class MemoryHealthService:
             )
             .label("rn")
         )
+        conditions = [
+            SleepReport.user_id == user_id,
+            SleepReport.started_at >= utcnow() - timedelta(days=_WINDOW_LOOKBACK_DAYS),
+        ]
+        if scope is not _ALL:
+            conditions.append(SleepReport.context_id == scope)
         subq = (
             select(
                 SleepReport.context_id,
@@ -264,7 +359,7 @@ class MemoryHealthService:
                 SleepReport.started_at,
                 rn,
             )
-            .where(SleepReport.user_id == user_id)
+            .where(*conditions)
             .subquery()
         )
         result = await self.db.execute(
@@ -289,19 +384,24 @@ class MemoryHealthService:
             )
         return dict(windows)
 
-    async def _fetch_merge_backlogs(self, user_id: str) -> dict[uuid.UUID | None, dict[str, Any]]:
+    async def _fetch_merge_backlogs(
+        self, user_id: str, scope: Any = _ALL
+    ) -> dict[uuid.UUID | None, dict[str, Any]]:
         """Soft-deleted merge losers per context: count + oldest age (days)."""
+        conditions = [
+            Memory.user_id == user_id,
+            Memory.deleted_by == "sleep_maintenance",
+            Memory.deleted_at.is_not(None),
+        ]
+        if scope is not _ALL:
+            conditions.append(Memory.context_id == scope)
         rows = await self.db.execute(
             select(
                 Memory.context_id,
                 func.count(Memory.id),
                 func.min(Memory.deleted_at),
             )
-            .where(
-                Memory.user_id == user_id,
-                Memory.deleted_by == "sleep_maintenance",
-                Memory.deleted_at.is_not(None),
-            )
+            .where(*conditions)
             .group_by(Memory.context_id)
         )
         now = utcnow()
@@ -311,16 +411,24 @@ class MemoryHealthService:
             backlogs[context_id] = {"count": int(count or 0), "oldest_days": oldest_days}
         return backlogs
 
-    async def _fetch_graph_stats(self, user_id: str) -> dict[uuid.UUID | None, dict[str, Any]]:
+    async def _fetch_graph_stats(
+        self, user_id: str, scope: Any = _ALL
+    ) -> dict[uuid.UUID | None, dict[str, Any]]:
         """Edge composition, weight-invariant violations and density, per
         context. Edges always carry a context; active memories may not."""
+        edge_conditions = [NeuralMemoryEdge.user_id == user_id]
+        memory_conditions = [Memory.user_id == user_id, Memory.deleted_at.is_(None)]
+        if scope is not _ALL:
+            edge_conditions.append(NeuralMemoryEdge.context_id == scope)
+            memory_conditions.append(Memory.context_id == scope)
+
         origin_rows = await self.db.execute(
             select(
                 NeuralMemoryEdge.context_id,
                 NeuralMemoryEdge.origin,
                 func.count(NeuralMemoryEdge.id),
             )
-            .where(NeuralMemoryEdge.user_id == user_id)
+            .where(*edge_conditions)
             .group_by(NeuralMemoryEdge.context_id, NeuralMemoryEdge.origin)
         )
         edges_by_scope: dict[uuid.UUID | None, dict[str, int]] = defaultdict(dict)
@@ -330,7 +438,7 @@ class MemoryHealthService:
         violation_rows = await self.db.execute(
             select(NeuralMemoryEdge.context_id, func.count(NeuralMemoryEdge.id))
             .where(
-                NeuralMemoryEdge.user_id == user_id,
+                *edge_conditions,
                 (NeuralMemoryEdge.weight < _EDGE_WEIGHT_MIN)
                 | (NeuralMemoryEdge.weight > _EDGE_WEIGHT_MAX),
             )
@@ -340,41 +448,54 @@ class MemoryHealthService:
 
         memory_rows = await self.db.execute(
             select(Memory.context_id, func.count(Memory.id))
-            .where(Memory.user_id == user_id, Memory.deleted_at.is_(None))
+            .where(*memory_conditions)
             .group_by(Memory.context_id)
         )
         memories = {cid: int(count or 0) for cid, count in memory_rows.all()}
 
         stats: dict[uuid.UUID | None, dict[str, Any]] = {}
-        for scope in set(edges_by_scope) | set(violations) | set(memories):
-            edges_by_origin = edges_by_scope.get(scope, {})
+        for key in set(edges_by_scope) | set(violations) | set(memories):
+            edges_by_origin = edges_by_scope.get(key, {})
             total_edges = sum(edges_by_origin.values())
-            active = memories.get(scope, 0)
-            stats[scope] = {
+            active = memories.get(key, 0)
+            stats[key] = {
                 "edges_by_origin": edges_by_origin,
                 "total_edges": total_edges,
-                "weight_violations": violations.get(scope, 0),
+                "weight_violations": violations.get(key, 0),
                 "active_memories": active,
                 "edges_per_memory": round(total_edges / active, 4) if active else 0.0,
             }
         return stats
 
-    async def _fetch_usage_counts(self, user_id: str) -> dict[uuid.UUID | None, dict[str, int]]:
-        """MCP tool call counts per context over the usage window."""
+    async def _fetch_usage_counts(
+        self, user_id: str, scope: Any = _ALL
+    ) -> dict[uuid.UUID | None, dict[str, int]]:
+        """MCP tool call counts per context over the usage window.
+
+        Attribution caveat: a cross-context recall(context_ids=[...]) is
+        logged under the FIRST listed context, so read activity on the other
+        listed contexts is invisible here. A write_only_store WARN on a
+        context that is only read via cross-context recall is a known false
+        positive until usage logging attributes all listed contexts
+        (documented in docs/ops/memory-health-report.md).
+        """
         since = utcnow() - timedelta(days=_USAGE_WINDOW_DAYS)
+        conditions = [
+            UsageStats.user_id == user_id,
+            UsageStats.created_at >= since,
+            UsageStats.endpoint.in_(
+                ["mcp:recall", "mcp:recall_upcoming", "mcp:remember", "mcp:explore"]
+            ),
+        ]
+        if scope is not _ALL:
+            conditions.append(UsageStats.context_id == scope)
         rows = await self.db.execute(
             select(
                 UsageStats.context_id,
                 UsageStats.endpoint,
                 func.count(UsageStats.id),
             )
-            .where(
-                UsageStats.user_id == user_id,
-                UsageStats.created_at >= since,
-                UsageStats.endpoint.in_(
-                    ["mcp:recall", "mcp:recall_upcoming", "mcp:remember", "mcp:explore"]
-                ),
-            )
+            .where(*conditions)
             .group_by(UsageStats.context_id, UsageStats.endpoint)
         )
         usage: dict[uuid.UUID | None, dict[str, int]] = defaultdict(dict)
@@ -382,8 +503,13 @@ class MemoryHealthService:
             usage[context_id][endpoint.removeprefix("mcp:")] = int(count)
         return dict(usage)
 
-    async def _fetch_config_postures(self, user_id: str) -> dict[uuid.UUID | None, dict[str, int]]:
-        """Search-config posture per owned context (0/1 flags per context)."""
+    async def _fetch_config_postures(
+        self, user_id: str, scope: Any = _ALL
+    ) -> dict[uuid.UUID | None, dict[str, bool]]:
+        """Search-config posture per owned context."""
+        conditions: list[Any] = list(self._owned_context_filter(user_id))
+        if scope is not _ALL:
+            conditions.append(ContextSearchConfig.context_id == scope)
         rows = await self.db.execute(
             select(
                 ContextSearchConfig.context_id,
@@ -391,14 +517,14 @@ class MemoryHealthService:
                 ContextSearchConfig.use_rerank,
             )
             .join(Context, Context.id == ContextSearchConfig.context_id)
-            .where(Context.created_by == user_id, Context.deleted_at.is_(None))
+            .where(*conditions)
         )
-        postures: dict[uuid.UUID | None, dict[str, int]] = {}
+        postures: dict[uuid.UUID | None, dict[str, bool]] = {}
         for context_id, reinforce_on, rerank_on in rows.all():
             postures[context_id] = {
-                "contexts_with_config": 1,
-                "reinforce_enabled": int(bool(reinforce_on)),
-                "use_rerank": int(bool(rerank_on)),
+                "has_config": True,
+                "reinforce_enabled": bool(reinforce_on),
+                "use_rerank": bool(rerank_on),
             }
         return postures
 
@@ -470,8 +596,12 @@ class MemoryHealthService:
         }
 
     @staticmethod
-    def _grade_graph(stats: dict[str, Any], *, cold_check: bool = True) -> dict[str, Any]:
-        """FAIL: weight invariant violated. WARN: suspiciously cold graph."""
+    def _grade_graph(stats: dict[str, Any], *, heuristics: bool = True) -> dict[str, Any]:
+        """FAIL: weight invariant violated. WARN: suspiciously cold graph.
+
+        ``heuristics=False`` (the unattributed bucket) skips the cold-graph
+        check but never the deterministic invariant.
+        """
         notes: list[dict[str, Any]] = []
         status = STATUS_OK
 
@@ -487,7 +617,7 @@ class MemoryHealthService:
                 )
             )
         elif (
-            cold_check
+            heuristics
             and stats["total_edges"] == 0
             and stats["active_memories"] >= _COLD_GRAPH_MIN_MEMORIES
         ):
@@ -500,18 +630,22 @@ class MemoryHealthService:
     @staticmethod
     def _grade_retrieval(
         usage: dict[str, int],
-        posture: dict[str, int],
+        posture: dict[str, bool],
         *,
         active_memories: int,
-        write_only_check: bool = True,
+        heuristics: bool = True,
     ) -> dict[str, Any]:
-        """Informational; WARN only when memory exists but nothing reads it."""
+        """Informational; WARN only when memory exists but nothing reads it.
+
+        ``heuristics=False`` (the unattributed bucket) skips the write-only
+        check — the bucket mixes scopes, so read/write ratios are noise.
+        """
         notes: list[dict[str, Any]] = []
         status = STATUS_OK
         recalls = usage.get("recall", 0)
         recall_upcoming = usage.get("recall_upcoming", 0)
 
-        if write_only_check and recalls + recall_upcoming == 0 and active_memories > 0:
+        if heuristics and recalls + recall_upcoming == 0 and active_memories > 0:
             status = STATUS_WARN
             notes.append(
                 _note(

--- a/backend/tests/api/test_admin_memory_health.py
+++ b/backend/tests/api/test_admin_memory_health.py
@@ -1,10 +1,13 @@
-"""Route-level tests for GET /api/v1/admin/memory-health (#1211).
+"""Route-level tests for GET /api/v1/admin/memory-health (#1211, #1225).
 
-Covers the admin gate (403 for non-admin), the 200 response shape through
-FastAPI serialization (MemoryHealthResponse(**report) — the dict-to-model
-boundary the service unit tests can't see), and the HEALTH-001 guard.
+Covers the admin gate (403 for non-admin), the two 200 response shapes
+through FastAPI serialization (breakdown vs ?context_id detail — the
+dict-to-model boundary the service unit tests can't see), the uniform 404
+for un-owned contexts, the 'unattributed' sentinel, the 422 for malformed
+scopes, and the HEALTH-001 guard.
 """
 
+import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -14,14 +17,37 @@ from api.main import app
 from auth.dependencies import get_current_user, require_admin
 from db.base import get_db
 
-_CANNED_REPORT = {
-    "generated_at": "2026-07-08T00:00:00Z",
+_CTX = str(uuid.uuid4())
+
+_CANNED_BREAKDOWN = {
+    "generated_at": "2026-07-12T00:00:00Z",
+    "overall_status": "warn",
+    "contexts": [
+        {
+            "context_id": _CTX,
+            "name": "Context A",
+            "overall_status": "warn",
+            "sections": {"consolidation": "warn", "graph": "ok", "retrieval": "ok"},
+        },
+        {
+            "context_id": None,
+            "name": None,
+            "overall_status": "ok",
+            "sections": {"consolidation": "ok", "graph": "ok", "retrieval": "ok"},
+        },
+    ],
+}
+
+_CANNED_DETAIL = {
+    "generated_at": "2026-07-12T00:00:00Z",
+    "context_id": _CTX,
+    "context_name": "Context A",
     "overall_status": "warn",
     "sections": {
         "consolidation": {
             "status": "warn",
             "metrics": {"reports_in_window": 3, "llm_call_failures": 2},
-            "notes": ["judge failures in the window: 2"],
+            "notes": [{"code": "judge_failures", "params": {"count": 2, "degraded_runs": 1}}],
         },
         "graph": {"status": "ok", "metrics": {"total_edges": 5}, "notes": []},
         "retrieval": {"status": "ok", "metrics": {"recall_calls": 7}, "notes": []},
@@ -43,6 +69,14 @@ def client():
     app.dependency_overrides.clear()
 
 
+def _as_admin():
+    async def admin():
+        return _admin_user()
+
+    app.dependency_overrides[require_admin] = admin
+    app.dependency_overrides[get_db] = _mock_get_db
+
+
 class TestAdminMemoryHealthRoute:
     def test_non_admin_gets_403(self, client) -> None:
         async def member_user():
@@ -54,26 +88,74 @@ class TestAdminMemoryHealthRoute:
         resp = client.get("/api/v1/admin/memory-health")
         assert resp.status_code == 403
 
-    def test_admin_gets_200_report_shape(self, client) -> None:
-        async def admin():
-            return _admin_user()
-
-        app.dependency_overrides[require_admin] = admin
-        app.dependency_overrides[get_db] = _mock_get_db
-
+    def test_breakdown_shape_without_context_id(self, client) -> None:
+        _as_admin()
         with patch(
-            "api.routes.admin_memory_health.MemoryHealthService.build_report",
-            new=AsyncMock(return_value=_CANNED_REPORT),
+            "api.routes.admin_memory_health.MemoryHealthService.build_breakdown",
+            new=AsyncMock(return_value=_CANNED_BREAKDOWN),
         ):
             resp = client.get("/api/v1/admin/memory-health")
 
         assert resp.status_code == 200
         body = resp.json()
         assert body["overall_status"] == "warn"
-        assert body["generated_at"] == "2026-07-08T00:00:00Z"
+        assert len(body["contexts"]) == 2
+        assert body["contexts"][0]["context_id"] == _CTX
+        assert body["contexts"][0]["sections"] == {
+            "consolidation": "warn",
+            "graph": "ok",
+            "retrieval": "ok",
+        }
+        # The unattributed entry serializes with null identity fields.
+        assert body["contexts"][1]["context_id"] is None
+        assert body["contexts"][1]["name"] is None
+
+    def test_detail_shape_with_context_id(self, client) -> None:
+        _as_admin()
+        with patch(
+            "api.routes.admin_memory_health.MemoryHealthService.build_context_report",
+            new=AsyncMock(return_value=_CANNED_DETAIL),
+        ) as mocked:
+            resp = client.get(f"/api/v1/admin/memory-health?context_id={_CTX}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["context_id"] == _CTX
+        assert body["context_name"] == "Context A"
         assert set(body["sections"]) == {"consolidation", "graph", "retrieval"}
-        assert body["sections"]["consolidation"]["notes"] == ["judge failures in the window: 2"]
-        assert body["sections"]["graph"]["metrics"]["total_edges"] == 5
+        note = body["sections"]["consolidation"]["notes"][0]
+        assert note == {"code": "judge_failures", "params": {"count": 2, "degraded_runs": 1}}
+        # The route parses the query param into a UUID scope.
+        assert mocked.await_args.args[1] == uuid.UUID(_CTX)
+
+    def test_unattributed_sentinel_maps_to_null_scope(self, client) -> None:
+        _as_admin()
+        canned = {**_CANNED_DETAIL, "context_id": None, "context_name": None}
+        with patch(
+            "api.routes.admin_memory_health.MemoryHealthService.build_context_report",
+            new=AsyncMock(return_value=canned),
+        ) as mocked:
+            resp = client.get("/api/v1/admin/memory-health?context_id=unattributed")
+
+        assert resp.status_code == 200
+        assert resp.json()["context_id"] is None
+        assert mocked.await_args.args[1] is None
+
+    def test_unowned_context_gets_uniform_404(self, client) -> None:
+        _as_admin()
+        with patch(
+            "api.routes.admin_memory_health.MemoryHealthService.build_context_report",
+            new=AsyncMock(return_value=None),
+        ):
+            resp = client.get(f"/api/v1/admin/memory-health?context_id={uuid.uuid4()}")
+
+        assert resp.status_code == 404
+        assert "Context not found" in resp.text
+
+    def test_malformed_context_id_gets_422(self, client) -> None:
+        _as_admin()
+        resp = client.get("/api/v1/admin/memory-health?context_id=not-a-uuid")
+        assert resp.status_code == 422
 
     def test_missing_user_id_yields_health_001(self, client) -> None:
         async def admin_without_id():

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -195,52 +195,46 @@ class TestGraphGrading:
         always look cold — the heuristic is skipped there, never a false WARN."""
         section = MemoryHealthService._grade_graph(
             _healthy_graph(total_edges=0, edges_by_origin={}, active_memories=100),
-            cold_check=False,
+            heuristics=False,
         )
         assert section["status"] == STATUS_OK
 
-    def test_weight_violation_still_fails_without_cold_check(self) -> None:
-        """Disabling the heuristic must not disable the invariant."""
+    def test_weight_violation_still_fails_without_heuristics(self) -> None:
+        """Disabling the heuristics must not disable the invariant."""
         section = MemoryHealthService._grade_graph(
-            _healthy_graph(weight_violations=1), cold_check=False
+            _healthy_graph(weight_violations=1), heuristics=False
         )
         assert section["status"] == STATUS_FAIL
+
+
+_POSTURE_ON = {"has_config": True, "reinforce_enabled": True, "use_rerank": False}
+_POSTURE_OFF = {"has_config": False, "reinforce_enabled": False, "use_rerank": False}
 
 
 class TestRetrievalGrading:
     def test_active_usage_is_ok(self) -> None:
         section = MemoryHealthService._grade_retrieval(
-            {"recall": 42, "remember": 10},
-            {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
-            active_memories=100,
+            {"recall": 42, "remember": 10}, _POSTURE_ON, active_memories=100
         )
         assert section["status"] == STATUS_OK
         assert section["metrics"]["recall_calls"] == 42
+        assert section["metrics"]["has_config"] is True
 
     def test_write_only_store_warns(self) -> None:
         section = MemoryHealthService._grade_retrieval(
-            {"remember": 5},
-            {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
-            active_memories=50,
+            {"remember": 5}, _POSTURE_ON, active_memories=50
         )
         assert section["status"] == STATUS_WARN
         note = next(n for n in section["notes"] if n["code"] == "write_only_store")
         assert note["params"]["active_memories"] == 50
 
     def test_empty_store_is_ok(self) -> None:
-        section = MemoryHealthService._grade_retrieval(
-            {},
-            {"contexts_with_config": 0, "reinforce_enabled": 0, "use_rerank": 0},
-            active_memories=0,
-        )
+        section = MemoryHealthService._grade_retrieval({}, _POSTURE_OFF, active_memories=0)
         assert section["status"] == STATUS_OK
 
     def test_write_only_check_disabled_for_unattributed_scope(self) -> None:
         section = MemoryHealthService._grade_retrieval(
-            {"remember": 5},
-            {"contexts_with_config": 0, "reinforce_enabled": 0, "use_rerank": 0},
-            active_memories=50,
-            write_only_check=False,
+            {"remember": 5}, _POSTURE_OFF, active_memories=50, heuristics=False
         )
         assert section["status"] == STATUS_OK
 
@@ -256,10 +250,7 @@ class TestScopeIsolation:
                 _CTX_B: _healthy_graph(),
             },
             usage={_CTX_A: {"recall": 1}, _CTX_B: {"recall": 9}},
-            postures={
-                _CTX_A: {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
-                _CTX_B: {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
-            },
+            postures={_CTX_A: dict(_POSTURE_ON), _CTX_B: dict(_POSTURE_ON)},
         )
 
     def test_warn_in_context_a_does_not_change_context_b(self) -> None:
@@ -410,9 +401,10 @@ class TestBuildBreakdown:
 class TestBuildContextReport:
     @pytest.mark.asyncio
     async def test_unowned_context_returns_none(self) -> None:
+        """Ownership is a single-row lookup — un-owned (or soft-deleted, or
+        unknown) resolves to None and the route maps that to a uniform 404."""
         svc = MemoryHealthService(AsyncMock())
-        p1, p2 = _patched(svc, contexts=[(_CTX_A, "A")], signals=_signals())
-        with p1, p2:
+        with patch.object(svc, "_resolve_owned_context", new=AsyncMock(return_value=None)):
             report = await svc.build_context_report("admin-user", _CTX_B)
         assert report is None
 
@@ -424,8 +416,10 @@ class TestBuildContextReport:
             graphs={_CTX_A: _healthy_graph()},
             usage={_CTX_A: {"recall": 2}},
         )
-        p1, p2 = _patched(svc, contexts=[(_CTX_A, "Context A")], signals=signals)
-        with p1, p2:
+        with (
+            patch.object(svc, "_resolve_owned_context", new=AsyncMock(return_value="Context A")),
+            patch.object(svc, "_fetch_signals", new=AsyncMock(return_value=signals)) as fetched,
+        ):
             report = await svc.build_context_report("admin-user", _CTX_A)
 
         assert report is not None
@@ -434,6 +428,8 @@ class TestBuildContextReport:
         assert report["overall_status"] == STATUS_FAIL
         assert set(report["sections"]) == {"consolidation", "graph", "retrieval"}
         assert report["sections"]["consolidation"]["notes"][0]["code"] == "latest_sleep_failed"
+        # The detail path narrows every fetch to the one scope.
+        assert fetched.await_args.kwargs.get("scope") == _CTX_A
 
     @pytest.mark.asyncio
     async def test_unattributed_scope_needs_no_ownership(self) -> None:
@@ -446,3 +442,64 @@ class TestBuildContextReport:
         assert report["context_id"] is None
         assert report["context_name"] is None
         assert report["overall_status"] == STATUS_OK
+
+
+class TestFoldOrphanScopes:
+    """Signals under a non-owned scope (soft-deleted context, shared context
+    created by another member) fold into the unattributed bucket — never
+    silently dropped (dropping would hide a Phase-1 WARN/FAIL)."""
+
+    def test_orphan_windows_and_graphs_fold_into_unattributed(self) -> None:
+        orphan = uuid.uuid4()
+        signals = _signals(
+            windows={orphan: [_report(status="failed")]},
+            graphs={orphan: _healthy_graph(weight_violations=2)},
+            usage={orphan: {"recall": 3}},
+            backlogs={orphan: {"count": 5, "oldest_days": 120}},
+        )
+
+        folded = MemoryHealthService._fold_orphan_scopes(signals, owned_ids={_CTX_A})
+
+        assert orphan not in folded["windows"]
+        assert folded["windows"][None][0]["status"] == "failed"
+        assert folded["graphs"][None]["weight_violations"] == 2
+        assert folded["usage"][None] == {"recall": 3}
+        assert folded["backlogs"][None] == {"count": 5, "oldest_days": 120}
+
+    def test_orphans_merge_with_existing_null_bucket(self) -> None:
+        orphan = uuid.uuid4()
+        signals = _signals(
+            backlogs={
+                None: {"count": 1, "oldest_days": 30},
+                orphan: {"count": 2, "oldest_days": 200},
+            },
+            usage={None: {"recall": 1}, orphan: {"recall": 2, "remember": 4}},
+        )
+
+        folded = MemoryHealthService._fold_orphan_scopes(signals, owned_ids=set())
+
+        assert folded["backlogs"][None] == {"count": 3, "oldest_days": 200}
+        assert folded["usage"][None] == {"recall": 3, "remember": 4}
+
+    def test_owned_scopes_are_untouched(self) -> None:
+        signals = _signals(windows={_CTX_A: [_report()]}, usage={_CTX_A: {"recall": 1}})
+
+        folded = MemoryHealthService._fold_orphan_scopes(signals, owned_ids={_CTX_A})
+
+        assert set(folded["windows"]) == {_CTX_A}
+        assert set(folded["usage"]) == {_CTX_A}
+
+    @pytest.mark.asyncio
+    async def test_orphan_fail_surfaces_as_unattributed_breakdown_entry(self) -> None:
+        """The end-to-end guarantee: a deterministic FAIL living in a
+        non-owned scope must flip the page-level overall, not vanish."""
+        svc = MemoryHealthService(AsyncMock())
+        orphan = uuid.uuid4()
+        signals = _signals(graphs={orphan: _healthy_graph(weight_violations=1)})
+        p1, p2 = _patched(svc, contexts=[(_CTX_A, "A")], signals=signals)
+        with p1, p2:
+            breakdown = await svc.build_breakdown("admin-user")
+
+        assert breakdown["overall_status"] == STATUS_FAIL
+        unattributed = next(e for e in breakdown["contexts"] if e["context_id"] is None)
+        assert unattributed["sections"]["graph"] == STATUS_FAIL

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -1,12 +1,16 @@
-"""#1211: consolidated memory-health report grading.
+"""#1211/#1225: per-context memory-health report grading.
 
-Pins the acceptance contract: a simulated judge death flips the
+Pins the acceptance contracts: a simulated judge death flips the
 consolidation section to warn/fail (the #1177 class of plausible success can
 no longer hide), the graph weight invariant fails deterministically (#1197
-class), and healthy inputs grade ok. FAIL fires only on deterministic facts;
-degradation signals produce WARN (a false FAIL erodes dashboard trust).
+class), healthy inputs grade ok, and — Phase 2 (#1225) — grading is
+context-isolated (a WARN-producing signal in context A must not change
+context B's grade), context-less signals surface as an explicit
+unattributed entry instead of being dropped, and notes are structured
+``{code, params}`` records with no issue IDs in the payload.
 """
 
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -18,6 +22,9 @@ from services.memory_health_service import (
     STATUS_WARN,
     MemoryHealthService,
 )
+
+_CTX_A = uuid.uuid4()
+_CTX_B = uuid.uuid4()
 
 
 def _report(status="completed", failures=0, overrides=0, deferred=0):
@@ -44,6 +51,23 @@ def _healthy_graph(**over):
     return stats
 
 
+def _codes(section) -> list[str]:
+    return [n["code"] for n in section["notes"]]
+
+
+def _signals(**over):
+    """A healthy signal-map fixture; override per test."""
+    base = {
+        "windows": {},
+        "backlogs": {},
+        "graphs": {},
+        "usage": {},
+        "postures": {},
+    }
+    base.update(over)
+    return base
+
+
 class TestConsolidationGrading:
     def test_healthy_window_is_ok(self) -> None:
         section = MemoryHealthService._grade_consolidation(
@@ -53,13 +77,13 @@ class TestConsolidationGrading:
         assert section["notes"] == []
 
     def test_latest_failed_run_is_fail(self) -> None:
-        """Total judge death (#1177 class) must be a hard FAIL."""
+        """Total judge death (the #1177 class) must be a hard FAIL."""
         section = MemoryHealthService._grade_consolidation(
             [_report(status="failed", failures=5), _report()],
             {"count": 0, "oldest_days": None},
         )
         assert section["status"] == STATUS_FAIL
-        assert any("#1177" in n for n in section["notes"])
+        assert "latest_sleep_failed" in _codes(section)
 
     def test_degraded_run_in_window_is_warn(self) -> None:
         section = MemoryHealthService._grade_consolidation(
@@ -88,7 +112,7 @@ class TestConsolidationGrading:
             {"count": 0, "oldest_days": None},
         )
         assert section["status"] == STATUS_WARN
-        assert any("failed sleep run" in n for n in section["notes"])
+        assert "failed_runs_recovered" in _codes(section)
 
     def test_backlog_at_threshold_is_ok_just_over_warns(self) -> None:
         """The 90-day backlog threshold is strict (>): 90d ok, 91d warn."""
@@ -104,30 +128,41 @@ class TestConsolidationGrading:
             [_report(deferred=12)], {"count": 0, "oldest_days": None}
         )
         assert section["status"] == STATUS_WARN
-        assert any("#1184" in n for n in section["notes"])
+        assert "deferred_pairs" in _codes(section)
+        note = next(n for n in section["notes"] if n["code"] == "deferred_pairs")
+        assert note["params"] == {"count": 12}
 
     def test_deferred_note_survives_coexisting_warn(self) -> None:
         """Every non-ok contribution gets a note — a judge-failure WARN must
-        not swallow the orthogonal deferred-pairs (#1184) explanation."""
+        not swallow the orthogonal deferred-pairs explanation (#1184 class)."""
         section = MemoryHealthService._grade_consolidation(
             [_report(status="degraded", failures=2, deferred=12)],
             {"count": 0, "oldest_days": None},
         )
         assert section["status"] == STATUS_WARN
-        assert any("#1183" in n for n in section["notes"])
-        assert any("#1184" in n for n in section["notes"])
+        assert "judge_failures" in _codes(section)
+        assert "deferred_pairs" in _codes(section)
 
-    def test_old_merge_backlog_warns_and_names_retention(self) -> None:
+    def test_old_merge_backlog_warns_with_threshold_params(self) -> None:
         section = MemoryHealthService._grade_consolidation(
             [_report()], {"count": 500, "oldest_days": 120}
         )
         assert section["status"] == STATUS_WARN
-        assert any("sleep_merge_retention_days" in n for n in section["notes"])
+        note = next(n for n in section["notes"] if n["code"] == "merge_backlog_old")
+        assert note["params"] == {"oldest_days": 120, "threshold_days": 90}
 
     def test_empty_window_is_ok(self) -> None:
         """No sleep runs yet is not a failure — sleep is opt-in (#558)."""
         section = MemoryHealthService._grade_consolidation([], {"count": 0, "oldest_days": None})
         assert section["status"] == STATUS_OK
+
+    def test_no_issue_ids_in_notes(self) -> None:
+        """#1225 Scope 3: issue references never leak into the payload."""
+        section = MemoryHealthService._grade_consolidation(
+            [_report(status="failed", failures=5), _report(deferred=3)],
+            {"count": 10, "oldest_days": 200},
+        )
+        assert "#" not in str(section["notes"])
 
 
 class TestGraphGrading:
@@ -139,13 +174,15 @@ class TestGraphGrading:
         class — a deterministic invariant violation, hard FAIL."""
         section = MemoryHealthService._grade_graph(_healthy_graph(weight_violations=3))
         assert section["status"] == STATUS_FAIL
-        assert any("#1197" in n for n in section["notes"])
+        note = next(n for n in section["notes"] if n["code"] == "edge_weight_violations")
+        assert note["params"]["count"] == 3
 
     def test_cold_graph_with_many_memories_warns(self) -> None:
         section = MemoryHealthService._grade_graph(
             _healthy_graph(total_edges=0, edges_by_origin={}, active_memories=100)
         )
         assert section["status"] == STATUS_WARN
+        assert "cold_graph" in _codes(section)
 
     def test_small_cold_store_is_ok(self) -> None:
         section = MemoryHealthService._grade_graph(
@@ -153,12 +190,28 @@ class TestGraphGrading:
         )
         assert section["status"] == STATUS_OK
 
+    def test_cold_check_disabled_for_unattributed_scope(self) -> None:
+        """Edges always carry a context, so the unattributed bucket would
+        always look cold — the heuristic is skipped there, never a false WARN."""
+        section = MemoryHealthService._grade_graph(
+            _healthy_graph(total_edges=0, edges_by_origin={}, active_memories=100),
+            cold_check=False,
+        )
+        assert section["status"] == STATUS_OK
+
+    def test_weight_violation_still_fails_without_cold_check(self) -> None:
+        """Disabling the heuristic must not disable the invariant."""
+        section = MemoryHealthService._grade_graph(
+            _healthy_graph(weight_violations=1), cold_check=False
+        )
+        assert section["status"] == STATUS_FAIL
+
 
 class TestRetrievalGrading:
     def test_active_usage_is_ok(self) -> None:
         section = MemoryHealthService._grade_retrieval(
             {"recall": 42, "remember": 10},
-            {"contexts_with_config": 3, "reinforce_enabled": 2, "use_rerank": 0},
+            {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
             active_memories=100,
         )
         assert section["status"] == STATUS_OK
@@ -171,6 +224,8 @@ class TestRetrievalGrading:
             active_memories=50,
         )
         assert section["status"] == STATUS_WARN
+        note = next(n for n in section["notes"] if n["code"] == "write_only_store")
+        assert note["params"]["active_memories"] == 50
 
     def test_empty_store_is_ok(self) -> None:
         section = MemoryHealthService._grade_retrieval(
@@ -180,6 +235,59 @@ class TestRetrievalGrading:
         )
         assert section["status"] == STATUS_OK
 
+    def test_write_only_check_disabled_for_unattributed_scope(self) -> None:
+        section = MemoryHealthService._grade_retrieval(
+            {"remember": 5},
+            {"contexts_with_config": 0, "reinforce_enabled": 0, "use_rerank": 0},
+            active_memories=50,
+            write_only_check=False,
+        )
+        assert section["status"] == STATUS_OK
+
+
+class TestScopeIsolation:
+    """The #1225 isolation contract: grading reads ONLY the scope's slice."""
+
+    def _warn_signals_for_a(self):
+        return _signals(
+            windows={_CTX_A: [_report(status="degraded", failures=3)]},
+            graphs={
+                _CTX_A: _healthy_graph(weight_violations=2),
+                _CTX_B: _healthy_graph(),
+            },
+            usage={_CTX_A: {"recall": 1}, _CTX_B: {"recall": 9}},
+            postures={
+                _CTX_A: {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
+                _CTX_B: {"contexts_with_config": 1, "reinforce_enabled": 1, "use_rerank": 0},
+            },
+        )
+
+    def test_warn_in_context_a_does_not_change_context_b(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        signals = self._warn_signals_for_a()
+
+        sections_a = svc._grade_scope(signals, _CTX_A)
+        sections_b = svc._grade_scope(signals, _CTX_B)
+
+        assert sections_a["consolidation"]["status"] == STATUS_WARN
+        assert sections_a["graph"]["status"] == STATUS_FAIL
+        for section in sections_b.values():
+            assert section["status"] == STATUS_OK
+
+    def test_unattributed_scope_skips_heuristics_but_grades_sleep(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        signals = _signals(
+            windows={None: [_report(status="failed")]},
+            graphs={None: _healthy_graph(total_edges=0, edges_by_origin={}, active_memories=99)},
+            usage={},
+        )
+
+        sections = svc._grade_scope(signals, None)
+
+        assert sections["consolidation"]["status"] == STATUS_FAIL
+        assert sections["graph"]["status"] == STATUS_OK  # cold-check skipped
+        assert sections["retrieval"]["status"] == STATUS_OK  # write-only skipped
+
 
 class TestFetchSleepWindowDefaults:
     @pytest.mark.asyncio
@@ -187,6 +295,7 @@ class TestFetchSleepWindowDefaults:
         """Reports written before #1198/#1184 added the detail keys (or with
         dedup_result=None) must flatten to zeros, not raise."""
         legacy_none = SimpleNamespace(
+            context_id=_CTX_A,
             status="completed",
             llm_call_failures=None,
             memories_merged=None,
@@ -194,6 +303,7 @@ class TestFetchSleepWindowDefaults:
             started_at=None,
         )
         legacy_no_details = SimpleNamespace(
+            context_id=_CTX_A,
             status="completed",
             llm_call_failures=0,
             memories_merged=1,
@@ -201,55 +311,138 @@ class TestFetchSleepWindowDefaults:
             started_at=None,
         )
         result = MagicMock()
-        result.scalars.return_value.all.return_value = [legacy_none, legacy_no_details]
+        result.all.return_value = [legacy_none, legacy_no_details]
         db = AsyncMock()
         db.execute = AsyncMock(return_value=result)
 
-        window = await MemoryHealthService(db)._fetch_sleep_window("u1")
+        windows = await MemoryHealthService(db)._fetch_sleep_windows("u1")
 
-        assert len(window) == 2
-        for row in window:
+        assert set(windows) == {_CTX_A}
+        assert len(windows[_CTX_A]) == 2
+        for row in windows[_CTX_A]:
             assert row["llm_call_failures"] == 0
             assert row["winner_overrides"] == 0
             assert row["deferred_pairs"] == 0
             assert row["oversize_clusters"] == 0
 
-
-class TestBuildReport:
     @pytest.mark.asyncio
-    async def test_overall_is_worst_section(self) -> None:
-        """Judge death anywhere makes the OVERALL document non-ok — the
-        acceptance criterion: a broken judge flips health within one cycle."""
-        svc = MemoryHealthService(AsyncMock())
-        with (
-            patch.object(
-                svc,
-                "_fetch_sleep_window",
-                new=AsyncMock(return_value=[_report(status="failed", failures=5)]),
-            ),
-            patch.object(
-                svc,
-                "_fetch_merge_backlog",
-                new=AsyncMock(return_value={"count": 0, "oldest_days": None}),
-            ),
-            patch.object(svc, "_fetch_graph_stats", new=AsyncMock(return_value=_healthy_graph())),
-            patch.object(svc, "_fetch_usage_counts", new=AsyncMock(return_value={"recall": 1})),
-            patch.object(
-                svc,
-                "_fetch_config_posture",
-                new=AsyncMock(
-                    return_value={
-                        "contexts_with_config": 1,
-                        "reinforce_enabled": 1,
-                        "use_rerank": 0,
-                    }
-                ),
-            ),
-        ):
-            report = await svc.build_report("admin-user")
+    async def test_null_context_reports_group_under_none(self) -> None:
+        """Context-less sleep runs land in the unattributed bucket — never
+        dropped (dropping would hide a Phase-1 WARN behind the grouping)."""
+        row = SimpleNamespace(
+            context_id=None,
+            status="failed",
+            llm_call_failures=4,
+            memories_merged=0,
+            dedup_result=None,
+            started_at=None,
+        )
+        result = MagicMock()
+        result.all.return_value = [row]
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=result)
 
+        windows = await MemoryHealthService(db)._fetch_sleep_windows("u1")
+
+        assert set(windows) == {None}
+        assert windows[None][0]["status"] == "failed"
+
+
+def _patched(svc: MemoryHealthService, *, contexts, signals):
+    return (
+        patch.object(svc, "_fetch_owned_contexts", new=AsyncMock(return_value=contexts)),
+        patch.object(svc, "_fetch_signals", new=AsyncMock(return_value=signals)),
+    )
+
+
+class TestBuildBreakdown:
+    @pytest.mark.asyncio
+    async def test_one_entry_per_context_and_overall_is_worst(self) -> None:
+        """Judge death in ONE context makes the page-level overall non-ok
+        AND names the context it came from — the #1225 acceptance criterion."""
+        svc = MemoryHealthService(AsyncMock())
+        signals = _signals(
+            windows={_CTX_A: [_report(status="failed", failures=5)]},
+            graphs={_CTX_A: _healthy_graph(), _CTX_B: _healthy_graph()},
+            usage={_CTX_A: {"recall": 1}, _CTX_B: {"recall": 1}},
+        )
+        p1, p2 = _patched(
+            svc, contexts=[(_CTX_A, "Context A"), (_CTX_B, "Context B")], signals=signals
+        )
+        with p1, p2:
+            breakdown = await svc.build_breakdown("admin-user")
+
+        assert breakdown["overall_status"] == STATUS_FAIL
+        by_id = {e["context_id"]: e for e in breakdown["contexts"]}
+        assert set(by_id) == {str(_CTX_A), str(_CTX_B)}
+        assert by_id[str(_CTX_A)]["overall_status"] == STATUS_FAIL
+        assert by_id[str(_CTX_A)]["name"] == "Context A"
+        assert by_id[str(_CTX_A)]["sections"]["consolidation"] == STATUS_FAIL
+        assert by_id[str(_CTX_B)]["overall_status"] == STATUS_OK
+
+    @pytest.mark.asyncio
+    async def test_zero_context_user_is_ok_with_empty_breakdown(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        p1, p2 = _patched(svc, contexts=[], signals=_signals())
+        with p1, p2:
+            breakdown = await svc.build_breakdown("admin-user")
+
+        assert breakdown["overall_status"] == STATUS_OK
+        assert breakdown["contexts"] == []
+        assert breakdown["generated_at"]
+
+    @pytest.mark.asyncio
+    async def test_unattributed_entry_appears_only_when_signals_exist(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        with_null = _signals(windows={None: [_report()]})
+        p1, p2 = _patched(svc, contexts=[(_CTX_A, "A")], signals=with_null)
+        with p1, p2:
+            breakdown = await svc.build_breakdown("admin-user")
+        ids = [e["context_id"] for e in breakdown["contexts"]]
+        assert ids == [str(_CTX_A), None]
+
+        p1, p2 = _patched(svc, contexts=[(_CTX_A, "A")], signals=_signals())
+        with p1, p2:
+            breakdown = await svc.build_breakdown("admin-user")
+        assert [e["context_id"] for e in breakdown["contexts"]] == [str(_CTX_A)]
+
+
+class TestBuildContextReport:
+    @pytest.mark.asyncio
+    async def test_unowned_context_returns_none(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        p1, p2 = _patched(svc, contexts=[(_CTX_A, "A")], signals=_signals())
+        with p1, p2:
+            report = await svc.build_context_report("admin-user", _CTX_B)
+        assert report is None
+
+    @pytest.mark.asyncio
+    async def test_owned_context_returns_scoped_document(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        signals = _signals(
+            windows={_CTX_A: [_report(status="failed")]},
+            graphs={_CTX_A: _healthy_graph()},
+            usage={_CTX_A: {"recall": 2}},
+        )
+        p1, p2 = _patched(svc, contexts=[(_CTX_A, "Context A")], signals=signals)
+        with p1, p2:
+            report = await svc.build_context_report("admin-user", _CTX_A)
+
+        assert report is not None
+        assert report["context_id"] == str(_CTX_A)
+        assert report["context_name"] == "Context A"
         assert report["overall_status"] == STATUS_FAIL
-        assert report["sections"]["consolidation"]["status"] == STATUS_FAIL
-        assert report["sections"]["graph"]["status"] == STATUS_OK
         assert set(report["sections"]) == {"consolidation", "graph", "retrieval"}
-        assert report["generated_at"]
+        assert report["sections"]["consolidation"]["notes"][0]["code"] == "latest_sleep_failed"
+
+    @pytest.mark.asyncio
+    async def test_unattributed_scope_needs_no_ownership(self) -> None:
+        svc = MemoryHealthService(AsyncMock())
+        p1, p2 = _patched(svc, contexts=[], signals=_signals())
+        with p1, p2:
+            report = await svc.build_context_report("admin-user", None)
+
+        assert report is not None
+        assert report["context_id"] is None
+        assert report["context_name"] is None
+        assert report["overall_status"] == STATUS_OK

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -938,7 +938,8 @@ See [Sleep Maintenance](sleep-maintenance.md) for the full Sleep cycle design, `
 
 | Endpoint                          | Purpose                                                       |
 |-----------------------------------|---------------------------------------------------------------|
-| `GET /api/v1/admin/memory-health` | Consolidated self-diagnosis report — consolidation / graph / retrieval sections graded `ok`/`warn`/`fail` from Sleep telemetry, graph invariants, and usage stats. Self-scoped (the calling admin's data partition). |
+| `GET /api/v1/admin/memory-health` | Per-context self-diagnosis breakdown — one graded entry per owned context (consolidation / graph / retrieval statuses, `ok`/`warn`/`fail`) from Sleep telemetry, graph invariants, and usage stats. Self-scoped (the calling admin's data partition). |
+| `GET /api/v1/admin/memory-health?context_id=<uuid>` | The 3-section detail document for one owned context (un-owned → 404). `context_id=unattributed` targets signals recorded without a context. |
 
 See [Memory Health Report](ops/memory-health-report.md) for every metric and threshold.
 

--- a/docs/ops/memory-health-report.md
+++ b/docs/ops/memory-health-report.md
@@ -1,18 +1,40 @@
-# Memory Health Report (#1211)
+# Memory Health Report (#1211, #1225)
 
 `GET /api/v1/admin/memory-health` assembles the signals the system already
 emits — Sleep reports, graph invariants, usage stats, search-config posture —
-into one thresholded self-diagnosis document. The motivating failure class:
+into thresholded self-diagnosis documents. The motivating failure class:
 memory bugs that manifest as *plausible successes* (`sleep_summary.ok=true`
 while every judge call failed, #1177). Each section grades `ok | warn | fail`;
-`overall_status` is the worst section.
+each document's `overall_status` is the worst section.
 
-Scope (Phase 1): self-scoped — the report covers the calling admin's own data
-partition, same discipline as the manual sleep trigger. Label-free signals
-only; gold-label rates (`stale_only`, P@k) belong to the eval CI gates
+Scoping (#1225, Phase 2): the report is broken down **per context**, so a
+warning always names the context it came from.
+
+- `GET /api/v1/admin/memory-health` — the breakdown: one graded entry per
+  owned context (`context_id`, display name, `overall_status`, per-section
+  statuses). No metric is summed across contexts; the page-level
+  `overall_status` is the worst entry. A user with zero contexts gets `ok`
+  with an empty list.
+- `GET /api/v1/admin/memory-health?context_id=<uuid>` — the 3-section
+  detailed document for that single context. Ownership is validated
+  (`created_by` = caller, not deleted); anything else is a uniform 404.
+- `GET /api/v1/admin/memory-health?context_id=unattributed` — the detail
+  document for signals recorded **without** a context (account-wide sleep
+  runs, cross-context recalls, legacy rows). These surface as an explicit
+  "unattributed" breakdown entry instead of being silently dropped —
+  dropping them would hide Phase-1 warnings behind the new grouping. The
+  unattributed entry skips the cold-graph and write-only heuristics (edges
+  always carry a context, and cross-context recalls land here, so both
+  would be noise) while still grading real facts like failed sleep runs.
+
+Everything stays self-scoped (the calling admin's own data partition, same
+discipline as the manual sleep trigger). Workspace-level rollup across
+members is deliberately Phase 3. Label-free signals only; gold-label rates
+(`stale_only`, P@k) belong to the eval CI gates
 ([eval README](../../backend/tests/eval/README.md), #1210).
 
-Web UI: **Admin → Memory Health** renders the same document.
+Web UI: **Admin → Memory Health** renders the breakdown as a status list
+with drill-down into the per-context detail.
 
 ## Grading philosophy
 
@@ -21,20 +43,24 @@ Web UI: **Admin → Memory Health** renders the same document.
 - **WARN** covers degradation signals worth a look but not proof of breakage.
 - Signals that exist only in logs (e.g. `reinforce_rerank_applied`) are
   excluded until persisted — never rendered as "pending".
+- **Isolation contract** (#1225): grading reads only the target context's
+  rows — a WARN-producing signal in context A cannot change context B's
+  grade (pinned by tests).
 
 ## Sections, metrics, thresholds
 
 ### consolidation
 
-Window: the 20 most recent Sleep reports for the user.
+Window: the 20 most recent Sleep reports **per context**.
 
-| Condition | Grade | Rationale |
-|---|---|---|
-| Latest sleep run `status=failed` | **fail** | Total judge death — the #1177 class. |
-| Any `llm_call_failures > 0` or `degraded` run in the window | warn | Partial judge death grades `degraded`, never a silent `completed` (#1183). |
-| `deferred_pairs > 0` in the window | warn | Cluster caps deferring candidate pairs unjudged — dedup may be structurally behind (#1184 class). |
-| Oldest `sleep_maintenance` soft-deleted merge loser > 90 days | warn | Backlog suggests a retention window is wanted (`sleep_merge_retention_days`, #1209). |
-| No sleep runs at all | ok | Sleep is opt-in (#558); absence is not failure. |
+| Condition | Grade | Note code | Rationale |
+|---|---|---|---|
+| Latest sleep run `status=failed` | **fail** | `latest_sleep_failed` | Total judge death — the #1177 class. |
+| Any `llm_call_failures > 0` or `degraded` run in the window | warn | `judge_failures` | Partial judge death grades `degraded`, never a silent `completed` (#1183). |
+| A `failed` run in the window with a recovered latest | warn | `failed_runs_recovered` | Recent instability is worth a look even after recovery. |
+| `deferred_pairs > 0` in the window | warn | `deferred_pairs` | Cluster caps deferring candidate pairs unjudged — dedup may be structurally behind (#1184 class). |
+| Oldest `sleep_maintenance` soft-deleted merge loser > 90 days | warn | `merge_backlog_old` | Backlog suggests a retention window is wanted (`sleep_merge_retention_days`, #1209). |
+| No sleep runs at all | ok | — | Sleep is opt-in (#558); absence is not failure. |
 
 Metrics: `reports_in_window`, `latest_status`, `llm_call_failures`,
 `degraded_runs`, `failed_runs`, `winner_overrides`, `deferred_pairs`,
@@ -42,25 +68,51 @@ Metrics: `reports_in_window`, `latest_status`, `llm_call_failures`,
 
 ### graph
 
-| Condition | Grade | Rationale |
-|---|---|---|
-| Any edge weight outside `[0.0, 3.0]` | **fail** | Deterministic invariant violation — the #1197 unclamped-accumulation class. |
-| Zero edges with ≥ 25 active memories | warn | The graph never warmed; check edge-formation gates / `sleep_mode`. |
+| Condition | Grade | Note code | Rationale |
+|---|---|---|---|
+| Any edge weight outside `[0.0, 3.0]` | **fail** | `edge_weight_violations` | Deterministic invariant violation — the #1197 unclamped-accumulation class. |
+| Zero edges with ≥ 25 active memories | warn | `cold_graph` | The graph never warmed; check edge-formation gates / `sleep_mode`. Skipped for the unattributed entry. |
 
 Metrics: `edges_by_origin` (hebbian / semantic / declared), `total_edges`,
 `weight_violations`, `active_memories`, `edges_per_memory`.
 
 ### retrieval
 
-Window: 7 days of `mcp:recall` / `mcp:remember` / `mcp:explore` usage.
+Window: 7 days of `mcp:recall` / `mcp:remember` / `mcp:explore` usage,
+attributed per context.
 
-| Condition | Grade | Rationale |
-|---|---|---|
-| Zero `recall()` calls with > 0 active memories | warn | The store is write-only — memory exists but nothing reads it. |
+| Condition | Grade | Note code | Rationale |
+|---|---|---|---|
+| Zero `recall()` calls with > 0 active memories | warn | `write_only_store` | The store is write-only — memory exists but nothing reads it. Skipped for the unattributed entry. |
 
-Metrics: `recall_calls`, `remember_calls`, `explore_calls`, `window_days`,
-plus config posture (`contexts_with_config`, `reinforce_enabled`,
-`use_rerank`).
+Metrics: `recall_calls`, `recall_upcoming_calls`, `remember_calls`,
+`explore_calls`, `window_days`, plus config posture
+(`contexts_with_config`, `reinforce_enabled`, `use_rerank` — 0/1 flags per
+context).
+
+## Structured notes (#1225)
+
+Section notes are structured records — `{"code": "<note_code>", "params":
+{...}}` — not prose. The frontend maps codes to localized strings
+(`en.json` / `ja.json` under `admin.memoryHealth.notes`) and interpolates
+the params; an unknown code renders a generic localized fallback (never a
+crash, never a blank). GitHub issue references never appear in the payload
+or the rendered UI — the note-code → design-rationale mapping in the tables
+above is the deep link for operators.
+
+| Note code | Params |
+|---|---|
+| `latest_sleep_failed` | — |
+| `judge_failures` | `count`, `degraded_runs` |
+| `failed_runs_recovered` | `count` |
+| `deferred_pairs` | `count` |
+| `merge_backlog_old` | `oldest_days`, `threshold_days` |
+| `edge_weight_violations` | `count`, `min`, `max` |
+| `cold_graph` | `active_memories` |
+| `write_only_store` | `window_days`, `active_memories` |
+
+Adding a note code is a three-place change: the service emits it, both
+message catalogs localize it, and the table above documents it.
 
 ## Relationship to the eval CI gates (#1210)
 

--- a/docs/ops/memory-health-report.md
+++ b/docs/ops/memory-health-report.md
@@ -19,13 +19,15 @@ warning always names the context it came from.
   detailed document for that single context. Ownership is validated
   (`created_by` = caller, not deleted); anything else is a uniform 404.
 - `GET /api/v1/admin/memory-health?context_id=unattributed` — the detail
-  document for signals recorded **without** a context (account-wide sleep
-  runs, cross-context recalls, legacy rows). These surface as an explicit
-  "unattributed" breakdown entry instead of being silently dropped —
-  dropping them would hide Phase-1 warnings behind the new grouping. The
-  unattributed entry skips the cold-graph and write-only heuristics (edges
-  always carry a context, and cross-context recalls land here, so both
-  would be noise) while still grading real facts like failed sleep runs.
+  document for signals that do not belong to an owned, live context:
+  recorded **without** a `context_id` (account-wide sleep runs, legacy
+  rows), or under a **soft-deleted** context, or under a **shared context
+  created by another member**. These fold into one explicit "unattributed"
+  breakdown entry instead of being silently dropped — dropping them would
+  hide Phase-1 warnings behind the new grouping. The unattributed entry
+  skips the cold-graph and write-only heuristics (it mixes scopes, so both
+  would be noise) while still grading deterministic facts like failed
+  sleep runs and edge-weight violations.
 
 Everything stays self-scoped (the calling admin's own data partition, same
 discipline as the manual sleep trigger). Workspace-level rollup across
@@ -51,7 +53,10 @@ with drill-down into the per-context detail.
 
 ### consolidation
 
-Window: the 20 most recent Sleep reports **per context**.
+Window: the 20 most recent Sleep reports **per context**, bounded to the
+last **180 days**. The recency bound keeps the window scan cheap as history
+grows and stops ancient failures in sparse contexts from resurfacing as
+eternal WARNs (the Phase-1 account-wide window had already aged them out).
 
 | Condition | Grade | Note code | Rationale |
 |---|---|---|---|
@@ -86,9 +91,14 @@ attributed per context.
 | Zero `recall()` calls with > 0 active memories | warn | `write_only_store` | The store is write-only — memory exists but nothing reads it. Skipped for the unattributed entry. |
 
 Metrics: `recall_calls`, `recall_upcoming_calls`, `remember_calls`,
-`explore_calls`, `window_days`, plus config posture
-(`contexts_with_config`, `reinforce_enabled`, `use_rerank` — 0/1 flags per
-context).
+`explore_calls`, `window_days`, plus config posture (`has_config`,
+`reinforce_enabled`, `use_rerank` — booleans per context).
+
+Attribution caveat: a cross-context `recall(context_ids=[...])` is logged
+under the **first** listed context only, so read activity on the other
+listed contexts is invisible to this section. A `write_only_store` WARN on
+a context that is only read via cross-context recall is a known false
+positive until usage logging attributes every listed context.
 
 ## Structured notes (#1225)
 

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.test.tsx
@@ -32,12 +32,18 @@ vi.mock("@/lib/api", async (importOriginal) => {
 });
 
 // Stable translator: `key` or `key:{json}` so param interpolation is visible.
-const stableTranslator = (key: string, values?: Record<string, unknown>) => {
-  if (values && Object.keys(values).length > 0) {
-    return `${key}:${JSON.stringify(values)}`;
-  }
-  return key;
-};
+// `.has` mirrors the real message catalog for the note codes under test —
+// the page treats the catalog as the single source of known codes.
+const CATALOG_NOTE_KEYS = new Set(["notes.judge_failures", "notes.unknown"]);
+const stableTranslator = Object.assign(
+  (key: string, values?: Record<string, unknown>) => {
+    if (values && Object.keys(values).length > 0) {
+      return `${key}:${JSON.stringify(values)}`;
+    }
+    return key;
+  },
+  { has: (key: string) => !key.startsWith("notes.") || CATALOG_NOTE_KEYS.has(key) },
+);
 
 vi.mock("next-intl", () => ({
   useTranslations: (_namespace: string) => stableTranslator,

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Tests for the Admin Memory Health page (#1225 Phase 2).
+ *
+ * Pins the per-context contract at the UI layer:
+ *   - the breakdown renders one row per entry, naming each context (the
+ *     unattributed bucket gets its localized label, never a blank)
+ *   - drill-down fetches ?context_id=<uuid> (or the 'unattributed'
+ *     sentinel) and renders the 3-section detail
+ *   - structured notes render via their message-catalog code with params
+ *     interpolated; unknown codes fall back to the generic message
+ *     (never crash, never blank)
+ *   - zero contexts renders the empty state, not an error
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import AdminMemoryHealthPage from "./page";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockGet = vi.fn();
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...original,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+    },
+  };
+});
+
+// Stable translator: `key` or `key:{json}` so param interpolation is visible.
+const stableTranslator = (key: string, values?: Record<string, unknown>) => {
+  if (values && Object.keys(values).length > 0) {
+    return `${key}:${JSON.stringify(values)}`;
+  }
+  return key;
+};
+
+vi.mock("next-intl", () => ({
+  useTranslations: (_namespace: string) => stableTranslator,
+  useLocale: () => "en",
+}));
+
+// ---------- Fixtures ---------------------------------------------------------
+
+const CTX_ID = "11111111-2222-3333-4444-555555555555";
+
+const BREAKDOWN = {
+  generated_at: "2026-07-12T00:00:00Z",
+  overall_status: "warn",
+  contexts: [
+    {
+      context_id: CTX_ID,
+      name: "Context A",
+      overall_status: "warn",
+      sections: { consolidation: "warn", graph: "ok", retrieval: "ok" },
+    },
+    {
+      context_id: null,
+      name: null,
+      overall_status: "ok",
+      sections: { consolidation: "ok", graph: "ok", retrieval: "ok" },
+    },
+  ],
+};
+
+const DETAIL = {
+  generated_at: "2026-07-12T00:00:00Z",
+  context_id: CTX_ID,
+  context_name: "Context A",
+  overall_status: "warn",
+  sections: {
+    consolidation: {
+      status: "warn",
+      metrics: { reports_in_window: 3 },
+      notes: [
+        { code: "judge_failures", params: { count: 2, degraded_runs: 1 } },
+        { code: "brand_new_code", params: { anything: true } },
+      ],
+    },
+    graph: {
+      status: "ok",
+      metrics: { edges_by_origin: { hebbian: 10 } },
+      notes: [],
+    },
+    retrieval: { status: "ok", metrics: { recall_calls: 7 }, notes: [] },
+  },
+};
+
+beforeEach(() => {
+  mockGet.mockReset();
+});
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("AdminMemoryHealthPage breakdown (#1225)", () => {
+  it("renders one row per context and labels the unattributed bucket", async () => {
+    mockGet.mockResolvedValueOnce(BREAKDOWN);
+
+    render(<AdminMemoryHealthPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Context A")).toBeInTheDocument();
+    });
+    expect(mockGet).toHaveBeenCalledWith("/api/v1/admin/memory-health");
+    expect(screen.getByText("unattributed")).toBeInTheDocument();
+    expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    expect(screen.getByTestId("context-unattributed")).toBeInTheDocument();
+  });
+
+  it("renders the empty state for a zero-context user", async () => {
+    mockGet.mockResolvedValueOnce({
+      generated_at: "2026-07-12T00:00:00Z",
+      overall_status: "ok",
+      contexts: [],
+    });
+
+    render(<AdminMemoryHealthPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("emptyTitle")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AdminMemoryHealthPage drill-down (#1225)", () => {
+  it("fetches the context detail and renders localized notes with a fallback", async () => {
+    mockGet.mockResolvedValueOnce(BREAKDOWN).mockResolvedValueOnce(DETAIL);
+
+    render(<AdminMemoryHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId(`context-${CTX_ID}`));
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        `/api/v1/admin/memory-health?context_id=${CTX_ID}`,
+      );
+    });
+    // Known code: localized via its catalog key with params interpolated.
+    await waitFor(() => {
+      expect(
+        screen.getByText('notes.judge_failures:{"count":2,"degraded_runs":1}'),
+      ).toBeInTheDocument();
+    });
+    // Unknown code: generic fallback naming the code — never blank.
+    expect(
+      screen.getByText('notes.unknown:{"code":"brand_new_code"}'),
+    ).toBeInTheDocument();
+    // No GitHub issue reference anywhere in the rendered document.
+    expect(document.body.textContent).not.toMatch(/#\d{3,}/);
+  });
+
+  it("uses the unattributed sentinel for the context-less bucket", async () => {
+    mockGet.mockResolvedValueOnce(BREAKDOWN).mockResolvedValueOnce({
+      ...DETAIL,
+      context_id: null,
+      context_name: null,
+    });
+
+    render(<AdminMemoryHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("context-unattributed")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("context-unattributed"));
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        "/api/v1/admin/memory-health?context_id=unattributed",
+      );
+    });
+  });
+});

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -1,30 +1,74 @@
 "use client";
 
 /**
- * Admin Memory Health Page (#1211)
+ * Admin Memory Health Page (#1211, #1225)
  *
- * Renders the consolidated memory-health report — the label-free runtime
- * self-diagnosis document (consolidation / graph / retrieval sections with
- * ok / warn / fail grading). Admin-only, self-scoped (Phase 1).
+ * Per-context memory-health report: a breakdown list (one graded entry per
+ * owned context, plus an "unattributed" bucket for context-less signals)
+ * with drill-down into the 3-section detail document (consolidation /
+ * graph / retrieval with ok / warn / fail grading). Section notes arrive
+ * as structured {code, params} records and are localized here — issue
+ * references never render in the UI (they live in
+ * docs/ops/memory-health-report.md). Admin-only, self-scoped.
  */
 
 import { useCallback, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { Activity } from "lucide-react";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
-import { CardLoadingState } from "@/components/common/LoadingState";
+import { CardLoadingState, TableLoadingState } from "@/components/common/LoadingState";
+import { EmptyState } from "@/components/ui/empty-state";
 import { apiClient } from "@/lib/api";
 
-type HealthSection = {
-  status: "ok" | "warn" | "fail";
-  metrics: Record<string, unknown>;
-  notes: string[];
+type HealthStatus = "ok" | "warn" | "fail";
+
+type HealthNote = {
+  code: string;
+  params: Record<string, unknown>;
 };
 
-type MemoryHealthResponse = {
+type HealthSection = {
+  status: HealthStatus;
+  metrics: Record<string, unknown>;
+  notes: HealthNote[];
+};
+
+type ContextEntry = {
+  context_id: string | null;
+  name: string | null;
+  overall_status: HealthStatus;
+  sections: Record<string, HealthStatus>;
+};
+
+type BreakdownResponse = {
   generated_at: string;
-  overall_status: "ok" | "warn" | "fail";
+  overall_status: HealthStatus;
+  contexts: ContextEntry[];
+};
+
+type DetailResponse = {
+  generated_at: string;
+  context_id: string | null;
+  context_name: string | null;
+  overall_status: HealthStatus;
   sections: Record<string, HealthSection>;
 };
+
+/** Query-param value selecting the context-less signal bucket. */
+const UNATTRIBUTED_SCOPE = "unattributed";
+
+/** Backend note codes with a message-catalog entry. Anything else renders
+ * the generic fallback — never a crash, never a blank note. */
+const KNOWN_NOTE_CODES = new Set([
+  "latest_sleep_failed",
+  "judge_failures",
+  "failed_runs_recovered",
+  "deferred_pairs",
+  "merge_backlog_old",
+  "edge_weight_violations",
+  "cold_graph",
+  "write_only_store",
+]);
 
 const STATUS_STYLES: Record<string, string> = {
   ok: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
@@ -59,20 +103,84 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
+function NoteText({ note }: { note: HealthNote }) {
+  const t = useTranslations("admin.memoryHealth");
+  if (!KNOWN_NOTE_CODES.has(note.code)) {
+    return <>{t("notes.unknown", { code: note.code })}</>;
+  }
+  return <>{t(`notes.${note.code}`, note.params as Record<string, string | number>)}</>;
+}
+
+function SectionCard({ name, section }: { name: string; section: HealthSection }) {
+  const t = useTranslations("admin.memoryHealth");
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="font-semibold">
+          {SECTION_LABEL_KEYS[name] ? t(SECTION_LABEL_KEYS[name]) : name}
+        </h2>
+        <StatusBadge status={section.status} />
+      </div>
+      {section.notes.length > 0 && (
+        <ul className="mb-3 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+          {section.notes.map((note, i) => (
+            <li key={`${note.code}-${i}`}>
+              <NoteText note={note} />
+            </li>
+          ))}
+        </ul>
+      )}
+      <table className="w-full table-fixed text-xs">
+        <tbody>
+          {Object.entries(section.metrics).map(([key, value]) => (
+            <tr key={key} className="border-t align-top">
+              <td className="w-1/2 break-all py-1 pr-2 font-mono text-muted-foreground">{key}</td>
+              {/* break-all: a long unbroken value (e.g. a JSON object) wraps
+                  inside its own cell instead of overlaying the neighbor. */}
+              <td className="w-1/2 break-all py-1 text-right font-mono">
+                {value === null
+                  ? t("emptyValue")
+                  : typeof value === "object"
+                    ? JSON.stringify(value)
+                    : String(value)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 export default function AdminMemoryHealthPage() {
   const t = useTranslations("admin.memoryHealth");
-  const [report, setReport] = useState<MemoryHealthResponse | null>(null);
+  const [breakdown, setBreakdown] = useState<BreakdownResponse | null>(null);
+  const [detail, setDetail] = useState<DetailResponse | null>(null);
+  const [selectedScope, setSelectedScope] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const load = useCallback(async () => {
+  const loadBreakdown = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const data = await apiClient.get<MemoryHealthResponse>(
-        "/api/v1/admin/memory-health",
+      const data = await apiClient.get<BreakdownResponse>("/api/v1/admin/memory-health");
+      setBreakdown(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const loadDetail = useCallback(async (scope: string) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await apiClient.get<DetailResponse>(
+        `/api/v1/admin/memory-health?context_id=${encodeURIComponent(scope)}`,
       );
-      setReport(data);
+      setDetail(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -81,8 +189,31 @@ export default function AdminMemoryHealthPage() {
   }, []);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    void loadBreakdown();
+  }, [loadBreakdown]);
+
+  const openDetail = (entry: ContextEntry) => {
+    const scope = entry.context_id ?? UNATTRIBUTED_SCOPE;
+    setSelectedScope(scope);
+    setDetail(null);
+    void loadDetail(scope);
+  };
+
+  const backToList = () => {
+    setSelectedScope(null);
+    setDetail(null);
+    void loadBreakdown();
+  };
+
+  const refresh = () => {
+    if (selectedScope) {
+      void loadDetail(selectedScope);
+    } else {
+      void loadBreakdown();
+    }
+  };
+
+  const inDetailView = selectedScope !== null;
 
   return (
     <div className="space-y-6 p-6">
@@ -91,65 +222,101 @@ export default function AdminMemoryHealthPage() {
           <h1 className="text-2xl font-bold">{t("title")}</h1>
           <p className="text-sm text-muted-foreground">{t("description")}</p>
         </div>
-        <button
-          type="button"
-          onClick={() => void load()}
-          className="rounded border px-3 py-1 text-sm hover:bg-accent"
-        >
-          {t("refresh")}
-        </button>
+        <div className="flex items-center gap-2">
+          {inDetailView && (
+            <button
+              type="button"
+              onClick={backToList}
+              className="rounded border px-3 py-1 text-sm hover:bg-accent"
+            >
+              {t("back")}
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={refresh}
+            className="rounded border px-3 py-1 text-sm hover:bg-accent"
+          >
+            {t("refresh")}
+          </button>
+        </div>
       </div>
 
-      {loading && <CardLoadingState count={3} />}
       <ErrorBanner error={error} />
 
-      {!loading && report && (
+      {!inDetailView && (
         <>
-          <div className="flex items-center gap-3">
-            <span className="text-sm font-medium">{t("overall")}</span>
-            <StatusBadge status={report.overall_status} />
-            <span className="text-xs text-muted-foreground">
-              {report.generated_at}
-            </span>
-          </div>
-
-          <div className="grid gap-4 md:grid-cols-3">
-            {Object.entries(report.sections).map(([name, section]) => (
-              <div key={name} className="rounded-lg border p-4">
-                <div className="mb-2 flex items-center justify-between">
-                  <h2 className="font-semibold capitalize">
-                    {SECTION_LABEL_KEYS[name] ? t(SECTION_LABEL_KEYS[name]) : name}
-                  </h2>
-                  <StatusBadge status={section.status} />
-                </div>
-                {section.notes.length > 0 && (
-                  <ul className="mb-3 list-disc space-y-1 pl-4 text-xs text-muted-foreground">
-                    {section.notes.map((note, i) => (
-                      <li key={i}>{note}</li>
-                    ))}
-                  </ul>
-                )}
-                <table className="w-full text-xs">
-                  <tbody>
-                    {Object.entries(section.metrics).map(([key, value]) => (
-                      <tr key={key} className="border-t">
-                        <td className="py-1 pr-2 font-mono text-muted-foreground">
-                          {key}
-                        </td>
-                        <td className="py-1 text-right font-mono">
-                          {value === null
-                            ? t("emptyValue")
-                            : typeof value === "object"
-                              ? JSON.stringify(value)
-                              : String(value)}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
+          {loading && <TableLoadingState rows={4} />}
+          {!loading && breakdown && (
+            <>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium">{t("overall")}</span>
+                <StatusBadge status={breakdown.overall_status} />
+                <span className="text-xs text-muted-foreground">{breakdown.generated_at}</span>
               </div>
-            ))}
-          </div>
+
+              {breakdown.contexts.length === 0 ? (
+                <EmptyState
+                  icon={Activity}
+                  title={t("emptyTitle")}
+                  description={t("emptyDescription")}
+                  compact
+                />
+              ) : (
+                <div className="divide-y rounded-lg border">
+                  {breakdown.contexts.map((entry) => (
+                    <button
+                      key={entry.context_id ?? UNATTRIBUTED_SCOPE}
+                      type="button"
+                      onClick={() => openDetail(entry)}
+                      className="flex w-full flex-wrap items-center justify-between gap-2 px-4 py-3 text-left hover:bg-accent"
+                      data-testid={`context-${entry.context_id ?? UNATTRIBUTED_SCOPE}`}
+                    >
+                      <div className="flex min-w-0 items-center gap-3">
+                        <StatusBadge status={entry.overall_status} />
+                        <span className="truncate font-medium">
+                          {entry.name ?? t("unattributed")}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {Object.entries(entry.sections).map(([name, status]) => (
+                          <span key={name} className="flex items-center gap-1 text-xs">
+                            <span className="text-muted-foreground">
+                              {SECTION_LABEL_KEYS[name] ? t(SECTION_LABEL_KEYS[name]) : name}
+                            </span>
+                            <StatusBadge status={status} />
+                          </span>
+                        ))}
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {inDetailView && (
+        <>
+          {loading && <CardLoadingState count={3} />}
+          {!loading && detail && (
+            <>
+              <div className="flex items-center gap-3">
+                <span className="text-sm font-medium">
+                  {detail.context_name ?? t("unattributed")}
+                </span>
+                <StatusBadge status={detail.overall_status} />
+                <span className="text-xs text-muted-foreground">{detail.generated_at}</span>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-3">
+                {Object.entries(detail.sections).map(([name, section]) => (
+                  <SectionCard key={name} name={name} section={section} />
+                ))}
+              </div>
+            </>
+          )}
         </>
       )}
     </div>

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -12,7 +12,7 @@
  * docs/ops/memory-health-report.md). Admin-only, self-scoped.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Activity } from "lucide-react";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
@@ -57,19 +57,6 @@ type DetailResponse = {
 /** Query-param value selecting the context-less signal bucket. */
 const UNATTRIBUTED_SCOPE = "unattributed";
 
-/** Backend note codes with a message-catalog entry. Anything else renders
- * the generic fallback — never a crash, never a blank note. */
-const KNOWN_NOTE_CODES = new Set([
-  "latest_sleep_failed",
-  "judge_failures",
-  "failed_runs_recovered",
-  "deferred_pairs",
-  "merge_backlog_old",
-  "edge_weight_violations",
-  "cold_graph",
-  "write_only_store",
-]);
-
 const STATUS_STYLES: Record<string, string> = {
   ok: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
   warn: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
@@ -88,6 +75,13 @@ const SECTION_LABEL_KEYS: Record<string, string> = {
   retrieval: "sections.retrieval",
 };
 
+type Translator = ReturnType<typeof useTranslations>;
+
+function sectionLabel(t: Translator, name: string): string {
+  const key = SECTION_LABEL_KEYS[name];
+  return key ? t(key) : name;
+}
+
 function StatusBadge({ status }: { status: string }) {
   const t = useTranslations("admin.memoryHealth");
   const labelKey = STATUS_LABEL_KEYS[status];
@@ -105,7 +99,9 @@ function StatusBadge({ status }: { status: string }) {
 
 function NoteText({ note }: { note: HealthNote }) {
   const t = useTranslations("admin.memoryHealth");
-  if (!KNOWN_NOTE_CODES.has(note.code)) {
+  // The message catalog is the single source of known note codes — an
+  // unknown code renders the generic fallback (never crash, never blank).
+  if (!t.has(`notes.${note.code}`)) {
     return <>{t("notes.unknown", { code: note.code })}</>;
   }
   return <>{t(`notes.${note.code}`, note.params as Record<string, string | number>)}</>;
@@ -116,9 +112,7 @@ function SectionCard({ name, section }: { name: string; section: HealthSection }
   return (
     <div className="rounded-lg border p-4">
       <div className="mb-2 flex items-center justify-between">
-        <h2 className="font-semibold">
-          {SECTION_LABEL_KEYS[name] ? t(SECTION_LABEL_KEYS[name]) : name}
-        </h2>
+        <h2 className="font-semibold">{sectionLabel(t, name)}</h2>
         <StatusBadge status={section.status} />
       </div>
       {section.notes.length > 0 && (
@@ -134,7 +128,7 @@ function SectionCard({ name, section }: { name: string; section: HealthSection }
         <tbody>
           {Object.entries(section.metrics).map(([key, value]) => (
             <tr key={key} className="border-t align-top">
-              <td className="w-1/2 break-all py-1 pr-2 font-mono text-muted-foreground">{key}</td>
+              <td className="w-1/2 py-1 pr-2 font-mono text-muted-foreground">{key}</td>
               {/* break-all: a long unbroken value (e.g. a JSON object) wraps
                   inside its own cell instead of overlaying the neighbor. */}
               <td className="w-1/2 break-all py-1 text-right font-mono">
@@ -160,57 +154,58 @@ export default function AdminMemoryHealthPage() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const loadBreakdown = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await apiClient.get<BreakdownResponse>("/api/v1/admin/memory-health");
-      setBreakdown(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // Monotonic request sequence: a response only lands if no newer request
+  // (or back-navigation) superseded it — otherwise a slow detail fetch for
+  // context A would overwrite the view after the user moved to context B.
+  const requestSeq = useRef(0);
 
-  const loadDetail = useCallback(async (scope: string) => {
+  const load = useCallback(async (scope: string | null) => {
+    const seq = ++requestSeq.current;
     setLoading(true);
     setError(null);
     try {
-      const data = await apiClient.get<DetailResponse>(
-        `/api/v1/admin/memory-health?context_id=${encodeURIComponent(scope)}`,
-      );
-      setDetail(data);
+      if (scope === null) {
+        const data = await apiClient.get<BreakdownResponse>("/api/v1/admin/memory-health");
+        if (seq !== requestSeq.current) return;
+        setBreakdown(data);
+      } else {
+        const data = await apiClient.get<DetailResponse>(
+          `/api/v1/admin/memory-health?context_id=${encodeURIComponent(scope)}`,
+        );
+        if (seq !== requestSeq.current) return;
+        setDetail(data);
+      }
     } catch (err) {
+      if (seq !== requestSeq.current) return;
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoading(false);
+      if (seq === requestSeq.current) setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void loadBreakdown();
-  }, [loadBreakdown]);
+    void load(null);
+  }, [load]);
 
   const openDetail = (entry: ContextEntry) => {
     const scope = entry.context_id ?? UNATTRIBUTED_SCOPE;
     setSelectedScope(scope);
     setDetail(null);
-    void loadDetail(scope);
+    void load(scope);
   };
 
   const backToList = () => {
+    // Invalidate any in-flight detail fetch and show the retained breakdown
+    // instantly — the refresh button covers wanting fresh data.
+    requestSeq.current += 1;
     setSelectedScope(null);
     setDetail(null);
-    void loadBreakdown();
+    setError(null);
+    setLoading(false);
   };
 
   const refresh = () => {
-    if (selectedScope) {
-      void loadDetail(selectedScope);
-    } else {
-      void loadBreakdown();
-    }
+    void load(selectedScope);
   };
 
   const inDetailView = selectedScope !== null;

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2811,9 +2811,13 @@
     },
     "memoryHealth": {
       "title": "Memory Health",
-      "description": "Consolidated self-diagnosis: consolidation, graph, and retrieval signals with ok/warn/fail grading",
+      "description": "Per-context self-diagnosis: consolidation, graph, and retrieval signals with ok/warn/fail grading",
       "refresh": "Refresh",
       "overall": "Overall",
+      "back": "Back to contexts",
+      "unattributed": "Unattributed (no context)",
+      "emptyTitle": "Nothing to grade yet",
+      "emptyDescription": "Health entries appear here once you have contexts or recorded signals.",
       "emptyValue": "—",
       "status": {
         "ok": "OK",
@@ -2824,6 +2828,17 @@
         "consolidation": "Consolidation",
         "graph": "Graph",
         "retrieval": "Retrieval"
+      },
+      "notes": {
+        "latest_sleep_failed": "The latest sleep run failed — total judge failure. Check the sleep LLM configuration.",
+        "judge_failures": "{count} judge failure(s) across {degraded_runs} degraded run(s) in the window — a partially dead judge grades 'degraded', never silently 'completed'.",
+        "failed_runs_recovered": "{count} failed sleep run(s) in the window — the latest run recovered, but recent instability is worth a look.",
+        "deferred_pairs": "{count} candidate pair(s) deferred unjudged (cluster caps) — dedup may be structurally behind.",
+        "merge_backlog_old": "The oldest merge loser is {oldest_days}d old (over {threshold_days}d) — consider a retention window.",
+        "edge_weight_violations": "{count} edge(s) outside the weight bounds [{min}, {max}] — an unclamped-accumulation bug.",
+        "cold_graph": "{active_memories} active memories but zero edges — the graph never warmed. Check edge-formation gates and the sleep mode.",
+        "write_only_store": "No recall calls in the last {window_days}d despite {active_memories} active memories — the store is write-only right now.",
+        "unknown": "Unrecognized health note (code: {code})."
       }
     },
     "sleepReports": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2831,7 +2831,7 @@
       },
       "notes": {
         "latest_sleep_failed": "The latest sleep run failed — total judge failure. Check the sleep LLM configuration.",
-        "judge_failures": "{count} judge failure(s) across {degraded_runs} degraded run(s) in the window — a partially dead judge grades 'degraded', never silently 'completed'.",
+        "judge_failures": "Judge failures in the window: {count} (degraded runs: {degraded_runs}) — a partially dead judge grades 'degraded', never silently 'completed'.",
         "failed_runs_recovered": "{count} failed sleep run(s) in the window — the latest run recovered, but recent instability is worth a look.",
         "deferred_pairs": "{count} candidate pair(s) deferred unjudged (cluster caps) — dedup may be structurally behind.",
         "merge_backlog_old": "The oldest merge loser is {oldest_days}d old (over {threshold_days}d) — consider a retention window.",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2831,7 +2831,7 @@
       },
       "notes": {
         "latest_sleep_failed": "直近の Sleep 実行が失敗しました — judge が全滅しています。Sleep の LLM 設定を確認してください。",
-        "judge_failures": "ウィンドウ内で {count} 件の judge 失敗（{degraded_runs} 件の degraded 実行）— 部分的に停止した judge は 'degraded' と判定され、静かに 'completed' にはなりません。",
+        "judge_failures": "ウィンドウ内の judge 失敗: {count} 件（degraded 実行: {degraded_runs} 件）— 部分的に停止した judge は 'degraded' と判定され、静かに 'completed' にはなりません。",
         "failed_runs_recovered": "ウィンドウ内に {count} 件の失敗した Sleep 実行 — 直近は回復していますが、最近の不安定さは確認する価値があります。",
         "deferred_pairs": "{count} 件の候補ペアが未判定のまま繰り延べ（クラスタ上限）— dedup が構造的に追いついていない可能性があります。",
         "merge_backlog_old": "最古のマージ敗者が {oldest_days} 日前のものです（{threshold_days} 日超）— 保持期間の設定を検討してください。",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2811,9 +2811,13 @@
     },
     "memoryHealth": {
       "title": "メモリーヘルス",
-      "description": "統合セルフ診断：consolidation / graph / retrieval のシグナルを ok/warn/fail で判定",
+      "description": "コンテキスト別セルフ診断：consolidation / graph / retrieval のシグナルを ok/warn/fail で判定",
       "refresh": "更新",
       "overall": "総合",
+      "back": "コンテキスト一覧へ戻る",
+      "unattributed": "未帰属（コンテキストなし）",
+      "emptyTitle": "まだ判定対象がありません",
+      "emptyDescription": "コンテキストまたは記録されたシグナルができると、ここにヘルス項目が表示されます。",
       "emptyValue": "—",
       "status": {
         "ok": "正常",
@@ -2824,6 +2828,17 @@
         "consolidation": "統合（consolidation）",
         "graph": "グラフ（graph）",
         "retrieval": "検索（retrieval）"
+      },
+      "notes": {
+        "latest_sleep_failed": "直近の Sleep 実行が失敗しました — judge が全滅しています。Sleep の LLM 設定を確認してください。",
+        "judge_failures": "ウィンドウ内で {count} 件の judge 失敗（{degraded_runs} 件の degraded 実行）— 部分的に停止した judge は 'degraded' と判定され、静かに 'completed' にはなりません。",
+        "failed_runs_recovered": "ウィンドウ内に {count} 件の失敗した Sleep 実行 — 直近は回復していますが、最近の不安定さは確認する価値があります。",
+        "deferred_pairs": "{count} 件の候補ペアが未判定のまま繰り延べ（クラスタ上限）— dedup が構造的に追いついていない可能性があります。",
+        "merge_backlog_old": "最古のマージ敗者が {oldest_days} 日前のものです（{threshold_days} 日超）— 保持期間の設定を検討してください。",
+        "edge_weight_violations": "{count} 本のエッジが重み範囲 [{min}, {max}] を外れています — 未クランプ累積系のバグです。",
+        "cold_graph": "アクティブメモリが {active_memories} 件あるのにエッジが 0 本 — グラフが一度も温まっていません。エッジ形成ゲートと sleep モードを確認してください。",
+        "write_only_store": "アクティブメモリが {active_memories} 件あるのに直近 {window_days} 日間 recall 呼び出しがありません — ストアが書き込み専用になっています。",
+        "unknown": "未知のヘルス注記です（コード: {code}）。"
       }
     },
     "sleepReports": {


### PR DESCRIPTION
Closes #1225

## Summary
- `GET /api/v1/admin/memory-health` now returns a **per-context breakdown**: one graded entry per owned context (context_id, display name, overall + per-section statuses); the page-level overall is the worst entry, and no metric is summed across contexts.
- `?context_id=<uuid>` returns the 3-section detail for that single context (ownership validated via a single-row lookup; un-owned/unknown → uniform 404). The sentinel `?context_id=unattributed` targets signals without an owned live context — NULL-context rows **and** orphan scopes (soft-deleted contexts, shared contexts created by another member) fold there instead of being silently dropped.
- Section notes are now structured `{code, params}` records localized via next-intl (en/ja); unknown codes render a generic fallback, and GitHub issue references no longer appear anywhere in the rendered UI (they live in code comments and docs/ops/memory-health-report.md).
- Admin UI: context list with status badges → drill-down detail (with an out-of-order-response guard); metrics-table CSS overflow fixed (long JSON values wrap with break-all instead of overlaying neighbors).

## Implementation notes
- MemoryHealthService: one GROUP BY query per signal (sleep window via row_number partition bounded to a 180-day lookback; merge backlog; graph stats; usage; config posture) — no per-context fan-out. `_fold_orphan_scopes` is the single seam re-keying non-owned scopes into the unattributed bucket. The unattributed bucket skips heuristic checks (cold-graph, write-only) but always grades deterministic facts (failed runs, weight violations).
- Ownership predicate defined once (`_owned_context_filter`) as the Phase-3 seam (workspace semantics later swap one predicate).
- Route: typed union query param (`uuid.UUID | Literal["unattributed"] | None`) + union response model — OpenAPI self-documenting; standard 422 for malformed scopes.
- Tests pin the isolation contract (a WARN/FAIL in context A cannot change context B's grade), the orphan fold (including end-to-end overall-FAIL propagation), zero-context → ok + empty, and the note-code contract. All 12 query shapes additionally verified to compile against the postgresql dialect.
- Known limitation (documented): cross-context `recall(context_ids=[...])` usage is logged under the first listed context only, so `write_only_store` can false-positive on contexts read exclusively via cross-context recall — the real fix belongs in usage logging (follow-up).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (mock-only SQL blind spot mitigated by dialect-compile check; minor follow-up gaps noted)
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: none

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1225-feat-per-context-memory-health-report.gate1.md
- ~/.claude/cache/gh-issue-driven/1225-feat-per-context-memory-health-report.gate2.md

🤖 Generated via /gh-issue-driven:ship
