### PR TITLE
fix(api): wire disallow_env_fallback into the LLM labeling path (#1242)

### DIFF
--- a/backend/src/services/analysis/byok_resolver.py
+++ b/backend/src/services/analysis/byok_resolver.py
@@ -70,7 +70,11 @@ async def assert_openai_byok_key_available(
     No env-var fallback is honored here. The analysis path requires
     an explicit BYOK row; ``OPENAI_API_KEY`` env-var is only the
     legacy dev fallback in ``LLMService`` and is not appropriate
-    for a paid feature.
+    for a paid feature. Since #1242 the actual labeling calls enforce
+    the same contract at call time (``call_with_fallback`` passes
+    ``disallow_env_fallback=True`` through ``complete_json``), so a
+    BYOK key deleted AFTER this pre-flight fails the run instead of
+    silently resolving the platform env credential.
 
     Args:
         db: AsyncSession bound to the request transaction.

--- a/backend/src/services/analysis/llm_caller.py
+++ b/backend/src/services/analysis/llm_caller.py
@@ -157,6 +157,12 @@ async def call_with_fallback(
                 provider="openai",
                 temperature=temperature,
                 max_tokens=max_tokens,
+                # #1242 strict BYOK: analysis is a paid feature — a BYOK
+                # key deleted mid-run must fail the run (ConfigurationError
+                # is not an LLMServiceError, so it escapes the fallback
+                # loop below immediately), never resolve the platform
+                # OPENAI_API_KEY env credential.
+                disallow_env_fallback=True,
             )
             return CallResult(parsed=response.parsed, response=response)
         except LLMServiceError as e:

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -121,6 +121,7 @@ class LLMService:
         provider: str | None = None,
         temperature: float = 0.1,
         max_tokens: int = 1024,
+        disallow_env_fallback: bool = False,
     ) -> LLMResponse:
         """Call LLM with JSON mode and return cost-grade response.
 
@@ -134,6 +135,14 @@ class LLMService:
             provider: LLM provider (default: from config)
             temperature: Sampling temperature
             max_tokens: Max response tokens
+            disallow_env_fallback: #1242 strict BYOK. When True, key
+                resolution requires an enabled ``external_api_keys``
+                row — the env-var fallback (the platform credential on
+                managed SaaS) is skipped and a missing row raises
+                ``ConfigurationError``. Paid features (Memory Analysis
+                labeling) set this so a mid-run BYOK key removal fails
+                the run instead of silently billing the platform key.
+                Mirrors ``EmbeddingService``'s flag (#708/#1030).
 
         Returns:
             LLMResponse — parsed JSON + per-class token counts +
@@ -141,12 +150,17 @@ class LLMService:
 
         Raises:
             LLMServiceError: On API error or JSON parse failure after retry
+            ConfigurationError: No resolvable API key for the provider.
         """
         resolved_model = model or os.getenv("SLEEP_LLM_MODEL", "gpt-5-nano")
         resolved_provider = provider or os.getenv("SLEEP_LLM_PROVIDER", "openai")
 
         provider_instance = await self._get_provider(
-            user_id, resolved_provider, context_id, workspace_id
+            user_id,
+            resolved_provider,
+            context_id,
+            workspace_id,
+            disallow_env_fallback=disallow_env_fallback,
         )
 
         # First attempt
@@ -353,8 +367,16 @@ class LLMService:
         provider_name: str,
         context_id: str | None = None,
         workspace_id: str | None = None,
+        *,
+        disallow_env_fallback: bool = False,
     ) -> LLMProvider:
