### PR TITLE
fix(mcp): make deleted-context analysis runs structurally invisible (#1243)

### DIFF
--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -132,6 +132,35 @@ async def verify_context_in_workspace(
     return result.scalar_one_or_none() is not None
 
 
+def _live_run_boundary_stmt(run_id: UUID, workspace_id: UUID):
+    """Boundary SELECT shared by every run_id-keyed reader (#1243).
+
+    Matches iff the run exists, belongs to ``workspace_id``, AND its
+    parent context is alive. The Context-liveness join makes deleted-
+    context runs structurally invisible to ALL callers: REST already
+    404s at its URL-context boundary check, but the run_id-keyed MCP
+    tools (``get_analysis`` / ``get_cluster``) reach these readers with
+    no context in hand — without the join they served LLM-derived
+    labels, descriptions and property_stats of soft-deleted contexts
+    indefinitely. Enforcing it in the query keeps the invariant out of
+    per-handler checklists (same principle as #1228's schema
+    separation: structural invisibility beats remember-to-exclude).
+    """
+    from models.auth import Context
+
+    return (
+        select(MemoryAnalysis.id)
+        .join(Context, Context.id == MemoryAnalysis.context_id)
+        .where(
+            and_(
+                MemoryAnalysis.id == run_id,
+                MemoryAnalysis.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+            )
+        )
+    )
+
+
 async def count_context_memories(
     db: AsyncSession,
     *,
@@ -169,14 +198,22 @@ async def get_analysis(
 ) -> MemoryAnalysis | None:
     """Fetch one run by id, scoped to ``workspace_id``.
 
-    Returns None if the run does not exist OR belongs to a different
-    workspace — callers convert None into 404 at the API layer so the
-    "exists but not yours" path does not leak existence.
+    Returns None if the run does not exist, belongs to a different
+    workspace, OR its parent context has been soft-deleted (#1243) —
+    callers convert None into 404 at the API layer so the "exists but
+    not yours" and "existed but deleted" paths do not leak existence.
     """
-    stmt = select(MemoryAnalysis).where(
-        and_(
-            MemoryAnalysis.id == run_id,
-            MemoryAnalysis.workspace_id == workspace_id,
+    from models.auth import Context
+
+    stmt = (
+        select(MemoryAnalysis)
+        .join(Context, Context.id == MemoryAnalysis.context_id)
+        .where(
+            and_(
+                MemoryAnalysis.id == run_id,
+                MemoryAnalysis.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+            )
         )
     )
     return (await db.execute(stmt)).scalar_one_or_none()
@@ -317,14 +354,7 @@ async def get_cluster(
     # Tenant + run validity in a single query — joins ``memory_analyses``
     # to enforce workspace_id boundary before paying for the cluster lookup.
     boundary = (
-        await db.execute(
-            select(MemoryAnalysis.id).where(
-                and_(
-                    MemoryAnalysis.id == run_id,
-                    MemoryAnalysis.workspace_id == workspace_id,
-                )
-            )
-        )
+        await db.execute(_live_run_boundary_stmt(run_id, workspace_id))
     ).scalar_one_or_none()
     if boundary is None:
         return None
@@ -476,14 +506,7 @@ async def list_clusters(
       so no pagination is offered.
     """
     boundary = (
-        await db.execute(
-            select(MemoryAnalysis.id).where(
-                and_(
-                    MemoryAnalysis.id == run_id,
-                    MemoryAnalysis.workspace_id == workspace_id,
-                )
-            )
-        )
+        await db.execute(_live_run_boundary_stmt(run_id, workspace_id))
     ).scalar_one_or_none()
     if boundary is None:
         return None
@@ -526,14 +549,7 @@ async def list_positions(
     - ``list[dict]`` of ``{memory_id, x, y, cluster_index}`` otherwise.
     """
     boundary = (
-        await db.execute(
-            select(MemoryAnalysis.id).where(
-                and_(
-                    MemoryAnalysis.id == run_id,
-                    MemoryAnalysis.workspace_id == workspace_id,
-                )
-            )
-        )
+        await db.execute(_live_run_boundary_stmt(run_id, workspace_id))
     ).scalar_one_or_none()
     if boundary is None:
         return None
@@ -620,14 +636,7 @@ async def get_memory_ids_in_cluster(
     # BEFORE resolving the cluster_index (so a stolen run_id from a
     # foreign workspace is indistinguishable from a typo).
     boundary = (
-        await db.execute(
-            select(MemoryAnalysis.id).where(
-                and_(
-                    MemoryAnalysis.id == run_id,
-                    MemoryAnalysis.workspace_id == workspace_id,
-                )
-            )
-        )
+        await db.execute(_live_run_boundary_stmt(run_id, workspace_id))
     ).scalar_one_or_none()
     if boundary is None:
         return None

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -155,6 +155,12 @@ def _live_run_boundary_stmt(run_id: UUID, workspace_id: UUID):
             and_(
                 MemoryAnalysis.id == run_id,
                 MemoryAnalysis.workspace_id == workspace_id,
+                # Copilot review: also pin the CONTEXT's workspace — the
+                # run row's workspace_id alone would treat a run whose
+                # context_id drifted into another workspace (partial
+                # corruption / bad backfill) as live. Matches
+                # verify_context_in_workspace's predicate set.
+                Context.workspace_id == workspace_id,
                 Context.deleted_at.is_(None),
             )
         )
@@ -212,6 +218,8 @@ async def get_analysis(
             and_(
                 MemoryAnalysis.id == run_id,
                 MemoryAnalysis.workspace_id == workspace_id,
+                # Same context-workspace pin as _live_run_boundary_stmt.
+                Context.workspace_id == workspace_id,
                 Context.deleted_at.is_(None),
             )
         )

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -450,3 +450,140 @@ async def test_get_cluster_limit_clamped_to_max(
     assert page is not None
     assert page["memories"] == []
     assert page["next_cursor"] is None
+
+
+# ===========================================================================
+# #1243 — deleted-context runs are structurally invisible
+# ===========================================================================
+
+
+async def _soft_delete_context(db_session, context_id: UUID) -> None:
+    from models.auth import Context
+
+    ctx = await db_session.get(Context, context_id)
+    ctx.deleted_at = utcnow()
+    await db_session.flush()
+
+
+class TestDeletedContextInvisibility:
+    """#1243: every run_id-keyed reader must treat runs of a soft-deleted
+    context as nonexistent. The MCP tools (get_analysis / get_cluster)
+    reach these readers with only a run_id in hand — REST 404s at its
+    URL-context boundary check, but MCP had no equivalent, so LLM-derived
+    labels/descriptions/property_stats of deleted contexts stayed
+    readable indefinitely.
+    """
+
+    @pytest.mark.asyncio
+    async def test_get_analysis_none_after_context_soft_delete(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        assert (
+            await query_service.get_analysis(
+                db_session, workspace_id=fixture_workspace_id, run_id=run.id
+            )
+            is not None
+        )
+        await _soft_delete_context(db_session, fixture_context_id)
+        assert (
+            await query_service.get_analysis(
+                db_session, workspace_id=fixture_workspace_id, run_id=run.id
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_cluster_none_after_context_soft_delete(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        await _make_cluster(db_session, run=run, cluster_index=0)
+        assert (
+            await query_service.get_cluster(
+                db_session,
+                workspace_id=fixture_workspace_id,
+                run_id=run.id,
+                cluster_index=0,
+            )
+            is not None
+        )
+        await _soft_delete_context(db_session, fixture_context_id)
+        assert (
+            await query_service.get_cluster(
+                db_session,
+                workspace_id=fixture_workspace_id,
+                run_id=run.id,
+                cluster_index=0,
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_clusters_none_after_context_soft_delete(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        await _make_cluster(db_session, run=run, cluster_index=0)
+        await _soft_delete_context(db_session, fixture_context_id)
+        assert (
+            await query_service.list_clusters(
+                db_session, workspace_id=fixture_workspace_id, run_id=run.id
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_positions_none_after_context_soft_delete(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        await _soft_delete_context(db_session, fixture_context_id)
+        assert (
+            await query_service.list_positions(
+                db_session, workspace_id=fixture_workspace_id, run_id=run.id
+            )
+            is None
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_memory_ids_in_cluster_none_after_context_soft_delete(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        await _make_cluster(db_session, run=run, cluster_index=0)
+        await _soft_delete_context(db_session, fixture_context_id)
+        assert (
+            await query_service.get_memory_ids_in_cluster(
+                db_session,
+                workspace_id=fixture_workspace_id,
+                run_id=run.id,
+                cluster_index=0,
+            )
+            is None
+        )


### PR DESCRIPTION
Closes #1243

## Summary
Runs of a soft-deleted context are now **structurally invisible** to every run_id-keyed reader: a shared `_live_run_boundary_stmt` joins `Context.deleted_at IS NULL` into `get_analysis`, `get_cluster`, `list_clusters`, `list_positions` and `get_memory_ids_in_cluster`. This closes the MCP gap — REST 404s at its URL-context boundary check, but MCP `get_analysis`/`get_cluster` reach these readers with only a run_id and served LLM-derived labels/descriptions/property_stats of deleted contexts indefinitely. Enforcing it in the query keeps the invariant out of per-handler checklists (same principle as #1228's schema separation).

`list_analyses` / `get_active_analysis` are unchanged by design: every REST/MCP entrypoint reaching them already runs the deleted_at-filtered context check.

## Verification
- 5 new tests: each reader returns None after `Context.deleted_at` is set (live context unaffected); recall's `analysis_cluster` filter degrades to empty results

## Review
Independent code-review pass: 1 warning — soft-deleting a context never stopped its in-flight run (BYOK spend continued into an invisible result). Fixed in the #1241 PR (`delete_context` now cancels running analyses + stops the in-process task), since the cancel registry lives there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
