### PR TITLE
feat(api): enforce a run-size cap for in-process analysis clustering (#1244)

### DIFF
--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -406,6 +406,10 @@ async def start_analysis(
 
     Error mapping (delegated to global handler via custom exceptions):
 
+    - 422 ValidationError — context exceeds the #1244 run-size cap
+      (checked BEFORE the idempotency guard, so an over-cap context
+      with a run already in flight gets 422, not the 409+run_id hint;
+      cancel/poll that run via the list endpoint).
     - 409 ConflictError  — a prior run is still ``running`` for the
       same (workspace, context). Body carries the existing run_id.
     - 422 ValidationError — BYOK key missing (orchestrator's

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -45,7 +45,11 @@ from models.analysis import MEMORY_ANALYSIS_CANCELLATION_REASONS, MEMORY_ANALYSI
 from models.api_base import TZAwareBaseModel
 from services.analysis import query_service
 from services.analysis.orchestrator import AnalysisOrchestrator, AnalysisParams
-from services.analysis.preview import DEFAULT_MODEL_ID, estimate_cost
+from services.analysis.preview import (
+    DEFAULT_MODEL_ID,
+    assert_run_size_within_cap,
+    estimate_cost,
+)
 from tasks.analysis_tasks import cancel_run_task, register_run_task, run_analysis_task
 from utils.exceptions import ConflictError, ValidationError
 from utils.logger import get_logger
@@ -362,6 +366,9 @@ async def preview_analysis(
         workspace_id=workspace_id,
         context_id=context_id,
     )
+    # #1244: run-size cap — surface the rejection at preview time so the
+    # user is not shown a price for a run that start would refuse.
+    assert_run_size_within_cap(memory_count)
     # v1 only supports the default model in the cost estimator;
     # body.model_id is forward-compat scaffolding (preview.py:73-77).
     estimate = estimate_cost(memory_count, model_id=DEFAULT_MODEL_ID)
@@ -406,6 +413,17 @@ async def start_analysis(
     """
     user_id, workspace_id, _tz = access
     await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    # #1244: run-size cap — reject BEFORE any row is created (422 names
+    # the limit and the context's count). Same full-context count
+    # semantics as /preview; vector_pull re-checks the filtered set as
+    # defense in depth.
+    memory_count = await query_service.count_context_memories(
+        db,
+        workspace_id=workspace_id,
+        context_id=context_id,
+    )
+    assert_run_size_within_cap(memory_count)
 
     params = _params_from_body(body)
     orchestrator = AnalysisOrchestrator(db)

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -607,10 +607,13 @@ class Settings(BaseSettings):
     # concurrency. Env: ANALYSIS_MAX_MEMORY_COUNT.
     analysis_max_memory_count: int = Field(
         default=10_000,
+        ge=1,
         description=(
             "Hard cap on memories per Memory Analysis run. Contexts above "
             "this are rejected at preview and start (422 naming the limit). "
-            "Self-host operators with larger containers may raise it."
+            "Self-host operators with larger containers may raise it. "
+            "Must be >= 1 — a zero/negative value would brick the feature "
+            "at runtime with a misleading message, so it fails at boot."
         ),
     )
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -596,6 +596,24 @@ class Settings(BaseSettings):
             s.strip().lower() for s in self.analysis_enabled_workspace_ids.split(",") if s.strip()
         ]
 
+    # Memory Analysis run-size cap (Issue #1244).
+    # The pipeline materializes every matching vector into one in-RAM numpy
+    # matrix and runs UMAP/KMeans inside the API process (the Option B
+    # analysis-worker externalization is not yet implemented), so run size
+    # directly bounds API-container memory/CPU. Default 10_000 = the
+    # basic-tier memory_limit (plan_tiers.py); ~10k × 3072 dims × 4 B
+    # ≈ 123 MB float32 plus UMAP's kNN working set — tolerable for one run,
+    # and the #1240 one-running-run index plus the 3/day quota bound
+    # concurrency. Env: ANALYSIS_MAX_MEMORY_COUNT.
+    analysis_max_memory_count: int = Field(
+        default=10_000,
+        description=(
+            "Hard cap on memories per Memory Analysis run. Contexts above "
+            "this are rejected at preview and start (422 naming the limit). "
+            "Self-host operators with larger containers may raise it."
+        ),
+    )
+
     # BM25 IDF Drift (Issue #343, #378)
     bm25_drift_cron_enabled: bool = Field(
         default=False,

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -265,11 +265,21 @@ async def handle_analyze_context(
                 # Preview path — same memory count semantics as REST /preview
                 # (delegates to ``query_service.count_context_memories``).
                 from services.analysis import query_service
-                from services.analysis.preview import DEFAULT_MODEL_ID, estimate_cost
+                from services.analysis.preview import (
+                    DEFAULT_MODEL_ID,
+                    assert_run_size_within_cap,
+                    estimate_cost,
+                )
 
                 memory_count = await query_service.count_context_memories(
                     db, workspace_id=workspace_id, context_id=context_id
                 )
+                # #1244: run-size cap — same rejection the real start
+                # returns, so dry_run callers see it before confirming.
+                try:
+                    assert_run_size_within_cap(memory_count)
+                except ValidationError as cap_exc:
+                    return _gate_error_response(cap_exc)
                 estimate = estimate_cost(memory_count, model_id=DEFAULT_MODEL_ID)
                 await _log_tool_usage(
                     db,
@@ -290,11 +300,24 @@ async def handle_analyze_context(
                 )
 
             # Real run — orchestrator.start() + commit + create_task.
+            from services.analysis import query_service
             from services.analysis.orchestrator import (
                 AnalysisOrchestrator,
                 AnalysisParams,
             )
+            from services.analysis.preview import assert_run_size_within_cap
             from tasks.analysis_tasks import register_run_task, run_analysis_task
+
+            # #1244: run-size cap — reject BEFORE any row is created.
+            # Same full-context count semantics as the dry_run path;
+            # vector_pull re-checks the filtered set as defense in depth.
+            memory_count = await query_service.count_context_memories(
+                db, workspace_id=workspace_id, context_id=context_id
+            )
+            try:
+                assert_run_size_within_cap(memory_count)
+            except ValidationError as cap_exc:
+                return _gate_error_response(cap_exc)
 
             params = AnalysisParams(
                 from_dt=None,

--- a/backend/src/services/analysis/preview.py
+++ b/backend/src/services/analysis/preview.py
@@ -79,6 +79,45 @@ class CostEstimate:
     breakdown: dict[str, int]
 
 
+def assert_run_size_within_cap(memory_count: int) -> None:
+    """Reject a run that would exceed ``ANALYSIS_MAX_MEMORY_COUNT`` (#1244).
+
+    The pipeline materializes every matching vector into one in-RAM
+    matrix and runs UMAP/KMeans inside the API process (the Option B
+    analysis-worker externalization is not yet implemented), so run
+    size directly bounds API-container memory/CPU — without a cap, one
+    202-accepted request on a large context can OOM the multi-tenant
+    API.
+
+    Shared by REST ``/preview`` + ``POST /analyses`` and MCP
+    ``analyze_context`` (both dry_run and real start), with a
+    defense-in-depth re-check in ``vector_pull`` after the filtered
+    set is known. v1 counts the FULL context — same semantics as the
+    preview count, which ignores filters to stay under the 200 ms
+    modal budget — so a filtered run on an over-cap context is
+    rejected conservatively. Filter-aware counting is a v1.5
+    follow-up.
+
+    Raises:
+        ValidationError: 422 naming both the limit and the actual
+            count so the client can render a actionable message.
+    """
+    from config.settings import get_settings
+    from utils.exceptions import ValidationError
+
+    cap = int(get_settings().analysis_max_memory_count)
+    if memory_count > cap:
+        raise ValidationError(
+            f"Context has {memory_count} memories, exceeding the per-run "
+            f"analysis cap of {cap}. Narrow the context (split it, or "
+            f"archive old memories) or — on self-host — raise "
+            f"ANALYSIS_MAX_MEMORY_COUNT.",
+            field="memory_count",
+            memory_count=memory_count,
+            limit=cap,
+        )
+
+
 def estimate_cost(memory_count: int, *, model_id: str = DEFAULT_MODEL_ID) -> CostEstimate:
     """Compute the pre-flight estimate for a memory_count-sized run.
 

--- a/backend/src/services/analysis/preview.py
+++ b/backend/src/services/analysis/preview.py
@@ -107,11 +107,15 @@ def assert_run_size_within_cap(memory_count: int) -> None:
 
     cap = int(get_settings().analysis_max_memory_count)
     if memory_count > cap:
+        # Copilot review: phrased as the RUN's memory count, not "the
+        # context has" — the vector_pull defense-in-depth re-check calls
+        # this with the FILTERED match count, where context-sized wording
+        # would be misleading.
         raise ValidationError(
-            f"Context has {memory_count} memories, exceeding the per-run "
-            f"analysis cap of {cap}. Narrow the context (split it, or "
-            f"archive old memories) or — on self-host — raise "
-            f"ANALYSIS_MAX_MEMORY_COUNT.",
+            f"This analysis run would include {memory_count} memories, "
+            f"exceeding the per-run analysis cap of {cap}. Narrow the "
+            f"scope (filters, split the context, or archive old memories) "
+            f"or — on self-host — raise ANALYSIS_MAX_MEMORY_COUNT.",
             field="memory_count",
             memory_count=memory_count,
             limit=cap,

--- a/backend/src/services/analysis/vector_pull.py
+++ b/backend/src/services/analysis/vector_pull.py
@@ -43,7 +43,7 @@ from typing import Any
 from uuid import UUID
 
 import numpy as np
-from sqlalchemy import and_, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.qdrant import (
@@ -216,6 +216,26 @@ async def pull_memories_with_vectors(
         .where(and_(*conditions))
         .order_by(Memory.created_at)
     )
+    # #1244: defense-in-depth run-size cap on the FILTERED set, checked
+    # via a COUNT probe BEFORE the row fetch — the guard must bound the
+    # SQL materialization itself, not just the downstream Qdrant fetch
+    # and numpy matrix. (A pre-cap 1M-memory context would otherwise
+    # load every row's metadata into RAM before being rejected.) The
+    # API/MCP entrypoints already reject over-cap contexts pre-start
+    # (full-context count); this re-check covers rows created before the
+    # cap existed and any future entrypoint that forgets the pre-flight.
+    # Raising here lands in the orchestrator's failure path (run marked
+    # 'failed' with this message) instead of OOMing the API container.
+    from services.analysis.preview import assert_run_size_within_cap
+
+    matched_count = int(
+        (
+            await db.execute(select(func.count()).select_from(Memory).where(and_(*conditions)))
+        ).scalar()
+        or 0
+    )
+    assert_run_size_within_cap(matched_count)
+
     memory_rows = list((await db.execute(stmt)).all())
 
     if not memory_rows:
@@ -223,17 +243,6 @@ async def pull_memories_with_vectors(
             "No memories matched the analysis filters; refusing to start an "
             "empty run. The API layer should pre-flight this and surface 422."
         )
-
-    # #1244: defense-in-depth run-size cap on the FILTERED set, before any
-    # Qdrant vector is fetched or the embedding matrix is materialized.
-    # The API/MCP entrypoints already reject over-cap contexts pre-start
-    # (full-context count); this re-check covers rows created before the
-    # cap existed and any future entrypoint that forgets the pre-flight.
-    # Raising here lands in the orchestrator's failure path (run marked
-    # 'failed' with this message) instead of OOMing the API container.
-    from services.analysis.preview import assert_run_size_within_cap
-
-    assert_run_size_within_cap(len(memory_rows))
 
     # 3. Pull vectors from Qdrant in semaphore-bounded parallel batches.
     #    ``retrieve`` (point-id lookup) is preferred over ``scroll`` because

--- a/backend/src/services/analysis/vector_pull.py
+++ b/backend/src/services/analysis/vector_pull.py
@@ -224,6 +224,17 @@ async def pull_memories_with_vectors(
             "empty run. The API layer should pre-flight this and surface 422."
         )
 
+    # #1244: defense-in-depth run-size cap on the FILTERED set, before any
+    # Qdrant vector is fetched or the embedding matrix is materialized.
+    # The API/MCP entrypoints already reject over-cap contexts pre-start
+    # (full-context count); this re-check covers rows created before the
+    # cap existed and any future entrypoint that forgets the pre-flight.
+    # Raising here lands in the orchestrator's failure path (run marked
+    # 'failed' with this message) instead of OOMing the API container.
+    from services.analysis.preview import assert_run_size_within_cap
+
+    assert_run_size_within_cap(len(memory_rows))
+
     # 3. Pull vectors from Qdrant in semaphore-bounded parallel batches.
     #    ``retrieve`` (point-id lookup) is preferred over ``scroll`` because
     #    we already know the exact IDs. ``_QDRANT_RETRIEVE_CONCURRENCY``

--- a/backend/tests/api/test_analyses_routes.py
+++ b/backend/tests/api/test_analyses_routes.py
@@ -118,6 +118,24 @@ class TestPreview:
         assert body["estimated_cost_cents"] >= 1
         assert "input_tokens" in body["breakdown"]
 
+    def test_preview_rejects_over_cap_context(self, client, db_mock, monkeypatch):
+        """#1244: preview 422s (naming the limit) instead of quoting a
+        price for a run that start would refuse."""
+        from config.settings import get_settings
+
+        monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 50)
+        db_mock.execute.side_effect = [
+            _scalar_one(_TEST_CONTEXT_ID),  # Context boundary
+            _scalar_one(51),  # count_context_memories → over cap
+        ]
+        response = client.post(
+            f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/preview",
+            json={},
+        )
+        assert response.status_code == 422, response.text
+        assert "50" in response.text
+        assert "51" in response.text
+
 
 # ============================================================================
 # POST / (start)
@@ -128,8 +146,12 @@ class TestStartRun:
     def test_returns_202_with_run_id_on_success(self, client, db_mock):
         run_id = uuid4()
         started_at = datetime(2026, 5, 2, 0, 0, 0)
-        # Boundary check passes; orchestrator stub returns a fake row.
-        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        # Boundary check passes; #1244 cap count under the limit;
+        # orchestrator stub returns a fake row.
+        db_mock.execute.side_effect = [
+            _scalar_one(_TEST_CONTEXT_ID),
+            _scalar_one(100),  # count_context_memories (run-size cap)
+        ]
 
         fake_analysis = MagicMock(id=run_id, status="running", started_at=started_at)
         with (
@@ -157,6 +179,26 @@ class TestStartRun:
             json={},
         )
         assert response.status_code == 404
+
+    def test_start_rejects_over_cap_before_creating_run(self, client, db_mock, monkeypatch):
+        """#1244: over-cap context → 422 BEFORE orchestrator.start()
+        creates any row (no quota slot consumed, no running row)."""
+        from config.settings import get_settings
+
+        monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 50)
+        db_mock.execute.side_effect = [
+            _scalar_one(_TEST_CONTEXT_ID),  # Context boundary
+            _scalar_one(51),  # count_context_memories → over cap
+        ]
+        with patch("api.routes.analyses.AnalysisOrchestrator") as orch_cls:
+            orch_cls.return_value.start = AsyncMock()
+            response = client.post(
+                f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses",
+                json={},
+            )
+        assert response.status_code == 422, response.text
+        assert "50" in response.text
+        orch_cls.return_value.start.assert_not_called()
 
 
 # ============================================================================

--- a/backend/tests/mcp_server/test_analysis_tools_cap.py
+++ b/backend/tests/mcp_server/test_analysis_tools_cap.py
@@ -1,0 +1,139 @@
+"""#1244: MCP ``analyze_context`` run-size cap enforcement tests.
+
+The REST enforcement points are covered in
+``tests/api/test_analyses_routes.py``; these tests pin the two MCP
+call sites (dry_run preview and the real start) — without them a
+mutation deleting either check passes the whole suite while MCP
+quotes prices for (or starts) runs that REST would refuse.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.analysis import handle_analyze_context
+
+
+def _fake_get_db(db_mock):
+    """Async-generator factory standing in for ``db.base.get_db``."""
+
+    async def _gen():
+        yield db_mock
+
+    return _gen
+
+
+def _envelope(result) -> dict:
+    assert result, "handler returned an empty response list"
+    return json.loads(result[0].text)
+
+
+@pytest.fixture
+def db_mock():
+    m = MagicMock()
+    m.execute = AsyncMock()
+    m.commit = AsyncMock()
+    m.rollback = AsyncMock()
+    return m
+
+
+@pytest.fixture
+def small_cap(monkeypatch):
+    from config.settings import get_settings
+
+    monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 50)
+
+
+class TestAnalyzeContextRunSizeCap:
+    @pytest.mark.asyncio
+    async def test_dry_run_rejects_over_cap_context(self, db_mock, small_cap):
+        """dry_run must return the same validation_error the real start
+        does — never quote a price for a run start would refuse."""
+        with (
+            patch("db.base.get_db", _fake_get_db(db_mock)),
+            patch(
+                "mcp_server.tools.analysis._verify_context_in_workspace_mcp",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "auth.analysis_gates.check_memory_analysis_access_mcp",
+                AsyncMock(return_value="UTC"),
+            ),
+            patch(
+                "services.analysis.query_service.count_context_memories",
+                AsyncMock(return_value=51),
+            ),
+        ):
+            result = await handle_analyze_context(
+                {"context_id": str(uuid4()), "dry_run": True},
+                "u1",
+                uuid4(),
+            )
+        body = _envelope(result)
+        assert body.get("error") == "validation_error", body
+        assert "50" in body.get("message", "")
+
+    @pytest.mark.asyncio
+    async def test_real_start_rejects_over_cap_before_creating_run(self, db_mock, small_cap):
+        """The real start must 422 BEFORE orchestrator.start() creates
+        any row — otherwise the run dies later in vector_pull having
+        consumed a daily-quota slot."""
+        with (
+            patch("db.base.get_db", _fake_get_db(db_mock)),
+            patch(
+                "mcp_server.tools.analysis._verify_context_in_workspace_mcp",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "auth.analysis_gates.check_memory_analysis_access_mcp",
+                AsyncMock(return_value="UTC"),
+            ),
+            patch(
+                "services.analysis.query_service.count_context_memories",
+                AsyncMock(return_value=51),
+            ),
+            patch("services.analysis.orchestrator.AnalysisOrchestrator") as orch_cls,
+        ):
+            result = await handle_analyze_context(
+                {"context_id": str(uuid4())},
+                "u1",
+                uuid4(),
+            )
+        body = _envelope(result)
+        assert body.get("error") == "validation_error", body
+        orch_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_under_cap_dry_run_returns_estimate(self, db_mock, small_cap):
+        """Control: an under-cap context still gets the cost preview."""
+        with (
+            patch("db.base.get_db", _fake_get_db(db_mock)),
+            patch(
+                "mcp_server.tools.analysis._verify_context_in_workspace_mcp",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "auth.analysis_gates.check_memory_analysis_access_mcp",
+                AsyncMock(return_value="UTC"),
+            ),
+            patch(
+                "services.analysis.query_service.count_context_memories",
+                AsyncMock(return_value=49),
+            ),
+            patch(
+                "mcp_server.tools.analysis._log_tool_usage",
+                AsyncMock(),
+            ),
+        ):
+            result = await handle_analyze_context(
+                {"context_id": str(uuid4()), "dry_run": True},
+                "u1",
+                uuid4(),
+            )
+        body = _envelope(result)
+        assert body.get("dry_run") is True, body
+        assert body.get("memory_count") == 49

--- a/backend/tests/services/analysis/test_preview_cap.py
+++ b/backend/tests/services/analysis/test_preview_cap.py
@@ -1,0 +1,38 @@
+"""#1244: run-size cap unit tests for ``assert_run_size_within_cap``.
+
+Route-level enforcement (REST preview/start) is covered in
+``tests/api/test_analyses_routes.py``; the vector_pull defense-in-depth
+re-check in ``tests/services/analysis/test_vector_pull_coverage.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from config.settings import get_settings
+from services.analysis.preview import assert_run_size_within_cap
+from utils.exceptions import ValidationError
+
+
+class TestRunSizeCap:
+    def test_at_cap_passes(self, monkeypatch) -> None:
+        monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 50)
+        assert_run_size_within_cap(50)  # must not raise
+
+    def test_under_cap_passes(self, monkeypatch) -> None:
+        monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 50)
+        assert_run_size_within_cap(2)
+
+    def test_over_cap_raises_naming_limit_and_count(self, monkeypatch) -> None:
+        monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 50)
+        with pytest.raises(ValidationError) as excinfo:
+            assert_run_size_within_cap(51)
+        message = str(excinfo.value)
+        assert "51" in message, "actual count missing from the error"
+        assert "50" in message, "configured limit missing from the error"
+
+    def test_default_cap_matches_documented_value(self) -> None:
+        """Pins the documented default (basic-tier memory_limit, see
+        settings.py rationale) so a silent change shows up in review.
+        """
+        assert get_settings().analysis_max_memory_count == 10_000

--- a/backend/tests/services/analysis/test_preview_cap.py
+++ b/backend/tests/services/analysis/test_preview_cap.py
@@ -32,7 +32,13 @@ class TestRunSizeCap:
         assert "50" in message, "configured limit missing from the error"
 
     def test_default_cap_matches_documented_value(self) -> None:
-        """Pins the documented default (basic-tier memory_limit, see
+        """Pins the DECLARED default (basic-tier memory_limit, see
         settings.py rationale) so a silent change shows up in review.
+        Reads the field default, not the env-loaded singleton — a
+        self-host operator who set ANALYSIS_MAX_MEMORY_COUNT (as the
+        feature's own docs suggest) must not get a spurious failure
+        from make test-local.
         """
-        assert get_settings().analysis_max_memory_count == 10_000
+        from config.settings import Settings
+
+        assert Settings.model_fields["analysis_max_memory_count"].default == 10_000

--- a/backend/tests/services/analysis/test_vector_pull_coverage.py
+++ b/backend/tests/services/analysis/test_vector_pull_coverage.py
@@ -840,3 +840,40 @@ class TestPullEdges:
         assert result.embeddings.shape == (5, 2)
         # Alignment preserved across batches.
         np.testing.assert_array_equal(result.embeddings[3], [3.0, 0.0])
+
+
+# ===========================================================================
+# #1244 — run-size cap defense in depth
+# ===========================================================================
+
+
+class TestRunSizeCapDefense:
+    @pytest.mark.asyncio
+    async def test_filtered_set_over_cap_raises_before_qdrant(
+        self, db_session, workspace_id, context_id, patch_qdrant, monkeypatch
+    ):
+        """#1244: the cap re-check fires on the filtered set BEFORE any
+        Qdrant vector is fetched or the embedding matrix materializes —
+        a pre-cap row (or an entrypoint that skipped the pre-flight)
+        fails the run instead of OOMing the API container.
+        """
+        from config.settings import get_settings
+        from utils.exceptions import ValidationError
+
+        m1 = await _make_memory(db_session, workspace_id=workspace_id, context_id=context_id)
+        m2 = await _make_memory(db_session, workspace_id=workspace_id, context_id=context_id)
+        client = patch_qdrant(
+            {
+                str(m1.id): [0.1, 0.2, 0.3, 0.4],
+                str(m2.id): [0.2, 0.3, 0.4, 0.5],
+            }
+        )
+        monkeypatch.setattr(get_settings(), "analysis_max_memory_count", 1)
+
+        with pytest.raises(ValidationError, match="cap of 1"):
+            await vector_pull.pull_memories_with_vectors(
+                db_session,
+                workspace_id=workspace_id,
+                context_id=context_id,
+            )
+        assert client.retrieve_calls == [], "Qdrant was queried despite the cap rejection"

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -321,7 +321,7 @@ Kagura Memory Cloud exposes 50 tools via the [Model Context Protocol (MCP)](http
 | Contexts | 7 | `get_context_info`, `list_contexts`, `create_context`, `update_context`, `delete_context`, `merge_contexts`, `update_search_config` |
 | Tags | 1 | `list_tags` — tag vocabulary discovery for alignment before `remember`/`recall` |
 | Files / R2 | 5 | `init_file_upload`, `complete_file_upload`, `list_files`, `get_file_download_url`, `delete_file` — binary attachments via R2 |
-| Analyses (Memory Analysis) | 5 | `analyze_context`, `list_analyses`, `get_analysis`, `get_active_analysis`, `get_cluster` — large-scale qualitative clustering (Owner + Pro plan) |
+| Analyses (Memory Analysis) | 5 | `analyze_context`, `list_analyses`, `get_analysis`, `get_active_analysis`, `get_cluster` — large-scale qualitative clustering (Owner + Pro plan; per-run size cap `ANALYSIS_MAX_MEMORY_COUNT`, default 10,000 memories — preview and start reject over-cap contexts with a 422 naming the limit) |
 | Resources | 6 | `setup_resource`, `setup_connector`, `list_resource_tokens`, `ingest_events`, `get_resource_impact`, `get_resource_schema` — external data ingestion + connector provisioning |
 | Secrets | 5 | `secret_register_pubkey`, `secret_put`, `secret_get`, `secret_list`, `secret_revoke_grant` — zero-knowledge secret store (age ciphertext; server never decrypts) |
 | Sleep Maintenance | 3 | `get_sleep_history`, `get_sleep_report`, `rollback_sleep_run` — background consolidation observability |


### PR DESCRIPTION
Closes #1244

## Summary
Per-run size cap for Memory Analysis: new `ANALYSIS_MAX_MEMORY_COUNT` setting (default 10,000 = basic-tier `memory_limit`; `ge=1`), enforced by a shared `assert_run_size_within_cap` at REST `/preview` + `POST /analyses` and MCP `analyze_context` (dry_run and real start) with a 422 naming the limit and the context's count. Defense-in-depth: `vector_pull` re-checks the **filtered** set via a COUNT probe **before** fetching any rows — the pipeline materializes every vector into an in-RAM matrix and runs UMAP/KMeans inside the API process (Option B worker externalization not yet implemented), so one over-cap request could otherwise OOM the multi-tenant API.

v1 counts the full context (same semantics as the preview count); filter-aware counting is a v1.5 follow-up. Docs: cap noted in `docs/concepts.md`.

## Verification
- Unit boundary tests, REST over-cap tests (preview + start, orchestrator never called), MCP handler tests (dry_run + real start — previously zero MCP-handler coverage), vector_pull probe test (Qdrant untouched on rejection)

## Review
Independent code-review pass: 5 findings, all fixed in ea42acf (COUNT probe before row fetch; MCP enforcement tests; env-independent default test; `ge=1` boot validation; 422-before-409 precedence documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
