### PR TITLE
feat(frontend): URL-synced drill-down for admin memory-health (#1227)

### DIFF
--- a/frontend/src/app/(authenticated)/admin/memory-health/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.test.tsx
@@ -12,7 +12,7 @@
  *   - zero contexts renders the empty state, not an error
  */
 
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 import AdminMemoryHealthPage from "./page";
@@ -28,6 +28,60 @@ vi.mock("@/lib/api", async (importOriginal) => {
     apiClient: {
       get: (...args: unknown[]) => mockGet(...args),
     },
+  };
+});
+
+// Stateful navigation mock (#1227): a tiny history store the mocked
+// useSearchParams subscribes to via useSyncExternalStore, so router.push
+// re-renders the page exactly like a real URL change, and browser
+// back/forward are simulated by moving the history index inside act().
+const { navMock } = vi.hoisted(() => {
+  let entries: string[] = [""];
+  let idx = 0;
+  const listeners = new Set<() => void>();
+  const notify = () => listeners.forEach((l) => l());
+  const navMock = {
+    getQs: () => entries[idx],
+    subscribe: (cb: () => void) => {
+      listeners.add(cb);
+      return () => listeners.delete(cb);
+    },
+    push(url: string) {
+      const q = url.indexOf("?");
+      entries = entries.slice(0, idx + 1).concat(q === -1 ? "" : url.slice(q + 1));
+      idx += 1;
+      notify();
+    },
+    back() {
+      if (idx > 0) {
+        idx -= 1;
+        notify();
+      }
+    },
+    forward() {
+      if (idx < entries.length - 1) {
+        idx += 1;
+        notify();
+      }
+    },
+    reset(initialQs = "") {
+      entries = [initialQs];
+      idx = 0;
+      listeners.clear();
+    },
+  };
+  return { navMock };
+});
+
+vi.mock("next/navigation", async () => {
+  const { useSyncExternalStore } = await import("react");
+  return {
+    useSearchParams: () => {
+      const qs = useSyncExternalStore(navMock.subscribe, navMock.getQs, navMock.getQs);
+      return new URLSearchParams(qs);
+    },
+    usePathname: () => "/admin/memory-health",
+    useRouter: () => ({ push: (url: string) => navMock.push(url) }),
   };
 });
 
@@ -98,6 +152,7 @@ const DETAIL = {
 
 beforeEach(() => {
   mockGet.mockReset();
+  navMock.reset();
 });
 
 // ---------- Tests ------------------------------------------------------------
@@ -181,5 +236,107 @@ describe("AdminMemoryHealthPage drill-down (#1225)", () => {
         "/api/v1/admin/memory-health?context_id=unattributed",
       );
     });
