### PR TITLE
fix(mcp): touch Context.last_used_at on memory operations (#1257)

### DIFF
--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -107,6 +107,15 @@ class Settings(BaseSettings):
         default=60,
         description="Min seconds between api_keys.last_used_at writes per key (Issue #947)",
     )
+    # Issue #1257: same pattern for contexts.last_used_at — memory operations
+    # (remember/recall/reference) mark the context as used so the list_contexts
+    # recency sort means something, but a context row is hotter than an API key
+    # row (every memory op in the workspace hits it), so the write is throttled
+    # to at most one per context per window.
+    context_last_used_throttle_seconds: int = Field(
+        default=60,
+        description="Min seconds between contexts.last_used_at writes per context (Issue #1257)",
+    )
     # ai-worker (kagura-chat-bridge) service auth. The worker presents this
     # as a Bearer token to GET /api/v1/workers/config (Spec 2026-06-02). Empty
     # disables the worker config endpoint (fail-closed). Use: openssl rand -hex 32.

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -271,6 +271,46 @@ async def _resolve_context_for_read(
         ) from exc
 
 
+def _touch_context_last_used(context: Any) -> bool:
+    """Throttled touch of ``Context.last_used_at`` (Issue #1257).
+
+    ``last_used_at`` feeds the ``list_contexts`` recency sort but was never
+    written after row creation, so it was effectively ``created_at``. Memory
+    operations (remember/recall/reference) call this on the Context row they
+    already resolved; the assignment rides the handler's existing
+    ``db.commit()`` — no extra SELECT, no extra flush.
+
+    Same hot-row reasoning as the api_keys throttle (#947): skip while the
+    stored timestamp is fresher than the window, and guard the assignment
+    itself (not just a flush) so a throttled call leaves the session clean.
+
+    tz note: this column is ``DateTime(timezone=True)`` — one of the few AWARE
+    columns (see .claude/rules/backend.md) — so the touch must write an aware
+    UTC value; ``list_contexts`` sorts against an aware ``_UTC_MIN`` sentinel
+    and a naive write would ``TypeError`` that sort. A naive stored value
+    (e.g. a direct-SQL backfill) is normalized to UTC rather than crashing.
+
+    Args:
+        context: Resolved ORM ``Context``, attached to the handler's session.
+
+    Returns:
+        True if the timestamp was written, False if throttled.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    from config.settings import get_settings
+
+    now = datetime.now(UTC)
+    last = context.last_used_at
+    if last is not None and last.tzinfo is None:
+        last = last.replace(tzinfo=UTC)
+    throttle = timedelta(seconds=get_settings().context_last_used_throttle_seconds)
+    if last is None or now - last >= throttle:
+        context.last_used_at = now
+        return True
+    return False
+
+
 def _resolve_context_id(arg_context_id: str) -> UUID:
     """Parse and return context_id from tool argument.
 

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -9,11 +9,13 @@ import logging
 import time
 from collections.abc import Coroutine
 from contextvars import ContextVar
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 from mcp.types import TextContent
 
+from config.settings import get_settings
 from mcp_server.tools._constants import T, get_tool_timeout
 
 if TYPE_CHECKING:
@@ -271,44 +273,66 @@ async def _resolve_context_for_read(
         ) from exc
 
 
-def _touch_context_last_used(context: Any) -> bool:
+async def _touch_context_last_used(db: "AsyncSession", context: Any) -> bool:
     """Throttled touch of ``Context.last_used_at`` (Issue #1257).
 
     ``last_used_at`` feeds the ``list_contexts`` recency sort but was never
     written after row creation, so it was effectively ``created_at``. Memory
-    operations (remember/recall/reference) call this on the Context row they
-    already resolved; the assignment rides the handler's existing
-    ``db.commit()`` — no extra SELECT, no extra flush.
+    operations call this on the Context row they already resolved. Same
+    hot-row reasoning as the api_keys throttle (#947): the in-memory precheck
+    against the loaded row costs no query at all while the stored timestamp is
+    fresher than the window.
 
-    Same hot-row reasoning as the api_keys throttle (#947): skip while the
-    stored timestamp is fresher than the window, and guard the assignment
-    itself (not just a flush) so a throttled call leaves the session clean.
+    CONTRACT — call this immediately before the handler's ``db.commit()``, and
+    when touching several contexts in one request, in ascending ``id`` order:
+
+    - The write is a single guarded Core UPDATE, not a dirty ORM attribute.
+      A dirty attribute would be autoflushed into the service pipeline (row
+      lock held across embedding/Qdrant I/O), persisted by any collaborator
+      that commits the shared session mid-request (e.g.
+      ``ContextSearchConfigRepository.create_or_get``), and would fire
+      ``Context.updated_at``'s ``onupdate=func.now()``. Executing at commit
+      time bounds the row lock to one round-trip and keeps error paths clean.
+    - ``updated_at`` is pinned to itself in SET so the column-level
+      ``onupdate`` does NOT fire — a recall must not rewrite the context's
+      "last modified" timestamp shown in the REST API.
+    - The WHERE clause re-checks the throttle so two concurrent requests that
+      both pass the in-memory precheck race safely (second one matches 0 rows).
+    - Ascending-id ordering across multiple touches keeps concurrent
+      overlapping cross-context recalls deadlock-free.
 
     tz note: this column is ``DateTime(timezone=True)`` — one of the few AWARE
-    columns (see .claude/rules/backend.md) — so the touch must write an aware
-    UTC value; ``list_contexts`` sorts against an aware ``_UTC_MIN`` sentinel
-    and a naive write would ``TypeError`` that sort. A naive stored value
-    (e.g. a direct-SQL backfill) is normalized to UTC rather than crashing.
+    columns (see .claude/rules/backend.md) — so the touch writes an aware UTC
+    value; ``list_contexts`` sorts against an aware ``_UTC_MIN`` sentinel. A
+    naive stored value (nullable legacy data / direct-SQL writes) is
+    normalized to UTC rather than crashing the precheck.
 
     Args:
-        context: Resolved ORM ``Context``, attached to the handler's session.
+        db: The handler's session (the UPDATE rides its next commit).
+        context: Resolved ORM ``Context`` (only ``id``/``last_used_at`` read).
 
     Returns:
-        True if the timestamp was written, False if throttled.
+        True if the guarded UPDATE was issued, False if throttled.
     """
