### PR TITLE
refactor(sleep): drop dead 'archive' option from consolidation judge (#1233)

### DIFF
--- a/backend/src/services/sleep/consolidation.py
+++ b/backend/src/services/sleep/consolidation.py
@@ -127,6 +127,10 @@ class ConsolidationPhase:
         # #1183: judge-failure counter (init here so the LLM judge helper can
         # be unit-tested without execute()).
         self._llm_failures: int = 0
+        # #1233: token/breakdown accumulators too — same rationale (the
+        # dedup phase established the pattern in #475).
+        self._tokens_used: int = 0
+        self._llm_breakdown: LLMCallBreakdown | None = None
 
     async def execute(
         self,
@@ -292,6 +296,11 @@ class ConsolidationPhase:
                             mem.reference_count or 0,
                         )
                     elif action == "archive":
+                        # #1233: unreachable via _llm_judge_batch (the prompt
+                        # no longer offers "archive" and the parser rejects
+                        # it) — kept as a defensive backstop so any future
+                        # decision source still cannot archive an ineligible
+                        # memory.
                         # #1229: the LLM only chooses AMONG deterministically
                         # archival-eligible candidates (shared predicate with
                         # the rule path above — see _archival_eligible).
@@ -420,7 +429,8 @@ class ConsolidationPhase:
     ) -> dict[UUID, str]:
         """Use LLM to judge borderline working memories.
 
-        Returns {memory_id: "promote"|"keep"|"archive"}.
+        Returns {memory_id: "promote"|"keep"} — "archive" is not offered
+        (#1233): rule-path archival is deterministic and already ran.
         """
         labels = list(string.ascii_uppercase[: len(batch)])
         label_to_id = dict(zip(labels, [m.id for m in batch], strict=True))
@@ -429,7 +439,7 @@ class ConsolidationPhase:
         random.shuffle(items)
 
         # The summary is untrusted (issue #919) — wrap it so an embedded
-        # instruction cannot steer the consolidation (promote/keep/archive) judgment.
+        # instruction cannot steer the consolidation (promote/keep) judgment.
         memory_lines = []
         for label, mem in items:
             age_days = (utcnow() - mem.created_at).days
@@ -459,14 +469,18 @@ class ConsolidationPhase:
             logger.warning("consolidation_llm_failed", error=str(e))
             return {}
 
-        # Parse with label validation
+        # Parse with label validation. #1233: "archive" is no longer offered
+        # (rule-path archival is deterministic and runs before the judge),
+        # so it is rejected here like any other invalid action; the
+        # execute()-side _archival_eligible guard remains as a defensive
+        # backstop should an archive decision ever reach it again.
         decisions: dict[UUID, str] = {}
         for item in llm_resp.parsed.get("decisions", []):
             label = item.get("label")
             action = item.get("action")
             if label not in label_to_id:
                 continue
-            if action not in ("promote", "keep", "archive"):
+            if action not in ("promote", "keep"):
                 continue
             decisions[label_to_id[label]] = action
 

--- a/backend/src/services/sleep/consolidation.py
+++ b/backend/src/services/sleep/consolidation.py
@@ -4,7 +4,7 @@ Issue #103: Replace rule-based consolidation with LLM-augmented version.
 
 Migrates logic from neural_tasks.py:consolidation_task (lines 92-225):
 - Fast path: existing rules for clear-cut cases (no LLM needed)
