### PR TITLE
fix(api): make analysis cancellation all-or-nothing and stop spend (#1241)

### DIFF
--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -36,16 +36,12 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from auth.analysis_gates import AnalysisReadAccess, AnalysisWriteAccess
 from db.base import get_db
-from models.analysis import (
-    MEMORY_ANALYSIS_CANCELLATION_REASONS,
-    MEMORY_ANALYSIS_STATUSES,
-    MemoryAnalysis,
-)
+from models.analysis import MEMORY_ANALYSIS_CANCELLATION_REASONS, MEMORY_ANALYSIS_STATUSES
 from models.api_base import TZAwareBaseModel
 from services.analysis import query_service
 from services.analysis.orchestrator import AnalysisOrchestrator, AnalysisParams
@@ -681,19 +677,32 @@ async def cancel_run(
         # eliminating the refresh-then-write window where a cancel was
         # silently overwritten by 'succeeded' (leaving a contradictory
         # cancellation_reason on a succeeded row).
-        locked = (
-            await db.execute(
-                select(MemoryAnalysis).where(MemoryAnalysis.id == row.id).with_for_update()
-            )
-        ).scalar_one_or_none()
-        if locked is not None and locked.status == _STATUS_RUNNING:
-            locked.status = _STATUS_CANCELLED
-            locked.cancellation_reason = _CANCEL_REASON_USER
+        #
+        # ``refresh(with_for_update=True)`` — NOT a plain locked SELECT.
+        # ``get_analysis`` above loaded this row into the session's
+        # identity map; a ``select(...).with_for_update()`` would take
+        # the DB lock but hand back the cached instance with its STALE
+        # attributes (the load-bearing gotcha documented in
+        # services/workspace_locks.py), so the lock-loser would still
+        # see 'running' and clobber the winner's committed terminal
+        # state. ``refresh`` always repopulates from the locked read —
+        # same protocol as reporter.py's persist guards.
+        try:
+            await db.refresh(row, with_for_update=True)
+        except ObjectDeletedError:
+            # Hard-deleted between the reads (context/workspace CASCADE)
+            # — same disclosure shape as the initial lookup miss.
+            raise HTTPException(
+                status_code=404, detail=f"Analysis run {run_id} not found"
+            ) from None
+        if row.status == _STATUS_RUNNING:
+            row.status = _STATUS_CANCELLED
+            row.cancellation_reason = _CANCEL_REASON_USER
             # finished_at is naive UTC — utcnow() returns naive UTC by
             # repo convention.
             from utils.datetime import utcnow
 
-            locked.finished_at = utcnow()
+            row.finished_at = utcnow()
             # Commit FIRST — releases the row lock so the background
             # task's own persist path can proceed and observe
             # 'cancelled' instead of deadlocking on the cancel.
@@ -713,8 +722,6 @@ async def cancel_run(
                 run_id=str(run_id),
                 cancelled_in_process=cancelled_in_process,
             )
-        if locked is not None:
-            row = locked
     # else: already terminal → return current state without flipping anything.
 
     return AnalysisCancelResponse.model_validate(row)

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -36,16 +36,21 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.analysis_gates import AnalysisReadAccess, AnalysisWriteAccess
 from db.base import get_db
-from models.analysis import MEMORY_ANALYSIS_CANCELLATION_REASONS, MEMORY_ANALYSIS_STATUSES
+from models.analysis import (
+    MEMORY_ANALYSIS_CANCELLATION_REASONS,
+    MEMORY_ANALYSIS_STATUSES,
+    MemoryAnalysis,
+)
 from models.api_base import TZAwareBaseModel
 from services.analysis import query_service
 from services.analysis.orchestrator import AnalysisOrchestrator, AnalysisParams
 from services.analysis.preview import DEFAULT_MODEL_ID, estimate_cost
-from tasks.analysis_tasks import run_analysis_task
+from tasks.analysis_tasks import cancel_run_task, register_run_task, run_analysis_task
 from utils.exceptions import ConflictError, ValidationError
 from utils.logger import get_logger
 
@@ -431,6 +436,8 @@ async def start_analysis(
     task = asyncio.create_task(run_analysis_task(analysis.id))
     _BACKGROUND_TASKS.add(task)
     task.add_done_callback(_log_background_task_result)
+    # #1241: register by run_id so DELETE can cancel the compute too.
+    register_run_task(analysis.id, task)
 
     logger.info(
         "analysis_run_kicked_off",
@@ -667,24 +674,47 @@ async def cancel_run(
         raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
 
     if row.status == _STATUS_RUNNING:
-        # Mark cancelled. Background task may still be mid-stage; it
-        # will complete and persist its own status update which the
-        # reporter will treat as a no-op since cancellation_reason is
-        # already set (status='cancelled' wins over the late update).
-        row.status = _STATUS_CANCELLED
-        row.cancellation_reason = _CANCEL_REASON_USER
-        # finished_at is naive UTC — utcnow() returns naive UTC by
-        # repo convention.
-        from utils.datetime import utcnow
+        # #1241: re-read under a row lock and re-check. The reporter's
+        # terminal writes (persist_results / persist_failure) take the
+        # same lock before deciding, so whichever side wins the lock
+        # decides the terminal state and the loser observes it —
+        # eliminating the refresh-then-write window where a cancel was
+        # silently overwritten by 'succeeded' (leaving a contradictory
+        # cancellation_reason on a succeeded row).
+        locked = (
+            await db.execute(
+                select(MemoryAnalysis).where(MemoryAnalysis.id == row.id).with_for_update()
+            )
+        ).scalar_one_or_none()
+        if locked is not None and locked.status == _STATUS_RUNNING:
+            locked.status = _STATUS_CANCELLED
+            locked.cancellation_reason = _CANCEL_REASON_USER
+            # finished_at is naive UTC — utcnow() returns naive UTC by
+            # repo convention.
+            from utils.datetime import utcnow
 
-        row.finished_at = utcnow()
-        await db.commit()
-        logger.info(
-            "analysis_run_cancelled",
-            run_id=str(run_id),
-            workspace_id=str(workspace_id),
-            context_id=str(context_id),
-        )
+            locked.finished_at = utcnow()
+            # Commit FIRST — releases the row lock so the background
+            # task's own persist path can proceed and observe
+            # 'cancelled' instead of deadlocking on the cancel.
+            await db.commit()
+            logger.info(
+                "analysis_run_cancelled",
+                run_id=str(run_id),
+                workspace_id=str(workspace_id),
+                context_id=str(context_id),
+            )
+            # #1241: a confirmed cancel also stops the compute (and its
+            # BYOK spend). Best-effort — see tasks/analysis_tasks.py for
+            # the multi-worker caveat.
+            cancelled_in_process = cancel_run_task(run_id)
+            logger.info(
+                "analysis_run_compute_cancel",
+                run_id=str(run_id),
+                cancelled_in_process=cancelled_in_process,
+            )
+        if locked is not None:
+            row = locked
     # else: already terminal → return current state without flipping anything.
 
     return AnalysisCancelResponse.model_validate(row)

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -294,7 +294,7 @@ async def handle_analyze_context(
                 AnalysisOrchestrator,
                 AnalysisParams,
             )
-            from tasks.analysis_tasks import run_analysis_task
+            from tasks.analysis_tasks import register_run_task, run_analysis_task
 
             params = AnalysisParams(
                 from_dt=None,
@@ -332,6 +332,9 @@ async def handle_analyze_context(
             task = asyncio.create_task(run_analysis_task(analysis.id))
             _BACKGROUND_TASKS.add(task)
             task.add_done_callback(_log_background_task_result)
+            # #1241: register by run_id so the REST DELETE soft-cancel can
+            # stop MCP-started compute too.
+            register_run_task(analysis.id, task)
 
             await _log_tool_usage(
                 db,

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -50,8 +50,11 @@ MEMORY_ANALYSIS_PAID_BY_VALUES: tuple[str, ...] = ("byok", "platform")
 # Issue #496: ``cancellation_reason`` enum-style values populated when
 # a run is soft-cancelled. Free-form for v1 (no DB CHECK), but the
 # tuple is the canonical taxonomy so route + MCP code share spelling.
+# ``context_deleted`` (#1241): the run's context was soft-deleted while
+# the run was in flight — deletion is the strongest stop signal, so the
+# run is cancelled rather than left billing BYOK for an invisible result.
 # Future taxonomy may add ``"timeout" / "admin" / "cost_cap"``.
-MEMORY_ANALYSIS_CANCELLATION_REASONS: tuple[str, ...] = ("user",)
+MEMORY_ANALYSIS_CANCELLATION_REASONS: tuple[str, ...] = ("user", "context_deleted")
 
 
 def _check_in_sql(column: str, values: tuple[str, ...]) -> str:

--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -313,7 +313,23 @@ async def label_clusters(
             )
         )
 
-    results = await asyncio.gather(*tasks)
+    try:
+        results = await asyncio.gather(*tasks)
+    except BaseException:
+        # #1241: plain gather() re-raises the first failure but leaves the
+        # sibling tasks RUNNING — each would keep making paid BYOK LLM
+        # calls for a run that is already failing (or being cancelled),
+        # then surface as "Task exception was never retrieved" orphans.
+        # Cancel the siblings and wait for settlement so no labeling task
+        # outlives the run. (``AnalysisLLMUpstreamError`` never reaches
+        # here — ``_label_one_cluster`` converts it to a failed
+        # ClusterLabel; this path is for unexpected errors such as
+        # ConfigurationError from a mid-run BYOK key removal, and for
+        # cancellation of the run task itself.)
+        for t in tasks:
+            t.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
     results.sort(key=lambda r: r.cluster_index)
 
     failed = sum(1 for r in results if r.failed)

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -278,6 +278,24 @@ async def persist_results(
     coords_2d = inputs.coords_2d
     cluster_results = inputs.cluster_results
 
+    # 0. Cancellation guard FIRST, under a row lock (#1241). The guard
+    #    used to run after the cluster/assignment flush — its early
+    #    ``return`` was then followed by the orchestrator's commit, so a
+    #    cancelled run permanently kept its cluster rows (served forever
+    #    by /clusters, /positions and MCP get_cluster, none of which
+    #    filter by status). ``with_for_update`` serializes against the
+    #    DELETE handler's own locked re-check: whichever side takes the
+    #    lock first decides the terminal state, and the loser observes
+    #    it after commit instead of overwriting it.
+    await db.refresh(analysis, with_for_update=True)
+    if analysis.status == _STATUS_CANCELLED:
+        logger.info(
+            "analysis_persist_skipped_due_to_cancel",
+            analysis_id=str(analysis.id),
+            cancellation_reason=analysis.cancellation_reason,
+        )
+        return
+
     n_clusters = len(cluster_results)
     members_by_idx = _index_members_by_cluster(cluster_labels_arr, n_clusters)
 
@@ -349,21 +367,12 @@ async def persist_results(
 
     # 4. Update the memory_analyses row. embedding_model was set by
     #    the orchestrator before this transaction opened — we only
-    #    finalize the run-level fields here.
-    #    First, refresh from DB to detect a concurrent soft-cancel
-    #    (DELETE /analyses/{run_id} flipped status to 'cancelled' in a
-    #    separate session while compute was running). Without this
-    #    guard the stale ORM instance would overwrite the cancellation
-    #    on flush — silent data loss for the cancellation_reason
-    #    audit trail. Issue #496 Copilot review.
-    await db.refresh(analysis)
-    if analysis.status == _STATUS_CANCELLED:
-        logger.info(
-            "analysis_persist_skipped_due_to_cancel",
-            analysis_id=str(analysis.id),
-            cancellation_reason=analysis.cancellation_reason,
-        )
-        return
+    #    finalize the run-level fields here. A concurrent soft-cancel
+    #    cannot slip in at this point: the row has been locked since
+    #    the step-0 ``with_for_update`` refresh, so the DELETE
+    #    handler's own locked re-check blocks until this transaction
+    #    commits (#1241; supersedes the #496 refresh-then-write guard
+    #    that raced in the window between refresh and commit).
     cost_actual_cents = _compute_actual_cost_cents(totals, dict(analysis.model_snapshot or {}))
     analysis.status = _STATUS_SUCCEEDED
     analysis.finished_at = utcnow()
@@ -433,8 +442,11 @@ async def persist_failure(
     # from DB so a concurrent DELETE soft-cancel is not silently flipped
     # to ``failed``. The compute exception is still recorded in the log
     # below; we just avoid corrupting the status + cancellation_reason
-    # audit trail. Issue #496 Copilot review.
-    await db.refresh(analysis)
+    # audit trail. Issue #496 Copilot review; #1241 upgraded the refresh
+    # to a row lock so a cancel committing between refresh and commit
+    # can no longer be overwritten (same protocol as ``persist_results``
+    # and the DELETE handler).
+    await db.refresh(analysis, with_for_update=True)
     if analysis.status == _STATUS_CANCELLED:
         logger.info(
             "analysis_persist_failure_skipped_due_to_cancel",

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -1074,6 +1074,47 @@ class ContextService:
             )
         )
 
+        # #1241/#1243: cancel any in-flight analysis run for this context.
+        # Deleting a context is the strongest "stop everything" signal a
+        # user can send — without this, the background pipeline kept
+        # charging the workspace's BYOK key for minutes and then persisted
+        # a full result set for a context that no longer exists (invisible
+        # to every reader after #1243's liveness join). Flipping the row
+        # makes the reporter's locked cancel guard skip the persist;
+        # cancel_run_task stops the in-process compute (best-effort — see
+        # tasks/analysis_tasks.py for the multi-worker caveat).
+        from models.analysis import MemoryAnalysis
+
+        running_analyses = list(
+            (
+                await self.db.execute(
+                    select(MemoryAnalysis).where(
+                        and_(
+                            MemoryAnalysis.workspace_id == context.workspace_id,
+                            MemoryAnalysis.context_id == context.id,
+                            MemoryAnalysis.status == "running",
+                        )
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for run in running_analyses:
+            run.status = "cancelled"
+            run.cancellation_reason = "context_deleted"
+            run.finished_at = utcnow()
+        if running_analyses:
+            from tasks.analysis_tasks import cancel_run_task
+
+            for run in running_analyses:
+                cancel_run_task(run.id)
+            logger.info(
+                "context_delete_cancelled_running_analyses",
+                context_id=str(context.id),
+                cancelled_run_ids=[str(r.id) for r in running_analyses],
+            )
+
         # Issue #84: Soft-delete context record (previously hard-deleted)
         context.deleted_at = utcnow()
         context.deleted_by = user_id

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from sqlalchemy import and_, delete, func, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.exc import ObjectDeletedError
 
 from auth.workspace_roles import WorkspaceRole
 from config.settings import get_settings
@@ -1100,19 +1101,36 @@ class ContextService:
             .scalars()
             .all()
         )
+        cancelled_runs = []
         for run in running_analyses:
+            # Copilot review (#1250): re-check under the same row lock the
+            # reporter's terminal writes take. The unlocked SELECT above is
+            # check-then-act — persist_results could commit 'succeeded'
+            # between it and this write, and a plain attribute flip on the
+            # identity-mapped instance would clobber that committed state.
+            # ``refresh(with_for_update=True)`` repopulates under the lock;
+            # skip runs that reached a terminal state while we waited.
+            try:
+                await self.db.refresh(run, with_for_update=True)
+            except ObjectDeletedError:
+                # Hard-deleted while we waited (workspace CASCADE) —
+                # nothing left to cancel.
+                continue
+            if run.status != "running":
+                continue
             run.status = "cancelled"
             run.cancellation_reason = "context_deleted"
             run.finished_at = utcnow()
-        if running_analyses:
+            cancelled_runs.append(run)
+        if cancelled_runs:
             from tasks.analysis_tasks import cancel_run_task
 
-            for run in running_analyses:
+            for run in cancelled_runs:
                 cancel_run_task(run.id)
             logger.info(
                 "context_delete_cancelled_running_analyses",
                 context_id=str(context.id),
-                cancelled_run_ids=[str(r.id) for r in running_analyses],
+                cancelled_run_ids=[str(r.id) for r in cancelled_runs],
             )
 
         # Issue #84: Soft-delete context record (previously hard-deleted)

--- a/backend/src/tasks/analysis_tasks.py
+++ b/backend/src/tasks/analysis_tasks.py
@@ -31,6 +31,7 @@ ties the failure to a worker invocation.
 
 from __future__ import annotations
 
+import asyncio
 from uuid import UUID
 
 from db.base import get_db
@@ -38,6 +39,43 @@ from services.analysis.orchestrator import AnalysisOrchestrator
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# #1241: in-process registry of live run tasks so a soft-cancel can also
+# stop the compute (and its BYOK spend), not just flip the row. Keyed by
+# ``memory_analyses.id``. Lives here — not in the REST module — because
+# both kickoff surfaces (api/routes/analyses.py and
+# mcp_server/tools/analysis.py) spawn ``run_analysis_task`` and the REST
+# DELETE handler must be able to cancel an MCP-started run too.
+# Best-effort by design: in a multi-process deployment the task may live
+# in another worker, in which case the reporter's locked cancellation
+# guard still prevents any post-cancel persist — only that worker's
+# in-flight LLM calls run to completion.
+_RUN_TASKS: dict[UUID, asyncio.Task[None]] = {}
+
+
+def register_run_task(run_id: UUID, task: asyncio.Task[None]) -> None:
+    """Track a spawned run task so ``cancel_run_task`` can find it.
+
+    The done-callback removes the entry regardless of outcome, so the
+    registry only ever holds live tasks.
+    """
+    _RUN_TASKS[run_id] = task
+    task.add_done_callback(lambda _t: _RUN_TASKS.pop(run_id, None))
+
+
+def cancel_run_task(run_id: UUID) -> bool:
+    """Cancel the in-process task for ``run_id`` if it is still live.
+
+    Returns True when a live task was found and cancellation was
+    requested; False when no task is registered in this process (other
+    worker, already finished, or crashed run).
+    """
+    task = _RUN_TASKS.get(run_id)
+    if task is None or task.done():
+        return False
+    task.cancel()
+    logger.info("analysis_run_task_cancel_requested", analysis_id=str(run_id))
+    return True
 
 
 async def run_analysis_task(analysis_id: UUID) -> None:
@@ -53,6 +91,14 @@ async def run_analysis_task(analysis_id: UUID) -> None:
         async for db in get_db():
             orchestrator = AnalysisOrchestrator(db)
             await orchestrator.run(analysis_id=analysis_id)
+    except asyncio.CancelledError:
+        # #1241: DELETE soft-cancel flipped the row (status='cancelled'
+        # committed under a row lock) and then cancelled this task.
+        # Nothing to persist — re-raise so the task ends in the
+        # cancelled state (`task.cancelled()` is True for the done
+        # callback).
+        logger.info("analysis_task_cancelled", analysis_id=str(analysis_id))
+        raise
     except Exception as e:  # noqa: BLE001
         # Failure path is already persisted by the orchestrator's
         # internal _mark_failed. This catch keeps the task from

--- a/backend/tests/api/test_analyses_routes.py
+++ b/backend/tests/api/test_analyses_routes.py
@@ -404,7 +404,6 @@ class TestListRunPositions:
 
 class TestCancelRun:
     def test_soft_cancels_running_run(self, client, db_mock):
-        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
         run_id = uuid4()
         fake_run = MagicMock(
             id=run_id,
@@ -420,9 +419,20 @@ class TestCancelRun:
             error=None,
             cancellation_reason=None,
         )
-        with patch(
-            "services.analysis.query_service.get_analysis",
-            AsyncMock(return_value=fake_run),
+        # Two executes: context boundary, then the #1241 locked re-fetch.
+        db_mock.execute.side_effect = [
+            _scalar_one(_TEST_CONTEXT_ID),
+            _scalar_one(fake_run),
+        ]
+        with (
+            patch(
+                "services.analysis.query_service.get_analysis",
+                AsyncMock(return_value=fake_run),
+            ),
+            patch(
+                "api.routes.analyses.cancel_run_task",
+                return_value=True,
+            ) as mock_cancel,
         ):
             response = client.delete(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}")
         assert response.status_code == 200, response.text
@@ -431,6 +441,64 @@ class TestCancelRun:
         assert body["cancellation_reason"] == "user"
         assert fake_run.status == "cancelled"
         assert fake_run.cancellation_reason == "user"
+        # #1241: a confirmed cancel also stops the in-process compute.
+        mock_cancel.assert_called_once_with(run_id)
+
+    def test_cancel_lost_race_returns_actual_terminal_state(self, client, db_mock):
+        """#1241: if persist_results wins the row lock and commits
+        'succeeded' first, the locked re-check must NOT flip the run to
+        cancelled (and must not cancel the finished task) — the response
+        reports the actual terminal state.
+        """
+        run_id = uuid4()
+        stale_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="running",  # stale pre-lock read
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=None,
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=None,
+            error=None,
+            cancellation_reason=None,
+        )
+        locked_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="succeeded",  # persist won the lock
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=datetime(2026, 5, 2),
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=4,
+            error=None,
+            cancellation_reason=None,
+        )
+        db_mock.execute.side_effect = [
+            _scalar_one(_TEST_CONTEXT_ID),
+            _scalar_one(locked_run),
+        ]
+        with (
+            patch(
+                "services.analysis.query_service.get_analysis",
+                AsyncMock(return_value=stale_run),
+            ),
+            patch(
+                "api.routes.analyses.cancel_run_task",
+                return_value=True,
+            ) as mock_cancel,
+        ):
+            response = client.delete(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "succeeded"
+        assert locked_run.status == "succeeded"
+        mock_cancel.assert_not_called()
 
     def test_idempotent_when_already_terminal(self, client, db_mock):
         """Already-succeeded runs return 200 with current state, no flip."""

--- a/backend/tests/api/test_analyses_routes.py
+++ b/backend/tests/api/test_analyses_routes.py
@@ -55,6 +55,7 @@ def db_mock():
     m.execute = AsyncMock()
     m.commit = AsyncMock()
     m.rollback = AsyncMock()
+    m.refresh = AsyncMock()
     return m
 
 
@@ -419,11 +420,7 @@ class TestCancelRun:
             error=None,
             cancellation_reason=None,
         )
-        # Two executes: context boundary, then the #1241 locked re-fetch.
-        db_mock.execute.side_effect = [
-            _scalar_one(_TEST_CONTEXT_ID),
-            _scalar_one(fake_run),
-        ]
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
         with (
             patch(
                 "services.analysis.query_service.get_analysis",
@@ -441,6 +438,11 @@ class TestCancelRun:
         assert body["cancellation_reason"] == "user"
         assert fake_run.status == "cancelled"
         assert fake_run.cancellation_reason == "user"
+        # #1241: the locked re-check MUST be refresh(with_for_update=True) —
+        # a plain locked SELECT would return the identity-mapped instance
+        # with STALE attributes (see services/workspace_locks.py) and the
+        # lock-loser would clobber the winner's committed terminal state.
+        db_mock.refresh.assert_awaited_once_with(fake_run, with_for_update=True)
         # #1241: a confirmed cancel also stops the in-process compute.
         mock_cancel.assert_called_once_with(run_id)
 
@@ -465,24 +467,17 @@ class TestCancelRun:
             error=None,
             cancellation_reason=None,
         )
-        locked_run = MagicMock(
-            id=run_id,
-            workspace_id=_TEST_WORKSPACE_ID,
-            context_id=_TEST_CONTEXT_ID,
-            status="succeeded",  # persist won the lock
-            triggered_by=_TEST_USER_ID,
-            started_at=datetime(2026, 5, 2),
-            finished_at=datetime(2026, 5, 2),
-            input_count=10,
-            cost_estimated_cents=5,
-            cost_actual_cents=4,
-            error=None,
-            cancellation_reason=None,
-        )
-        db_mock.execute.side_effect = [
-            _scalar_one(_TEST_CONTEXT_ID),
-            _scalar_one(locked_run),
-        ]
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+
+        async def _refresh_reveals_success(instance, **kwargs):
+            # Simulates the locked repopulating read: persist_results won
+            # the lock and committed 'succeeded' — refresh(with_for_update)
+            # overwrites the stale in-memory 'running'.
+            instance.status = "succeeded"
+            instance.finished_at = datetime(2026, 5, 2)
+            instance.cost_actual_cents = 4
+
+        db_mock.refresh = AsyncMock(side_effect=_refresh_reveals_success)
         with (
             patch(
                 "services.analysis.query_service.get_analysis",
@@ -497,8 +492,41 @@ class TestCancelRun:
         assert response.status_code == 200, response.text
         body = response.json()
         assert body["status"] == "succeeded"
-        assert locked_run.status == "succeeded"
+        assert stale_run.status == "succeeded"
+        assert stale_run.cancellation_reason is None  # never clobbered
         mock_cancel.assert_not_called()
+
+    def test_cancel_hard_deleted_run_returns_404(self, client, db_mock):
+        """#1241: the run row vanished (context/workspace CASCADE) between
+        the initial read and the locked refresh — 404, not a 200 with a
+        stale 'running' body implying the cancel is still possible."""
+        from sqlalchemy.orm.exc import ObjectDeletedError
+
+        run_id = uuid4()
+        stale_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="running",
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=None,
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=None,
+            error=None,
+            cancellation_reason=None,
+        )
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        db_mock.refresh = AsyncMock(
+            side_effect=ObjectDeletedError(MagicMock(), "row deleted by CASCADE")
+        )
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=stale_run),
+        ):
+            response = client.delete(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}")
+        assert response.status_code == 404, response.text
 
     def test_idempotent_when_already_terminal(self, client, db_mock):
         """Already-succeeded runs return 200 with current state, no flip."""

--- a/backend/tests/services/analysis/test_labeler_coverage.py
+++ b/backend/tests/services/analysis/test_labeler_coverage.py
@@ -723,3 +723,54 @@ class TestClusterLabelDataclass:
         )
         with pytest.raises(AttributeError):
             cl.label = "y"  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# #1241 — sibling cancellation on unexpected labeling errors
+# --------------------------------------------------------------------------- #
+class TestLabelClustersSiblingCancellation:
+    @pytest.mark.asyncio
+    async def test_unexpected_error_cancels_sibling_tasks(self, monkeypatch) -> None:
+        """#1241: when one labeling task raises something other than
+        ``AnalysisLLMUpstreamError`` (e.g. ConfigurationError from a
+        mid-run BYOK key removal), the run fails — the remaining tasks
+        must be CANCELLED, not left running paid LLM calls in the
+        background ("Task exception was never retrieved" orphans).
+        """
+        import asyncio
+
+        cancelled: dict[int, bool] = {}
+
+        async def fake_label_one(*, cluster_index, **kwargs):
+            if cluster_index == 0:
+                await asyncio.sleep(0.01)
+                raise RuntimeError("unexpected labeling failure")
+            try:
+                await asyncio.sleep(30)
+            except asyncio.CancelledError:
+                cancelled[cluster_index] = True
+                raise
+            return ClusterLabel(
+                cluster_index=cluster_index,
+                label="never",
+                description="",
+                label_confidence=0.5,
+                representative_memory_ids=[],
+                breakdown=None,
+            )
+
+        monkeypatch.setattr(labeler, "_label_one_cluster", fake_label_one)
+
+        memories = [_mem(), _mem()]
+        with pytest.raises(RuntimeError, match="unexpected labeling failure"):
+            await label_clusters(
+                cluster_labels=np.array([0, 1]),
+                centroids=np.zeros((2, 4)),
+                embeddings=np.ones((2, 4)),
+                memories=memories,
+                user_id="u1",
+                workspace_id="ws",
+                context_id="ctx",
+            )
+
+        assert cancelled.get(1) is True, "sibling task was not cancelled"

--- a/backend/tests/services/analysis/test_reporter_coverage.py
+++ b/backend/tests/services/analysis/test_reporter_coverage.py
@@ -687,6 +687,85 @@ class TestPersistResults:
         )
         assert report is None
 
+    async def test_cancelled_run_leaves_no_cluster_or_assignment_rows(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        """#1241: the cancel guard must run BEFORE any cluster/assignment
+        write. The guard's early ``return`` is followed by the orchestrator's
+        ``commit`` — anything already flushed at that point would be
+        permanently committed for a cancelled run and served forever by
+        the /clusters, /positions and MCP get_cluster readers.
+        """
+        analysis = await _make_analysis(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        mem = await _make_db_memory(
+            db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+        )
+        memories = [
+            MemoryRecord(
+                id=mem.id,
+                type="note",
+                summary="m",
+                tags=[],
+                importance=0.5,
+                created_at=datetime(2026, 1, 1),
+            )
+        ]
+        inputs = PersistInputs(
+            analysis=analysis,
+            memories=memories,
+            embeddings=np.zeros((1, 4)),
+            cluster_labels=np.array([0]),
+            coords_2d=np.array([[0.0, 0.0]]),
+            cluster_results=[_cluster_label(cluster_index=0, breakdown=None)],
+            silhouette=0.0,
+            size_variance=0.0,
+            outlier_ratio=0.0,
+            window_from=None,
+            window_to=None,
+        )
+
+        analysis.status = "cancelled"
+        analysis.cancellation_reason = "user"
+        await db_session.flush()
+
+        await persist_results(
+            db_session,
+            inputs=inputs,
+            user_id="rep_user",
+            workspace_id=str(fixture_workspace_id),
+            context_id=str(fixture_context_id),
+        )
+
+        clusters = (
+            (
+                await db_session.execute(
+                    select(MemoryAnalysisCluster).where(
+                        MemoryAnalysisCluster.analysis_id == analysis.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assignments = (
+            (
+                await db_session.execute(
+                    select(MemoryAnalysisAssignment).where(
+                        MemoryAnalysisAssignment.analysis_id == analysis.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert clusters == []
+        assert assignments == []
+
     async def test_failed_cluster_excluded_from_label_confidence(
         self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
     ):

--- a/backend/tests/services/test_context_delete_cancels_analysis.py
+++ b/backend/tests/services/test_context_delete_cancels_analysis.py
@@ -1,0 +1,104 @@
+"""#1241/#1243: deleting a context cancels its in-flight analysis run.
+
+Without this, the background pipeline kept charging the workspace's
+BYOK key after the user deleted the context — the strongest stop signal
+they can send — and then persisted a full result set that #1243's
+liveness join makes permanently invisible.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from models.analysis import MemoryAnalysis
+from models.auth import Context, Workspace, WorkspaceMember, WorkspaceRole
+from models.llm_pricing import LLMPricing
+from services.context_service import ContextService
+from utils.datetime import utcnow
+
+
+async def _seed(db_session):
+    ws = Workspace(id=uuid4(), name="Del Test", owner_user_id="del_user")
+    db_session.add(ws)
+    await db_session.flush()
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id="del_user", role=WorkspaceRole.OWNER)
+    )
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name="del_ctx",
+        display_name="Del Context",
+        created_by="del_user",
+        is_private=False,
+    )
+    db_session.add(ctx)
+    pricing = LLMPricing(
+        provider="openai",
+        model=f"gpt-test-{uuid4().hex[:8]}",
+        unit_type="input_tokens",
+        price_per_unit="0.001",
+        currency="USD",
+        effective_from=datetime(2024, 1, 1),
+    )
+    db_session.add(pricing)
+    await db_session.flush()
+    return ws, ctx, pricing
+
+
+class TestDeleteContextCancelsRunningAnalysis:
+    @pytest.mark.asyncio
+    async def test_running_analysis_cancelled_and_task_stopped(self, db_session):
+        ws, ctx, pricing = await _seed(db_session)
+        run = MemoryAnalysis(
+            workspace_id=ws.id,
+            context_id=ctx.id,
+            triggered_by="del_user",
+            model_id=pricing.id,
+            model_snapshot={},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(run)
+        await db_session.flush()
+
+        with patch("tasks.analysis_tasks.cancel_run_task", return_value=True) as mock_cancel:
+            await ContextService(db_session).delete_context("del_user", ctx.id, _commit=False)
+
+        assert run.status == "cancelled"
+        assert run.cancellation_reason == "context_deleted"
+        assert run.finished_at is not None
+        mock_cancel.assert_called_once_with(run.id)
+
+    @pytest.mark.asyncio
+    async def test_terminal_runs_left_untouched(self, db_session):
+        ws, ctx, pricing = await _seed(db_session)
+        done = MemoryAnalysis(
+            workspace_id=ws.id,
+            context_id=ctx.id,
+            triggered_by="del_user",
+            model_id=pricing.id,
+            model_snapshot={},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="succeeded",
+            paid_by="byok",
+            finished_at=utcnow(),
+        )
+        db_session.add(done)
+        await db_session.flush()
+
+        with patch("tasks.analysis_tasks.cancel_run_task") as mock_cancel:
+            await ContextService(db_session).delete_context("del_user", ctx.id, _commit=False)
+
+        assert done.status == "succeeded"
+        assert done.cancellation_reason is None
+        mock_cancel.assert_not_called()


### PR DESCRIPTION
Closes #1241

## Summary
Makes analysis cancellation all-or-nothing and stops the spend:
- `persist_results` checks the cancel guard **first**, under `refresh(with_for_update=True)` — a cancelled run no longer gets its cluster/assignment rows committed and served forever.
- `persist_failure` and the DELETE handler take the same row lock; whichever side wins decides the terminal state and the loser observes it (no more clobbered cancels / contradictory `cancellation_reason` on succeeded rows).
- DELETE cancels the in-process compute via a run-task registry in `tasks/analysis_tasks.py` (wired at both REST and MCP kickoff; best-effort in multi-worker deployments — the row lock still prevents any post-cancel persist).
- `label_clusters` cancels sibling tasks on the first non-upstream error and awaits settlement (no orphaned paid LLM calls).
- `delete_context` cancels in-flight analyses (`cancellation_reason=context_deleted`) — deleting a context is the strongest stop signal, and after #1243 the orphaned result would be permanently invisible.

## Verification
- TDD: cancelled-run-leaves-no-rows (fails pre-fix), sibling-cancellation, refresh-protocol route tests (pin `with_for_update=True`), hard-deleted-run 404, context-delete cancellation
- `test_reporter_coverage.py` / `test_labeler_coverage.py` / `test_analyses_routes.py` / `test_context_delete_cancels_analysis.py`: all green locally

## Review
Independent code-review pass: 3 findings, all fixed in a0841c0 — including a **critical**: the locked re-check returned the identity-mapped instance with stale attributes (the `workspace_locks.py` gotcha), so the lock-loser would have clobbered the winner's committed state; now `refresh(with_for_update=True)` like the reporter side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