-    from datetime import UTC, datetime, timedelta
-
-    from config.settings import get_settings
-
     now = datetime.now(UTC)
     last = context.last_used_at
     if last is not None and last.tzinfo is None:
         last = last.replace(tzinfo=UTC)
     throttle = timedelta(seconds=get_settings().context_last_used_throttle_seconds)
-    if last is None or now - last >= throttle:
-        context.last_used_at = now
-        return True
-    return False
+    if last is not None and now - last < throttle:
+        return False
+
+    from sqlalchemy import or_, update
+
+    from models.auth import Context
+
+    await db.execute(
+        update(Context)
+        .where(Context.id == context.id)
+        .where(or_(Context.last_used_at.is_(None), Context.last_used_at <= now - throttle))
+        .values(last_used_at=now, updated_at=Context.updated_at)
+    )
+    return True
 
 
 def _resolve_context_id(arg_context_id: str) -> UUID:

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -585,6 +585,8 @@ async def handle_list_contexts(
 
             from datetime import UTC, datetime
 
+            from utils.datetime import to_utc_iso
+
             # ``Context.last_used_at`` is declared as ``DateTime(timezone=True)``
             # (see models/auth.py) — populated values are aware. Use an aware
             # UTC sentinel so the ``None`` branch sorts consistently; mixing a
@@ -620,7 +622,10 @@ async def handle_list_contexts(
                     "summary": ctx.summary,
                     "is_private": ctx.is_private,
                     "is_locked": ctx.is_locked,
-                    "last_used_at": ctx.last_used_at.isoformat() if ctx.last_used_at else None,
+                    # #1257 made this live data; Z-suffix per backend.md (raw
+                    # .isoformat() rendered '+00:00', unlike every other
+                    # timestamp on the MCP surface, e.g. tags[].last_used_at).
+                    "last_used_at": to_utc_iso(ctx.last_used_at),
                     "embedding_model": cfg.embedding_model if cfg else _settings2.embedding_model,
                 }
                 if include_stats:

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -77,9 +77,6 @@ async def handle_remember(
                 return perm_error
 
             current_context = await _resolve_context(db, user_id, current_context_id)
-            # #1257: memory ops mark the context as used (throttled write,
-            # persisted by the db.commit() below).
-            _touch_context_last_used(current_context)
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -96,6 +93,9 @@ async def handle_remember(
             await _log_tool_usage(
                 db, user_id, "remember", start_time, 200, current_context_id, workspace_id
             )
+            # #1257: memory ops mark the context as used (guarded UPDATE at
+            # commit time — see the helper's contract).
+            await _touch_context_last_used(db, current_context)
             await db.commit()
 
             return [
@@ -198,6 +198,9 @@ async def handle_update_memory(
             await _log_tool_usage(
                 db, user_id, "update_memory", start_time, 200, current_context_id, workspace_id
             )
+            # #1257 review: update_memory is a memory op too — a context kept
+            # alive purely by external_id upserts must not sort as never-used.
+            await _touch_context_last_used(db, current_context)
             await db.commit()
 
             return [
@@ -460,6 +463,10 @@ async def handle_recall(
             # Issue #81: Cross-context recall — context_ids overrides context_id
             context_ids_arg = args.get("context_ids")
             cross_context_ids: list[UUID] | None = None
+            # #1257: every context read by this call gets its last_used_at
+            # touched — but only at commit time on the success path (see the
+            # helper's contract), so collect the resolved rows here.
+            secondary_contexts: list[Any] = []
 
             if isinstance(context_ids_arg, list) and context_ids_arg:
                 # #1228 review: enforce the inputSchema's maxItems server-side
@@ -512,9 +519,7 @@ async def handle_recall(
                             "All contexts in cross-context recall must share the "
                             "same privacy setting (all shared or all private).",
                         )
-                    # #1257: every listed context counts as used, not just the
-                    # billable primary (throttled; rides the commit below).
-                    _touch_context_last_used(cross_ctx)
+                    secondary_contexts.append(cross_ctx)
 
                 # Validate all contexts use the same embedding model
                 from repositories.config_repository import ContextSearchConfigRepository
@@ -539,10 +544,6 @@ async def handle_recall(
                     )
                 current_context_id = _resolve_context_id(args["context_id"])
                 current_context = await _resolve_context_for_read(db, user_id, current_context_id)
-
-            # #1257: recall marks the (primary) context as used — throttled
-            # write, persisted by the db.commit() below.
-            _touch_context_last_used(current_context)
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -600,6 +601,13 @@ async def handle_recall(
                 # rows so per-context read visibility sees them.
                 attributed_context_ids=(cross_context_ids[1:] if cross_context_ids else None),
             )
+            # #1257: mark every recalled context as used. Ascending-id order
+            # keeps concurrent overlapping cross-context recalls deadlock-free
+            # (see the helper's contract).
+            for touch_ctx in sorted(
+                [current_context, *secondary_contexts], key=lambda c: str(c.id)
+            ):
+                await _touch_context_last_used(db, touch_ctx)
             await db.commit()
 
             response_data: dict[str, Any] = {
@@ -707,6 +715,9 @@ async def handle_forget(
             await _log_tool_usage(
                 db, user_id, "forget", start_time, 200, current_context_id, workspace_id
             )
+            # #1257 review: forget is a memory op too — deletion-only
+            # maintenance still counts as using the context.
+            await _touch_context_last_used(db, current_context)
             await db.commit()
 
             return [
@@ -759,9 +770,6 @@ async def handle_reference(
             # resolver so deny reasons (private non-creator, not a workspace
             # member, etc.) cannot be distinguished by callers.
             current_context = await _resolve_context_for_read(db, user_id, current_context_id)
-            # #1257: reference marks the context as used (throttled write,
-            # persisted by the db.commit() below).
-            _touch_context_last_used(current_context)
 
             service = MemoryService(db)
             try:
@@ -805,6 +813,9 @@ async def handle_reference(
             await _log_tool_usage(
                 db, user_id, "reference", start_time, 200, current_context_id, workspace_id
             )
+            # #1257: reference marks the context as used (guarded UPDATE at
+            # commit time; the memory_not_found return above never touches).
+            await _touch_context_last_used(db, current_context)
             await db.commit()
 
             return [

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -20,6 +20,7 @@ from mcp_server.tools._helpers import (
     _resolve_context,
     _resolve_context_for_read,
     _resolve_context_id,
+    _touch_context_last_used,
     _validate_memory_id,
     execute_with_timeout,
 )
@@ -76,6 +77,9 @@ async def handle_remember(
                 return perm_error
 
             current_context = await _resolve_context(db, user_id, current_context_id)
+            # #1257: memory ops mark the context as used (throttled write,
+            # persisted by the db.commit() below).
+            _touch_context_last_used(current_context)
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -508,6 +512,9 @@ async def handle_recall(
                             "All contexts in cross-context recall must share the "
                             "same privacy setting (all shared or all private).",
                         )
+                    # #1257: every listed context counts as used, not just the
+                    # billable primary (throttled; rides the commit below).
+                    _touch_context_last_used(cross_ctx)
 
                 # Validate all contexts use the same embedding model
                 from repositories.config_repository import ContextSearchConfigRepository
@@ -532,6 +539,10 @@ async def handle_recall(
                     )
                 current_context_id = _resolve_context_id(args["context_id"])
                 current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+
+            # #1257: recall marks the (primary) context as used — throttled
+            # write, persisted by the db.commit() below.
+            _touch_context_last_used(current_context)
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -747,7 +758,10 @@ async def handle_reference(
             # Issue #708 bundle: migrate read paths to the CWE-639-uniform
             # resolver so deny reasons (private non-creator, not a workspace
             # member, etc.) cannot be distinguished by callers.
-            await _resolve_context_for_read(db, user_id, current_context_id)
+            current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+            # #1257: reference marks the context as used (throttled write,
+            # persisted by the db.commit() below).
+            _touch_context_last_used(current_context)
 
             service = MemoryService(db)
             try:

--- a/backend/tests/mcp_server/test_context_last_used_touch.py
+++ b/backend/tests/mcp_server/test_context_last_used_touch.py
@@ -2,15 +2,25 @@
 
 The column feeds the ``list_contexts`` recency sort but was never written
 after row creation, so it was effectively ``created_at``. The fix mirrors the
-api_keys.last_used_at throttle (#947): remember/recall/reference mark the
-already-resolved Context row as used, at most once per
-``context_last_used_throttle_seconds`` window per context.
+api_keys.last_used_at throttle (#947) with a free in-memory precheck, but
+writes via a single guarded Core UPDATE at commit time (not a dirty ORM
+attribute) so that:
 
-Follows the mock-db handler convention of tests/mcp_server/ (patch
-db.base.get_db + the context resolver + the service). The throttle-window
-arithmetic is pinned on the helper directly (where settings can be patched
-without touching the handler path); the handler tests pin the WIRING — which
-tools touch which contexts.
+- the contexts row lock spans one round-trip, not the recall pipeline;
+- error paths / mid-request commits by collaborators never persist a touch;
+- ``Context.updated_at``'s ``onupdate=func.now()`` does NOT fire (a recall
+  must not rewrite the "last modified" timestamp shown in the REST API).
+
+Throttle arithmetic and SQL shape are pinned on the helper directly; the
+handler tests pin the WIRING — which tools touch which contexts. Settings are
+always patched (mcp_server.tools._helpers.get_settings): the ambient
+CONTEXT_LAST_USED_THROTTLE_SECONDS env var must not leak into assertions.
+
+Production rows normally carry a creation-time value (server_default), so
+"an immediate repeat call is suppressed" is modeled by a fresh stored stamp:
+a second request re-reads the row and sees the just-written timestamp. The
+``None`` branch is defensive coverage for the nullable column, not a state
+the ORM/SQL defaults can produce.
 """
 
 import contextlib
@@ -23,68 +33,112 @@ from uuid import uuid4
 import pytest
 
 from mcp_server.tools._helpers import _touch_context_last_used
-from mcp_server.tools.memory import handle_recall, handle_reference, handle_remember
+from mcp_server.tools.memory import (
+    handle_forget,
+    handle_recall,
+    handle_reference,
+    handle_remember,
+    handle_update_memory,
+)
 
 
-def _make_context(last_used_at=None, workspace_id=None, is_private=False):
+def _make_context(last_used_at=None, workspace_id=None):
     return SimpleNamespace(
+        id=uuid4(),
+        name="ctx",
         last_used_at=last_used_at,
         workspace_id=workspace_id or uuid4(),
-        is_private=is_private,
+        is_private=False,
     )
 
 
+def _patched_settings(seconds=3600):
+    """Pin the throttle window — never read ambient env in tests."""
+    return patch(
+        "mcp_server.tools._helpers.get_settings",
+        return_value=SimpleNamespace(context_last_used_throttle_seconds=seconds),
+    )
+
+
+def _touch_statements(db: AsyncMock):
+    """The contexts-touch UPDATE statements issued on a mock session."""
+    return [
+        call.args[0]
+        for call in db.execute.await_args_list
+        if "UPDATE contexts" in str(call.args[0])
+    ]
+
+
 # ============================================================================
-# Helper: throttle arithmetic
+# Helper: throttle arithmetic + statement shape
 # ============================================================================
 
 
 class TestTouchContextLastUsed:
-    def _settings(self, seconds=60):
-        return patch(
-            "config.settings.get_settings",
-            return_value=SimpleNamespace(context_last_used_throttle_seconds=seconds),
-        )
-
-    def test_never_used_context_writes_aware_utc(self):
+    @pytest.mark.asyncio
+    async def test_never_used_context_issues_guarded_update(self):
+        db = AsyncMock()
         ctx = _make_context(last_used_at=None)
-        with self._settings():
-            assert _touch_context_last_used(ctx) is True
-        # Aware UTC — list_contexts sorts against an aware _UTC_MIN sentinel;
-        # a naive write would TypeError that sort.
-        assert ctx.last_used_at is not None
-        assert ctx.last_used_at.utcoffset() == timedelta(0)
+        with _patched_settings():
+            assert await _touch_context_last_used(db, ctx) is True
+        db.execute.assert_awaited_once()
 
-    def test_fresh_timestamp_is_throttled(self):
-        stamp = datetime.now(UTC)
-        ctx = _make_context(last_used_at=stamp)
-        with self._settings():
-            assert _touch_context_last_used(ctx) is False
-        assert ctx.last_used_at is stamp
+    @pytest.mark.asyncio
+    async def test_fresh_timestamp_is_throttled_with_zero_queries(self):
+        db = AsyncMock()
+        ctx = _make_context(last_used_at=datetime.now(UTC))
+        with _patched_settings(seconds=3600):
+            assert await _touch_context_last_used(db, ctx) is False
+        db.execute.assert_not_awaited()
 
-    def test_stale_timestamp_writes(self):
+    @pytest.mark.asyncio
+    async def test_stale_timestamp_writes(self):
+        db = AsyncMock()
         stamp = datetime.now(UTC) - timedelta(seconds=61)
         ctx = _make_context(last_used_at=stamp)
-        with self._settings(seconds=60):
-            assert _touch_context_last_used(ctx) is True
-        assert ctx.last_used_at > stamp
+        with _patched_settings(seconds=60):
+            assert await _touch_context_last_used(db, ctx) is True
+        db.execute.assert_awaited_once()
 
-    def test_naive_stored_value_is_normalized_not_typeerror(self):
-        # A direct-SQL backfill could leave a naive value in the aware column;
-        # the hot path must normalize (naive == UTC by project convention),
-        # not crash on aware-vs-naive subtraction.
-        naive_stale = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)
+    @pytest.mark.asyncio
+    async def test_naive_stored_value_is_normalized_not_typeerror(self):
+        # The column is nullable and legacy/direct-SQL writes could be naive;
+        # the precheck must normalize (naive == UTC by project convention),
+        # not crash the hot recall path on aware-vs-naive subtraction.
+        db = AsyncMock()
+        naive_stale = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=2)
         ctx = _make_context(last_used_at=naive_stale)
-        with self._settings(seconds=60):
-            assert _touch_context_last_used(ctx) is True
-        assert ctx.last_used_at.utcoffset() == timedelta(0)
+        with _patched_settings(seconds=60):
+            assert await _touch_context_last_used(db, ctx) is True
 
-    def test_naive_fresh_value_is_throttled(self):
-        naive_fresh = datetime.now(UTC).replace(tzinfo=None)
-        ctx = _make_context(last_used_at=naive_fresh)
-        with self._settings(seconds=60):
-            assert _touch_context_last_used(ctx) is False
-        assert ctx.last_used_at is naive_fresh
+    @pytest.mark.asyncio
+    async def test_naive_fresh_value_is_throttled(self):
+        db = AsyncMock()
+        ctx = _make_context(last_used_at=datetime.now(UTC).replace(tzinfo=None))
+        with _patched_settings(seconds=3600):
+            assert await _touch_context_last_used(db, ctx) is False
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_update_pins_updated_at_and_reguards_in_where(self):
+        """The two load-bearing properties of the statement itself:
+
+        1. ``updated_at`` is explicitly SET to itself so the column-level
+           ``onupdate=func.now()`` does not fire — a pure read (recall) must
+           not rewrite the context's "last modified" timestamp.
+        2. The WHERE clause re-checks the throttle so two concurrent requests
+           that both passed the in-memory precheck race safely.
+        """
+        db = AsyncMock()
+        ctx = _make_context(last_used_at=None)
+        with _patched_settings():
+            await _touch_context_last_used(db, ctx)
+
+        sql = str(db.execute.await_args.args[0]).replace("\n", " ")
+        assert "UPDATE contexts" in sql
+        assert "updated_at=contexts.updated_at" in sql.replace(" ", "")
+        assert "contexts.last_used_at IS NULL" in sql
+        assert "contexts.last_used_at <=" in sql
 
 
 # ============================================================================
@@ -103,8 +157,10 @@ def _recall_result():
 
 @contextlib.contextmanager
 def _patched_recall(resolver: AsyncMock):
+    db = AsyncMock()
+
     async def mock_get_db():
-        yield AsyncMock()
+        yield db
 
     service = MagicMock()
     service.recall = AsyncMock(return_value=_recall_result())
@@ -115,6 +171,7 @@ def _patched_recall(resolver: AsyncMock):
     config_repo.create_or_get = AsyncMock(return_value=config)
 
     with (
+        _patched_settings(),
         patch("db.base.get_db", new=mock_get_db),
         patch("mcp_server.tools.memory._resolve_context_for_read", new=resolver),
         patch("mcp_server.tools.memory._context_response_fields", return_value={}),
@@ -125,70 +182,49 @@ def _patched_recall(resolver: AsyncMock):
             new=MagicMock(return_value=config_repo),
         ),
     ):
-        yield
+        yield db
 
 
 @pytest.mark.asyncio
 async def test_recall_bumps_never_used_context():
     ctx = _make_context(last_used_at=None)
 
-    with _patched_recall(AsyncMock(return_value=ctx)):
+    with _patched_recall(AsyncMock(return_value=ctx)) as db:
         result = await handle_recall(
             {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
         )
 
     assert json.loads(result[0].text)["status"] == "success"
-    assert ctx.last_used_at is not None
-    assert ctx.last_used_at.utcoffset() == timedelta(0)
+    assert len(_touch_statements(db)) == 1
 
 
 @pytest.mark.asyncio
 async def test_recall_within_throttle_window_does_not_write():
-    """The regression #1257 exists to prevent: a hot MCP client recalling in a
-    loop must NOT trigger a contexts-row write per call. A just-written
-    timestamp is inside any sane window (default 60s), so the second recall
-    leaves the exact same object in place."""
-    stamp = datetime.now(UTC)
-    ctx = _make_context(last_used_at=stamp)
+    """The regression #1257's throttle exists to prevent: a hot MCP client
+    recalling in a loop must NOT trigger a contexts-row write per call. An
+    immediate repeat request re-reads the row and sees the just-written
+    timestamp, which is exactly this fresh-stamp case."""
+    ctx = _make_context(last_used_at=datetime.now(UTC))
 
-    with _patched_recall(AsyncMock(return_value=ctx)):
+    with _patched_recall(AsyncMock(return_value=ctx)) as db:
         result = await handle_recall(
             {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
         )
 
     assert json.loads(result[0].text)["status"] == "success"
-    assert ctx.last_used_at is stamp
+    assert len(_touch_statements(db)) == 0
 
 
 @pytest.mark.asyncio
-async def test_recall_bump_then_immediate_recall_is_suppressed():
-    """End-to-end shape of the throttle: first recall writes (was never used),
-    an immediate second recall is a no-op on the same row."""
-    ctx = _make_context(last_used_at=None)
-
-    with _patched_recall(AsyncMock(return_value=ctx)):
-        await handle_recall(
-            {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
-        )
-        first_stamp = ctx.last_used_at
-        assert first_stamp is not None
-
-        await handle_recall(
-            {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
-        )
-
-    assert ctx.last_used_at is first_stamp
-
-
-@pytest.mark.asyncio
-async def test_cross_context_recall_touches_every_listed_context():
-    """#1228 cross-context recall: the secondaries are read too — all listed
-    contexts count as used, not just the billable primary."""
+async def test_cross_context_recall_touches_every_listed_context_in_id_order():
+    """#1228 cross-context recall: all listed contexts count as used, not just
+    the billable primary — and the touches are issued in ascending id order so
+    concurrent overlapping recalls cannot deadlock on opposite lock order."""
     ws = uuid4()
     primary = _make_context(last_used_at=None, workspace_id=ws)
     secondary = _make_context(last_used_at=None, workspace_id=ws)
 
-    with _patched_recall(AsyncMock(side_effect=[primary, secondary])):
+    with _patched_recall(AsyncMock(side_effect=[primary, secondary])) as db:
         result = await handle_recall(
             {"query": "q", "context_ids": [str(uuid4()), str(uuid4())]},
             user_id="u1",
@@ -196,32 +232,66 @@ async def test_cross_context_recall_touches_every_listed_context():
         )
 
     assert json.loads(result[0].text)["status"] == "success"
-    assert primary.last_used_at is not None
-    assert secondary.last_used_at is not None
+    stmts = _touch_statements(db)
+    assert len(stmts) == 2
+    touched_ids = [
+        next(v for v in stmt.compile().params.values() if isinstance(v, type(primary.id)))
+        for stmt in stmts
+    ]
+    assert touched_ids == sorted([primary.id, secondary.id], key=str)
+
+
+@pytest.mark.asyncio
+async def test_recall_validation_error_touches_nothing():
+    """Error paths must not mark contexts as used — the guarded UPDATE is only
+    issued on the success path, immediately before commit, so a mid-request
+    commit by a collaborator (e.g. create_or_get) cannot persist a touch for a
+    recall that then fails validation."""
+    ws_a, ws_b = uuid4(), uuid4()
+    primary = _make_context(last_used_at=None, workspace_id=ws_a)
+    foreign = _make_context(last_used_at=None, workspace_id=ws_b)
+
+    with _patched_recall(AsyncMock(side_effect=[primary, foreign])) as db:
+        result = await handle_recall(
+            {"query": "q", "context_ids": [str(uuid4()), str(uuid4())]},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["error"] == "workspace_mismatch"
+    assert len(_touch_statements(db)) == 0
 
 
 # ============================================================================
-# Handler wiring: remember / reference
+# Handler wiring: remember / update_memory / forget / reference
 # ============================================================================
+
+
+@contextlib.contextmanager
+def _patched_write_handler(context, service):
+    db = AsyncMock()
+
+    async def mock_get_db():
+        yield db
+
+    with (
+        _patched_settings(),
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.memory._resolve_context", new=AsyncMock(return_value=context)),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+        patch("services.memory_service.MemoryService", new=MagicMock(return_value=service)),
+    ):
+        yield db
 
 
 @pytest.mark.asyncio
 async def test_remember_bumps_context():
     ctx = _make_context(last_used_at=None)
-
-    async def mock_get_db():
-        yield AsyncMock()
-
     service = MagicMock()
     service.remember = AsyncMock(return_value=SimpleNamespace(memory_id=uuid4(), scope="personal"))
 
-    with (
-        patch("db.base.get_db", new=mock_get_db),
-        patch("mcp_server.tools.memory._resolve_context", new=AsyncMock(return_value=ctx)),
-        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
-        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
-        patch("services.memory_service.MemoryService", new=MagicMock(return_value=service)),
-    ):
+    with _patched_write_handler(ctx, service) as db:
         result = await handle_remember(
             {
                 "summary": "touch test: remember marks the context used",
@@ -234,15 +304,61 @@ async def test_remember_bumps_context():
         )
 
     assert json.loads(result[0].text)["status"] == "success"
-    assert ctx.last_used_at is not None
+    assert len(_touch_statements(db)) == 1
 
 
 @pytest.mark.asyncio
-async def test_reference_bumps_context():
+async def test_update_memory_bumps_context():
+    """#1257 review: a context maintained purely via external_id upserts must
+    not sort as never-used."""
+    ctx = _make_context(last_used_at=None)
+    service = MagicMock()
+    service.update_memory = AsyncMock(
+        return_value=SimpleNamespace(
+            memory_id=uuid4(), operation="update", re_embedded=False, scope="personal"
+        )
+    )
+
+    with _patched_write_handler(ctx, service) as db:
+        result = await handle_update_memory(
+            {
+                "memory_id": str(uuid4()),
+                "summary": "touch test: update_memory marks the context used",
+                "context_id": str(uuid4()),
+            },
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert len(_touch_statements(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_forget_bumps_context():
+    ctx = _make_context(last_used_at=None)
+    service = MagicMock()
+    service.forget = AsyncMock(return_value=SimpleNamespace(deleted_count=1, memory_ids=[uuid4()]))
+
+    with _patched_write_handler(ctx, service) as db:
+        result = await handle_forget(
+            {"memory_id": str(uuid4()), "context_id": str(uuid4())},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert len(_touch_statements(db)) == 1
+
+
+@pytest.mark.asyncio
+async def test_reference_bumps_context_but_not_on_memory_miss():
     ctx = _make_context(last_used_at=None)
 
+    db = AsyncMock()
+
     async def mock_get_db():
-        yield AsyncMock()
+        yield db
 
     reference_result = SimpleNamespace(
         memory_id=uuid4(),
@@ -269,6 +385,7 @@ async def test_reference_bumps_context():
     service.reference = AsyncMock(return_value=reference_result)
 
     with (
+        _patched_settings(),
         patch("db.base.get_db", new=mock_get_db),
         patch("mcp_server.tools.memory._resolve_context_for_read", new=AsyncMock(return_value=ctx)),
         patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
@@ -279,9 +396,23 @@ async def test_reference_bumps_context():
             user_id="u1",
             workspace_id=None,
         )
+        assert json.loads(result[0].text)["status"] == "success"
+        assert len(_touch_statements(db)) == 1
 
-    assert json.loads(result[0].text)["status"] == "success"
-    assert ctx.last_used_at is not None
+        # A miss returns memory_not_found BEFORE the touch — failed lookups
+        # must not mark the context as used (and must not leave a flushed
+        # UPDATE holding the contexts row lock on a rollback-free return).
+        db.execute.reset_mock()
+        from utils.exceptions import NotFoundException
+
+        service.reference = AsyncMock(side_effect=NotFoundException("Memory not found"))
+        result = await handle_reference(
+            {"memory_id": str(uuid4()), "context_id": str(uuid4())},
+            user_id="u1",
+            workspace_id=None,
+        )
+        assert json.loads(result[0].text)["error"] == "memory_not_found"
+        assert len(_touch_statements(db)) == 0
 
 
 # ============================================================================
@@ -301,14 +432,17 @@ def _listable_context(name, last_used_at):
 
 
 @pytest.mark.asyncio
-async def test_list_contexts_sorts_by_recency_with_never_used_last():
-    """The sort the touch exists to make meaningful: freshest first, and
-    ``None`` (never used, pre-backfill rows) sorts last via the aware
-    ``_UTC_MIN`` sentinel without tripping aware-vs-naive comparison."""
+async def test_list_contexts_sorts_by_recency_with_null_last():
+    """The sort the touch exists to make meaningful: freshest first. ``None``
+    (nullable column; not produced by the ORM/SQL defaults, which stamp
+    creation time) sorts last via the aware ``_UTC_MIN`` sentinel without
+    tripping aware-vs-naive comparison, and the wire shape is the project-wide
+    Z-suffix (to_utc_iso), not raw ``.isoformat()`` (+00:00)."""
     from mcp_server.tools.context import handle_list_contexts
+    from utils.datetime import to_utc_iso
 
     now = datetime.now(UTC)
-    never = _listable_context("never-used", None)
+    never = _listable_context("null-last-used", None)
     old = _listable_context("old", now - timedelta(days=1))
     fresh = _listable_context("fresh", now)
 
@@ -335,6 +469,7 @@ async def test_list_contexts_sorts_by_recency_with_never_used_last():
 
     payload = json.loads(result[0].text)
     assert payload["status"] == "success"
-    assert [c["name"] for c in payload["contexts"]] == ["fresh", "old", "never-used"]
-    assert payload["contexts"][0]["last_used_at"] == fresh.last_used_at.isoformat()
+    assert [c["name"] for c in payload["contexts"]] == ["fresh", "old", "null-last-used"]
+    assert payload["contexts"][0]["last_used_at"] == to_utc_iso(fresh.last_used_at)
+    assert payload["contexts"][0]["last_used_at"].endswith("Z")
     assert payload["contexts"][2]["last_used_at"] is None

--- a/backend/tests/mcp_server/test_context_last_used_touch.py
+++ b/backend/tests/mcp_server/test_context_last_used_touch.py
@@ -1,0 +1,340 @@
+"""#1257: memory operations must touch ``Context.last_used_at`` (throttled).
+
+The column feeds the ``list_contexts`` recency sort but was never written
+after row creation, so it was effectively ``created_at``. The fix mirrors the
+api_keys.last_used_at throttle (#947): remember/recall/reference mark the
+already-resolved Context row as used, at most once per
+``context_last_used_throttle_seconds`` window per context.
+
+Follows the mock-db handler convention of tests/mcp_server/ (patch
+db.base.get_db + the context resolver + the service). The throttle-window
+arithmetic is pinned on the helper directly (where settings can be patched
+without touching the handler path); the handler tests pin the WIRING — which
+tools touch which contexts.
+"""
+
+import contextlib
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools._helpers import _touch_context_last_used
+from mcp_server.tools.memory import handle_recall, handle_reference, handle_remember
+
+
+def _make_context(last_used_at=None, workspace_id=None, is_private=False):
+    return SimpleNamespace(
+        last_used_at=last_used_at,
+        workspace_id=workspace_id or uuid4(),
+        is_private=is_private,
+    )
+
+
+# ============================================================================
+# Helper: throttle arithmetic
+# ============================================================================
+
+
+class TestTouchContextLastUsed:
+    def _settings(self, seconds=60):
+        return patch(
+            "config.settings.get_settings",
+            return_value=SimpleNamespace(context_last_used_throttle_seconds=seconds),
+        )
+
+    def test_never_used_context_writes_aware_utc(self):
+        ctx = _make_context(last_used_at=None)
+        with self._settings():
+            assert _touch_context_last_used(ctx) is True
+        # Aware UTC — list_contexts sorts against an aware _UTC_MIN sentinel;
+        # a naive write would TypeError that sort.
+        assert ctx.last_used_at is not None
+        assert ctx.last_used_at.utcoffset() == timedelta(0)
+
+    def test_fresh_timestamp_is_throttled(self):
+        stamp = datetime.now(UTC)
+        ctx = _make_context(last_used_at=stamp)
+        with self._settings():
+            assert _touch_context_last_used(ctx) is False
+        assert ctx.last_used_at is stamp
+
+    def test_stale_timestamp_writes(self):
+        stamp = datetime.now(UTC) - timedelta(seconds=61)
+        ctx = _make_context(last_used_at=stamp)
+        with self._settings(seconds=60):
+            assert _touch_context_last_used(ctx) is True
+        assert ctx.last_used_at > stamp
+
+    def test_naive_stored_value_is_normalized_not_typeerror(self):
+        # A direct-SQL backfill could leave a naive value in the aware column;
+        # the hot path must normalize (naive == UTC by project convention),
+        # not crash on aware-vs-naive subtraction.
+        naive_stale = datetime.now(UTC).replace(tzinfo=None) - timedelta(hours=1)
+        ctx = _make_context(last_used_at=naive_stale)
+        with self._settings(seconds=60):
+            assert _touch_context_last_used(ctx) is True
+        assert ctx.last_used_at.utcoffset() == timedelta(0)
+
+    def test_naive_fresh_value_is_throttled(self):
+        naive_fresh = datetime.now(UTC).replace(tzinfo=None)
+        ctx = _make_context(last_used_at=naive_fresh)
+        with self._settings(seconds=60):
+            assert _touch_context_last_used(ctx) is False
+        assert ctx.last_used_at is naive_fresh
+
+
+# ============================================================================
+# Handler wiring: recall
+# ============================================================================
+
+
+def _recall_result():
+    result = MagicMock()
+    result.results = []
+    result.related_tags = []
+    result.explore_hints = None
+    result.confidence = None
+    return result
+
+
+@contextlib.contextmanager
+def _patched_recall(resolver: AsyncMock):
+    async def mock_get_db():
+        yield AsyncMock()
+
+    service = MagicMock()
+    service.recall = AsyncMock(return_value=_recall_result())
+
+    config = MagicMock()
+    config.embedding_model = "text-embedding-3-small"
+    config_repo = MagicMock()
+    config_repo.create_or_get = AsyncMock(return_value=config)
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.memory._resolve_context_for_read", new=resolver),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+        patch("services.memory_service.MemoryService", new=MagicMock(return_value=service)),
+        patch(
+            "repositories.config_repository.ContextSearchConfigRepository",
+            new=MagicMock(return_value=config_repo),
+        ),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_recall_bumps_never_used_context():
+    ctx = _make_context(last_used_at=None)
+
+    with _patched_recall(AsyncMock(return_value=ctx)):
+        result = await handle_recall(
+            {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert ctx.last_used_at is not None
+    assert ctx.last_used_at.utcoffset() == timedelta(0)
+
+
+@pytest.mark.asyncio
+async def test_recall_within_throttle_window_does_not_write():
+    """The regression #1257 exists to prevent: a hot MCP client recalling in a
+    loop must NOT trigger a contexts-row write per call. A just-written
+    timestamp is inside any sane window (default 60s), so the second recall
+    leaves the exact same object in place."""
+    stamp = datetime.now(UTC)
+    ctx = _make_context(last_used_at=stamp)
+
+    with _patched_recall(AsyncMock(return_value=ctx)):
+        result = await handle_recall(
+            {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert ctx.last_used_at is stamp
+
+
+@pytest.mark.asyncio
+async def test_recall_bump_then_immediate_recall_is_suppressed():
+    """End-to-end shape of the throttle: first recall writes (was never used),
+    an immediate second recall is a no-op on the same row."""
+    ctx = _make_context(last_used_at=None)
+
+    with _patched_recall(AsyncMock(return_value=ctx)):
+        await handle_recall(
+            {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
+        )
+        first_stamp = ctx.last_used_at
+        assert first_stamp is not None
+
+        await handle_recall(
+            {"query": "q", "context_id": str(uuid4())}, user_id="u1", workspace_id=None
+        )
+
+    assert ctx.last_used_at is first_stamp
+
+
+@pytest.mark.asyncio
+async def test_cross_context_recall_touches_every_listed_context():
+    """#1228 cross-context recall: the secondaries are read too — all listed
+    contexts count as used, not just the billable primary."""
+    ws = uuid4()
+    primary = _make_context(last_used_at=None, workspace_id=ws)
+    secondary = _make_context(last_used_at=None, workspace_id=ws)
+
+    with _patched_recall(AsyncMock(side_effect=[primary, secondary])):
+        result = await handle_recall(
+            {"query": "q", "context_ids": [str(uuid4()), str(uuid4())]},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert primary.last_used_at is not None
+    assert secondary.last_used_at is not None
+
+
+# ============================================================================
+# Handler wiring: remember / reference
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_remember_bumps_context():
+    ctx = _make_context(last_used_at=None)
+
+    async def mock_get_db():
+        yield AsyncMock()
+
+    service = MagicMock()
+    service.remember = AsyncMock(return_value=SimpleNamespace(memory_id=uuid4(), scope="personal"))
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.memory._resolve_context", new=AsyncMock(return_value=ctx)),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+        patch("services.memory_service.MemoryService", new=MagicMock(return_value=service)),
+    ):
+        result = await handle_remember(
+            {
+                "summary": "touch test: remember marks the context used",
+                "content": "remember must bump Context.last_used_at (#1257)",
+                "type": "fact",
+                "context_id": str(uuid4()),
+            },
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert ctx.last_used_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reference_bumps_context():
+    ctx = _make_context(last_used_at=None)
+
+    async def mock_get_db():
+        yield AsyncMock()
+
+    reference_result = SimpleNamespace(
+        memory_id=uuid4(),
+        summary="s",
+        context_summary=None,
+        content="c",
+        details=None,
+        type="fact",
+        scope="personal",
+        importance=0.5,
+        tags=[],
+        context=None,
+        created_at=datetime.now(UTC),
+        updated_at=None,
+        client="mcp",
+        source_uri=None,
+        source_type=None,
+        outgoing_links=[],
+        outgoing_has_more=False,
+        incoming_links=[],
+        incoming_has_more=False,
+    )
+    service = MagicMock()
+    service.reference = AsyncMock(return_value=reference_result)
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.memory._resolve_context_for_read", new=AsyncMock(return_value=ctx)),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+        patch("services.memory_service.MemoryService", new=MagicMock(return_value=service)),
+    ):
+        result = await handle_reference(
+            {"memory_id": str(uuid4()), "context_id": str(uuid4())},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    assert ctx.last_used_at is not None
+
+
+# ============================================================================
+# list_contexts recency sort (consumes the touched values)
+# ============================================================================
+
+
+def _listable_context(name, last_used_at):
+    return SimpleNamespace(
+        id=uuid4(),
+        name=name,
+        summary=None,
+        is_private=True,
+        is_locked=False,
+        last_used_at=last_used_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_contexts_sorts_by_recency_with_never_used_last():
+    """The sort the touch exists to make meaningful: freshest first, and
+    ``None`` (never used, pre-backfill rows) sorts last via the aware
+    ``_UTC_MIN`` sentinel without tripping aware-vs-naive comparison."""
+    from mcp_server.tools.context import handle_list_contexts
+
+    now = datetime.now(UTC)
+    never = _listable_context("never-used", None)
+    old = _listable_context("old", now - timedelta(days=1))
+    fresh = _listable_context("fresh", now)
+
+    db = AsyncMock()
+    exec_result = MagicMock()
+    exec_result.scalars.return_value.all.return_value = []  # no per-context search configs
+    db.execute = AsyncMock(return_value=exec_result)
+
+    async def mock_get_db():
+        yield db
+
+    context_service = MagicMock()
+    context_service.list_contexts = AsyncMock(return_value=[never, old, fresh])
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch(
+            "services.context_service.ContextService",
+            new=MagicMock(return_value=context_service),
+        ),
+        patch("mcp_server.tools.context._log_tool_usage", new=AsyncMock()),
+    ):
+        result = await handle_list_contexts({}, user_id="u1", workspace_id=None)
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    assert [c["name"] for c in payload["contexts"]] == ["fresh", "old", "never-used"]
+    assert payload["contexts"][0]["last_used_at"] == fresh.last_used_at.isoformat()
+    assert payload["contexts"][2]["last_used_at"] is None

--- a/backend/tests/mcp_server/test_memory_reference_tool.py
+++ b/backend/tests/mcp_server/test_memory_reference_tool.py
@@ -70,7 +70,12 @@ async def test_reference_surfaces_links_scope_provenance():
     with ExitStack() as stack:
         stack.enter_context(patch("db.base.get_db", new=gen))
         stack.enter_context(
-            patch("mcp_server.tools.memory._resolve_context_for_read", new=AsyncMock())
+            # last_used_at must be a real sentinel (not a MagicMock attribute):
+            # #1257 touches the resolved context's timestamp with datetime math.
+            patch(
+                "mcp_server.tools.memory._resolve_context_for_read",
+                new=AsyncMock(return_value=MagicMock(last_used_at=None)),
+            )
         )
         stack.enter_context(patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()))
         stack.enter_context(patch("services.memory_service.MemoryService", return_value=svc))

--- a/backend/tests/mcp_server/test_recall_cross_context_attribution.py
+++ b/backend/tests/mcp_server/test_recall_cross_context_attribution.py
@@ -36,7 +36,9 @@ def _patched(log_tool_usage: AsyncMock):
     async def mock_get_db():
         yield AsyncMock()
 
-    shared_context = MagicMock()
+    # last_used_at must be a real sentinel (not a MagicMock attribute): #1257
+    # touches the resolved context's timestamp with datetime math.
+    shared_context = MagicMock(last_used_at=None)
 
     service = MagicMock()
     service.recall = AsyncMock(return_value=_recall_result())


### PR DESCRIPTION
Closes #1257

## Summary
- `Context.last_used_at` (added in #169) was never written after row creation, so the MCP `list_contexts` "recent usage" sort was effectively `created_at` ordering and meaningless for active contexts.
- All five MCP memory operations (`remember`, `recall` incl. cross-context secondaries, `reference`, `update_memory`, `forget`) now mark the context as used, throttled to at most one write per context per `context_last_used_throttle_seconds` (new setting, default 60s — same hot-row reasoning as the #947 `api_keys.last_used_at` throttle).
- The write is a single guarded Core UPDATE issued immediately before the handler's commit — not a dirty ORM attribute — with `updated_at` pinned to itself so the column-level `onupdate` does not fire.
- `list_contexts` now serializes `last_used_at` via `to_utc_iso` (Z suffix) per the backend datetime convention.

## Implementation notes
- **Why commit-time guarded UPDATE instead of the #947 dirty-attribute pattern**: an in-session 10-angle adversarial review confirmed four hazards with the naive approach — (1) `Context.updated_at`'s `onupdate=func.now()` fired on read-path touches, rewriting the "last modified" timestamp shown in the REST API; (2) autoflush emitted the UPDATE at the service's first SELECT, holding the contexts row lock across the embedding/Qdrant pipeline; (3) `ContextSearchConfigRepository.create_or_get`'s internal commit persisted touches on cross-context validation-error paths; (4) caller-supplied `context_ids` order created a Postgres deadlock surface. The final shape fixes all four: free in-memory precheck (zero queries when throttled), race-safe DB-side re-guard in WHERE, `updated_at` self-pin, ascending-id touch ordering.
- No schema migration (column exists since #169 with `server_default=func.now()`); one additive setting in `config/settings.py`.
- 15 regression tests pin the throttle arithmetic, the statement shape (onupdate suppression + WHERE re-guard), the wiring of all five handlers (including negative cases: validation errors and reference misses touch nothing), and the `list_contexts` recency sort (first test to cover it). Tests pin settings explicitly — the ambient `CONTEXT_LAST_USED_THROTTLE_SECONDS` env flake was reproduced and eliminated.
- Follow-ups (out of scope, recorded on #1257): `load_pinned`/`recall_upcoming` (no commit in those handlers), REST transport touch, shared throttle-predicate helper.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: not run (ship-only mode — issue filed and implemented in-session with a 10-angle adversarial /code-review, 15 findings reported and fixed)
- review provider: none

Test state: `tests/mcp_server` 301 passed; full backend unit suite 4422 passed; DB integration suite 488 passed / 9 env-gated skips.

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1257-fix-context-last-used-touch.gate2.md

🤖 Generated via /gh-issue-driven:ship
🤖 Generated with [Claude Code](https://claude.com/claude-code)