-- Borderline: LLM decides promote/keep/archive
+- Borderline: LLM decides promote/keep (#1233: archival is rule-path only)
 - LLM off: identical behavior to legacy consolidation_task
 - Bridge node protection: never delete memories with high centrality
 
@@ -481,6 +481,16 @@ class ConsolidationPhase:
             if label not in label_to_id:
                 continue
             if action not in ("promote", "keep"):
+                # #1233 review: "archive" is retired, but a judge that still
+                # emits it signals schema drift (model change, stale
+                # provider-side prompt cache) — surface it, or llm_promoted
+                # quietly collapses with nothing tying it to the cause.
+                if action == "archive":
+                    logger.info(
+                        "consolidation_judge_returned_retired_action",
+                        action=action,
+                        label=str(label),
+                    )
                 continue
             decisions[label_to_id[label]] = action
 

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -306,19 +306,19 @@ Promotion criteria:
 - The information is likely to be useful beyond the current session
 - The memory is well-formed and self-contained
 
-Archive criteria:
-- The memory is purely ephemeral (session state, temporary debugging)
-- The information has been superseded by newer memories
-- The memory is poorly formed or lacks actionable content
-
 When uncertain, prefer "keep" — premature promotion clutters long-term memory, \
-but premature archival loses information permanently.
+and a kept memory can always be promoted on a later pass.
 
 You MUST respond with valid JSON only.
 
 {INJECTION_RESISTANCE_DIRECTIVE}\
 """
 
+# #1233: the judge decides promote vs keep ONLY. Deletion is not on the
+# menu: rule-path archival is deterministic (_archival_eligible + isolation,
+# see consolidation.py) and runs before the judge, so an LLM archive pick
+# was always either redundant or guarded out — dead tokens and wasted
+# probability mass.
 CONSOLIDATION_JUDGE_USER = """\
 Evaluate these working memories for consolidation.
 
@@ -330,7 +330,7 @@ Respond with this exact JSON schema:
   "decisions": [
     {{
       "label": "A",
-      "action": "promote" | "keep" | "archive",
+      "action": "promote" | "keep",
       "reason": "brief justification"
     }}
   ]

--- a/backend/tests/services/sleep/test_consolidation.py
+++ b/backend/tests/services/sleep/test_consolidation.py
@@ -218,53 +218,87 @@ class TestAdoptionArchivalGrandfather:
 
 
 class TestLLMJudgeParsing:
-    """Test LLM response parsing for consolidation."""
+    """Parse contract of ``_llm_judge_batch`` — exercised through the REAL
+    parser (#1233 replaced inline simulations that could silently drift
+    from production)."""
 
-    def test_valid_promote_response(self):
-        id_a = uuid4()
-        label_to_id = {"A": id_a}
+    async def _parse(self, consolidation_phase, memory, decisions):
+        resp = MagicMock()
+        resp.parsed = {"decisions": decisions}
+        resp.total_tokens = 10
+        consolidation_phase.llm_service.complete_json = AsyncMock(return_value=resp)
+        return await consolidation_phase._llm_judge_batch(
+            [memory], "user-1", "ctx-1", "ws-1", SleepBudget(), _make_config()
+        )
 
-        response = {
-            "decisions": [{"label": "A", "action": "promote", "reason": "durable knowledge"}]
-        }
+    @pytest.mark.asyncio
+    async def test_valid_promote_response(self, consolidation_phase):
+        mem = _make_working_memory()
+        decisions = await self._parse(
+            consolidation_phase,
+            mem,
+            [{"label": "A", "action": "promote", "reason": "durable knowledge"}],
+        )
+        assert decisions == {mem.id: "promote"}
 
-        # Simulate parsing logic
-        decisions = {}
-        for item in response.get("decisions", []):
-            label = item.get("label")
-            action = item.get("action")
-            if label in label_to_id and action in ("promote", "keep", "archive"):
-                decisions[label_to_id[label]] = action
+    @pytest.mark.asyncio
+    async def test_valid_keep_response(self, consolidation_phase):
+        mem = _make_working_memory()
+        decisions = await self._parse(
+            consolidation_phase,
+            mem,
+            [{"label": "A", "action": "keep", "reason": "uncertain"}],
+        )
+        assert decisions == {mem.id: "keep"}
 
-        assert decisions[id_a] == "promote"
+    @pytest.mark.asyncio
+    async def test_archive_action_dropped_at_parse(self, consolidation_phase):
+        """#1233: 'archive' is no longer offered to the judge — a response
+        that uses it anyway is dropped at parse. The execute()-side
+        ``_archival_eligible`` guard stays as the defensive backstop."""
+        mem = _make_working_memory()
+        decisions = await self._parse(
+            consolidation_phase,
+            mem,
+            [{"label": "A", "action": "archive", "reason": "stale"}],
+        )
+        assert decisions == {}
 
-    def test_invalid_action_ignored(self):
-        label_to_id = {"A": uuid4()}
+    @pytest.mark.asyncio
+    async def test_invalid_action_ignored(self, consolidation_phase):
+        mem = _make_working_memory()
+        decisions = await self._parse(
+            consolidation_phase,
+            mem,
+            [{"label": "A", "action": "destroy", "reason": "bad action"}],
+        )
+        assert decisions == {}
 
-        response = {"decisions": [{"label": "A", "action": "destroy", "reason": "bad action"}]}
+    @pytest.mark.asyncio
+    async def test_invalid_label_ignored(self, consolidation_phase):
+        mem = _make_working_memory()
+        decisions = await self._parse(
+            consolidation_phase,
+            mem,
+            [{"label": "Z", "action": "promote", "reason": "hallucinated"}],
+        )
+        assert decisions == {}
 
-        decisions = {}
-        for item in response.get("decisions", []):
-            label = item.get("label")
-            action = item.get("action")
-            if label in label_to_id and action in ("promote", "keep", "archive"):
-                decisions[label_to_id[label]] = action
 
-        assert len(decisions) == 0
+class TestConsolidationPromptContract:
+    """#1233: the judge prompt no longer offers the dead 'archive' action —
+    rule-path archival is deterministic and the judge's archive picks were
+    either redundant or guarded out, wasting tokens and probability mass."""
 
-    def test_invalid_label_ignored(self):
-        label_to_id = {"A": uuid4()}
+    def test_prompt_no_longer_offers_archive(self):
+        from services.sleep.prompts import (
+            CONSOLIDATION_JUDGE_SYSTEM,
+            CONSOLIDATION_JUDGE_USER,
+        )
 
-        response = {"decisions": [{"label": "Z", "action": "promote", "reason": "hallucinated"}]}
-
-        decisions = {}
-        for item in response.get("decisions", []):
-            label = item.get("label")
-            action = item.get("action")
-            if label in label_to_id and action in ("promote", "keep", "archive"):
-                decisions[label_to_id[label]] = action
-
-        assert len(decisions) == 0
+        assert '"archive"' not in CONSOLIDATION_JUDGE_USER
+        assert '"promote" | "keep"' in CONSOLIDATION_JUDGE_USER
+        assert "archive" not in CONSOLIDATION_JUDGE_SYSTEM.lower()
 
 
 def _isolation_memory(*, importance, access_count, age_days, reference_count=0):

--- a/backend/tests/services/sleep/test_consolidation_coverage.py
+++ b/backend/tests/services/sleep/test_consolidation_coverage.py
@@ -207,16 +207,17 @@ class TestLLMBorderlinePath:
 
     @pytest.mark.asyncio
     async def test_llm_archive_connected_memory_is_protected(self):
-        # Graph present and the node is NOT isolated → bridge protection: the
-        # LLM "archive" verdict must be vetoed. #1229: the memory must be
+        # Graph present and the node is NOT isolated → bridge protection: an
+        # "archive" decision must be vetoed. #1229: the memory must be
         # deterministically archival-eligible (age >= 30d, cutoff opted-in)
         # or the eligibility guard short-circuits before the isolation veto
-        # is ever exercised (this test was briefly vacuous).
+        # is ever exercised. #1233 review: the parser now drops "archive",
+        # so this must bypass it (mock _llm_judge_batch) like the other
+        # backstop tests — routing through complete_json made it vacuous
+        # (mutation-confirmed: removing the isolation veto stayed green).
         mem = _make_memory(age_days=40)
         phase, llm = _build_phase([mem])
-        llm.complete_json = AsyncMock(
-            return_value=_make_llm_response([{"label": "A", "action": "archive"}])
-        )
+        phase._llm_judge_batch = AsyncMock(return_value={mem.id: "archive"})
         connected = {
             "centrality": 0.1,
             "edge_count": 1,

--- a/backend/tests/services/sleep/test_consolidation_coverage.py
+++ b/backend/tests/services/sleep/test_consolidation_coverage.py
@@ -186,12 +186,14 @@ class TestLLMBorderlinePath:
         assert result.llm_calls_used == 1
 
     @pytest.mark.asyncio
-    async def test_llm_archive_fresh_memory_is_guarded(self):
-        # #1229: a fresh borderline memory (age 10d, cutoff unset) is not
-        # deterministically archival-eligible — the LLM's "archive" verdict
-        # is refused, never a deletion. (Pre-#1229 this test asserted the
-        # LLM could delete it — the exact hazard that ate the eval's
-        # freshly-ingested current docs.)
+    async def test_llm_archive_response_dropped_at_parse(self):
+        # #1233: "archive" is no longer offered to the judge — an LLM
+        # response that uses it anyway is dropped at PARSE, so nothing is
+        # deleted and nothing is guarded (the guard counter only moves for
+        # decisions that reach the execute loop, which parse now prevents).
+        # Pre-#1229 this test asserted the LLM could delete a fresh memory;
+        # #1229 turned that into a guarded refusal; #1233 removes the
+        # option at the source.
         mem = _make_memory()
         phase, llm = _build_phase([mem])
         llm.complete_json = AsyncMock(
@@ -200,7 +202,7 @@ class TestLLMBorderlinePath:
         result, _, _ = await _run_with_graph(phase, total_edges=0, config=_make_config())
 
         assert result.details["llm_archived"] == 0
-        assert result.details["llm_archive_guarded"] == 1
+        assert result.details["llm_archive_guarded"] == 0
         phase.memory_repo.delete.assert_not_called()
 
     @pytest.mark.asyncio
@@ -235,16 +237,16 @@ class TestLLMBorderlinePath:
         phase.memory_repo.delete.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_llm_archive_isolated_with_graph_deletes(self):
-        # #1229: the LLM archive lane survives only for memories that were
-        # NOT rule-deletable at rule time (connected then) but read as
-        # isolated by the LLM-path re-check — deterministic eligibility
-        # (age/adoption/cutoff) still holds, so the verdict proceeds.
+    async def test_archive_backstop_still_deletes_eligible_isolated(self):
+        # #1233: the parse path can no longer emit "archive", but the
+        # execute()-side lane is kept as a defensive backstop for any
+        # future decision source. Bypass the parser (mock _llm_judge_batch
+        # directly) to pin the backstop's behavior: deterministic
+        # eligibility (age/adoption/cutoff) + isolation still required,
+        # and an eligible isolated memory is deleted.
         mem = _make_memory(age_days=40)
         phase, llm = _build_phase([mem])
-        llm.complete_json = AsyncMock(
-            return_value=_make_llm_response([{"label": "A", "action": "archive"}])
-        )
+        phase._llm_judge_batch = AsyncMock(return_value={mem.id: "archive"})
         connected = {
             "centrality": 0.1,
             "edge_count": 1,
@@ -366,7 +368,7 @@ class TestLLMJudgeBatch:
                 return_value=_make_llm_response(
                     [
                         {"label": "A", "action": "promote"},
-                        {"label": "B", "action": "archive"},
+                        {"label": "B", "action": "keep"},
                     ]
                 )
             )
@@ -375,7 +377,7 @@ class TestLLMJudgeBatch:
 
         # No shuffle → label A is mems[0], B is mems[1].
         assert decisions[mems[0].id] == "promote"
-        assert decisions[mems[1].id] == "archive"
+        assert decisions[mems[1].id] == "keep"
         assert budget.llm_calls_used == 1
         assert phase._tokens_used == 42
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -225,7 +225,7 @@ Conflating "recently co-recalled" with "content-similar" causes edge survival to
 Edge `origin` and `Memory.scope` (`working` / `persistent`) are **two independent axes** managed by different subsystems:
 
 - **`origin`** controls *edge* lifetime — see the table above.
-- **`scope`** controls *memory node* lifetime — `working` memories are promoted to `persistent` (or archived) by the Sleep Consolidation phase based on access patterns and LLM judgment. See [Sleep Maintenance](sleep-maintenance.md).
+- **`scope`** controls *memory node* lifetime — `working` memories are promoted to `persistent` (or archived) by the Sleep Consolidation phase. Promotion is decided by adoption-gated rules plus LLM judgment for borderline cases; archival is exclusively the deterministic rule path's job — the LLM judge decides `promote` vs `keep` only (#1233). See [Sleep Maintenance](sleep-maintenance.md).
 
 Hebbian edges supply *signal* to consolidation (a working memory that gets reinforced via co-recall is more likely to be promoted), but Hebbian learning itself does not look at `scope` — `HebbianLearner.queue_update` creates edges between any co-activated pair regardless of whether the endpoints are `working` or `persistent`. In the neuroscience analogy, this is a two-level consolidation: edge consolidation (Hebbian → Semantic) and node consolidation (working → persistent) happen on different timescales and via different mechanisms.
 

--- a/docs/sleep-maintenance.md
+++ b/docs/sleep-maintenance.md
@@ -87,6 +87,7 @@ Adjusts memory importance using LLM scoring combined with EMA smoothing.
 Promotes, keeps, or archives working memories based on fast-path rules plus LLM judgment for borderline cases.
 
 - **Algorithm**: rule-based fast path for clear-cut `promote` / `archive` decisions (no LLM) → LLM judgment only for borderline cases → bridge-node protection (never delete memories with high graph centrality).
+- **Judge actions** (#1233): the LLM judge decides `promote` vs `keep` only. Archival is exclusively the deterministic rule path's job (`_archival_eligible` + isolation, which runs *before* the judge) — the judge's `archive` option was removed because its picks were always either redundant or guarded out (#1229), wasting prompt tokens and probability mass. The eligibility guard remains in code as a defensive backstop; `llm_archive_guarded` stays in the report vocabulary (expected 0).
 - **LLM**: yes (optional — in non-LLM mode, behavior matches the legacy `consolidation_task`).
 - **Replaces**: the pre-Sleep rule-only `consolidation_task`.
 


### PR DESCRIPTION
Closes #1233

## Summary

- Since #1229, consolidation archival is deterministically gated: the rule path deletes eligible+isolated memories **before** the LLM judge runs, and any LLM `archive` pick failing `_archival_eligible` is guarded out. The judge's `archive` option could only ever be redundant or vetoed — dead prompt tokens and wasted probability mass on every consolidation call.
- The judge prompt now offers **`promote` | `keep` only**: the system prompt's Archive criteria block is removed (the "when uncertain, prefer keep" guidance is rephrased to stand without it), the response schema drops `"archive"`, and the parser rejects it like any other invalid action.
- The execute()-side eligibility guard (`_archival_eligible` + isolation re-check) is **kept as a defensive backstop** for any future decision source; `llm_archived` / `llm_archive_guarded` stay in the report vocabulary (expected 0 from now on).

## Implementation notes

- Accumulator init (`_tokens_used`, `_llm_breakdown`) moved into `__init__` so `_llm_judge_batch` is unit-testable without `execute()` — the #475 pattern the dedup phase already uses.
- `TestLLMJudgeParsing` now exercises the REAL parser through `_llm_judge_batch` (the previous tests re-implemented the parse loop inline and could drift from production silently).
- The backstop lane keeps its own test (`test_archive_backstop_still_deletes_eligible_isolated`, parser bypassed via a mocked `_llm_judge_batch`), so the #1229 guard contract stays pinned independently of the prompt change.
- `docs/sleep-maintenance.md` Phase 4 documents the new judge action set and why archival is rule-path-only.

## Live eval (AC: prompt changes shift judge behavior)

Executed on the local WSL stack (this branch, frozen update_slice corpus, 2026-07-13):

- **`llm_archive_guarded == 0`** across the run (0 guarded-log events; the consolidation report records `"llm_archive_guarded": 0`) — the AC's dead-option signal is gone at the source.
- All #1210 contracts PASS: `stale_only_zero` (0), `mc_update_success_floor` (0.98 >= 0.8), `vr_sanity_band` (0.42), `llm_call_failures_zero` (0). `make eval-update` exit 0, `make eval-ci-gates` exit 0.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CAIO)
- review provider: none

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1233-refactor-drop-dead-archive-judge-option.gate1.md
- ~/.claude/cache/gh-issue-driven/1233-refactor-drop-dead-archive-judge-option.gate2.md

🤖 Generated via /gh-issue-driven:ship