-        """Instantiate the correct LLM provider with resolved API key."""
+        """Instantiate the correct LLM provider with resolved API key.
+
+        ``disallow_env_fallback`` (#1242) applies to API-key providers
+        only — the ``self_hosted`` branch resolves a base URL, not
+        billable key material, so its env/settings fallback is
+        deliberately exempt.
+        """
         provider_cls = _PROVIDERS.get(provider_name)
         if provider_cls is None:
             raise ConfigurationError(
@@ -390,7 +412,13 @@ class LLMService:
                 self._last_self_hosted_base_url = base_url
             return self._self_hosted_provider
 
-        api_key = await self._get_user_api_key(user_id, provider_name, context_id, workspace_id)
+        api_key = await self._get_user_api_key(
+            user_id,
+            provider_name,
+            context_id,
+            workspace_id,
+            disallow_env_fallback=disallow_env_fallback,
+        )
         return provider_cls(api_key)
 
     async def _get_user_api_key(
@@ -399,6 +427,8 @@ class LLMService:
         provider: str,
         context_id: str | None = None,
         workspace_id: str | None = None,
+        *,
+        disallow_env_fallback: bool = False,
     ) -> str:
         """Resolve the API key for the calling user's workspace context.
 
@@ -410,19 +440,24 @@ class LLMService:
         2. Workspace-scoped key (workspace_id matches AND context_id IS NULL)
         3. Provider-specific environment variable (e.g., OPENAI_API_KEY,
            ANTHROPIC_API_KEY, GOOGLE_API_KEY, SELF_HOSTED_BASE_URL, OLLAMA_API_KEY)
-           — development fallback only
+           — development / self-host fallback. Skipped entirely when
+           ``disallow_env_fallback`` is True (#1242): on managed SaaS the
+           env var is the platform's own credential, and a paid BYOK
+           feature must never bill it.
 
         Args:
             user_id: Caller's user ID — logged for audit, NOT used as a filter.
             provider: Provider name (e.g. ``"openai"``, ``"anthropic"``).
             context_id: Optional context UUID.
             workspace_id: Workspace UUID; when omitted the DB lookup is skipped.
+            disallow_env_fallback: Require a DB (BYOK) key; see above.
 
         Returns:
             Decrypted API key.
 
         Raises:
-            ConfigurationError: If neither a DB key nor an env var is available.
+            ConfigurationError: If neither a DB key nor an env var is
+                available — or, in strict mode, no DB key exists.
         """
         from uuid import UUID
 
@@ -467,6 +502,25 @@ class LLMService:
                 workspace_id=workspace_id,
             )
             return api_key
+
+        # #1242 strict BYOK: a paid feature must fail here, BEFORE the env
+        # fallback below — os.getenv would silently resolve the platform's
+        # own credential on managed SaaS while the ledger attributes the
+        # spend to the user's key (paid_by='byok' is a source-fixed label).
+        if disallow_env_fallback:
+            logger.info(
+                "llm_api_key_env_fallback_disallowed",
+                provider=provider,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                context_id=context_id,
+            )
+            raise ConfigurationError(
+                f"No enabled {provider} BYOK key found for this workspace. "
+                "This feature requires an explicit BYOK key (env-var fallback "
+                "is disabled for paid features); add one under Integrations "
+                "> External Keys."
+            )
 
         # Environment fallback — provider-specific env var first, then generic
         env_var_map = {

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -515,11 +515,21 @@ class LLMService:
                 workspace_id=workspace_id,
                 context_id=context_id,
             )
+            if workspace_id:
+                raise ConfigurationError(
+                    f"No enabled {provider} BYOK key found for this workspace. "
+                    "This feature requires an explicit BYOK key (env-var fallback "
+                    "is disabled for paid features); add one under Integrations "
+                    "> External Keys."
+                )
+            # No workspace_id → the DB lookup above was skipped entirely.
+            # Telling the user to add a key would misdirect debugging: the
+            # bug is the CALLER omitting workspace_id in strict mode.
             raise ConfigurationError(
-                f"No enabled {provider} BYOK key found for this workspace. "
-                "This feature requires an explicit BYOK key (env-var fallback "
-                "is disabled for paid features); add one under Integrations "
-                "> External Keys."
+                f"{provider} BYOK key resolution requires a workspace_id, but "
+                "none was provided by the caller (strict mode skips the "
+                "env-var fallback). This is a calling-code bug, not a "
+                "missing-key configuration issue."
             )
 
         # Environment fallback — provider-specific env var first, then generic