+  });
+});
+
+describe("AdminMemoryHealthPage URL-synced drill-down (#1227)", () => {
+  it("deep-links straight into the detail view without a list fetch", async () => {
+    // AC: refresh/bookmark of a detail URL renders the detail directly —
+    // this is also the page-refresh case (F5 == fresh render with the param).
+    navMock.reset(`context_id=${CTX_ID}`);
+    mockGet.mockResolvedValueOnce(DETAIL);
+
+    render(<AdminMemoryHealthPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Context A")).toBeInTheDocument();
+    });
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith(`/api/v1/admin/memory-health?context_id=${CTX_ID}`);
+  });
+
+  it("deep-links to the unattributed scope like any context", async () => {
+    navMock.reset("context_id=unattributed");
+    mockGet.mockResolvedValueOnce({ ...DETAIL, context_id: null, context_name: null });
+
+    render(<AdminMemoryHealthPage />);
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith(
+        "/api/v1/admin/memory-health?context_id=unattributed",
+      );
+    });
+  });
+
+  it("drill-down pushes the scope into the URL", async () => {
+    mockGet.mockResolvedValueOnce(BREAKDOWN).mockResolvedValueOnce(DETAIL);
+
+    render(<AdminMemoryHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId(`context-${CTX_ID}`));
+
+    await waitFor(() => {
+      expect(navMock.getQs()).toBe(`context_id=${CTX_ID}`);
+    });
+  });
+
+  it("browser back returns to the retained list without a refetch; forward reloads the detail", async () => {
+    mockGet.mockResolvedValueOnce(BREAKDOWN).mockResolvedValueOnce(DETAIL);
+
+    render(<AdminMemoryHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId(`context-${CTX_ID}`));
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    // Browser back: the retained breakdown renders instantly — no refetch.
+    act(() => {
+      navMock.back();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    });
+    expect(mockGet).toHaveBeenCalledTimes(2);
+
+    // Browser forward: back into the detail view (fresh fetch).
+    mockGet.mockResolvedValueOnce(DETAIL);
+    act(() => {
+      navMock.forward();
+    });
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledTimes(3);
+    });
+    expect(mockGet).toHaveBeenLastCalledWith(
+      `/api/v1/admin/memory-health?context_id=${CTX_ID}`,
+    );
+  });
+
+  it("the in-page back button clears the URL param and shows the retained list", async () => {
+    mockGet.mockResolvedValueOnce(BREAKDOWN).mockResolvedValueOnce(DETAIL);
+
+    render(<AdminMemoryHealthPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId(`context-${CTX_ID}`));
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledTimes(2);
+    });
+
+    fireEvent.click(screen.getByText("back"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`context-${CTX_ID}`)).toBeInTheDocument();
+    });
+    expect(navMock.getQs()).toBe("");
+    expect(mockGet).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -18,6 +18,7 @@ import { Activity } from "lucide-react";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { CardLoadingState, TableLoadingState } from "@/components/common/LoadingState";
 import { EmptyState } from "@/components/ui/empty-state";
+import { useContextScopeParam } from "@/hooks/useContextScopeParam";
 import { apiClient } from "@/lib/api";
 
 type HealthStatus = "ok" | "warn" | "fail";
