### PR TITLE
fix(api): harden analysis run-start against stuck-running rows and races (#1240)

### DIFF
--- a/backend/alembic/versions/e61_1240_one_running_uq.py
+++ b/backend/alembic/versions/e61_1240_one_running_uq.py
@@ -1,0 +1,75 @@
+"""#1240: partial unique index — one 'running' analysis per (workspace, context).
+
+``AnalysisOrchestrator.start()``'s idempotency guard is SELECT-then-INSERT:
+two concurrent starts can both pass the SELECT before either flushes, creating
+duplicate ``status='running'`` rows and bypassing the daily quota's read-only
+COUNT. This index makes the DB enforce the invariant; the loser's INSERT
+raises IntegrityError, which ``start()`` translates to the same 409
+ConflictError the guard raises.
+
+Pre-step: the bug this fixes also STRANDS rows at 'running' (malformed MCP
+date params / ``_mark_failed`` on a poisoned session — both fixed in the same
+PR). A production DB may therefore already hold duplicate running rows for
+one (workspace, context), which would make CREATE UNIQUE INDEX fail. Mark all
+but the NEWEST running row per pair as failed first — the older ones are by
+definition abandoned (a genuinely live run would have refused to start while
+they were running).
+
+Blue-green safety: additive index + a data repair on rows old app code only
+ever reads by id or lists; old app code keeps working unchanged.
+
+Revision ID: e61_1240_one_running_uq
+Revises: e60_1228_read_attributions
+
+Note: revision IDs must stay <= 32 chars — ``alembic_version.version_num``
+is varchar(32).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision = "e61_1240_one_running_uq"
+down_revision = "e60_1228_read_attributions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Repair duplicate running rows, then create the partial unique index."""
+    op.execute(
+        sa.text(
+            """
+            UPDATE memory_analyses
+            SET status = 'failed',
+                error = 'Superseded duplicate running row, repaired by the '
+                        '#1240 one-running-run migration.',
+                finished_at = (now() AT TIME ZONE 'utc')
+            WHERE id IN (
+                SELECT id FROM (
+                    SELECT id,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY workspace_id, context_id
+                               ORDER BY started_at DESC, id DESC
+                           ) AS rn
+                    FROM memory_analyses
+                    WHERE status = 'running'
+                ) ranked
+                WHERE ranked.rn > 1
+            )
+            """
+        )
+    )
+    op.create_index(
+        "uq_memory_analyses_one_running",
+        "memory_analyses",
+        ["workspace_id", "context_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'running'"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the partial unique index (the data repair is not reverted)."""
+    op.drop_index("uq_memory_analyses_one_running", table_name="memory_analyses")

--- a/backend/alembic/versions/e61_1240_one_running_uq.py
+++ b/backend/alembic/versions/e61_1240_one_running_uq.py
@@ -15,8 +15,16 @@ but the NEWEST running row per pair as failed first — the older ones are by
 definition abandoned (a genuinely live run would have refused to start while
 they were running).
 
-Blue-green safety: additive index + a data repair on rows old app code only
-ever reads by id or lists; old app code keeps working unchanged.
+Blue-green safety: additive index + a data repair. Two residual windows
+while OLD app code still serves traffic (both self-heal, neither corrupts):
+
+1. Old code can commit a fresh duplicate 'running' pair between the repair
+   UPDATE's snapshot and the index build — CREATE UNIQUE INDEX then fails
+   and the migration transaction rolls back; RE-RUNNING the deploy repairs
+   the new duplicate and succeeds.
+2. Once the index exists, old code losing the start race surfaces a raw
+   IntegrityError (500) instead of the new code's 409 translation — a
+   correct rejection with a rougher status code, gone after cutover.
 
 Revision ID: e61_1240_one_running_uq
 Revises: e60_1228_read_attributions

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -159,11 +159,13 @@ async def check_memory_analysis_quota(
     # handler share one session per request), so a racing second request
     # blocks HERE until the first request's row is committed and its
     # COUNT below sees it. Without the lock, N concurrent starts all
-    # read the pre-insert count and exceed the daily cap. Taken AFTER
-    # ``get_effective_quotas``: that service may commit internally when
-    # it recalculates addon columns, which would release an
-    # earlier-acquired xact lock. Same precedent as
-    # ``connector_provisioning.py``'s provisioning lock.
+    # read the pre-insert count and exceed the daily cap. Load-bearing
+    # invariant: NOTHING between this lock and the post-INSERT commit
+    # may commit the session (a commit releases an xact lock) —
+    # ``get_effective_quotas`` is a pure read since #570 and runs before
+    # the lock anyway; keep any future recalc/commit paths above this
+    # line. Same precedent as ``connector_provisioning.py``'s
+    # provisioning lock.
     await db.execute(
         text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))").bindparams(
             key=f"memory_analysis_quota:{workspace_id}"

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -49,7 +49,7 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from fastapi import Depends, HTTPException
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Re-exported from ``auth.analysis_allowlist`` so existing callers
@@ -141,15 +141,6 @@ async def check_memory_analysis_quota(
             f"Workspace {workspace_id} disappeared mid-request — gate cannot evaluate quota"
         )
 
-    count_stmt = select(func.count(MemoryAnalysis.id)).where(
-        and_(
-            MemoryAnalysis.workspace_id == workspace_id,
-            MemoryAnalysis.started_at >= day_start_utc,
-            MemoryAnalysis.started_at < day_end_utc,
-        )
-    )
-    used_today = int((await db.execute(count_stmt)).scalar() or 0)
-
     effective = await EffectiveQuotaService(db).get_effective_quotas(workspace_id)
     limit_today = int(effective["analysis_runs_per_day"])
     # Refresh the workspace row AFTER ``get_effective_quotas`` runs —
@@ -160,6 +151,33 @@ async def check_memory_analysis_quota(
     # producing an inconsistent body. Issue #496 Copilot review.
     await db.refresh(workspace_row)
     addon_bonus = int(workspace_row.addon_analysis_bonus or 0)
+
+    # #1240: serialize concurrent quota evaluations per workspace.
+    # ``pg_advisory_xact_lock`` holds until this transaction ends — the
+    # SAME transaction later INSERTs the ``memory_analyses`` row in
+    # ``orchestrator.start()`` (FastAPI dependency caching / the MCP
+    # handler share one session per request), so a racing second request
+    # blocks HERE until the first request's row is committed and its
+    # COUNT below sees it. Without the lock, N concurrent starts all
+    # read the pre-insert count and exceed the daily cap. Taken AFTER
+    # ``get_effective_quotas``: that service may commit internally when
+    # it recalculates addon columns, which would release an
+    # earlier-acquired xact lock. Same precedent as
+    # ``connector_provisioning.py``'s provisioning lock.
+    await db.execute(
+        text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))").bindparams(
+            key=f"memory_analysis_quota:{workspace_id}"
+        )
+    )
+
+    count_stmt = select(func.count(MemoryAnalysis.id)).where(
+        and_(
+            MemoryAnalysis.workspace_id == workspace_id,
+            MemoryAnalysis.started_at >= day_start_utc,
+            MemoryAnalysis.started_at < day_end_utc,
+        )
+    )
+    used_today = int((await db.execute(count_stmt)).scalar() or 0)
 
     if used_today >= limit_today:
         # day_end_utc is naive UTC; reformat with caller tz for the

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -165,6 +165,20 @@ class MemoryAnalysis(Base):
             "context_id",
             "started_at",
         ),
+        # #1240: DB-enforced one-running-run invariant. The orchestrator's
+        # SELECT-then-INSERT idempotency guard is a check-then-insert race —
+        # two concurrent start() calls can both pass the SELECT before either
+        # flushes. This partial unique index makes the loser's INSERT fail
+        # with IntegrityError, which start() translates to the same 409
+        # ConflictError the guard raises. Terminal rows (succeeded/failed/
+        # cancelled) accumulate freely — only 'running' participates.
+        Index(
+            "uq_memory_analyses_one_running",
+            "workspace_id",
+            "context_id",
+            unique=True,
+            postgresql_where=text("status = 'running'"),
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -46,6 +46,7 @@ import umap  # noqa: F401
 from sklearn.cluster import KMeans  # noqa: F401
 from sklearn.metrics import silhouette_score  # noqa: F401
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.analysis import (
@@ -160,6 +161,33 @@ def _params_iso_to_naive_utc(s: str | None, *, end_of_day: bool = False) -> date
     if end_of_day and len(s) == 10 and "T" not in s:
         dt = dt + timedelta(days=1)
     return dt
+
+
+def _validate_date_params(params: AnalysisParams) -> None:
+    """Reject malformed ``from``/``to`` BEFORE any row is created (#1240).
+
+    Runs the exact parser ``run()`` will use (``_params_iso_to_naive_utc``)
+    on the serialized params, so start-time acceptance and run-time parsing
+    cannot diverge. REST already rejects at the Pydantic boundary
+    (``AnalysisPreviewRequest._validate_iso8601``); this guard covers MCP —
+    which delivers raw strings via ``AnalysisParams.extra`` — and any future
+    entrypoint. Without it a malformed date raises in ``run()`` AFTER the
+    ``memory_analyses`` row is INSERTed at status='running', stranding the
+    run: the quota slot stays consumed and the idempotency guard 409-blocks
+    every future run on the context.
+    """
+    jsonb = params.to_jsonb()
+    for key, end_of_day in (("from", False), ("to", True)):
+        value = jsonb.get(key)
+        try:
+            _params_iso_to_naive_utc(value, end_of_day=end_of_day)
+        except (ValueError, TypeError) as e:
+            raise ValidationError(
+                f"Invalid ISO-8601 datetime for {key!r}: {value!r}. "
+                "Expected forms: '2026-05-02T00:00:00Z', "
+                "'2026-05-02T09:00:00+09:00', or naive 'YYYY-MM-DDTHH:MM:SS'.",
+                field=key,
+            ) from e
 
 
 async def _resolve_pricing_row(db: AsyncSession, model_id: int | None) -> tuple[LLMPricing, dict]:
@@ -281,6 +309,8 @@ class AnalysisOrchestrator:
         caller can ``await db.commit()`` and return ``analysis.id``
         in the 202 response.
         """
+        _validate_date_params(params)
+
         await assert_openai_byok_key_available(
             self.db,
             workspace_id=workspace_id,
@@ -328,7 +358,24 @@ class AnalysisOrchestrator:
             status=_STATUS_RUNNING,
         )
         self.db.add(analysis)
-        await self.db.flush()
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            # Lost the race with a concurrent start: the partial unique
+            # index ``uq_memory_analyses_one_running`` rejected a second
+            # 'running' row for this (workspace, context) — the SELECT
+            # guard above is check-then-insert and cannot see a row the
+            # racing transaction has not committed yet (#1240). Roll back
+            # so the session is usable, then surface the same 409 the
+            # guard raises, with the winner's run_id when visible.
+            await self.db.rollback()
+            prior = (await self.db.execute(running_stmt)).scalar_one_or_none()
+            raise ConflictError(
+                "An analysis run is already in progress"
+                + (f" (run_id={prior.id})" if prior is not None else "")
+                + ". Wait for it to finish or cancel.",
+                run_id=str(prior.id) if prior is not None else None,
+            ) from exc
         logger.info(
             "analysis_run_started",
             analysis_id=str(analysis.id),
@@ -358,18 +405,23 @@ class AnalysisOrchestrator:
             )
 
         params_jsonb = dict(analysis.params or {})
-        # Normalize tz-aware ISO strings to NAIVE UTC so the filter
-        # binds cleanly against ``Memory.created_at`` (TIMESTAMP WITHOUT
-        # TIME ZONE — naive UTC by repo convention #489). API callers
-        # may submit either tz-aware (e.g. "...+09:00") or naive ISO
-        # strings; both routes converge here.
-        from_dt = _params_iso_to_naive_utc(params_jsonb.get("from"))
-        # ``to`` is inclusive at the day level for date-only inputs — see
-        # _params_iso_to_naive_utc / #820. Datetimes with time components
-        # stay exclusive so callers needing precision are not surprised.
-        to_dt = _params_iso_to_naive_utc(params_jsonb.get("to"), end_of_day=True)
 
         try:
+            # Normalize tz-aware ISO strings to NAIVE UTC so the filter
+            # binds cleanly against ``Memory.created_at`` (TIMESTAMP WITHOUT
+            # TIME ZONE — naive UTC by repo convention #489). API callers
+            # may submit either tz-aware (e.g. "...+09:00") or naive ISO
+            # strings; both routes converge here. ``start()`` validates
+            # these pre-INSERT (#1240); parsing INSIDE the try keeps a
+            # malformed value on a pre-#1240 row from stranding the run
+            # at 'running' — it lands in ``_mark_failed`` like any other
+            # stage failure.
+            from_dt = _params_iso_to_naive_utc(params_jsonb.get("from"))
+            # ``to`` is inclusive at the day level for date-only inputs — see
+            # _params_iso_to_naive_utc / #820. Datetimes with time components
+            # stay exclusive so callers needing precision are not surprised.
+            to_dt = _params_iso_to_naive_utc(params_jsonb.get("to"), end_of_day=True)
+
             # Stage [C] — pull memories + their existing Qdrant vectors.
             # This is the LAST DB-using step before compute. After it
             # we commit the read-side state and release the connection
@@ -508,7 +560,24 @@ class AnalysisOrchestrator:
         ``persist_results``' caller-managed try/except. We commit the
         status update separately so ``status='failed'`` is observable
         to the API caller polling the run row.
+
+        Failures raised OUTSIDE that try (vector_pull's SELECT, the
+        mid-run commit, the locale fetch) can leave the session's
+        transaction in a failed state; roll back FIRST so
+        ``persist_failure``'s refresh/UPDATE runs on a clean
+        transaction. Without this the refresh raises
+        ``PendingRollbackError`` and the row is stranded at
+        status='running' — permanently 409-blocking the context via
+        the idempotency guard (#1240).
         """
+        try:
+            await self.db.rollback()
+        except Exception:
+            logger.warning(
+                "analysis_mark_failed_rollback_error",
+                analysis_id=str(analysis.id),
+                exc_info=True,
+            )
         try:
             await persist_failure(self.db, analysis=analysis, error_message=error_message)
             await self.db.commit()

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -361,6 +361,15 @@ class AnalysisOrchestrator:
         try:
             await self.db.flush()
         except IntegrityError as exc:
+            # Only the partial unique index means "lost the race with a
+            # concurrent start" — other IntegrityErrors (e.g. the contexts
+            # CASCADE FK after a mid-request context delete, or the
+            # llm_pricing RESTRICT FK) are NOT a conflicting run and must
+            # not be translated to a 409 telling the user to wait for a
+            # run that does not exist. Re-raise those for the generic
+            # 500 path.
+            if "uq_memory_analyses_one_running" not in str(exc.orig):
+                raise
             # Lost the race with a concurrent start: the partial unique
             # index ``uq_memory_analyses_one_running`` rejected a second
             # 'running' row for this (workspace, context) — the SELECT

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -49,6 +49,7 @@ from sqlalchemy import and_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from db.constraint_names import integrity_error_constraint_name
 from models.analysis import (
     MEMORY_ANALYSIS_PAID_BY_VALUES,
     MEMORY_ANALYSIS_STATUSES,
@@ -184,7 +185,7 @@ def _validate_date_params(params: AnalysisParams) -> None:
         except (ValueError, TypeError) as e:
             raise ValidationError(
                 f"Invalid ISO-8601 datetime for {key!r}: {value!r}. "
-                "Expected forms: '2026-05-02T00:00:00Z', "
+                "Expected forms: date-only '2026-05-02', '2026-05-02T00:00:00Z', "
                 "'2026-05-02T09:00:00+09:00', or naive 'YYYY-MM-DDTHH:MM:SS'.",
                 field=key,
             ) from e
@@ -367,8 +368,16 @@ class AnalysisOrchestrator:
             # llm_pricing RESTRICT FK) are NOT a conflicting run and must
             # not be translated to a 409 telling the user to wait for a
             # run that does not exist. Re-raise those for the generic
-            # 500 path.
-            if "uq_memory_analyses_one_running" not in str(exc.orig):
+            # 500 path. Structured diagnostics first (asyncpg/psycopg via
+            # the shared helper); message substring only as the fallback
+            # for wrapper shapes without them — so an unusual driver
+            # chain degrades to the old behavior, never to a wrong 409.
+            constraint = integrity_error_constraint_name(exc)
+            if constraint is not None:
+                is_running_race = constraint == "uq_memory_analyses_one_running"
+            else:
+                is_running_race = "uq_memory_analyses_one_running" in str(exc.orig)
+            if not is_running_race:
                 raise
             # Lost the race with a concurrent start: the partial unique
             # index ``uq_memory_analyses_one_running`` rejected a second

--- a/backend/tests/auth/test_analysis_gates_coverage.py
+++ b/backend/tests/auth/test_analysis_gates_coverage.py
@@ -845,3 +845,54 @@ class TestCheckMemoryAnalysisAccessMcp:
                 require_quota=False,
             )
         assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# #1240 — the quota gate serializes concurrent evaluations per workspace
+# ---------------------------------------------------------------------------
+
+
+class TestQuotaAdvisoryLock:
+    @pytest.mark.asyncio
+    async def test_quota_check_acquires_advisory_xact_lock(self, db_session, pro_workspace):
+        """#1240: the gate MUST hold a pg advisory xact lock through the
+        quota COUNT — this is the whole fix for the concurrent-start
+        quota over-admission race (the partial unique index only guards
+        same-context duplicates, not the per-workspace daily cap).
+        Deleting the lock statement makes this fail.
+        """
+        from sqlalchemy import text as sql_text
+
+        from auth.analysis_gates import check_memory_analysis_quota
+
+        before = int(
+            (
+                await db_session.execute(
+                    sql_text(
+                        "SELECT count(*) FROM pg_locks "
+                        "WHERE locktype = 'advisory' AND pid = pg_backend_pid()"
+                    )
+                )
+            ).scalar()
+            or 0
+        )
+        await check_memory_analysis_quota(
+            db_session,
+            workspace_id=pro_workspace.id,
+            user_timezone="UTC",
+        )
+        # The xact lock is held until this transaction ends, so it must
+        # be visible from within the same (still-open) transaction.
+        after = int(
+            (
+                await db_session.execute(
+                    sql_text(
+                        "SELECT count(*) FROM pg_locks "
+                        "WHERE locktype = 'advisory' AND pid = pg_backend_pid()"
+                    )
+                )
+            ).scalar()
+            or 0
+        )
+        assert after > before, "quota gate did not acquire the advisory xact lock"
+        await db_session.rollback()

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -793,3 +793,47 @@ class TestStartIntegrityErrorScoping:
                     user_id="u1",
                     params=AnalysisParams(),
                 )
+
+
+class TestStartIntegrityErrorStructuredDiagnostics:
+    @pytest.mark.asyncio
+    async def test_structured_constraint_name_translates_to_conflict(
+        self, db_session, monkeypatch
+    ) -> None:
+        """Copilot review (#1249): the asyncpg/psycopg structured path —
+        ``orig.constraint_name`` — must drive the 409 translation without
+        relying on message-substring matching."""
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        row = LLMPricing(
+            provider="openai",
+            model="gpt-5-nano",
+            unit_type="input_tokens",
+            price_per_unit="0.001",
+            currency="USD",
+            effective_from=datetime(2024, 1, 1),
+        )
+        db_session.add(row)
+        await db_session.flush()
+
+        orig = MagicMock()
+        orig.constraint_name = "uq_memory_analyses_one_running"
+        orig.__str__ = lambda self: "unique violation (message deliberately nameless)"
+
+        async def racing_flush(*args, **kwargs):
+            raise IntegrityError("INSERT INTO memory_analyses ...", {}, orig)
+
+        monkeypatch.setattr(db_session, "flush", racing_flush)
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            with pytest.raises(ConflictError, match="already in progress"):
+                await service.start(
+                    workspace_id=ws_id,
+                    context_id=ctx_id,
+                    user_id="u1",
+                    params=AnalysisParams(),
+                )

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -744,3 +744,52 @@ class TestOneRunningPartialUniqueIndex:
                     user_id="u1",
                     params=AnalysisParams(),
                 )
+
+
+class TestStartIntegrityErrorScoping:
+    @pytest.mark.asyncio
+    async def test_foreign_key_integrity_error_not_translated_to_conflict(
+        self, db_session, monkeypatch
+    ) -> None:
+        """#1240 review: only the one-running unique index means "lost the
+        race". An FK violation (context deleted mid-request, pricing row
+        gone) must NOT become a 409 telling the user to wait for a run
+        that does not exist — it re-raises for the generic 500 path.
+        """
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        row = LLMPricing(
+            provider="openai",
+            model="gpt-5-nano",
+            unit_type="input_tokens",
+            price_per_unit="0.001",
+            currency="USD",
+            effective_from=datetime(2024, 1, 1),
+        )
+        db_session.add(row)
+        await db_session.flush()
+
+        async def fk_violating_flush(*args, **kwargs):
+            raise IntegrityError(
+                "INSERT INTO memory_analyses ...",
+                {},
+                Exception(
+                    'insert or update on table "memory_analyses" violates '
+                    'foreign key constraint "memory_analyses_context_id_fkey"'
+                ),
+            )
+
+        monkeypatch.setattr(db_session, "flush", fk_violating_flush)
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            with pytest.raises(IntegrityError):
+                await service.start(
+                    workspace_id=ws_id,
+                    context_id=ctx_id,
+                    user_id="u1",
+                    params=AnalysisParams(),
+                )

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -13,7 +13,8 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import text
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import IntegrityError
 
 from models.analysis import MemoryAnalysis
 from models.auth import Context, Workspace
@@ -510,3 +511,236 @@ class TestMarkFailed:
         mock_persist.assert_awaited_once_with(
             db_session, analysis=analysis, error_message="it broke"
         )
+
+    @pytest.mark.asyncio
+    async def test_mark_failed_recovers_poisoned_session(self, db_session) -> None:
+        """#1240: a DBAPIError mid-run leaves the session transaction in a
+        failed state. ``_mark_failed`` must roll back FIRST — without that,
+        ``persist_failure``'s ``db.refresh()`` raises PendingRollbackError
+        and the row is stranded at status='running' forever.
+        """
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.commit()
+
+        # Poison the transaction the way a mid-run DB error does: the
+        # failed statement leaves the tx aborted until a rollback.
+        with pytest.raises(Exception, match="division by zero"):
+            await db_session.execute(text("SELECT 1/0"))
+
+        service = AnalysisOrchestrator(db_session)
+        await service._mark_failed(analysis, "boom after poisoned tx")
+
+        await db_session.refresh(analysis)
+        assert analysis.status == "failed"
+        assert "boom after poisoned tx" in (analysis.error or "")
+
+
+# ---------------------------------------------------------------------------
+# #1240 — start-time date validation (shared with run()'s parser)
+# ---------------------------------------------------------------------------
+
+
+class TestStartValidatesDateParams:
+    """Malformed from/to must be rejected BEFORE any row is INSERTed.
+
+    The MCP path delivers raw strings via ``AnalysisParams.extra`` —
+    without start-time validation they explode in ``run()`` after the
+    row exists at status='running' (quota slot consumed, context
+    409-blocked by the idempotency guard). #1240.
+    """
+
+    async def _count_rows(self, db_session, ws_id) -> int:
+        result = await db_session.execute(
+            select(func.count(MemoryAnalysis.id)).where(MemoryAnalysis.workspace_id == ws_id)
+        )
+        return int(result.scalar() or 0)
+
+    @pytest.mark.asyncio
+    async def test_malformed_from_rejected_before_insert(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        await _seed_pricing(db_session)
+
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            with pytest.raises(ValidationError, match="ISO-8601"):
+                await service.start(
+                    workspace_id=ws_id,
+                    context_id=ctx_id,
+                    user_id="u1",
+                    params=AnalysisParams(extra={"from": "not-a-date"}),
+                )
+        assert await self._count_rows(db_session, ws_id) == 0
+
+    @pytest.mark.asyncio
+    async def test_malformed_to_rejected_before_insert(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        await _seed_pricing(db_session)
+
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            with pytest.raises(ValidationError, match="ISO-8601"):
+                await service.start(
+                    workspace_id=ws_id,
+                    context_id=ctx_id,
+                    user_id="u1",
+                    params=AnalysisParams(extra={"to": "2026-13-99"}),
+                )
+        assert await self._count_rows(db_session, ws_id) == 0
+
+    @pytest.mark.asyncio
+    async def test_valid_extra_date_strings_accepted(self, db_session) -> None:
+        """Valid MCP-shaped raw strings still start a run (no regression)."""
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        row = LLMPricing(
+            provider="openai",
+            model="gpt-5-nano",
+            unit_type="input_tokens",
+            price_per_unit="0.001",
+            currency="USD",
+            effective_from=datetime(2024, 1, 1),
+        )
+        db_session.add(row)
+        await db_session.flush()
+
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            analysis = await service.start(
+                workspace_id=ws_id,
+                context_id=ctx_id,
+                user_id="u1",
+                params=AnalysisParams(
+                    extra={"from": "2026-05-01", "to": "2026-05-28T23:59:59+09:00"}
+                ),
+            )
+        assert analysis.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# #1240 — one-running-run invariant enforced by the DB, not just a SELECT
+# ---------------------------------------------------------------------------
+
+
+def _make_running_row(ws_id, ctx_id, pricing_id, status="running") -> MemoryAnalysis:
+    return MemoryAnalysis(
+        workspace_id=ws_id,
+        context_id=ctx_id,
+        triggered_by="u1",
+        model_id=pricing_id,
+        model_snapshot={},
+        embedding_model="em",
+        params={},
+        input_count=0,
+        status=status,
+        paid_by="byok",
+    )
+
+
+class TestOneRunningPartialUniqueIndex:
+    @pytest.mark.asyncio
+    async def test_second_running_insert_blocked_by_index(self, db_session) -> None:
+        """The partial unique index rejects a second 'running' row even
+        when the SELECT-then-INSERT guard was raced past (#1240 TOCTOU).
+        """
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+
+        db_session.add(_make_running_row(ws_id, ctx_id, pricing.id))
+        await db_session.flush()
+        db_session.add(_make_running_row(ws_id, ctx_id, pricing.id))
+        with pytest.raises(IntegrityError, match="uq_memory_analyses_one_running"):
+            await db_session.flush()
+        await db_session.rollback()
+
+    @pytest.mark.asyncio
+    async def test_terminal_rows_not_blocked(self, db_session) -> None:
+        """Only 'running' participates in the partial index — history rows
+        (succeeded/failed/cancelled) may accumulate freely.
+        """
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+
+        db_session.add(_make_running_row(ws_id, ctx_id, pricing.id, status="succeeded"))
+        db_session.add(_make_running_row(ws_id, ctx_id, pricing.id, status="succeeded"))
+        db_session.add(_make_running_row(ws_id, ctx_id, pricing.id, status="failed"))
+        db_session.add(_make_running_row(ws_id, ctx_id, pricing.id, status="running"))
+        await db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_start_translates_integrity_error_to_conflict(
+        self, db_session, monkeypatch
+    ) -> None:
+        """When start() loses the race at flush time (unique violation),
+        the caller sees the same 409 ConflictError as the SELECT guard.
+        """
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        row = LLMPricing(
+            provider="openai",
+            model="gpt-5-nano",
+            unit_type="input_tokens",
+            price_per_unit="0.001",
+            currency="USD",
+            effective_from=datetime(2024, 1, 1),
+        )
+        db_session.add(row)
+        await db_session.flush()
+
+        async def racing_flush(*args, **kwargs):
+            raise IntegrityError(
+                "INSERT INTO memory_analyses ...",
+                {},
+                Exception(
+                    "duplicate key value violates unique constraint "
+                    '"uq_memory_analyses_one_running"'
+                ),
+            )
+
+        monkeypatch.setattr(db_session, "flush", racing_flush)
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            with pytest.raises(ConflictError, match="already in progress"):
+                await service.start(
+                    workspace_id=ws_id,
+                    context_id=ctx_id,
+                    user_id="u1",
+                    params=AnalysisParams(),
+                )


### PR DESCRIPTION
Closes #1240

## Summary
Three fixes for analysis run-state integrity:
1. **Pre-INSERT date validation** — `start()` now validates `from`/`to` with `run()`'s own parser (`_params_iso_to_naive_utc`), covering the MCP path that delivered raw strings via `AnalysisParams.extra`; `run()` additionally parses inside its `try` so pre-fix rows land in `_mark_failed` instead of stranding at `running`.
2. **`_mark_failed` rolls back first** — a `DBAPIError` mid-run left the session poisoned; `persist_failure`'s refresh raised `PendingRollbackError` and the row was stranded at `running` (permanently 409-blocking the context).
3. **DB-enforced one-running invariant + locked quota** — partial unique index `uq_memory_analyses_one_running` (migration `e61`, with duplicate-row repair pre-step), `IntegrityError`-to-409 translation scoped to that constraint, and `pg_advisory_xact_lock` serializing the daily-quota COUNT per workspace.

## Verification
- TDD: poisoned-session regression test (fails pre-fix with `InFailedSQLTransactionError`), pre-INSERT validation tests, partial-index tests, 409-translation + FK-scoping tests, pg_locks-based advisory-lock test
- `tests/services/analysis/test_orchestrator.py` + `tests/auth/test_analysis_gates_coverage.py` + `tests/api/`: all green locally

## Review
Independent code-review pass: 4 findings, all fixed in 37bf364 (constraint-name scoping for the 409 translation, advisory-lock test coverage, honest blue-green migration docstring, corrected stale comment about `get_effective_quotas`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
