### PR TITLE
perf(db): index memory_analysis_assignments.memory_id for cascade deletes (#1245)

### DIFF
--- a/backend/alembic/versions/e62_1245_assign_mem_idx.py
+++ b/backend/alembic/versions/e62_1245_assign_mem_idx.py
@@ -1,0 +1,44 @@
+"""#1245: index memory_analysis_assignments.memory_id for FK cascade deletes.
+
+``memory_analysis_assignments.memory_id`` carries an ON DELETE CASCADE FK
+to ``memories``, but no index leads with ``memory_id`` — the PK is
+``(analysis_id, memory_id)`` and the secondary indexes cover only
+``cluster_id`` / ``(analysis_id, cluster_id)``. Every hard DELETE of a
+``memories`` row therefore fires the RI trigger's
+``DELETE FROM memory_analysis_assignments WHERE memory_id = $1`` as a full
+sequential scan. Hard deletes are routine (sleep merge-retention purge,
+admin user purge, resource re-indexing), and assignment rows accumulate at
+~1 per analyzed memory per run, so bulk purges degrade into N table scans
+under row locks.
+
+Blue-green safety: pure additive index; old app code is unaffected.
+
+Revision ID: e62_1245_assign_mem_idx
+Revises: e61_1240_one_running_uq
+
+Note: revision IDs must stay <= 32 chars — ``alembic_version.version_num``
+is varchar(32).
+"""
+
+from alembic import op
+
+# revision identifiers
+revision = "e62_1245_assign_mem_idx"
+down_revision = "e61_1240_one_running_uq"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_memory_analysis_assignments_memory",
+        "memory_analysis_assignments",
+        ["memory_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_memory_analysis_assignments_memory",
+        table_name="memory_analysis_assignments",
+    )

--- a/backend/alembic/versions/e62_1245_assign_mem_idx.py
+++ b/backend/alembic/versions/e62_1245_assign_mem_idx.py
@@ -11,7 +11,14 @@ admin user purge, resource re-indexing), and assignment rows accumulate at
 ~1 per analyzed memory per run, so bulk purges degrade into N table scans
 under row locks.
 
