### PR TITLE
fix(api): attribute cross-context recall reads to all listed contexts (#1228)

### DIFF
--- a/backend/alembic/versions/e60_1228_context_read_attributions.py
+++ b/backend/alembic/versions/e60_1228_context_read_attributions.py
@@ -1,0 +1,70 @@
+"""#1228: add context_read_attributions (cross-context recall read visibility).
+
+A cross-context ``recall(context_ids=[A, B, ...])`` bills one quota unit —
+the single ``usage_stats`` row under the primary context (A). Reads on the
+other listed contexts were invisible to per-context consumers, so the
+memory-health retrieval section false-WARNed ``write_only_store`` on
+contexts read exclusively via cross-context recall.
+
+This table records one diagnostic attribution row per ADDITIONAL listed
+context. It is deliberately separate from ``usage_stats``: every
+``usage_stats`` reader counts rows for quota/billing/analytics, and a
+same-table marker would tax each of them with an exclusion filter.
+Attribution rows are structurally invisible to them by construction.
+
+Blue-green safety: pure CREATE TABLE — no existing table or app code is
+touched; old app code never references the table.
+
+Revision ID: e60_1228_context_read_attributions
+Revises: e59_1220_router_calibrations
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers
+revision = "e60_1228_context_read_attributions"
+down_revision = "e59_1220_router_calibrations"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the context_read_attributions table + indexes."""
+    op.create_table(
+        "context_read_attributions",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(255), nullable=False),
+        sa.Column(
+            "context_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("endpoint", sa.String(255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "idx_context_read_attr_user_created",
+        "context_read_attributions",
+        ["user_id", "created_at"],
+    )
+    op.create_index(
+        "idx_context_read_attr_context",
+        "context_read_attributions",
+        ["context_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the context_read_attributions table."""
+    op.drop_index("idx_context_read_attr_context", table_name="context_read_attributions")
+    op.drop_index("idx_context_read_attr_user_created", table_name="context_read_attributions")
+    op.drop_table("context_read_attributions")

--- a/backend/alembic/versions/e60_1228_read_attributions.py
+++ b/backend/alembic/versions/e60_1228_read_attributions.py
@@ -15,8 +15,13 @@ Attribution rows are structurally invisible to them by construction.
 Blue-green safety: pure CREATE TABLE — no existing table or app code is
 touched; old app code never references the table.
 
-Revision ID: e60_1228_context_read_attributions
+Revision ID: e60_1228_read_attributions
 Revises: e59_1220_router_calibrations
+
+Note: revision IDs must stay <= 32 chars — ``alembic_version.version_num``
+is varchar(32), and a longer ID fails the version-table UPDATE at upgrade
+time (StringDataRightTruncationError; caught by the migration round-trip
+test on this very revision's first draft).
 """
 
 import sqlalchemy as sa
@@ -25,7 +30,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from alembic import op
 
 # revision identifiers
-revision = "e60_1228_context_read_attributions"
+revision = "e60_1228_read_attributions"
 down_revision = "e59_1220_router_calibrations"
 branch_labels = None
 depends_on = None

--- a/backend/alembic/versions/e60_1228_read_attributions.py
+++ b/backend/alembic/versions/e60_1228_read_attributions.py
@@ -49,12 +49,11 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.Column("endpoint", sa.String(255), nullable=False),
-        sa.Column(
-            "created_at",
-            sa.DateTime(),
-            nullable=False,
-            server_default=sa.text("now()"),
-        ),
+        # No server_default: the writer (_log_tool_usage) always supplies
+        # created_at explicitly, and the model's client-side default keeps
+        # create_all/alembic parity (the drift gate flags a server default
+        # that exists on only one side).
+        sa.Column("created_at", sa.DateTime(), nullable=False),
     )
     op.create_index(
         "idx_context_read_attr_user_created",

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -496,7 +496,7 @@ async def _log_tool_usage(
         # Use independent session: log_usage() calls db.commit() internally,
         # which would prematurely commit the handler's transaction if shared.
         async for log_db in get_db():
-            await log_usage(
+            billable_row_written = await log_usage(
                 db=log_db,
                 user_id=user_id,
                 endpoint=f"mcp:{tool_name}",
@@ -506,7 +506,11 @@ async def _log_tool_usage(
                 context_id=str(context_id) if context_id else None,
                 workspace_id=str(workspace_id) if workspace_id else None,
             )
-            if attributed_context_ids:
+            # #1228: attribution rows only make sense alongside the billable
+            # row — log_usage swallows its own failure, and writing the
+            # secondaries without the primary would count reads on the
+            # listed contexts while the primary's read stays invisible.
+            if billable_row_written and attributed_context_ids:
                 from models.auth import ContextReadAttribution
                 from utils.datetime import utcnow
 

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -468,6 +468,8 @@ async def _log_tool_usage(
     status_code: int,
     context_id: UUID | str | None = None,
     workspace_id: UUID | None = None,
+    *,
+    attributed_context_ids: list[UUID] | None = None,
 ) -> None:
     """Log tool usage metrics.
 
@@ -479,6 +481,12 @@ async def _log_tool_usage(
         status_code: HTTP-style status code (200=success, 500=error)
         context_id: Context ID (optional)
         workspace_id: Workspace ID (optional)
+        attributed_context_ids: #1228 — ADDITIONAL contexts read by this
+            call (cross-context recall lists several but bills one unit).
+            Each gets a diagnostic row in context_read_attributions,
+            structurally invisible to UsageStats row-count consumers
+            (quota, workspace analytics); the memory-health retrieval
+            grading merges them into per-context read counts.
     """
     from db.base import get_db
     from utils.usage_logger import log_usage
@@ -498,5 +506,20 @@ async def _log_tool_usage(
                 context_id=str(context_id) if context_id else None,
                 workspace_id=str(workspace_id) if workspace_id else None,
             )
+            if attributed_context_ids:
+                from models.auth import ContextReadAttribution
+                from utils.datetime import utcnow
+
+                now = utcnow()
+                for cid in attributed_context_ids:
+                    log_db.add(
+                        ContextReadAttribution(
+                            user_id=user_id,
+                            context_id=cid,
+                            endpoint=f"mcp:{tool_name}",
+                            created_at=now,
+                        )
+                    )
+                await log_db.commit()
     except Exception as e:
         logger.warning("tool_usage_log_failed: tool=%s error=%s", tool_name, str(e))

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -28,6 +28,10 @@ from utils.exceptions import NotFoundException
 
 logger = logging.getLogger(__name__)
 
+# #1228: server-side cap for cross-context recall — MUST stay in sync with
+# the recall inputSchema's context_ids maxItems in _definitions.py.
+MAX_CROSS_CONTEXT_IDS = 20
+
 
 async def handle_remember(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None
@@ -454,10 +458,25 @@ async def handle_recall(
             cross_context_ids: list[UUID] | None = None
 
             if isinstance(context_ids_arg, list) and context_ids_arg:
+                # #1228 review: enforce the inputSchema's maxItems server-side
+                # (the schema is advisory for non-validating clients) — a
+                # single billable call must not fan out into unbounded
+                # permission resolves and attribution rows.
+                if len(context_ids_arg) > MAX_CROSS_CONTEXT_IDS:
+                    return _error_response(
+                        "too_many_context_ids",
+                        f"context_ids accepts at most {MAX_CROSS_CONTEXT_IDS} entries.",
+                    )
                 # Multi-context mode. Use _resolve_context_for_read so deny
                 # reasons (private non-creator, not a workspace member, etc.)
                 # surface as a uniform context_not_found (CWE-639 / OWASP A01).
-                cross_context_ids = [_resolve_context_id(cid) for cid in context_ids_arg]
+                # Order-preserving dedup (#1228 review): duplicated ids would
+                # each burn a permission resolve and write an attribution row
+                # (including one for the primary itself), inflating the
+                # per-context read counts the attribution table exists to fix.
+                cross_context_ids = list(
+                    dict.fromkeys(_resolve_context_id(cid) for cid in context_ids_arg)
+                )
                 current_context_id = cross_context_ids[0]
                 current_context = await _resolve_context_for_read(db, user_id, current_context_id)
                 # #708 H3: all contexts must belong to the same workspace —

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -558,7 +558,17 @@ async def handle_recall(
             ]
 
             await _log_tool_usage(
-                db, user_id, "recall", start_time, 200, current_context_id, workspace_id
+                db,
+                user_id,
+                "recall",
+                start_time,
+                200,
+                current_context_id,
+                workspace_id,
+                # #1228: the primary context carries the billable UsageStats
+                # row; the other listed contexts get diagnostic attribution
+                # rows so per-context read visibility sees them.
+                attributed_context_ids=(cross_context_ids[1:] if cross_context_ids else None),
             )
             await db.commit()
 

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1224,6 +1224,44 @@ class UsageStats(Base):
     )
 
 
+class ContextReadAttribution(Base):
+    """Diagnostic read-attribution for cross-context recall (#1228).
+
+    A cross-context ``recall(context_ids=[A, B, ...])`` bills ONE quota
+    unit — the single ``UsageStats`` row logged under the primary context
+    (A). Read activity on the other listed contexts is recorded here, one
+    row per ADDITIONAL context, so per-context read visibility (the
+    memory-health retrieval grading) sees them.
+
+    Deliberately a separate table, not extra ``UsageStats`` rows: every
+    ``UsageStats`` consumer counts rows for quota/billing/analytics, and a
+    marker-based scheme would tax each of them (7 call sites today, every
+    future one) with a "remember to exclude" filter. Attribution rows are
+    structurally invisible to them by construction.
+
+    ``context_id`` cascades on context deletion (unlike ``UsageStats``'
+    SET NULL): an attribution row for a deleted context carries no
+    diagnostic value, while billing rows must survive for audit.
+    """
+
+    __tablename__ = "context_read_attributions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    context_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("contexts.id", ondelete="CASCADE"), nullable=False
+    )
+    endpoint: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=func.now())
+
+    __table_args__ = (
+        # The memory-health usage window scans (user_id, created_at) and
+        # groups by context_id — one covering index serves both shapes.
+        Index("idx_context_read_attr_user_created", "user_id", "created_at"),
+        Index("idx_context_read_attr_context", "context_id"),
+    )
+
+
 # ============================================================================
 # Context-based Multi-Collection (Issue #82 → #160: renamed from Project)
 # ============================================================================

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -81,6 +81,10 @@ OPERATIONAL_TABLES: frozenset[str] = frozenset(
         "context_search_configs",
         "plan_changes",
         "usage_stats",
+        # #1228: diagnostic read-attribution for cross-context recall —
+        # usage telemetry like usage_stats (no user content, no learned
+        # structure; erased with the user, cascades with the context).
+        "context_read_attributions",
         "audit_logs",
         "erasure_requests",
         "signup_allowlist",

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -962,7 +962,7 @@ class AccountErasureService:
         """
         # Optional model imports so the service doesn't crash if a model
         # is renamed/removed in a future refactor.
-        from models.auth import PlanChange, UsageStats
+        from models.auth import ContextReadAttribution, PlanChange, UsageStats
         from models.memory import GraphMemory
 
         user_id = target.user_id
@@ -990,6 +990,12 @@ class AccountErasureService:
         )
         counts["usage_stats"] = await self._count_and_delete(
             UsageStats, UsageStats.user_id == user_id
+        )
+        # #1228: diagnostic cross-context read attributions are per-user
+        # data too (context_id FK cascades on context deletion, but the
+        # user sweep must not rely on that).
+        counts["context_read_attributions"] = await self._count_and_delete(
+            ContextReadAttribution, ContextReadAttribution.user_id == user_id
         )
 
         # Workspace memberships and invitations.

--- a/backend/src/services/memory_health_service.py
+++ b/backend/src/services/memory_health_service.py
@@ -45,7 +45,7 @@ from typing import Any
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.auth import Context, UsageStats
+from models.auth import Context, ContextReadAttribution, UsageStats
 from models.config import ContextSearchConfig
 from models.memory import Memory, NeuralMemoryEdge
 from models.sleep import SleepReport
@@ -472,20 +472,18 @@ class MemoryHealthService:
     ) -> dict[uuid.UUID | None, dict[str, int]]:
         """MCP tool call counts per context over the usage window.
 
-        Attribution caveat: a cross-context recall(context_ids=[...]) is
-        logged under the FIRST listed context, so read activity on the other
-        listed contexts is invisible here. A write_only_store WARN on a
-        context that is only read via cross-context recall is a known false
-        positive until usage logging attributes all listed contexts
-        (documented in docs/ops/memory-health-report.md).
+        #1228: a cross-context recall(context_ids=[...]) bills one unit
+        (the UsageStats row under the FIRST listed context); reads on the
+        other listed contexts arrive as context_read_attributions rows and
+        are merged in here — a context read only via cross-context recall
+        no longer false-WARNs write_only_store.
         """
         since = utcnow() - timedelta(days=_USAGE_WINDOW_DAYS)
+        watched_endpoints = ["mcp:recall", "mcp:recall_upcoming", "mcp:remember", "mcp:explore"]
         conditions = [
             UsageStats.user_id == user_id,
             UsageStats.created_at >= since,
-            UsageStats.endpoint.in_(
-                ["mcp:recall", "mcp:recall_upcoming", "mcp:remember", "mcp:explore"]
-            ),
+            UsageStats.endpoint.in_(watched_endpoints),
         ]
         if scope is not _ALL:
             conditions.append(UsageStats.context_id == scope)
@@ -501,6 +499,26 @@ class MemoryHealthService:
         usage: dict[uuid.UUID | None, dict[str, int]] = defaultdict(dict)
         for context_id, endpoint, count in rows.all():
             usage[context_id][endpoint.removeprefix("mcp:")] = int(count)
+
+        attr_conditions = [
+            ContextReadAttribution.user_id == user_id,
+            ContextReadAttribution.created_at >= since,
+            ContextReadAttribution.endpoint.in_(watched_endpoints),
+        ]
+        if scope is not _ALL:
+            attr_conditions.append(ContextReadAttribution.context_id == scope)
+        attr_rows = await self.db.execute(
+            select(
+                ContextReadAttribution.context_id,
+                ContextReadAttribution.endpoint,
+                func.count(ContextReadAttribution.id),
+            )
+            .where(*attr_conditions)
+            .group_by(ContextReadAttribution.context_id, ContextReadAttribution.endpoint)
+        )
+        for context_id, endpoint, count in attr_rows.all():
+            key = endpoint.removeprefix("mcp:")
+            usage[context_id][key] = usage[context_id].get(key, 0) + int(count)
         return dict(usage)
 
     async def _fetch_config_postures(

--- a/backend/src/utils/usage_logger.py
+++ b/backend/src/utils/usage_logger.py
@@ -24,7 +24,7 @@ async def log_usage(
     context_id: str | None = None,  # Bugfix: Add context_id for stats tracking
     workspace_id: str | None = None,  # Bugfix: Add workspace_id for stats tracking
     api_key_id: int | None = None,  # Issue #626: per-key attribution
-) -> None:
+) -> bool:
     """Log API or MCP tool usage to usage_stats table.
 
     This function is used by both:
@@ -50,6 +50,12 @@ async def log_usage(
 
         # MCP tool (from handler)
         await log_usage(db, user_id, "mcp:recall", "MCP", 200, 80)
+
+    Returns:
+        True when the row was written; False when the insert failed (the
+        error is logged and swallowed — logging must never break the main
+        flow, but callers chaining dependent writes, e.g. #1228 attribution
+        rows, need the signal).
     """
     try:
         # Use utcnow() for timezone-naive datetime (matches DB schema)
@@ -79,6 +85,7 @@ async def log_usage(
             status=status_code,
             response_time_ms=response_time_ms,
         )
+        return True
 
     except Exception as e:
         await db.rollback()
@@ -89,3 +96,4 @@ async def log_usage(
             endpoint=endpoint,
         )
         # Don't raise - logging should not break the main flow
+        return False

--- a/backend/tests/mcp_server/test_helpers.py
+++ b/backend/tests/mcp_server/test_helpers.py
@@ -1,6 +1,8 @@
 """Tests for MCP tool helper functions."""
 
 import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -8,6 +10,7 @@ import pytest
 from mcp_server.tools._helpers import (
     _context_response_fields,
     _error_response,
+    _log_tool_usage,
     _resolve_context_id,
     _success_response,
     _validate_memory_id,
@@ -134,3 +137,68 @@ class TestValidateMemoryId:
         assert error is not None
         data = json.loads(error[0].text)
         assert data["error"] == "invalid_memory_id_format"
+
+
+class TestLogToolUsageAttribution:
+    """#1228: cross-context recall bills ONE quota unit (the single
+    UsageStats row under the primary context) but must record diagnostic
+    read-attribution rows for every ADDITIONAL listed context in the
+    separate context_read_attributions table — structurally invisible to
+    every UsageStats row-count consumer (quota, workspace analytics)."""
+
+    def _fake_db_env(self):
+        session = AsyncMock()
+        session.add = MagicMock()  # sync method on AsyncSession
+
+        async def fake_get_db():
+            yield session
+
+        return session, fake_get_db
+
+    @pytest.mark.asyncio
+    async def test_attribution_rows_written_for_additional_contexts(self):
+        session, fake_get_db = self._fake_db_env()
+        primary, extra_1, extra_2 = uuid4(), uuid4(), uuid4()
+        log_usage_mock = AsyncMock()
+
+        with (
+            patch("db.base.get_db", new=fake_get_db),
+            patch("utils.usage_logger.log_usage", new=log_usage_mock),
+        ):
+            await _log_tool_usage(
+                AsyncMock(),
+                "user-1",
+                "recall",
+                time.time(),
+                200,
+                primary,
+                None,
+                attributed_context_ids=[extra_1, extra_2],
+            )
+
+        # Exactly ONE billable UsageStats row, under the primary context.
+        log_usage_mock.assert_awaited_once()
+        assert log_usage_mock.await_args.kwargs["context_id"] == str(primary)
+        # One attribution row per ADDITIONAL context, none for the primary.
+        added = [call.args[0] for call in session.add.call_args_list]
+        assert len(added) == 2
+        assert {row.context_id for row in added} == {extra_1, extra_2}
+        assert all(row.endpoint == "mcp:recall" for row in added)
+        assert all(row.user_id == "user-1" for row in added)
+        session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_attribution_rows_by_default(self):
+        """Single-context calls (the overwhelming majority) are unchanged:
+        one UsageStats row, zero attribution rows."""
+        session, fake_get_db = self._fake_db_env()
+        log_usage_mock = AsyncMock()
+
+        with (
+            patch("db.base.get_db", new=fake_get_db),
+            patch("utils.usage_logger.log_usage", new=log_usage_mock),
+        ):
+            await _log_tool_usage(AsyncMock(), "user-1", "recall", time.time(), 200, uuid4(), None)
+
+        log_usage_mock.assert_awaited_once()
+        session.add.assert_not_called()

--- a/backend/tests/mcp_server/test_helpers.py
+++ b/backend/tests/mcp_server/test_helpers.py
@@ -202,3 +202,31 @@ class TestLogToolUsageAttribution:
 
         log_usage_mock.assert_awaited_once()
         session.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_attribution_when_billable_row_failed(self):
+        """#1228 review: log_usage swallows its own insert failure — if the
+        billable UsageStats row was NOT written, attribution rows must not
+        be written either, or reads count on the secondaries while the
+        primary's read is invisible (the mirror image of the false-WARN
+        this table exists to fix)."""
+        session, fake_get_db = self._fake_db_env()
+        log_usage_mock = AsyncMock(return_value=False)
+
+        with (
+            patch("db.base.get_db", new=fake_get_db),
+            patch("utils.usage_logger.log_usage", new=log_usage_mock),
+        ):
+            await _log_tool_usage(
+                AsyncMock(),
+                "user-1",
+                "recall",
+                time.time(),
+                200,
+                uuid4(),
+                None,
+                attributed_context_ids=[uuid4()],
+            )
+
+        log_usage_mock.assert_awaited_once()
+        session.add.assert_not_called()

--- a/backend/tests/mcp_server/test_recall_cross_context_attribution.py
+++ b/backend/tests/mcp_server/test_recall_cross_context_attribution.py
@@ -105,3 +105,44 @@ async def test_single_context_recall_attributes_nothing():
     call = log_tool_usage.await_args
     assert call.args[5] == ctx_a
     assert not call.kwargs.get("attributed_context_ids")
+
+
+@pytest.mark.asyncio
+async def test_duplicate_context_ids_are_deduplicated():
+    """#1228 review: duplicated ids would each burn a permission resolve and
+    write an attribution row — recall(context_ids=[A, B, A, B]) must
+    attribute B exactly once and never attribute the primary A."""
+    ctx_a, ctx_b = uuid4(), uuid4()
+    log_tool_usage = AsyncMock()
+
+    with _patched(log_tool_usage):
+        result = await handle_recall(
+            {"query": "q", "context_ids": [str(ctx_a), str(ctx_b), str(ctx_a), str(ctx_b)]},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    call = log_tool_usage.await_args
+    assert call.args[5] == ctx_a
+    assert call.kwargs["attributed_context_ids"] == [ctx_b]
+
+
+@pytest.mark.asyncio
+async def test_context_ids_capped_at_schema_max():
+    """#1228 review: the inputSchema's maxItems:20 is advisory for
+    non-validating clients — the handler must enforce it server-side so a
+    single billable call cannot write unbounded attribution rows."""
+    ids = [str(uuid4()) for _ in range(21)]
+    log_tool_usage = AsyncMock()
+
+    with _patched(log_tool_usage):
+        result = await handle_recall(
+            {"query": "q", "context_ids": ids}, user_id="u1", workspace_id=None
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "error"
+    assert payload["error"] == "too_many_context_ids"
+    log_tool_usage.assert_not_awaited()

--- a/backend/tests/mcp_server/test_recall_cross_context_attribution.py
+++ b/backend/tests/mcp_server/test_recall_cross_context_attribution.py
@@ -1,0 +1,107 @@
+"""#1228: cross-context recall must hand the ADDITIONAL listed contexts to
+the usage logger for diagnostic read-attribution.
+
+Follows the mock-db handler convention of tests/mcp_server/ (patch
+db.base.get_db + the context resolver + the service, then inspect the
+_log_tool_usage call). The row-writing behavior itself is covered in
+test_helpers.py::TestLogToolUsageAttribution; this suite pins the handler
+side of the contract: WHICH context ids get attributed.
+"""
+
+import contextlib
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.memory import handle_recall
+
+
+def _recall_result():
+    result = MagicMock()
+    result.results = []
+    result.related_tags = []
+    result.explore_hints = None
+    result.confidence = None
+    return result
+
+
+@contextlib.contextmanager
+def _patched(log_tool_usage: AsyncMock):
+    """Patch the handler's collaborators so the test exercises pure handler
+    logic: same workspace/privacy/embedding-model for every listed context
+    (the #708 mismatch guards all pass)."""
+
+    async def mock_get_db():
+        yield AsyncMock()
+
+    shared_context = MagicMock()
+
+    service = MagicMock()
+    service.recall = AsyncMock(return_value=_recall_result())
+    service_cls = MagicMock(return_value=service)
+
+    config = MagicMock()
+    config.embedding_model = "text-embedding-3-small"
+    config_repo = MagicMock()
+    config_repo.create_or_get = AsyncMock(return_value=config)
+    config_repo_cls = MagicMock(return_value=config_repo)
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch(
+            "mcp_server.tools.memory._resolve_context_for_read",
+            new=AsyncMock(return_value=shared_context),
+        ),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+        patch("mcp_server.tools.memory._log_tool_usage", new=log_tool_usage),
+        patch("services.memory_service.MemoryService", new=service_cls),
+        patch(
+            "repositories.config_repository.ContextSearchConfigRepository",
+            new=config_repo_cls,
+        ),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_cross_context_recall_attributes_additional_contexts():
+    ctx_a, ctx_b, ctx_c = uuid4(), uuid4(), uuid4()
+    log_tool_usage = AsyncMock()
+
+    with _patched(log_tool_usage):
+        result = await handle_recall(
+            {"query": "q", "context_ids": [str(ctx_a), str(ctx_b), str(ctx_c)]},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    log_tool_usage.assert_awaited_once()
+    call = log_tool_usage.await_args
+    # Primary context carries the single billable UsageStats row...
+    assert call.args[5] == ctx_a
+    # ...and every ADDITIONAL listed context is attributed, in order.
+    assert call.kwargs["attributed_context_ids"] == [ctx_b, ctx_c]
+
+
+@pytest.mark.asyncio
+async def test_single_context_recall_attributes_nothing():
+    ctx_a = uuid4()
+    log_tool_usage = AsyncMock()
+
+    with _patched(log_tool_usage):
+        result = await handle_recall(
+            {"query": "q", "context_id": str(ctx_a)},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    log_tool_usage.assert_awaited_once()
+    call = log_tool_usage.await_args
+    assert call.args[5] == ctx_a
+    assert not call.kwargs.get("attributed_context_ids")

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -929,3 +929,28 @@ def test_get_session_manager_returns_module_state(monkeypatch):
 
     monkeypatch.setattr(auth_module, "_session_manager", None)
     assert auth_module.get_session_manager() is None
+
+
+class TestDeletePostgresSweep:
+    """#1228: the per-user Postgres sweep must include the diagnostic
+    context_read_attributions table — attribution rows where the erased
+    user read a context in ANOTHER user's workspace survive the
+    workspace-cascade deletion, so the user_id sweep is the only
+    mechanism removing them on GDPR erasure."""
+
+    @pytest.mark.asyncio
+    async def test_sweep_covers_context_read_attributions(self):
+        from models.auth import ContextReadAttribution
+
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=3)
+        svc._pseudonymize_field = AsyncMock(return_value=0)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        target = _user()
+
+        counts = await svc._delete_postgres(target)
+
+        assert counts["context_read_attributions"] == 3
+        swept_models = [call.args[0] for call in svc._count_and_delete.await_args_list]
+        assert ContextReadAttribution in swept_models

--- a/backend/tests/services/test_memory_health_service.py
+++ b/backend/tests/services/test_memory_health_service.py
@@ -537,3 +537,66 @@ class TestFoldOrphanScopes:
         assert breakdown["overall_status"] == STATUS_FAIL
         unattributed = next(e for e in breakdown["contexts"] if e["context_id"] is None)
         assert unattributed["sections"]["graph"] == STATUS_FAIL
+
+
+class TestFetchUsageCountsAttribution:
+    """#1228: cross-context recall attribution rows (the separate
+    context_read_attributions table) must merge into the per-context usage
+    counts so a context read ONLY via cross-context recall stops
+    false-WARNing write_only_store — the exact false-WARN class the
+    grading philosophy forbids."""
+
+    def _db_with_result_sets(self, usage_rows, attribution_rows):
+        db = AsyncMock()
+        first, second = MagicMock(), MagicMock()
+        first.all.return_value = usage_rows
+        second.all.return_value = attribution_rows
+        db.execute = AsyncMock(side_effect=[first, second])
+        return db
+
+    @pytest.mark.asyncio
+    async def test_attribution_rows_merge_into_usage_counts(self) -> None:
+        db = self._db_with_result_sets(
+            usage_rows=[(_CTX_A, "mcp:recall", 4), (_CTX_B, "mcp:remember", 5)],
+            attribution_rows=[(_CTX_B, "mcp:recall", 3)],
+        )
+        svc = MemoryHealthService(db)
+
+        usage = await svc._fetch_usage_counts("user-1")
+
+        assert usage[_CTX_A] == {"recall": 4}
+        # B keeps its own writes AND gains the attributed reads.
+        assert usage[_CTX_B] == {"remember": 5, "recall": 3}
+
+    @pytest.mark.asyncio
+    async def test_same_context_and_endpoint_counts_sum(self) -> None:
+        """A context that is BOTH the primary of some calls and attributed
+        in others sums the two sources, never overwrites."""
+        db = self._db_with_result_sets(
+            usage_rows=[(_CTX_A, "mcp:recall", 4)],
+            attribution_rows=[(_CTX_A, "mcp:recall", 2)],
+        )
+        svc = MemoryHealthService(db)
+
+        usage = await svc._fetch_usage_counts("user-1")
+
+        assert usage[_CTX_A] == {"recall": 6}
+
+    @pytest.mark.asyncio
+    async def test_attributed_only_context_no_longer_warns_write_only(self) -> None:
+        """AC pin (#1228): active memories + reads arriving exclusively via
+        cross-context recall attribution → retrieval grades OK, not
+        write_only_store."""
+        db = self._db_with_result_sets(
+            usage_rows=[],
+            attribution_rows=[(_CTX_B, "mcp:recall", 3)],
+        )
+        svc = MemoryHealthService(db)
+
+        usage = await svc._fetch_usage_counts("user-1")
+        section = MemoryHealthService._grade_retrieval(
+            usage.get(_CTX_B, {}), _POSTURE_ON, active_memories=50
+        )
+
+        assert section["status"] == STATUS_OK
+        assert "write_only_store" not in _codes(section)

--- a/docs/ops/memory-health-report.md
+++ b/docs/ops/memory-health-report.md
@@ -95,11 +95,13 @@ Metrics: `recall_calls`, `recall_upcoming_calls`, `remember_calls`,
 `explore_calls`, `window_days`, plus config posture (`has_config`,
 `reinforce_enabled`, `use_rerank` — booleans per context).
 
-Attribution caveat: a cross-context `recall(context_ids=[...])` is logged
-under the **first** listed context only, so read activity on the other
-listed contexts is invisible to this section. A `write_only_store` WARN on
-a context that is only read via cross-context recall is a known false
-positive until usage logging attributes every listed context.
+Attribution (#1228): a cross-context `recall(context_ids=[...])` bills one
+quota unit — the `usage_stats` row under the **first** listed context —
+and records a diagnostic `context_read_attributions` row for every other
+listed context. This section merges both sources, so a context read only
+via cross-context recall counts as read activity and no longer
+false-WARNs `write_only_store`. Attribution rows are diagnostic only:
+quota and workspace usage analytics never count them.
 
 ## Structured notes (#1225)
 


### PR DESCRIPTION
Closes #1228

## Summary

- A cross-context `recall(context_ids=[A, B, ...])` logged usage under the FIRST listed context only, so read activity on the other listed contexts was invisible to per-context consumers — the memory-health retrieval section false-WARNed `write_only_store` on contexts read exclusively via cross-context recall (known limitation since #1225).
- Reads on the additional listed contexts are now recorded in a new **`context_read_attributions`** table: one diagnostic row per additional context, written by `_log_tool_usage` alongside the single billable `UsageStats` row (primary context, unchanged).
- **Why a separate table instead of marker rows in `usage_stats`**: every `usage_stats` reader counts rows for quota/billing/analytics — 7 call sites today (quota_service, workspace_service ×3, routes/workspace ×4-ish), and a same-table marker would tax each of them (and every future reader) with a remember-to-exclude filter — the same "silently broken filter contract" class as #1229. Attribution rows are structurally invisible to them by construction, so **quota (one call = one unit) and workspace usage views are unaffected without touching a single existing query**.
- `MemoryHealthService._fetch_usage_counts` merges both sources (same window/endpoint/scope filters), closing the false-WARN. Account erasure sweeps the new table by `user_id`. The docs caveat is replaced with the new attribution contract.

## Implementation notes

- Migration `e60_1228_read_attributions`: pure CREATE TABLE (blue-green safe). Two review-cycle fixes baked in:
  - revision IDs must stay ≤ 32 chars (`alembic_version.version_num` is varchar(32)) — the first draft's 34-char ID failed the round-trip test with `StringDataRightTruncationError`; documented in the migration docstring.
  - no `server_default` on `created_at` — the writer always supplies it and the create_all-vs-alembic drift gate flags one-sided server defaults.
- `ContextReadAttribution.context_id` cascades on context deletion (unlike `UsageStats`' SET NULL): attribution rows for a deleted context carry no diagnostic value, while billing rows must survive for audit.
- Attribution writing is fail-soft (same swallow pattern as usage logging): a failed attribution insert never breaks the recall or loses the already-committed billable row.
- Handler error paths (404/500) do not attribute — only successful recalls count as reads.
- `context_ids` is schema-capped at 20 items (`maxItems`), bounding attribution writes per call.

## Verification

- `eval-update` not re-run: the change is pure usage-telemetry — no retrieval, ranking, or sleep behavior is touched.
- `make test-integration` on the local stack: migration round-trip + create_all-vs-alembic drift gate + erasure integration all pass. The only failures (3) are pre-existing `test_resource_indexer_qdrant.py` cases broken by a removed qdrant-client API (`QdrantClient.search`) — unrelated to this change, follow-up filed separately.
- Unit: 57 tests across `test_helpers.py` (attribution row writing), `test_recall_cross_context_attribution.py` (handler passes `cross_context_ids[1:]`), `test_memory_health_service.py` (merge + AC pin: attribution-only context grades OK, not `write_only_store`).

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CIO — pivoted the design from method-marker rows to the separate table)
- review provider: none

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1228-fix-cross-context-recall-usage-attribution.gate1.md
- ~/.claude/cache/gh-issue-driven/1228-fix-cross-context-recall-usage-attribution.gate2.md

🤖 Generated via /gh-issue-driven:ship