@@ -148,9 +149,11 @@ function SectionCard({ name, section }: { name: string; section: HealthSection }
 
 export default function AdminMemoryHealthPage() {
   const t = useTranslations("admin.memoryHealth");
+  // #1227: the selected scope lives in the URL (?context_id=<uuid|unattributed>)
+  // so deep links, refresh, and browser back/forward all address the view.
+  const [selectedScope, setSelectedScope] = useContextScopeParam();
   const [breakdown, setBreakdown] = useState<BreakdownResponse | null>(null);
   const [detail, setDetail] = useState<DetailResponse | null>(null);
-  const [selectedScope, setSelectedScope] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -158,6 +161,10 @@ export default function AdminMemoryHealthPage() {
   // (or back-navigation) superseded it — otherwise a slow detail fetch for
   // context A would overwrite the view after the user moved to context B.
   const requestSeq = useRef(0);
+  // Mirror of `breakdown` for the scope effect below: back-navigation must
+  // read "is a list retained?" without re-running the effect when the
+  // breakdown response lands.
+  const breakdownRef = useRef<BreakdownResponse | null>(null);
 
   const load = useCallback(async (scope: string | null) => {
     const seq = ++requestSeq.current;
@@ -167,6 +174,7 @@ export default function AdminMemoryHealthPage() {
       if (scope === null) {
         const data = await apiClient.get<BreakdownResponse>("/api/v1/admin/memory-health");
         if (seq !== requestSeq.current) return;
+        breakdownRef.current = data;
         setBreakdown(data);
       } else {
         const data = await apiClient.get<DetailResponse>(
@@ -183,25 +191,34 @@ export default function AdminMemoryHealthPage() {
     }
   }, []);
 
+  // The URL is the single navigation source (#1227): this effect covers
+  // first mount (list or deep-linked detail), drill-down clicks, the
+  // in-page back button, and browser back/forward alike.
   useEffect(() => {
-    void load(null);
-  }, [load]);
+    if (selectedScope === null) {
+      if (breakdownRef.current) {
+        // Back-navigation with a retained breakdown: invalidate any
+        // in-flight detail fetch and show the kept list instantly — the
+        // refresh button covers wanting fresh data.
+        requestSeq.current += 1;
+        setDetail(null);
+        setError(null);
+        setLoading(false);
+      } else {
+        void load(null);
+      }
+    } else {
+      setDetail(null);
+      void load(selectedScope);
+    }
+  }, [selectedScope, load]);
 
   const openDetail = (entry: ContextEntry) => {
-    const scope = entry.context_id ?? UNATTRIBUTED_SCOPE;
-    setSelectedScope(scope);
-    setDetail(null);
-    void load(scope);
+    setSelectedScope(entry.context_id ?? UNATTRIBUTED_SCOPE);
   };
 
   const backToList = () => {
-    // Invalidate any in-flight detail fetch and show the retained breakdown
-    // instantly — the refresh button covers wanting fresh data.
-    requestSeq.current += 1;
     setSelectedScope(null);
-    setDetail(null);
-    setError(null);
-    setLoading(false);
   };
 
   const refresh = () => {

--- a/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/memory-health/page.tsx
@@ -205,6 +205,11 @@ export default function AdminMemoryHealthPage() {
         setError(null);
         setLoading(false);
       } else {
+        // Deep-link → back: no retained list, fetch it. Clear the stale
+        // detail too — leaving it set would paint the PREVIOUS context's
+        // sections for one frame on the next drill-down (the clearing
+        // effect only runs post-commit, after the browser painted).
+        setDetail(null);
         void load(null);
       }
     } else {

--- a/frontend/src/hooks/useContextScopeParam.test.ts
+++ b/frontend/src/hooks/useContextScopeParam.test.ts
@@ -1,0 +1,96 @@
+/**
+ * #1227: URL-scope hook for the admin memory-health drill-down.
+ *
+ * The same-value guard matters for history integrity: without it a fast
+ * double-click on a context row (router.push commits in a transition, so
+ * the list can still be interactive when the second click lands) pushes
+ * duplicate identical entries and the first browser Back press appears
+ * dead. Mirrors the useTabParam.test.ts mock convention.
+ */
+
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useContextScopeParam } from "./useContextScopeParam";
+
+const { mockGet, mockPush, mockToString } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockPush: vi.fn(),
+  mockToString: vi.fn(() => ""),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: mockGet, toString: mockToString }),
+  usePathname: () => "/admin/memory-health",
+  useRouter: () => ({ push: mockPush }),
+}));
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPush.mockReset();
+  mockToString.mockReset().mockReturnValue("");
+});
+
+describe("useContextScopeParam", () => {
+  it("reads the scope from the URL", () => {
+    mockGet.mockReturnValue("ctx-1");
+    const { result } = renderHook(() => useContextScopeParam());
+    expect(result.current[0]).toBe("ctx-1");
+  });
+
+  it("pushes the scope into the URL (navigation, not replace)", () => {
+    mockGet.mockReturnValue(null);
+    const { result } = renderHook(() => useContextScopeParam());
+
+    act(() => {
+      result.current[1]("ctx-1");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/admin/memory-health?context_id=ctx-1");
+  });
+
+  it("clearing the scope pushes the bare pathname", () => {
+    mockGet.mockReturnValue("ctx-1");
+    mockToString.mockReturnValue("context_id=ctx-1");
+    const { result } = renderHook(() => useContextScopeParam());
+
+    act(() => {
+      result.current[1](null);
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/admin/memory-health");
+  });
+
+  it("setting the CURRENT scope again is a no-op (no duplicate history entry)", () => {
+    mockGet.mockReturnValue("ctx-1");
+    const { result } = renderHook(() => useContextScopeParam());
+
+    act(() => {
+      result.current[1]("ctx-1");
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("clearing an already-absent scope is a no-op", () => {
+    mockGet.mockReturnValue(null);
+    const { result } = renderHook(() => useContextScopeParam());
+
+    act(() => {
+      result.current[1](null);
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated params when setting the scope", () => {
+    mockGet.mockReturnValue(null);
+    mockToString.mockReturnValue("tab=overview");
+    const { result } = renderHook(() => useContextScopeParam());
+
+    act(() => {
+      result.current[1]("ctx-1");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/admin/memory-health?tab=overview&context_id=ctx-1");
+  });
+});

--- a/frontend/src/hooks/useContextScopeParam.ts
+++ b/frontend/src/hooks/useContextScopeParam.ts
@@ -32,6 +32,13 @@ export function useContextScopeParam(): readonly [string | null, (scope: string 
 
   const setScope = useCallback(
     (next: string | null) => {
+      // Same-value no-op: router.push commits in a transition, so a fast
+      // double-click can land before the first navigation renders — without
+      // this guard it pushes a duplicate identical history entry and the
+      // first browser Back press appears dead.
+      if (next === searchParams.get(CONTEXT_SCOPE_PARAM)) {
+        return;
+      }
       const params = new URLSearchParams(searchParams.toString());
       if (next) {
         params.set(CONTEXT_SCOPE_PARAM, next);

--- a/frontend/src/hooks/useContextScopeParam.ts
+++ b/frontend/src/hooks/useContextScopeParam.ts
@@ -1,0 +1,48 @@
+"use client";
+
+/**
+ * useContextScopeParam — read/write the `?context_id=` deep-link parameter
+ * for the admin memory-health drill-down (#1227).
+ *
+ * Returns `[scope, setScope]`. Unlike `useMemoryIdParam` (dialog state) and
+ * `useTabParam` (tab facets), which use `router.replace`, scope changes here
+ * are NAVIGATION between two distinct views: `setScope` uses `router.push`
+ * so the browser back button returns from a context's detail to the
+ * breakdown list and forward returns to the detail.
+ *
+ * The value is either a context UUID or the `"unattributed"` sentinel;
+ * validation is the API's job — an unknown value surfaces as the detail
+ * fetch's error banner, exactly like a stale bookmark.
+ *
+ * `setScope`'s identity changes whenever `searchParams` does (it closes over
+ * the latest query string to preserve unrelated params) — same contract as
+ * `useMemoryIdParam`; do not cache it expecting referential equality.
+ */
+
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export const CONTEXT_SCOPE_PARAM = "context_id";
+
+export function useContextScopeParam(): readonly [string | null, (scope: string | null) => void] {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const scope = searchParams.get(CONTEXT_SCOPE_PARAM);
+
+  const setScope = useCallback(
+    (next: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) {
+        params.set(CONTEXT_SCOPE_PARAM, next);
+      } else {
+        params.delete(CONTEXT_SCOPE_PARAM);
+      }
+      const qs = params.toString();
+      router.push(`${pathname}${qs ? `?${qs}` : ""}`);
+    },
+    [pathname, router, searchParams],
+  );
+
+  return [scope, setScope] as const;
+}


### PR DESCRIPTION
Closes #1227

## Summary

- The admin memory-health drill-down scope lived in local `useState` only — refresh, the back button, or bookmarking a context's health detail dropped the operator back to the breakdown list.
- The scope now lives in the URL (`?context_id=<uuid|unattributed>`) via a new `useContextScopeParam` hook. Unlike `useMemoryIdParam`/`useTabParam` (`router.replace` — dialog/tab state), scope changes are navigation between two views: the hook uses **`router.push`** so browser back returns from detail to list and forward returns to detail.
- The page treats the URL as the single navigation source: one effect covers first mount (list or deep-linked detail), drill-down clicks, the in-page back button, and browser back/forward alike. The monotonic request-sequence guard and the retained-breakdown instant back are preserved (`breakdown` mirrored in a ref so back-navigation reads it without re-running the effect).

## Acceptance criteria coverage

- Deep-linking renders the detail directly — pinned with `toHaveBeenCalledTimes(1)` (no list fetch); this is also the page-refresh case (F5 == fresh render with the param).
- Browser back shows the retained list **without a refetch**; forward reloads the detail.
- `unattributed` is URL-addressable like any context.
- Tests use a stateful `next/navigation` mock (a `useSyncExternalStore`-backed history store), so `router.push` re-renders exactly like a real URL change and back/forward are exercised as history moves — not implementation pokes. 9/9 page tests, 771/771 full frontend suite, `tsc --noEmit` clean.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (search-param approach per the issue's first option; nested route not needed since the page retains list state for instant back)
- review provider: none

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1227-feat-memory-health-url-synced-drilldown.gate2.md

🤖 Generated via /gh-issue-driven:ship