-Blue-green safety: pure additive index; old app code is unaffected.
+Blue-green safety: the same accumulation argument that motivates the index
+means the table can be large, so the build follows the b02/e26/e29 pattern —
+``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` inside ``autocommit_block``
+(Alembic wraps migrations in a transaction by default; ``CONCURRENTLY``
+cannot run inside one), with an INVALID-leftover guard so a retry after a
+mid-build failure rebuilds cleanly. A plain transactional ``CREATE INDEX``
+would take a SHARE lock that blocks the analysis pipeline's bulk assignment
+INSERTs and every memories-delete RI trigger for the build duration.
 
 Revision ID: e62_1245_assign_mem_idx
 Revises: e61_1240_one_running_uq
@@ -20,25 +27,57 @@ Note: revision IDs must stay <= 32 chars — ``alembic_version.version_num``
 is varchar(32).
 """
 
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers
-revision = "e62_1245_assign_mem_idx"
-down_revision = "e61_1240_one_running_uq"
-branch_labels = None
-depends_on = None
+revision: str = "e62_1245_assign_mem_idx"
+down_revision: str | Sequence[str] | None = "e61_1240_one_running_uq"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_INDEX_NAME = "idx_memory_analysis_assignments_memory"
+_INDEX_DDL = (
+    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
+    "ON memory_analysis_assignments (memory_id)"
+)
+
+
+def _index_is_invalid(name: str) -> bool:
+    """Return True if ``name`` exists in ``pg_index`` in an INVALID state.
+
+    A mid-build failure of ``CREATE INDEX CONCURRENTLY`` leaves the index
+    row with ``indisvalid = false``. A retry's ``IF NOT EXISTS`` would skip
+    it (the name exists) without rebuilding — so the leftover must be
+    dropped first. Same guard as e29_619.
+    """
+    bind = op.get_bind()
+    row = bind.execute(
+        sa.text(
+            "SELECT 1 "
+            "FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid "
+            "WHERE c.relname = :name AND i.indisvalid IS FALSE"
+        ),
+        {"name": name},
+    ).first()
+    return row is not None
 
 
 def upgrade() -> None:
-    op.create_index(
-        "idx_memory_analysis_assignments_memory",
-        "memory_analysis_assignments",
-        ["memory_id"],
-    )
+    """Build the memory_id FK index concurrently."""
+    invalid = _index_is_invalid(_INDEX_NAME)
+
+    with op.get_context().autocommit_block():
+        if invalid:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
+        op.execute(sa.text(_INDEX_DDL))
 
 
 def downgrade() -> None:
-    op.drop_index(
-        "idx_memory_analysis_assignments_memory",
-        table_name="memory_analysis_assignments",
-    )
+    """Drop the memory_id FK index concurrently."""
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -309,6 +309,16 @@ class MemoryAnalysisAssignment(Base):
             "analysis_id",
             "cluster_id",
         ),
+        # #1245: leading-column index for the memories FK. The PK is
+        # (analysis_id, memory_id) — useless for a memory_id-only lookup —
+        # so every hard DELETE of a memories row (sleep merge-retention
+        # purge, admin user purge, resource re-indexing) fired the
+        # ON DELETE CASCADE RI trigger as a full sequential scan of this
+        # table, once per deleted row.
+        Index(
+            "idx_memory_analysis_assignments_memory",
+            "memory_id",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/tests/integration/test_e62_1245_assign_mem_idx.py
+++ b/backend/tests/integration/test_e62_1245_assign_mem_idx.py
@@ -1,0 +1,98 @@
+"""Migration round-trip test for #1245 (e62_1245_assign_mem_idx).
+
+Verifies (mirrors the e29_619 pattern):
+1. Upgrade builds ``idx_memory_analysis_assignments_memory`` on
+   ``memory_analysis_assignments (memory_id)`` — the leading-column index
+   the memories ON DELETE CASCADE RI trigger needs.
+2. Downgrade drops it; the pre-existing cluster indexes survive.
+
+Complements the ORM-side parity pin in
+``tests/services/analysis/test_query_service.py`` — without this, a rename
+or typo in the migration would ship alembic-provisioned databases without
+the index while the create_all-based suite stayed green.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from alembic import command
+from tests.integration.test_alembic_migrations import (
+    _alembic_at_test_db,
+    _get_alembic_config,
+    _reset_alembic_state,
+    _sync_engine,
+)
+
+E62_REVISION = "e62_1245_assign_mem_idx"
+PRIOR_HEAD = "e61_1240_one_running_uq"
+INDEX_NAME = "idx_memory_analysis_assignments_memory"
+
+
+def _index_def(conn: Connection) -> str | None:
+    """Return the ``pg_indexes`` definition for the FK index, or None."""
+    return conn.execute(
+        text("SELECT indexdef FROM pg_indexes WHERE indexname = :n"),
+        {"n": INDEX_NAME},
+    ).scalar_one_or_none()
+
+
+def _leave_db_at_head() -> None:
+    """Convention: integration suite expects the test DB at head after each test."""
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), "head")
+
+
+def test_e62_upgrade_creates_memory_id_index() -> None:
+    """Upgrade builds the memory_id leading-column index."""
+    _reset_alembic_state()
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), PRIOR_HEAD)
+
+    engine = _sync_engine()
+    try:
+        with engine.connect() as conn:
+            assert _index_def(conn) is None, f"{INDEX_NAME} should not exist before upgrade"
+
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E62_REVISION)
+
+        with engine.connect() as conn:
+            indexdef = _index_def(conn)
+            assert indexdef is not None, f"{INDEX_NAME} not created by upgrade"
+            assert "memory_id" in indexdef
+            assert "memory_analysis_assignments" in indexdef
+    finally:
+        engine.dispose()
+        _leave_db_at_head()
+
+
+def test_e62_downgrade_drops_index() -> None:
+    """Downgrade removes the FK index; the cluster indexes survive."""
+    _reset_alembic_state()
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), E62_REVISION)
+        command.downgrade(_get_alembic_config(), PRIOR_HEAD)
+
+    engine = _sync_engine()
+    try:
+        with engine.connect() as conn:
+            assert _index_def(conn) is None, "index should be dropped on downgrade"
+            surviving = (
+                conn.execute(
+                    text(
+                        "SELECT indexname FROM pg_indexes "
+                        "WHERE tablename = 'memory_analysis_assignments' "
+                        "AND indexname IN ("
+                        "'idx_memory_analysis_assignments_cluster', "
+                        "'idx_memory_analysis_assignments_analysis_cluster')"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(surviving) == 2, f"pre-existing cluster indexes affected: {surviving}"
+    finally:
+        engine.dispose()
+        _leave_db_at_head()

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -587,3 +587,25 @@ class TestDeletedContextInvisibility:
             )
             is None
         )
+
+
+# ===========================================================================
+# #1245 — memory_id FK-cascade index parity pin
+# ===========================================================================
+
+
+class TestAssignmentMemoryIdIndex:
+    def test_memory_id_leading_index_declared(self):
+        """#1245: the memories FK needs a leading-column index — the PK
+        (analysis_id, memory_id) cannot serve the RI trigger's
+        memory_id-only DELETE lookup. Pins model-side parity with
+        migration e62 (create_all-vs-alembic drift gate).
+        """
+        names = {idx.name for idx in MemoryAnalysisAssignment.__table__.indexes}
+        assert "idx_memory_analysis_assignments_memory" in names
+        idx = next(
+            i
+            for i in MemoryAnalysisAssignment.__table__.indexes
+            if i.name == "idx_memory_analysis_assignments_memory"
+        )
+        assert [c.name for c in idx.columns] == ["memory_id"]


### PR DESCRIPTION
Closes #1245

## Summary
`memory_analysis_assignments.memory_id` carries an ON DELETE CASCADE FK to `memories`, but no index led with `memory_id` — the PK is `(analysis_id, memory_id)` and the secondary indexes cover only `cluster_id` / `(analysis_id, cluster_id)`. Every hard DELETE of a `memories` row (sleep merge-retention purge, admin user purge, resource re-indexing) fired the RI trigger's `DELETE ... WHERE memory_id = $1` as a full sequential scan.

Adds `idx_memory_analysis_assignments_memory` via migration `e62` (chained on `e61`), built with `CREATE INDEX CONCURRENTLY IF NOT EXISTS` inside `autocommit_block` with the INVALID-leftover retry guard (b02/e26/e29 pattern) — the same accumulation argument that motivates the index means the table can be large enough for a transactional build's SHARE-lock window to stall the analysis pipeline and memories-delete paths during deploy. Model `__table_args__` parity included.

## Verification
- ORM parity pin test (index name + column list on `__table__.indexes`)
- Migration round-trip integration test against real PostgreSQL (upgrade creates, downgrade drops, sibling cluster indexes survive) — 2 passed locally

## Review
Independent code-review pass: 2 findings, both fixed (CONCURRENTLY per repo convention in 8f57126; migration-side round-trip test in 37e1d68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