--- a/backend/tests/services/analysis/test_llm_caller.py
+++ b/backend/tests/services/analysis/test_llm_caller.py
@@ -163,3 +163,48 @@ def test_filter_hallucinated_ids_all_hallucinated() -> None:
     """All candidates outside the requested set returns empty list."""
     requested = frozenset({"id-1"})
     assert filter_hallucinated_ids(["id-evil-1", "id-evil-2"], requested) == []
+
+
+@pytest.mark.asyncio
+async def test_calls_pass_strict_byok_flag() -> None:
+    """#1242: the analysis wrapper is the paid-feature path — every
+    ``complete_json`` call must request strict BYOK resolution so a
+    mid-run key removal cannot fall back to the platform env key."""
+    llm_service = AsyncMock()
+    llm_service.complete_json = AsyncMock(return_value=_ok_response("gpt-5-nano"))
+
+    await call_with_fallback(
+        llm_service,
+        user_id="u1",
+        workspace_id="w1",
+        context_id=None,
+        system_prompt="sys",
+        prompt="p",
+    )
+
+    for call in llm_service.complete_json.call_args_list:
+        assert call.kwargs.get("disallow_env_fallback") is True
+
+
+@pytest.mark.asyncio
+async def test_configuration_error_propagates_without_fallback() -> None:
+    """#1242: ConfigurationError (BYOK row gone mid-run) is NOT an
+    upstream provider failure — it must escape immediately and fail the
+    run, not burn the remaining fallback-chain attempts."""
+    from utils.exceptions import ConfigurationError
+
+    llm_service = AsyncMock()
+    llm_service.complete_json = AsyncMock(
+        side_effect=ConfigurationError("openai API key not configured (BYOK required)")
+    )
+
+    with pytest.raises(ConfigurationError):
+        await call_with_fallback(
+            llm_service,
+            user_id="u1",
+            workspace_id="w1",
+            context_id=None,
+            system_prompt="sys",
+            prompt="p",
+        )
+    assert llm_service.complete_json.call_count == 1

--- a/backend/tests/services/test_llm_service.py
+++ b/backend/tests/services/test_llm_service.py
@@ -389,3 +389,19 @@ class TestStrictByokKeyResolution:
             disallow_env_fallback=True,
         )
         assert llm_service._get_provider.call_args.kwargs.get("disallow_env_fallback") is True
