### PR TITLE
fix(api): fail analysis runs when most clusters fail labeling (#1246)

### DIFF
--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -120,8 +120,15 @@ class ClusterLabel:
             cluster row is still written (with empty label) so the
             persistence transaction stays atomic; the reporter aborts
             the persist (run marked failed) only when strictly more
-            than ``MAX_CLUSTER_FAILURE_RATIO`` of clusters fail
-            (#1246).
+            than ``MAX_CLUSTER_FAILURE_RATIO`` of LABELABLE clusters
+            fail (#1246).
+        empty: True for the ``_empty_cluster_label`` sentinel — the
+            cluster had no members, so no labeling was attempted.
+            Excluded from the #1246 failure-ratio DENOMINATOR: on
+            degenerate embeddings KMeans can leave most clusters empty,
+            and counting those un-labelable sentinels would dilute the
+            ratio until a run whose every REAL cluster failed still
+            persisted as an unqualified success.
     """
 
     cluster_index: int
@@ -131,6 +138,7 @@ class ClusterLabel:
     representative_memory_ids: list[str]
     breakdown: LLMCallBreakdown | None
     failed: bool = False
+    empty: bool = False
 
 
 def _select_representatives(
@@ -375,6 +383,7 @@ async def _empty_cluster_label(cluster_index: int) -> ClusterLabel:
         representative_memory_ids=[],
         breakdown=None,
         failed=False,
+        empty=True,
     )
 
 

--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -77,6 +77,28 @@ _REPS_PER_CLUSTER = 5
 # quota.
 _LLM_CONCURRENCY = 8
 
+# #1246: run-level failure threshold for ``ClusterLabel.failed``.
+# ``ClusterLabel``'s docstring promised this constant since #495 but it
+# was never defined — a run whose EVERY cluster failed labeling
+# persisted as an unqualified ``status='succeeded'`` built entirely of
+# "(unlabeled)" rows. The reporter aborts the persist (and the
+# orchestrator marks the run failed) when STRICTLY MORE than this
+# ratio of clusters failed. Exactly-half stays a success: half the
+# clusters still carry usable labels, and ``quality.labeling_failures``
+# surfaces the rest.
+MAX_CLUSTER_FAILURE_RATIO = 0.5
+
+
+class ClusterLabelingThresholdExceeded(Exception):
+    """More than ``MAX_CLUSTER_FAILURE_RATIO`` of clusters failed labeling.
+
+    Raised by ``reporter.persist_results`` BEFORE any cluster/assignment
+    row is written; the orchestrator's generic failure path persists
+    ``status='failed'`` with this message so the user sees the cause
+    (typically an invalid/exhausted BYOK key or a provider outage)
+    instead of a hollow success. (#1246)
+    """
+
 
 @dataclass(frozen=True)
 class ClusterLabel:
@@ -96,9 +118,10 @@ class ClusterLabel:
             actually came from, after fallback chain resolution).
         failed: True if the cluster failed all fallback models. The
             cluster row is still written (with empty label) so the
-            persistence transaction stays atomic; the orchestrator
-            rolls back the whole run only if too many clusters
-            fail (see ``MAX_CLUSTER_FAILURE_RATIO``).
+            persistence transaction stays atomic; the reporter aborts
+            the persist (run marked failed) only when strictly more
+            than ``MAX_CLUSTER_FAILURE_RATIO`` of clusters fail
+            (#1246).
     """
 
     cluster_index: int

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -309,11 +309,18 @@ async def persist_results(
     # ``status='succeeded'`` with ``label_confidence=0.0`` — an
     # unqualified success built entirely of "(unlabeled)" rows, with the
     # daily-quota slot consumed and no error surfaced.
+    #
+    # The DENOMINATOR is the LABELABLE cluster count — "(empty)"
+    # sentinels never attempt labeling and cannot fail, so counting
+    # them would dilute the ratio on degenerate embeddings (KMeans can
+    # leave most clusters empty) until a run whose every real cluster
+    # failed still slipped through as a success.
     labeling_failures = sum(1 for cl in cluster_results if cl.failed)
-    if n_clusters > 0 and (labeling_failures / n_clusters) > MAX_CLUSTER_FAILURE_RATIO:
+    labelable = sum(1 for cl in cluster_results if not cl.empty)
+    if labelable > 0 and (labeling_failures / labelable) > MAX_CLUSTER_FAILURE_RATIO:
         raise ClusterLabelingThresholdExceeded(
-            f"Cluster labeling failed for {labeling_failures}/{n_clusters} clusters "
-            f"(more than MAX_CLUSTER_FAILURE_RATIO={MAX_CLUSTER_FAILURE_RATIO}). "
+            f"Cluster labeling failed for {labeling_failures}/{labelable} labelable "
+            f"clusters (more than MAX_CLUSTER_FAILURE_RATIO={MAX_CLUSTER_FAILURE_RATIO}). "
             "Check the workspace BYOK key and the provider status; the run is "
             "marked failed instead of persisting mostly-unlabeled clusters."
         )

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -46,7 +46,11 @@ from models.analysis import (
     MemoryAnalysisCluster,
 )
 from models.sleep import SLEEP_REPORT_PAID_BY_VALUES, SLEEP_REPORT_SOURCES
-from services.analysis.labeler import ClusterLabel
+from services.analysis.labeler import (
+    MAX_CLUSTER_FAILURE_RATIO,
+    ClusterLabel,
+    ClusterLabelingThresholdExceeded,
+)
 from services.analysis.property_stats import (
     MemoryFacets,
     aggregate_cluster_stats,
@@ -297,6 +301,23 @@ async def persist_results(
         return
 
     n_clusters = len(cluster_results)
+
+    # #1246: enforce the labeler's documented failure contract BEFORE any
+    # row is written (and before any SQL — the session has no open
+    # transaction here, so the orchestrator's failure path starts clean).
+    # Without this a run whose every cluster failed labeling persisted as
+    # ``status='succeeded'`` with ``label_confidence=0.0`` — an
+    # unqualified success built entirely of "(unlabeled)" rows, with the
+    # daily-quota slot consumed and no error surfaced.
+    labeling_failures = sum(1 for cl in cluster_results if cl.failed)
+    if n_clusters > 0 and (labeling_failures / n_clusters) > MAX_CLUSTER_FAILURE_RATIO:
+        raise ClusterLabelingThresholdExceeded(
+            f"Cluster labeling failed for {labeling_failures}/{n_clusters} clusters "
+            f"(more than MAX_CLUSTER_FAILURE_RATIO={MAX_CLUSTER_FAILURE_RATIO}). "
+            "Check the workspace BYOK key and the provider status; the run is "
+            "marked failed instead of persisting mostly-unlabeled clusters."
+        )
+
     members_by_idx = _index_members_by_cluster(cluster_labels_arr, n_clusters)
 
     # 1. Cluster rows. We generate UUIDs client-side so the assignment
@@ -362,7 +383,9 @@ async def persist_results(
         "label_confidence": avg_label_confidence,
         "n_clusters": n_clusters,
         "n_memories": len(memories),
-        "labeling_failures": sum(1 for cl in cluster_results if cl.failed),
+        # Below the #1246 threshold by construction — the guard at the
+        # top of this function raised otherwise.
+        "labeling_failures": labeling_failures,
     }
 
     # 4. Update the memory_analyses row. embedding_model was set by

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -303,9 +303,11 @@ async def persist_results(
     n_clusters = len(cluster_results)
 
     # #1246: enforce the labeler's documented failure contract BEFORE any
-    # row is written (and before any SQL — the session has no open
-    # transaction here, so the orchestrator's failure path starts clean).
-    # Without this a run whose every cluster failed labeling persisted as
+    # row is written. Runs AFTER the #1241 locked cancel guard by design:
+    # a concurrent user cancel wins over the threshold failure, and the
+    # raise reaches the orchestrator's failure path whose persist_failure
+    # re-checks cancellation under the same lock. Without this check a
+    # run whose every cluster failed labeling persisted as
     # ``status='succeeded'`` with ``label_confidence=0.0`` — an
     # unqualified success built entirely of "(unlabeled)" rows, with the
     # daily-quota slot consumed and no error surfaced.

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -837,3 +837,81 @@ class TestStartIntegrityErrorStructuredDiagnostics:
                     user_id="u1",
                     params=AnalysisParams(),
                 )
+
+
+class TestRunLabelingThresholdContract:
+    @pytest.mark.asyncio
+    async def test_threshold_exceeded_marks_run_failed_with_cause(self, db_session) -> None:
+        """#1246 end-to-end contract: ClusterLabelingThresholdExceeded from
+        the persist stage must land the run at status='failed' with the
+        cause in memory_analyses.error — a future refactor that 'handles'
+        the exception softly would leave threshold-failed runs stuck at
+        'running' with a green suite.
+        """
+        from services.analysis.labeler import ClusterLabelingThresholdExceeded
+
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={"model": "gpt-5-nano"},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        fake_pull = MagicMock()
+        fake_pull.memories = [MagicMock(), MagicMock()]
+        fake_pull.embeddings = [[0.1]]
+        fake_pull.embedding_model = "test-model"
+        threshold_error = ClusterLabelingThresholdExceeded(
+            "Cluster labeling failed for 2/2 labelable clusters "
+            "(more than MAX_CLUSTER_FAILURE_RATIO=0.5)."
+        )
+
+        with (
+            patch(
+                "services.analysis.orchestrator.pull_memories_with_vectors",
+                new=AsyncMock(return_value=fake_pull),
+            ),
+            patch(
+                "services.analysis.orchestrator.cluster_high_dim",
+                return_value=MagicMock(
+                    labels=[],
+                    centroids=[],
+                    n_clusters=0,
+                    silhouette=0.0,
+                    size_variance=0.0,
+                    outlier_ratio=0.0,
+                ),
+            ),
+            patch("services.analysis.orchestrator.project_to_2d", return_value=[]),
+            patch(
+                "services.analysis.orchestrator.estimate_cost",
+                return_value=MagicMock(estimated_cost_cents=42),
+            ),
+            patch(
+                "services.analysis.orchestrator.analysis_labeler.label_clusters",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "services.analysis.orchestrator.persist_results",
+                new=AsyncMock(side_effect=threshold_error),
+            ),
+        ):
+            with pytest.raises(ClusterLabelingThresholdExceeded):
+                await service.run(analysis_id=analysis.id)
+
+        await db_session.refresh(analysis)
+        assert analysis.status == "failed"
+        assert "MAX_CLUSTER_FAILURE_RATIO" in (analysis.error or "")

--- a/backend/tests/services/analysis/test_reporter_coverage.py
+++ b/backend/tests/services/analysis/test_reporter_coverage.py
@@ -944,3 +944,150 @@ class TestPersistFailure:
         assert analysis.status == "cancelled"
         assert analysis.error is None
         assert analysis.cancellation_reason == "user"
+
+
+# ===========================================================================
+# #1246 — labeling-failure threshold (MAX_CLUSTER_FAILURE_RATIO)
+# ===========================================================================
+
+
+class TestLabelingFailureThreshold:
+    """#1246: a run where MORE than MAX_CLUSTER_FAILURE_RATIO of clusters
+    failed labeling must not persist as an unqualified 'succeeded' —
+    the docstring contract referenced a constant that never existed.
+    """
+
+    async def _inputs_with_failures(
+        self,
+        db_session,
+        workspace_id,
+        context_id,
+        pricing,
+        *,
+        failed_flags: list[bool],
+    ) -> PersistInputs:
+        analysis = await _make_analysis(
+            db_session,
+            workspace_id=workspace_id,
+            context_id=context_id,
+            pricing=pricing,
+        )
+        n = len(failed_flags)
+        mems = [
+            await _make_db_memory(db_session, workspace_id=workspace_id, context_id=context_id)
+            for _ in range(n)
+        ]
+        memories = [
+            MemoryRecord(
+                id=m.id,
+                type="note",
+                summary="m",
+                tags=[],
+                importance=0.5,
+                created_at=datetime(2026, 1, 1),
+            )
+            for m in mems
+        ]
+        cluster_results = [
+            _cluster_label(
+                cluster_index=i,
+                label="(unlabeled)" if failed else f"cluster-{i}",
+                label_confidence=0.0 if failed else 0.9,
+                failed=failed,
+                breakdown=None,
+            )
+            for i, failed in enumerate(failed_flags)
+        ]
+        return PersistInputs(
+            analysis=analysis,
+            memories=memories,
+            embeddings=np.zeros((n, 4)),
+            cluster_labels=np.array(list(range(n))),
+            coords_2d=np.zeros((n, 2)),
+            cluster_results=cluster_results,
+            silhouette=0.0,
+            size_variance=0.0,
+            outlier_ratio=0.0,
+            window_from=None,
+            window_to=None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_clusters_failed_raises_and_persists_nothing(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        from services.analysis.labeler import ClusterLabelingThresholdExceeded
+
+        inputs = await self._inputs_with_failures(
+            db_session,
+            fixture_workspace_id,
+            fixture_context_id,
+            fixture_pricing,
+            failed_flags=[True, True],
+        )
+        with pytest.raises(ClusterLabelingThresholdExceeded, match="2/2"):
+            await persist_results(
+                db_session,
+                inputs=inputs,
+                user_id="rep_user",
+                workspace_id=str(fixture_workspace_id),
+                context_id=str(fixture_context_id),
+            )
+        clusters = (
+            (
+                await db_session.execute(
+                    select(MemoryAnalysisCluster).where(
+                        MemoryAnalysisCluster.analysis_id == inputs.analysis.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert clusters == []
+
+    @pytest.mark.asyncio
+    async def test_more_than_half_failed_raises(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        from services.analysis.labeler import ClusterLabelingThresholdExceeded
+
+        inputs = await self._inputs_with_failures(
+            db_session,
+            fixture_workspace_id,
+            fixture_context_id,
+            fixture_pricing,
+            failed_flags=[True, True, False],
+        )
+        with pytest.raises(ClusterLabelingThresholdExceeded, match="2/3"):
+            await persist_results(
+                db_session,
+                inputs=inputs,
+                user_id="rep_user",
+                workspace_id=str(fixture_workspace_id),
+                context_id=str(fixture_context_id),
+            )
+
+    @pytest.mark.asyncio
+    async def test_exactly_half_failed_still_succeeds(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        """Exactly-half is a (degraded but real) success: half the
+        clusters carry usable labels and quality.labeling_failures
+        surfaces the rest."""
+        inputs = await self._inputs_with_failures(
+            db_session,
+            fixture_workspace_id,
+            fixture_context_id,
+            fixture_pricing,
+            failed_flags=[True, False],
+        )
+        await persist_results(
+            db_session,
+            inputs=inputs,
+            user_id="rep_user",
+            workspace_id=str(fixture_workspace_id),
+            context_id=str(fixture_context_id),
+        )
+        assert inputs.analysis.status == "succeeded"
+        assert inputs.analysis.quality["labeling_failures"] == 1

--- a/backend/tests/services/analysis/test_reporter_coverage.py
+++ b/backend/tests/services/analysis/test_reporter_coverage.py
@@ -1091,3 +1091,73 @@ class TestLabelingFailureThreshold:
         )
         assert inputs.analysis.status == "succeeded"
         assert inputs.analysis.quality["labeling_failures"] == 1
+
+
+class TestLabelingFailureThresholdEmptyClusters:
+    """#1246 review: '(empty)' sentinels are un-labelable and must not
+    dilute the failure-ratio denominator — on degenerate embeddings
+    KMeans leaves most clusters empty, and a run whose every REAL
+    cluster failed would otherwise persist as a hollow success.
+    """
+
+    @pytest.mark.asyncio
+    async def test_empties_do_not_dilute_the_ratio(
+        self, db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+    ):
+        from services.analysis.labeler import ClusterLabelingThresholdExceeded
+
+        analysis = await _make_analysis(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+        )
+        mem = await _make_db_memory(
+            db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+        )
+        memories = [
+            MemoryRecord(
+                id=mem.id,
+                type="note",
+                summary="m",
+                tags=[],
+                importance=0.5,
+                created_at=datetime(2026, 1, 1),
+            )
+        ]
+        # 9 empty sentinels + 1 REAL cluster that failed labeling:
+        # old ratio 1/10 = 0.1 (hollow success); new ratio 1/1 = 1.0.
+        cluster_results = [
+            ClusterLabel(
+                cluster_index=i,
+                label="(empty)",
+                description="No memories were assigned to this cluster.",
+                label_confidence=0.0,
+                representative_memory_ids=[],
+                breakdown=None,
+                failed=False,
+                empty=True,
+            )
+            for i in range(9)
+        ] + [_cluster_label(cluster_index=9, label="(unlabeled)", failed=True, breakdown=None)]
+        inputs = PersistInputs(
+            analysis=analysis,
+            memories=memories,
+            embeddings=np.zeros((1, 4)),
+            cluster_labels=np.array([9]),
+            coords_2d=np.array([[0.0, 0.0]]),
+            cluster_results=cluster_results,
+            silhouette=0.0,
+            size_variance=0.0,
+            outlier_ratio=0.0,
+            window_from=None,
+            window_to=None,
+        )
+        with pytest.raises(ClusterLabelingThresholdExceeded, match="1/1"):
+            await persist_results(
+                db_session,
+                inputs=inputs,
+                user_id="rep_user",
+                workspace_id=str(fixture_workspace_id),
+                context_id=str(fixture_context_id),
+            )


### PR DESCRIPTION
Closes #1246

## Summary
Defines `MAX_CLUSTER_FAILURE_RATIO = 0.5` — the constant the labeler docstring has promised since #495 but never existed — and enforces it: `persist_results` raises `ClusterLabelingThresholdExceeded` **before any row is written** when strictly more than half of the *labelable* clusters failed labeling; the orchestrator's failure path lands the run at `status='failed'` with the cause in `memory_analyses.error`. Exactly-half remains a (degraded but real) success with `quality.labeling_failures` surfaced. "(empty)" sentinels are excluded from the denominator via a new `ClusterLabel.empty` field so degenerate KMeans runs cannot dilute the ratio.

## Verification
- All-failed raises + persists nothing; 2/3 raises; exactly-half succeeds; empty-dilution case (9 empty + 1 failed real cluster raises); orchestrator-level contract test (`status='failed'`, error contains the constant name)

## Review
Independent code-review pass: 2 findings, fixed in a3c20f8 (empty-cluster denominator; end-to-end orchestrator contract test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