+
+    @pytest.mark.asyncio
+    async def test_get_provider_forwards_strict_flag_to_key_resolution(
+        self, llm_service, monkeypatch
+    ):
+        """#1242 chain link 2: ``_get_provider`` must forward the flag to
+        the REAL ``_get_user_api_key`` — the complete_json-level test
+        mocks _get_provider away, so without this test a refactor that
+        drops the kwarg re-enables the platform env fallback silently.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test-1242")
+        with pytest.raises(ConfigurationError):
+            await llm_service._get_provider("u1", "openai", disallow_env_fallback=True)
+        # Default mode still resolves the env key end-to-end.
+        provider = await llm_service._get_provider("u1", "openai")
+        assert provider is not None

--- a/backend/tests/services/test_llm_service.py
+++ b/backend/tests/services/test_llm_service.py
@@ -301,3 +301,91 @@ class TestGetProvider:
         """Test unknown provider raises ConfigurationError."""
         with pytest.raises(ConfigurationError, match="Unknown LLM provider"):
             await llm_service._get_provider("user-1", "unknown")
+
+
+class TestStrictByokKeyResolution:
+    """#1242: ``disallow_env_fallback`` — strict BYOK for paid features.
+
+    The analysis labeling path requires an explicit BYOK row; the
+    ``OPENAI_API_KEY`` env var is the platform embedding credential on
+    managed SaaS, so falling back to it mid-run silently shifts BYOK
+    costs onto the platform. Mirrors the embedding-path mechanism
+    (``EmbeddingService`` #708/#1030).
+    """
+
+    @pytest.mark.asyncio
+    async def test_env_fallback_used_by_default(self, llm_service, monkeypatch):
+        """Self-host/dev contract unchanged: default resolution still
+        honors the env var when no BYOK row exists."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test-1242")
+        key = await llm_service._get_user_api_key("u1", "openai")
+        assert key == "sk-env-test-1242"
+
+    @pytest.mark.asyncio
+    async def test_disallow_env_fallback_raises_despite_env(self, llm_service, monkeypatch):
+        """Strict mode: no BYOK row → ConfigurationError even when the
+        env var is set — and the key material never leaks into the
+        error message."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test-1242")
+        with pytest.raises(ConfigurationError) as excinfo:
+            await llm_service._get_user_api_key("u1", "openai", disallow_env_fallback=True)
+        assert "sk-env-test-1242" not in str(excinfo.value)
+        assert "BYOK" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_disallow_env_fallback_with_workspace_but_no_row(
+        self, llm_service, mock_db, monkeypatch
+    ):
+        """Strict mode with a workspace that has no enabled key: the
+        DB lookup misses and the env var must still be skipped."""
+        from unittest.mock import MagicMock
+        from uuid import uuid4
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test-1242")
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        mock_db.execute = AsyncMock(return_value=result)
+        with pytest.raises(ConfigurationError):
+            await llm_service._get_user_api_key(
+                "u1", "openai", workspace_id=str(uuid4()), disallow_env_fallback=True
+            )
+
+    @pytest.mark.asyncio
+    async def test_disallow_env_fallback_still_resolves_db_key(
+        self, llm_service, mock_db, monkeypatch
+    ):
+        """Strict mode disables ONLY the env fallback — an enabled BYOK
+        row resolves exactly as before."""
+        from unittest.mock import MagicMock
+        from uuid import uuid4
+
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env-test-1242")
+        entry = MagicMock(encrypted_value="encrypted-blob")
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=entry)
+        mock_db.execute = AsyncMock(return_value=result)
+
+        fake_encryptor = MagicMock()
+        fake_encryptor.decrypt = MagicMock(return_value="sk-db-key")
+        with patch("services.llm_service.get_encryptor", return_value=fake_encryptor):
+            key = await llm_service._get_user_api_key(
+                "u1", "openai", workspace_id=str(uuid4()), disallow_env_fallback=True
+            )
+        assert key == "sk-db-key"
+
+    @pytest.mark.asyncio
+    async def test_complete_json_threads_flag_to_provider_resolution(self, llm_service):
+        """``complete_json(disallow_env_fallback=True)`` must reach
+        ``_get_provider`` — the flag is useless if it stops at the
+        public surface."""
+        provider = AsyncMock()
+        provider.complete_json = AsyncMock(return_value=_make_provider_response('{"ok": true}'))
+        llm_service._get_provider = AsyncMock(return_value=provider)
+
+        await llm_service.complete_json(
+            "u1",
+            "prompt",
+            workspace_id="ws",
+            disallow_env_fallback=True,
+        )
+        assert llm_service._get_provider.call_args.kwargs.get("disallow_env_fallback") is True


### PR DESCRIPTION
Closes #1242

## Summary
Strict BYOK for the analysis labeling path: `LLMService.complete_json` / `_get_provider` / `_get_user_api_key` gain `disallow_env_fallback` (default `False`, mirroring `EmbeddingService`'s #708/#1030 mechanism). In strict mode, key resolution requires an enabled `external_api_keys` row and raises `ConfigurationError` **before** the `os.getenv` fallback — on managed SaaS that env var is the platform's own credential, and a BYOK key deleted mid-run must fail the run instead of silently billing it. `call_with_fallback` (the analysis wrapper) always passes `True`; `ConfigurationError` escapes the fallback loop immediately.

Self-host / dev / sleep-pipeline behavior is unchanged (all other callers keep the default; verified all four sleep call sites use keyword args).

## Verification
- Strict-mode unit tests (env set + no row raises; DB row still resolves; key material never in the error), chain-link test through the real `_get_provider`, wrapper-flag test, ConfigurationError-propagation test (no retry storm)

## Review
Independent code-review pass: 2 findings, fixed in fcb0468 (untested middle chain link; misleading message when the caller omits `workspace_id` in strict mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
