### PR TITLE
refactor(api): shared REST/MCP resource batch ingest service (#1255)

### DIFF
--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -613,12 +613,14 @@ async def ingest_batch(
     ]
     created_ids = result.created_ids
 
-    # 4. Commit + post-commit indexer boundary (shared service).
+    # 4. Commit + post-commit indexer boundary (shared service). The scheduler
+    #    is injected so the service never imports from this adapter layer.
     await resource_ingest_service.finalize_batch(
         db,
         workspace_id=context.workspace_id,
         resource_id=resource_id,
         created_ids=created_ids,
+        schedule_indexer=_schedule_indexer_for_resource,
     )
 
     if created_ids:

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -16,6 +16,7 @@ from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import services.resource_ingest_service as resource_ingest_service
 from auth.resource_tokens import ResourceTokenManager
 from db.base import get_db
 from db.constraint_names import (
@@ -36,6 +37,7 @@ from services.connector_provisioning import (
     validate_connector_idempotency_key,
 )
 from services.permission_service import PermissionService
+from services.resource_ingest_service import IngestItemError
 from services.resource_lookup import resolve_resource_pk
 from services.resource_quota_service import check_event_quota
 from utils.datetime import utcnow
@@ -46,8 +48,35 @@ logger = get_logger(__name__)
 
 router = APIRouter(prefix="/resources", tags=["resource-ingest"])
 
-# Maximum payload size (100KB)
-MAX_PAYLOAD_SIZE_BYTES = 100_000
+# Maximum payload size (100KB) — single source in the shared ingest service
+# (Issue #1255); the single-event path below reads the same constant.
+MAX_PAYLOAD_SIZE_BYTES = resource_ingest_service.MAX_PAYLOAD_SIZE_BYTES
+
+
+def _format_batch_item_error(err: IngestItemError) -> dict:
+    """Render a structured batch item error in the historic REST wire shape.
+
+    The strings are byte-compatible with the pre-#1255 in-handler messages;
+    every REST item error carries ``doc_id``.
+    """
+    kind = err.kind
+    if kind == resource_ingest_service.KIND_PAYLOAD_TOO_LARGE:
+        message = f"Payload too large: {err.detail['payload_size']} bytes"
+    elif kind == resource_ingest_service.KIND_IDEMPOTENCY_INVALID:
+        message = err.detail["message"]
+    elif kind == resource_ingest_service.KIND_DUPLICATE_VERSION:
+        message = f"Duplicate version {err.detail['version']}"
+    elif kind == resource_ingest_service.KIND_DUPLICATE_IDEMPOTENCY:
+        message = "Duplicate idempotency key"
+    elif kind == resource_ingest_service.KIND_CONSTRAINT_VIOLATION:
+        message = "Database constraint violation"
+    elif kind == resource_ingest_service.KIND_UNEXPECTED:
+        message = err.detail["message"]
+    else:
+        # Validation kinds are unreachable on this surface (Pydantic already
+        # rejected the request with 422); keep a defensive generic message.
+        message = "Invalid event"
+    return {"index": err.index, "doc_id": err.doc_id, "error": message}
 
 
 # ============================================================================
@@ -542,7 +571,6 @@ async def ingest_batch(
     """
     # Context is resolved and workspace-verified in the dependency — always non-None here.
     token_record, quota_per_hour, context = auth
-    connector_id = await get_connector_id_for_resource_pk(db, token_record.resource_pk)
 
     logger.info(
         "resource_batch_ingest_started",
@@ -551,132 +579,50 @@ async def ingest_batch(
     )
 
     # 1. Validate batch size (already enforced by Pydantic, but double-check)
-    if len(request.events) > 100:
-        raise ValidationError("Batch size exceeds maximum (100 events)")
+    if len(request.events) > resource_ingest_service.MAX_BATCH_SIZE:
+        raise ValidationError(
+            f"Batch size exceeds maximum ({resource_ingest_service.MAX_BATCH_SIZE} events)"
+        )
 
-    # 2. Check quota for entire batch (workspace-scoped counter shared with MCP)
+    # 2. Check quota for entire batch (workspace-scoped counter shared with MCP).
+    #    The token dependency already resolved the effective per-hour quota;
+    #    RateLimitError propagates as the existing 429 contract.
     await check_event_quota(
         resource_id, context.workspace_id, quota_per_hour, count=len(request.events)
     )
 
-    # 3. Process events
-    created_ids: list[int] = []
-    errors: list[dict] = []
+    # 3. Domain validation + persistence via the shared service (Issue #1255).
+    #    Inputs are Pydantic-validated, so the validation pass only adds the
+    #    byte-accurate payload-size check; the token carries the authoritative
+    #    resource_pk, so no slug re-resolution is needed on this surface.
+    valid_events, validation_errors = resource_ingest_service.validate_events(
+        [event_req.model_dump() for event_req in request.events]
+    )
+    result = await resource_ingest_service.persist_events(
+        db,
+        resource_id=resource_id,
+        resource_pk=token_record.resource_pk,
+        events=valid_events,
+    )
 
-    for idx, event_req in enumerate(request.events):
-        try:
-            # Validate payload size
-            if event_req.payload:
-                import json
+    # Historic REST ordering: item errors sorted by event index (validation
+    # and persistence failures interleaved in a single sequential loop).
+    errors = [
+        _format_batch_item_error(err)
+        for err in sorted([*validation_errors, *result.errors], key=lambda e: e.index)
+    ]
+    created_ids = result.created_ids
 
-                payload_size = len(json.dumps(event_req.payload))
-                if payload_size > MAX_PAYLOAD_SIZE_BYTES:
-                    errors.append(
-                        {
-                            "index": idx,
-                            "doc_id": event_req.doc_id,
-                            "error": f"Payload too large: {payload_size} bytes",
-                        }
-                    )
-                    continue
+    # 4. Commit + post-commit indexer boundary (shared service).
+    await resource_ingest_service.finalize_batch(
+        db,
+        workspace_id=context.workspace_id,
+        resource_id=resource_id,
+        created_ids=created_ids,
+    )
 
-            try:
-                validate_connector_idempotency_key(
-                    connector_id=connector_id,
-                    idempotency_key=event_req.idempotency_key,
-                )
-            except ValidationError as e:
-                errors.append({"index": idx, "doc_id": event_req.doc_id, "error": e.message})
-                continue
-
-            # Create event — see single-ingest path for the resource_pk rationale.
-            event = ResourceEvent(
-                resource_id=resource_id,
-                resource_pk=token_record.resource_pk,
-                op=event_req.op,
-                doc_id=event_req.doc_id,
-                version=event_req.version,
-                payload=event_req.payload,
-                idempotency_key=event_req.idempotency_key,
-                event_metadata=event_req.event_metadata,
-                importance=event_req.importance
-                if event_req.importance is not None
-                else 0.6,  # Issue #262
-            )
-
-            # SAVEPOINT per event so an IntegrityError on one row does not
-            # abort the outer transaction and break partial-success for the
-            # sibling events. Mirrors the MCP batch path in
-            # ``mcp_server/tools/resource.py``.
-            async with db.begin_nested():
-                db.add(event)
-                await db.flush()
-            created_ids.append(event.id)
-
-        except IntegrityError as e:
-            constraint = integrity_error_constraint_name(e)
-
-            if constraint == RESOURCE_EVENTS_UPSERT_UNIQUE:
-                logger.debug(
-                    "duplicate_version_skipped",
-                    doc_id=event_req.doc_id,
-                    version=event_req.version,
-                )
-                errors.append(
-                    {
-                        "index": idx,
-                        "doc_id": event_req.doc_id,
-                        "error": f"Duplicate version {event_req.version}",
-                    }
-                )
-
-            elif constraint == RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE:
-                logger.debug("duplicate_idempotency_key_skipped", key=event_req.idempotency_key)
-                errors.append(
-                    {
-                        "index": idx,
-                        "doc_id": event_req.doc_id,
-                        "error": "Duplicate idempotency key",
-                    }
-                )
-
-            else:
-                # Batch keeps partial-success: log + per-item error,
-                # do not re-raise (would abort sibling events).
-                logger.error(
-                    "batch_event_integrity_error_unhandled",
-                    index=idx,
-                    constraint=constraint,
-                    error=str(e),
-                )
-                errors.append(
-                    {
-                        "index": idx,
-                        "doc_id": event_req.doc_id,
-                        "error": "Database constraint violation",
-                    }
-                )
-
-        except Exception as e:
-            logger.error("batch_event_unexpected_error", index=idx, error=str(e))
-            errors.append(
-                {
-                    "index": idx,
-                    "doc_id": event_req.doc_id,
-                    "error": str(e),
-                }
-            )
-
-    # 4. Commit all successfully created events
-    # NOTE: Batch ingest uses partial-success model (some events can fail while others succeed)
-    # This is intentional for resilience. If atomic behavior is needed, use individual requests.
-    await db.commit()
-
-    # 5. Schedule indexer run
     if created_ids:
-        await _schedule_indexer_for_resource(db, context.workspace_id, resource_id)
-
-        # 6. Log usage statistics (Issue #242)
+        # 5. Log usage statistics (Issue #242)
         from utils.usage_logger import log_usage
 
         await log_usage(

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -639,12 +639,19 @@ async def handle_ingest_events(
                 _format_batch_item_error(err) for err in [*validation_errors, *persist_errors]
             ]
 
-            # Commit + post-commit indexer boundary (shared service).
+            # Commit + post-commit indexer boundary (shared service). The
+            # scheduler is injected so the service never imports from the
+            # adapter layer; this lazy import mirrors the pre-refactor MCP
+            # path and keeps the routes module as the helper's single home
+            # (it also serves the REST single-event path).
+            from api.routes.resource_ingest import _schedule_indexer_for_resource
+
             await resource_ingest_service.finalize_batch(
                 db,
                 workspace_id=workspace_id,
                 resource_id=resource_id,
                 created_ids=created_ids,
+                schedule_indexer=_schedule_indexer_for_resource,
             )
 
             await _log_tool_usage(

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -11,7 +11,6 @@ Provides 5 tools for managing resources via MCP:
 - list_resource_tokens: List tokens for a resource
 """
 
-import json
 import logging
 import re
 import time
@@ -20,6 +19,7 @@ from uuid import UUID
 
 from mcp.types import TextContent
 
+import services.resource_ingest_service as resource_ingest_service
 from mcp_server.tools._helpers import (
     _check_viewer_permission,
     _error_response,
@@ -27,6 +27,7 @@ from mcp_server.tools._helpers import (
     _log_tool_usage,
     _success_response,
 )
+from services.resource_ingest_service import IngestItemError
 from services.resource_quota_service import (
     check_event_quota,
     resolve_workspace_event_quota_per_hour,
@@ -38,11 +39,62 @@ logger = logging.getLogger(__name__)
 # Resource ID format: lowercase alphanumeric + underscore + hyphen
 _RESOURCE_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
 
-# Max payload size per event (100KB)
-_MAX_PAYLOAD_SIZE_BYTES = 100_000
+# Max payload size per event (100KB) — single source in the shared ingest
+# service (Issue #1255).
+_MAX_PAYLOAD_SIZE_BYTES = resource_ingest_service.MAX_PAYLOAD_SIZE_BYTES
 
 # Max events per batch
-_MAX_BATCH_SIZE = 100
+_MAX_BATCH_SIZE = resource_ingest_service.MAX_BATCH_SIZE
+
+
+def _format_batch_item_error(err: IngestItemError) -> dict:
+    """Render a structured batch item error in the historic MCP wire shape.
+
+    Strings are byte-compatible with the pre-#1255 in-handler messages.
+    Only the idempotency-validation error carries a ``doc_id`` field (the
+    duplicate messages embed the doc_id in the string instead) — preserved
+    from the original envelope.
+    """
+    svc = resource_ingest_service
+    kind = err.kind
+    doc_id_field = False
+    if kind == svc.KIND_NOT_AN_OBJECT:
+        message = "event must be an object"
+    elif kind == svc.KIND_INVALID_OP:
+        message = f"Invalid op: {err.detail.get('op')}"
+    elif kind == svc.KIND_MISSING_DOC_ID:
+        message = "Missing doc_id"
+    elif kind == svc.KIND_PAYLOAD_REQUIRED:
+        message = "payload required for upsert"
+    elif kind == svc.KIND_VERSION_NOT_INT:
+        message = "version must be an integer"
+    elif kind == svc.KIND_VERSION_TOO_SMALL_UPSERT:
+        message = "version >= 1 required for upsert"
+    elif kind == svc.KIND_PAYLOAD_TOO_LARGE:
+        message = f"Payload too large: {err.detail['payload_size']} bytes (max {err.detail['max']})"
+    elif kind == svc.KIND_IMPORTANCE_NOT_NUMBER:
+        message = "importance must be a number"
+    elif kind == svc.KIND_IMPORTANCE_OUT_OF_RANGE:
+        message = "importance must be between 0.0 and 1.0"
+    elif kind == svc.KIND_PAYLOAD_NOT_NULL_DELETE:
+        message = "payload must be null for delete"
+    elif kind == svc.KIND_VERSION_TOO_SMALL:
+        message = "version must be >= 1"
+    elif kind == svc.KIND_IDEMPOTENCY_INVALID:
+        message = err.detail["message"]
+        doc_id_field = True
+    elif kind == svc.KIND_DUPLICATE_VERSION:
+        message = f"Duplicate version for doc_id={err.doc_id}"
+    elif kind == svc.KIND_DUPLICATE_IDEMPOTENCY:
+        message = "Duplicate idempotency_key"
+    elif kind == svc.KIND_CONSTRAINT_VIOLATION:
+        message = "Unable to ingest event due to a constraint violation"
+    else:  # KIND_UNEXPECTED — previously failed the whole call; now per-item.
+        message = "Unexpected error ingesting event"
+    out: dict[str, Any] = {"index": err.index, "error": message}
+    if doc_id_field:
+        out["doc_id"] = err.doc_id
+    return out
 
 
 # ============================================================================
@@ -546,104 +598,16 @@ async def handle_ingest_events(
                     retry_after_seconds=quota_err.retry_after,
                 )
 
+            # Domain validation + persistence via the shared service
+            # (Issue #1255). The MCP surface relies on the service for all
+            # per-item validation; wire strings are rendered locally by
+            # _format_batch_item_error to stay byte-compatible.
+            valid_events, validation_errors = resource_ingest_service.validate_events(events)
+
             created_ids: list[int] = []
-            errors: list[dict] = []
-            valid_events: list[dict[str, Any]] = []
-
-            for i, event_data in enumerate(events):
-                if not isinstance(event_data, dict):
-                    errors.append({"index": i, "error": "event must be an object"})
-                    continue
-                op = event_data.get("op")
-                doc_id = event_data.get("doc_id")
-
-                # Basic validation
-                if op not in ("upsert", "delete"):
-                    errors.append({"index": i, "error": f"Invalid op: {op}"})
-                    continue
-                if not doc_id:
-                    errors.append({"index": i, "error": "Missing doc_id"})
-                    continue
-
-                payload = event_data.get("payload")
-                version = None
-
-                # Upsert requires payload and version >= 1
-                if op == "upsert":
-                    if not payload:
-                        errors.append({"index": i, "error": "payload required for upsert"})
-                        continue
-                    version = event_data.get("version")
-                    try:
-                        version = int(version) if version is not None else None
-                    except (ValueError, TypeError):
-                        errors.append({"index": i, "error": "version must be an integer"})
-                        continue
-                    if version is None or version < 1:
-                        errors.append({"index": i, "error": "version >= 1 required for upsert"})
-                        continue
-
-                # Payload size check
-                if payload:
-                    payload_size = len(json.dumps(payload).encode("utf-8"))
-                    if payload_size > _MAX_PAYLOAD_SIZE_BYTES:
-                        errors.append(
-                            {
-                                "index": i,
-                                "error": f"Payload too large: {payload_size} bytes "
-                                f"(max {_MAX_PAYLOAD_SIZE_BYTES})",
-                            }
-                        )
-                        continue
-
-                # Validate importance range
-                importance = event_data.get("importance", 0.6)
-                try:
-                    importance = float(importance)
-                except (ValueError, TypeError):
-                    errors.append({"index": i, "error": "importance must be a number"})
-                    continue
-                if importance < 0.0 or importance > 1.0:
-                    errors.append({"index": i, "error": "importance must be between 0.0 and 1.0"})
-                    continue
-
-                # Delete validation: payload must be null, version (if provided) must be >= 1
-                if op == "delete":
-                    if payload is not None:
-                        errors.append({"index": i, "error": "payload must be null for delete"})
-                        continue
-                    version = event_data.get("version")
-                    if version is not None:
-                        try:
-                            version = int(version)
-                        except (ValueError, TypeError):
-                            errors.append({"index": i, "error": "version must be an integer"})
-                            continue
-                        if version < 1:
-                            errors.append({"index": i, "error": "version must be >= 1"})
-                            continue
-
-                valid_events.append(
-                    {
-                        "index": i,
-                        "op": op,
-                        "doc_id": doc_id,
-                        "version": version,
-                        "payload": payload if op == "upsert" else None,
-                        "idempotency_key": event_data.get("idempotency_key"),
-                        "event_metadata": event_data.get("event_metadata", {}),
-                        "importance": importance,
-                    }
-                )
+            persist_errors: list[IngestItemError] = []
 
             if valid_events:
-                from services.connector_provisioning import (
-                    get_connector_id_for_resource_pk,
-                    validate_connector_idempotency_key,
-                )
-                from services.resource_lookup import resolve_resource_pk
-                from utils.exceptions import ValidationError
-
                 # Resolve resources.id once per batch via the shared chokepoint
                 # (Issue #390 Phase 2). If the Resource entity row does not
                 # exist, ingest cannot safely proceed — the before_insert
@@ -652,95 +616,38 @@ async def handle_ingest_events(
                 # as generic "constraint violation" strings. Reject the batch
                 # up front with an actionable error so the caller knows to run
                 # ``setup_resource`` or ``setup_connector`` first.
-                resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+                resource_pk = await resource_ingest_service.resolve_authoritative_resource_pk(
+                    db, workspace_id=workspace_id, resource_id=resource_id
+                )
                 if resource_pk is None:
                     return _error_response(
                         "resource_not_found",
                         f"Resource '{resource_id}' has no backing entity row in your workspace.",
                         help="Run setup_resource() or setup_connector() first to bind the resource.",
                     )
-                connector_id = await get_connector_id_for_resource_pk(db, resource_pk)
 
-                # Process events
-                from sqlalchemy.exc import IntegrityError
-
-                from db.constraint_names import (
-                    RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE,
-                    RESOURCE_EVENTS_UPSERT_UNIQUE,
-                    integrity_error_constraint_name,
-                )
-                from models.resource import ResourceEvent
-
-            for event_data in valid_events:
-                i = event_data["index"]
-                doc_id = event_data["doc_id"]
-                try:
-                    validate_connector_idempotency_key(
-                        connector_id=connector_id,
-                        idempotency_key=event_data["idempotency_key"],
-                    )
-                except ValidationError as ve:
-                    errors.append({"index": i, "doc_id": doc_id, "error": ve.message})
-                    continue
-
-                event = ResourceEvent(
+                result = await resource_ingest_service.persist_events(
+                    db,
                     resource_id=resource_id,
                     resource_pk=resource_pk,
-                    op=event_data["op"],
-                    doc_id=doc_id,
-                    version=event_data["version"],
-                    payload=event_data["payload"],
-                    idempotency_key=event_data["idempotency_key"],
-                    event_metadata=event_data["event_metadata"],
-                    importance=event_data["importance"],
+                    events=valid_events,
                 )
+                created_ids = result.created_ids
+                persist_errors = result.errors
 
-                try:
-                    async with db.begin_nested():
-                        db.add(event)
-                        await db.flush()
-                    created_ids.append(event.id)
-                except IntegrityError as ie:
-                    constraint = integrity_error_constraint_name(ie)
-                    if constraint == RESOURCE_EVENTS_UPSERT_UNIQUE:
-                        errors.append(
-                            {
-                                "index": i,
-                                "error": f"Duplicate version for doc_id={doc_id}",
-                            }
-                        )
-                    elif constraint == RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE:
-                        errors.append(
-                            {
-                                "index": i,
-                                "error": "Duplicate idempotency_key",
-                            }
-                        )
-                    else:
-                        # Do not leak raw DB constraint details to clients;
-                        # log the constraint name for triage instead.
-                        logger.warning(
-                            "ingest_events integrity error: resource_id=%s index=%s doc_id=%s constraint=%s",
-                            resource_id,
-                            i,
-                            doc_id,
-                            constraint,
-                            exc_info=ie,
-                        )
-                        errors.append(
-                            {
-                                "index": i,
-                                "error": "Unable to ingest event due to a constraint violation",
-                            }
-                        )
-                    continue
+            # Historic MCP ordering: validation errors first (pass 1), then
+            # persistence errors (pass 2).
+            errors = [
+                _format_batch_item_error(err) for err in [*validation_errors, *persist_errors]
+            ]
 
-            # Schedule indexer if any events were created
-            if created_ids:
-                from api.routes.resource_ingest import _schedule_indexer_for_resource
-
-                await _schedule_indexer_for_resource(db, workspace_id, resource_id)
-                await db.commit()
+            # Commit + post-commit indexer boundary (shared service).
+            await resource_ingest_service.finalize_batch(
+                db,
+                workspace_id=workspace_id,
+                resource_id=resource_id,
+                created_ids=created_ids,
+            )
 
             await _log_tool_usage(
                 db,

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -39,11 +39,9 @@ logger = logging.getLogger(__name__)
 # Resource ID format: lowercase alphanumeric + underscore + hyphen
 _RESOURCE_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
 
-# Max payload size per event (100KB) — single source in the shared ingest
-# service (Issue #1255).
-_MAX_PAYLOAD_SIZE_BYTES = resource_ingest_service.MAX_PAYLOAD_SIZE_BYTES
-
-# Max events per batch
+# Max events per batch — single source in the shared ingest service
+# (Issue #1255); the per-event payload-size cap lives there too
+# (resource_ingest_service.MAX_PAYLOAD_SIZE_BYTES).
 _MAX_BATCH_SIZE = resource_ingest_service.MAX_BATCH_SIZE
 
 

--- a/backend/src/services/resource_ingest_service.py
+++ b/backend/src/services/resource_ingest_service.py
@@ -25,6 +25,7 @@ Design notes:
 from __future__ import annotations
 
 import json
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
@@ -180,13 +181,14 @@ def validate_events(
                 continue
 
         if op == "delete":
-            # Truthiness, not `is not None`: an explicit empty-dict payload on
-            # a delete is normalized to None (`payload if op == "upsert"` below
-            # already drops it). The REST surface always accepted `payload: {}`
-            # (its Pydantic validator uses truthiness), so rejecting it here
-            # would regress REST behavior; the MCP surface previously rejected
-            # it and is relaxed to match (#1255 equivalence).
-            if payload:
+            # Exactly None or {} is accepted; {} is normalized to None
+            # (`payload if op == "upsert"` below drops it). The REST surface
+            # always accepted `payload: {}` (its Pydantic validator uses
+            # truthiness), so rejecting it here would regress REST behavior;
+            # the MCP surface previously rejected it and is relaxed to match
+            # (#1255 equivalence). Other falsy-but-non-null shapes ([], "", 0)
+            # stay rejected — bare truthiness would silently accept them.
+            if payload is not None and payload != {}:
                 errors.append(
                     IngestItemError(index=i, kind=KIND_PAYLOAD_NOT_NULL_DELETE, doc_id=doc_id)
                 )
@@ -382,6 +384,7 @@ async def finalize_batch(
     workspace_id: UUID,
     resource_id: str,
     created_ids: list[int],
+    schedule_indexer: Callable[[AsyncSession, UUID, str], Awaitable[None]],
 ) -> None:
     """Commit the batch, then schedule the indexer from the post-commit boundary.
 
@@ -393,6 +396,11 @@ async def finalize_batch(
     #1255 asks for). The indexer is scheduled only when at least one event was
     created.
 
+    ``schedule_indexer`` is injected by the adapter (both surfaces pass the
+    routes module's ``_schedule_indexer_for_resource``, which is also used by
+    the single-event path) so this service never imports from the adapter
+    layer.
+
     Conscious trade-off: if indexer scheduling (or the second commit) fails
     after the first commit, the event rows stay durable while the caller sees
     an error — the pre-refactor MCP path rolled the whole batch back in that
@@ -402,11 +410,5 @@ async def finalize_batch(
     await db.commit()
 
     if created_ids:
-        # Lazy import from the routes module: it is the single home of the
-        # scheduling helper (also used by the single-event path) and the
-        # established patch target in the test suite. Moving it is out of
-        # scope for #1255 ("no broad cleanup of unrelated Resource tools").
-        from api.routes.resource_ingest import _schedule_indexer_for_resource
-
-        await _schedule_indexer_for_resource(db, workspace_id, resource_id)
+        await schedule_indexer(db, workspace_id, resource_id)
         await db.commit()

--- a/backend/src/services/resource_ingest_service.py
+++ b/backend/src/services/resource_ingest_service.py
@@ -180,7 +180,13 @@ def validate_events(
                 continue
 
         if op == "delete":
-            if payload is not None:
+            # Truthiness, not `is not None`: an explicit empty-dict payload on
+            # a delete is normalized to None (`payload if op == "upsert"` below
+            # already drops it). The REST surface always accepted `payload: {}`
+            # (its Pydantic validator uses truthiness), so rejecting it here
+            # would regress REST behavior; the MCP surface previously rejected
+            # it and is relaxed to match (#1255 equivalence).
+            if payload:
                 errors.append(
                     IngestItemError(index=i, kind=KIND_PAYLOAD_NOT_NULL_DELETE, doc_id=doc_id)
                 )
@@ -386,6 +392,12 @@ async def finalize_batch(
     scheduled before commit — this is the single, clearly defined boundary
     #1255 asks for). The indexer is scheduled only when at least one event was
     created.
+
+    Conscious trade-off: if indexer scheduling (or the second commit) fails
+    after the first commit, the event rows stay durable while the caller sees
+    an error — the pre-refactor MCP path rolled the whole batch back in that
+    case. Recovery is the offset-based IndexerState catch-up on the next
+    successful ingest for the resource.
     """
     await db.commit()
 

--- a/backend/src/services/resource_ingest_service.py
+++ b/backend/src/services/resource_ingest_service.py
@@ -1,0 +1,400 @@
+"""Shared Resource batch-ingest domain service.
+
+Issue #1255: REST ``api/routes/resource_ingest.py::ingest_batch`` and MCP
+``mcp_server/tools/resource.py::handle_ingest_events`` previously implemented
+the same domain pipeline independently. They are now thin adapters over this
+module: the adapters keep authentication, authorization, wire parsing, and
+response/error serialization; this service owns per-event domain validation,
+authoritative Resource resolution, per-event SAVEPOINT persistence with
+constraint classification, the commit boundary, and post-commit indexer
+scheduling.
+
+Design notes:
+    - The service returns *structured* item errors (``IngestItemError`` with a
+      ``kind`` plus formatting params). Each adapter renders its own historic
+      wire strings from them, so the REST response schema and the MCP envelope
+      stay byte-compatible with their pre-refactor shapes.
+    - Payload size is measured in UTF-8 **bytes** (the semantic the constant
+      ``MAX_PAYLOAD_SIZE_BYTES`` names). The REST path previously counted
+      ``str`` characters, which under-counted multibyte payloads.
+    - Quota enforcement stays in the adapters via the already-shared
+      ``services.resource_quota_service`` helpers (both surfaces reserve
+      against the same workspace-scoped Redis counter before any write).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+MAX_BATCH_SIZE = 100
+MAX_PAYLOAD_SIZE_BYTES = 100_000
+DEFAULT_IMPORTANCE = 0.6  # Issue #262
+
+# Structured error kinds. Adapters map these to their historic wire strings —
+# never serialize the kind itself (or raw DB constraint details) to clients.
+KIND_NOT_AN_OBJECT = "not_an_object"
+KIND_INVALID_OP = "invalid_op"
+KIND_MISSING_DOC_ID = "missing_doc_id"
+KIND_PAYLOAD_REQUIRED = "payload_required"
+KIND_VERSION_NOT_INT = "version_not_int"
+KIND_VERSION_TOO_SMALL_UPSERT = "version_too_small_upsert"
+KIND_PAYLOAD_TOO_LARGE = "payload_too_large"
+KIND_IMPORTANCE_NOT_NUMBER = "importance_not_number"
+KIND_IMPORTANCE_OUT_OF_RANGE = "importance_out_of_range"
+KIND_PAYLOAD_NOT_NULL_DELETE = "payload_not_null_delete"
+KIND_VERSION_TOO_SMALL = "version_too_small"
+KIND_IDEMPOTENCY_INVALID = "idempotency_invalid"
+KIND_DUPLICATE_VERSION = "duplicate_version"
+KIND_DUPLICATE_IDEMPOTENCY = "duplicate_idempotency"
+KIND_CONSTRAINT_VIOLATION = "constraint_violation"
+KIND_UNEXPECTED = "unexpected"
+
+
+@dataclass(frozen=True)
+class IngestEventInput:
+    """One normalized, domain-valid event ready for persistence."""
+
+    index: int
+    op: str
+    doc_id: str
+    version: int | None
+    payload: dict | None
+    idempotency_key: str | None
+    event_metadata: dict | None
+    importance: float
+
+
+@dataclass(frozen=True)
+class IngestItemError:
+    """Structured per-item failure; adapters own the wire message."""
+
+    index: int
+    kind: str
+    doc_id: str | None = None
+    detail: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class IngestBatchResult:
+    """Outcome of the persistence pass."""
+
+    created_ids: list[int] = field(default_factory=list)
+    errors: list[IngestItemError] = field(default_factory=list)
+
+
+def validate_events(
+    raw_events: list[Any],
+) -> tuple[list[IngestEventInput], list[IngestItemError]]:
+    """Validate raw event dicts into normalized inputs.
+
+    Implements the domain rules both surfaces share. REST inputs arrive
+    Pydantic-validated (``ResourceEventRequest``), so for that adapter this
+    pass only adds the byte-accurate payload-size check; the MCP adapter
+    relies on it for all per-item validation. Check order is preserved from
+    the historic MCP implementation so first-error precedence is unchanged
+    (op → doc_id → upsert payload/version → payload size → importance →
+    delete rules).
+
+    An explicit ``importance: null`` is treated as absent and takes
+    ``DEFAULT_IMPORTANCE`` (the REST semantic; the MCP path previously
+    rejected an explicit null — unified per #1255's equivalence criterion).
+    """
+    valid: list[IngestEventInput] = []
+    errors: list[IngestItemError] = []
+
+    for i, event_data in enumerate(raw_events):
+        if not isinstance(event_data, dict):
+            errors.append(IngestItemError(index=i, kind=KIND_NOT_AN_OBJECT))
+            continue
+
+        op = event_data.get("op")
+        doc_id = event_data.get("doc_id")
+
+        if op not in ("upsert", "delete"):
+            errors.append(IngestItemError(index=i, kind=KIND_INVALID_OP, detail={"op": op}))
+            continue
+        if not doc_id:
+            errors.append(IngestItemError(index=i, kind=KIND_MISSING_DOC_ID))
+            continue
+
+        payload = event_data.get("payload")
+        version: int | None = None
+
+        if op == "upsert":
+            if not payload:
+                errors.append(IngestItemError(index=i, kind=KIND_PAYLOAD_REQUIRED, doc_id=doc_id))
+                continue
+            version = event_data.get("version")
+            try:
+                version = int(version) if version is not None else None
+            except (ValueError, TypeError):
+                errors.append(IngestItemError(index=i, kind=KIND_VERSION_NOT_INT, doc_id=doc_id))
+                continue
+            if version is None or version < 1:
+                errors.append(
+                    IngestItemError(index=i, kind=KIND_VERSION_TOO_SMALL_UPSERT, doc_id=doc_id)
+                )
+                continue
+
+        if payload:
+            payload_size = len(json.dumps(payload).encode("utf-8"))
+            if payload_size > MAX_PAYLOAD_SIZE_BYTES:
+                errors.append(
+                    IngestItemError(
+                        index=i,
+                        kind=KIND_PAYLOAD_TOO_LARGE,
+                        doc_id=doc_id,
+                        detail={
+                            "payload_size": payload_size,
+                            "max": MAX_PAYLOAD_SIZE_BYTES,
+                        },
+                    )
+                )
+                continue
+
+        importance_raw = event_data.get("importance")
+        if importance_raw is None:
+            importance = DEFAULT_IMPORTANCE
+        else:
+            try:
+                importance = float(importance_raw)
+            except (ValueError, TypeError):
+                errors.append(
+                    IngestItemError(index=i, kind=KIND_IMPORTANCE_NOT_NUMBER, doc_id=doc_id)
+                )
+                continue
+            if importance < 0.0 or importance > 1.0:
+                errors.append(
+                    IngestItemError(index=i, kind=KIND_IMPORTANCE_OUT_OF_RANGE, doc_id=doc_id)
+                )
+                continue
+
+        if op == "delete":
+            if payload is not None:
+                errors.append(
+                    IngestItemError(index=i, kind=KIND_PAYLOAD_NOT_NULL_DELETE, doc_id=doc_id)
+                )
+                continue
+            version = event_data.get("version")
+            if version is not None:
+                try:
+                    version = int(version)
+                except (ValueError, TypeError):
+                    errors.append(
+                        IngestItemError(index=i, kind=KIND_VERSION_NOT_INT, doc_id=doc_id)
+                    )
+                    continue
+                if version < 1:
+                    errors.append(
+                        IngestItemError(index=i, kind=KIND_VERSION_TOO_SMALL, doc_id=doc_id)
+                    )
+                    continue
+
+        valid.append(
+            IngestEventInput(
+                index=i,
+                op=op,
+                doc_id=doc_id,
+                version=version,
+                payload=payload if op == "upsert" else None,
+                idempotency_key=event_data.get("idempotency_key"),
+                event_metadata=event_data.get("event_metadata", {}),
+                importance=importance,
+            )
+        )
+
+    return valid, errors
+
+
+async def resolve_authoritative_resource_pk(
+    db: AsyncSession, *, workspace_id: UUID, resource_id: str
+) -> UUID | None:
+    """Resolve ``resources.id`` via the shared chokepoint (Issue #390 Phase 2).
+
+    Returns ``None`` when the Resource entity row does not exist in the
+    workspace — the adapter rejects the batch up front with an actionable
+    error instead of letting the ``before_insert`` invariant listener raise a
+    masked IntegrityError for every event.
+    """
+    from services.resource_lookup import resolve_resource_pk
+
+    return await resolve_resource_pk(db, workspace_id, resource_id)
+
+
+async def persist_events(
+    db: AsyncSession,
+    *,
+    resource_id: str,
+    resource_pk: UUID,
+    events: list[IngestEventInput],
+) -> IngestBatchResult:
+    """Persist validated events with per-event SAVEPOINT isolation.
+
+    Each event is inserted inside ``db.begin_nested()`` so an IntegrityError
+    on one row cannot abort the outer transaction and break partial success
+    for the sibling events. IntegrityErrors are classified by constraint name
+    (``db.constraint_names``); raw constraint details are never placed in the
+    structured error — only the classification and formatting params.
+
+    A non-IntegrityError failure on one event is likewise recorded as a
+    per-item ``KIND_UNEXPECTED`` error and processing continues (partial
+    success; the pre-refactor MCP path failed the whole call here).
+
+    Nothing is committed — see :func:`finalize_batch` for the commit and
+    indexer boundary.
+    """
+    from db.constraint_names import (
+        RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE,
+        RESOURCE_EVENTS_UPSERT_UNIQUE,
+        integrity_error_constraint_name,
+    )
+    from models.resource import ResourceEvent
+    from services.connector_provisioning import (
+        get_connector_id_for_resource_pk,
+        validate_connector_idempotency_key,
+    )
+    from utils.exceptions import ValidationError
+
+    connector_id = await get_connector_id_for_resource_pk(db, resource_pk)
+
+    result = IngestBatchResult()
+
+    for ev in events:
+        try:
+            try:
+                validate_connector_idempotency_key(
+                    connector_id=connector_id,
+                    idempotency_key=ev.idempotency_key,
+                )
+            except ValidationError as ve:
+                result.errors.append(
+                    IngestItemError(
+                        index=ev.index,
+                        kind=KIND_IDEMPOTENCY_INVALID,
+                        doc_id=ev.doc_id,
+                        detail={"message": ve.message},
+                    )
+                )
+                continue
+
+            event = ResourceEvent(
+                resource_id=resource_id,
+                resource_pk=resource_pk,
+                op=ev.op,
+                doc_id=ev.doc_id,
+                version=ev.version,
+                payload=ev.payload,
+                idempotency_key=ev.idempotency_key,
+                event_metadata=ev.event_metadata,
+                importance=ev.importance,
+            )
+
+            async with db.begin_nested():
+                db.add(event)
+                await db.flush()
+            result.created_ids.append(event.id)
+
+        except IntegrityError as ie:
+            constraint = integrity_error_constraint_name(ie)
+            if constraint == RESOURCE_EVENTS_UPSERT_UNIQUE:
+                logger.debug(
+                    "batch_event_duplicate_version_skipped",
+                    doc_id=ev.doc_id,
+                    version=ev.version,
+                )
+                result.errors.append(
+                    IngestItemError(
+                        index=ev.index,
+                        kind=KIND_DUPLICATE_VERSION,
+                        doc_id=ev.doc_id,
+                        detail={"version": ev.version},
+                    )
+                )
+            elif constraint == RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE:
+                logger.debug(
+                    "batch_event_duplicate_idempotency_key_skipped",
+                    key=ev.idempotency_key,
+                )
+                result.errors.append(
+                    IngestItemError(
+                        index=ev.index,
+                        kind=KIND_DUPLICATE_IDEMPOTENCY,
+                        doc_id=ev.doc_id,
+                    )
+                )
+            else:
+                # Partial success: log the constraint name for triage; never
+                # leak raw DB constraint details to clients.
+                logger.error(
+                    "batch_event_integrity_error_unhandled",
+                    resource_id=resource_id,
+                    index=ev.index,
+                    doc_id=ev.doc_id,
+                    constraint=constraint,
+                )
+                result.errors.append(
+                    IngestItemError(
+                        index=ev.index,
+                        kind=KIND_CONSTRAINT_VIOLATION,
+                        doc_id=ev.doc_id,
+                        detail={"constraint": constraint},
+                    )
+                )
+
+        except Exception as e:
+            logger.error(
+                "batch_event_unexpected_error",
+                resource_id=resource_id,
+                index=ev.index,
+                error=str(e),
+            )
+            result.errors.append(
+                IngestItemError(
+                    index=ev.index,
+                    kind=KIND_UNEXPECTED,
+                    doc_id=ev.doc_id,
+                    detail={"message": str(e)},
+                )
+            )
+
+    return result
+
+
+async def finalize_batch(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    resource_id: str,
+    created_ids: list[int],
+) -> None:
+    """Commit the batch, then schedule the indexer from the post-commit boundary.
+
+    The event rows are committed first so the batch's partial-success outcome
+    is durable regardless of what indexer scheduling does; the IndexerState
+    rows are then written and committed explicitly (the pre-refactor REST path
+    relied on the ``get_db`` teardown auto-commit for them, and the MCP path
+    scheduled before commit — this is the single, clearly defined boundary
+    #1255 asks for). The indexer is scheduled only when at least one event was
+    created.
+    """
+    await db.commit()
+
+    if created_ids:
+        # Lazy import from the routes module: it is the single home of the
+        # scheduling helper (also used by the single-event path) and the
+        # established patch target in the test suite. Moving it is out of
+        # scope for #1255 ("no broad cleanup of unrelated Resource tools").
+        from api.routes.resource_ingest import _schedule_indexer_for_resource
+
+        await _schedule_indexer_for_resource(db, workspace_id, resource_id)
+        await db.commit()

--- a/backend/tests/services/test_resource_ingest_service.py
+++ b/backend/tests/services/test_resource_ingest_service.py
@@ -1,0 +1,385 @@
+"""Characterization tests for the shared Resource batch-ingest service.
+
+Issue #1255: REST ``ingest_batch`` and MCP ``handle_ingest_events`` become
+thin adapters over ``services.resource_ingest_service``. These tests pin the
+domain semantics both surfaces previously implemented independently, plus the
+per-surface wire strings the adapters must keep byte-compatible.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from db.constraint_names import (
+    RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE,
+    RESOURCE_EVENTS_UPSERT_UNIQUE,
+)
+from services import resource_ingest_service as svc
+from services.resource_ingest_service import (
+    IngestEventInput,
+    IngestItemError,
+    validate_events,
+)
+
+# ============================================================================
+# validate_events — domain validation shared by both surfaces
+# ============================================================================
+
+
+class TestValidateEvents:
+    def test_valid_upsert_passes(self):
+        valid, errors = validate_events(
+            [{"op": "upsert", "doc_id": "d1", "version": 1, "payload": {"x": 1}}]
+        )
+        assert errors == []
+        assert len(valid) == 1
+        ev = valid[0]
+        assert ev.index == 0
+        assert ev.op == "upsert"
+        assert ev.doc_id == "d1"
+        assert ev.version == 1
+        assert ev.payload == {"x": 1}
+        assert ev.importance == svc.DEFAULT_IMPORTANCE
+
+    def test_valid_delete_passes_without_version(self):
+        valid, errors = validate_events([{"op": "delete", "doc_id": "d1"}])
+        assert errors == []
+        assert valid[0].version is None
+        assert valid[0].payload is None
+
+    def test_valid_delete_with_version(self):
+        valid, errors = validate_events([{"op": "delete", "doc_id": "d1", "version": 5}])
+        assert errors == []
+        assert valid[0].version == 5
+
+    @pytest.mark.parametrize(
+        ("event", "kind"),
+        [
+            ("not a dict", svc.KIND_NOT_AN_OBJECT),
+            ({"op": "bogus", "doc_id": "d1"}, svc.KIND_INVALID_OP),
+            ({"op": "upsert"}, svc.KIND_MISSING_DOC_ID),
+            ({"op": "upsert", "doc_id": "d1"}, svc.KIND_PAYLOAD_REQUIRED),
+            (
+                {"op": "upsert", "doc_id": "d1", "payload": {"x": 1}, "version": "nan"},
+                svc.KIND_VERSION_NOT_INT,
+            ),
+            (
+                {"op": "upsert", "doc_id": "d1", "payload": {"x": 1}},
+                svc.KIND_VERSION_TOO_SMALL_UPSERT,
+            ),
+            (
+                {"op": "upsert", "doc_id": "d1", "payload": {"x": 1}, "version": 0},
+                svc.KIND_VERSION_TOO_SMALL_UPSERT,
+            ),
+            (
+                {
+                    "op": "upsert",
+                    "doc_id": "d1",
+                    "payload": {"x": 1},
+                    "version": 1,
+                    "importance": "high",
+                },
+                svc.KIND_IMPORTANCE_NOT_NUMBER,
+            ),
+            (
+                {
+                    "op": "upsert",
+                    "doc_id": "d1",
+                    "payload": {"x": 1},
+                    "version": 1,
+                    "importance": 1.5,
+                },
+                svc.KIND_IMPORTANCE_OUT_OF_RANGE,
+            ),
+            (
+                {"op": "delete", "doc_id": "d1", "payload": {"x": 1}},
+                svc.KIND_PAYLOAD_NOT_NULL_DELETE,
+            ),
+            ({"op": "delete", "doc_id": "d1", "version": 0}, svc.KIND_VERSION_TOO_SMALL),
+            ({"op": "delete", "doc_id": "d1", "version": "nan"}, svc.KIND_VERSION_NOT_INT),
+        ],
+    )
+    def test_invalid_events_classified(self, event, kind):
+        valid, errors = validate_events([event])
+        assert valid == []
+        assert len(errors) == 1
+        assert errors[0].kind == kind
+        assert errors[0].index == 0
+
+    def test_payload_size_is_measured_in_bytes(self):
+        # Multibyte payload: character count is under the cap, byte count over.
+        # The service uses bytes — the semantic MAX_PAYLOAD_SIZE_BYTES names.
+        big = {"t": "あ" * (svc.MAX_PAYLOAD_SIZE_BYTES // 3)}
+        valid, errors = validate_events(
+            [{"op": "upsert", "doc_id": "d1", "version": 1, "payload": big}]
+        )
+        assert valid == []
+        assert errors[0].kind == svc.KIND_PAYLOAD_TOO_LARGE
+        assert errors[0].detail["payload_size"] > svc.MAX_PAYLOAD_SIZE_BYTES
+
+    def test_explicit_null_importance_uses_default(self):
+        # Unified semantic: explicit null == absent == default (REST behavior;
+        # the MCP path previously rejected an explicit null).
+        valid, errors = validate_events(
+            [
+                {
+                    "op": "upsert",
+                    "doc_id": "d1",
+                    "version": 1,
+                    "payload": {"x": 1},
+                    "importance": None,
+                }
+            ]
+        )
+        assert errors == []
+        assert valid[0].importance == svc.DEFAULT_IMPORTANCE
+
+    def test_oversized_delete_payload_reports_size_before_null_rule(self):
+        # Precedence pin: the payload-size check runs before the
+        # delete-payload-must-be-null rule (both surfaces' historic order).
+        big = {"t": "x" * (svc.MAX_PAYLOAD_SIZE_BYTES + 1)}
+        valid, errors = validate_events([{"op": "delete", "doc_id": "d1", "payload": big}])
+        assert errors[0].kind == svc.KIND_PAYLOAD_TOO_LARGE
+
+    def test_indices_preserved_across_mixed_batch(self):
+        valid, errors = validate_events(
+            [
+                {"op": "bogus", "doc_id": "d0"},
+                {"op": "upsert", "doc_id": "d1", "version": 1, "payload": {"x": 1}},
+                {"op": "upsert", "doc_id": "d2"},
+            ]
+        )
+        assert [e.index for e in errors] == [0, 2]
+        assert [v.index for v in valid] == [1]
+
+
+# ============================================================================
+# persist_events — SAVEPOINT processing + constraint classification
+# ============================================================================
+
+
+def _make_input(index: int = 0, **overrides) -> IngestEventInput:
+    base = {
+        "index": index,
+        "op": "upsert",
+        "doc_id": f"d{index}",
+        "version": 1,
+        "payload": {"x": 1},
+        "idempotency_key": None,
+        "event_metadata": {},
+        "importance": 0.6,
+    }
+    base.update(overrides)
+    return IngestEventInput(**base)
+
+
+def _mock_db(connector_id=None):
+    db = AsyncMock()
+    connector_result = MagicMock()
+    connector_result.scalar_one_or_none.return_value = connector_id
+    db.execute.side_effect = [connector_result]
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    nested = AsyncMock()
+    nested.__aenter__ = AsyncMock(return_value=None)
+    nested.__aexit__ = AsyncMock(return_value=None)
+    db.begin_nested = MagicMock(return_value=nested)
+    return db
+
+
+def _integrity_error_for(constraint: str) -> IntegrityError:
+    # integrity_error_constraint_name reads error.orig.constraint_name
+    # (asyncpg shape) first — attach the name directly to the orig exception.
+    orig = Exception(f'violates constraint "{constraint}"')
+    orig.constraint_name = constraint  # type: ignore[attr-defined]
+    return IntegrityError("stmt", {}, orig)
+
+
+class TestPersistEvents:
+    @pytest.mark.asyncio
+    async def test_created_event_id_collected(self):
+        db = _mock_db()
+
+        def _add(obj):
+            obj.id = 42
+
+        db.add = MagicMock(side_effect=_add)
+        result = await svc.persist_events(
+            db, resource_id="res1", resource_pk=uuid4(), events=[_make_input()]
+        )
+        assert result.created_ids == [42]
+        assert result.errors == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("constraint", "kind"),
+        [
+            (RESOURCE_EVENTS_UPSERT_UNIQUE, svc.KIND_DUPLICATE_VERSION),
+            (RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE, svc.KIND_DUPLICATE_IDEMPOTENCY),
+            ("some_other_constraint", svc.KIND_CONSTRAINT_VIOLATION),
+        ],
+    )
+    async def test_integrity_errors_classified_by_constraint(self, constraint, kind):
+        db = _mock_db()
+        db.flush = AsyncMock(side_effect=_integrity_error_for(constraint))
+        result = await svc.persist_events(
+            db, resource_id="res1", resource_pk=uuid4(), events=[_make_input()]
+        )
+        assert result.created_ids == []
+        assert len(result.errors) == 1
+        assert result.errors[0].kind == kind
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_recorded_and_siblings_continue(self):
+        # Partial success: a non-IntegrityError on one event must not abort
+        # the sibling events (previously the MCP path failed the whole call).
+        db = _mock_db()
+        ids = iter([1, 2])
+
+        def _add(obj):
+            obj.id = next(ids)
+
+        db.add = MagicMock(side_effect=_add)
+        db.flush = AsyncMock(side_effect=[RuntimeError("boom"), None])
+        result = await svc.persist_events(
+            db,
+            resource_id="res1",
+            resource_pk=uuid4(),
+            events=[_make_input(0), _make_input(1)],
+        )
+        assert len(result.errors) == 1
+        assert result.errors[0].kind == svc.KIND_UNEXPECTED
+        assert result.errors[0].index == 0
+        assert len(result.created_ids) == 1
+
+    @pytest.mark.asyncio
+    async def test_invalid_idempotency_key_recorded_per_item(self):
+        db = _mock_db(connector_id=uuid4())
+        with patch(
+            "services.connector_provisioning.validate_connector_idempotency_key"
+        ) as mock_validate:
+            from utils.exceptions import ValidationError
+
+            mock_validate.side_effect = ValidationError("bad prefix")
+            result = await svc.persist_events(
+                db,
+                resource_id="res1",
+                resource_pk=uuid4(),
+                events=[_make_input(idempotency_key="wrong")],
+            )
+        assert result.created_ids == []
+        assert result.errors[0].kind == svc.KIND_IDEMPOTENCY_INVALID
+        assert result.errors[0].detail["message"] == "bad prefix"
+
+
+# ============================================================================
+# finalize_batch — the post-commit indexer boundary
+# ============================================================================
+
+
+class TestFinalizeBatch:
+    @pytest.mark.asyncio
+    async def test_commits_then_schedules_then_commits(self):
+        db = AsyncMock()
+        calls: list[str] = []
+        db.commit = AsyncMock(side_effect=lambda: calls.append("commit"))
+
+        async def _schedule(db_, ws, rid):
+            calls.append("schedule")
+
+        with patch("api.routes.resource_ingest._schedule_indexer_for_resource", new=_schedule):
+            await svc.finalize_batch(db, workspace_id=uuid4(), resource_id="res1", created_ids=[1])
+        assert calls == ["commit", "schedule", "commit"]
+
+    @pytest.mark.asyncio
+    async def test_no_indexer_when_nothing_created(self):
+        db = AsyncMock()
+        db.commit = AsyncMock()
+        with patch(
+            "api.routes.resource_ingest._schedule_indexer_for_resource",
+            new=AsyncMock(),
+        ) as mock_schedule:
+            await svc.finalize_batch(db, workspace_id=uuid4(), resource_id="res1", created_ids=[])
+        mock_schedule.assert_not_awaited()
+        db.commit.assert_awaited_once()
+
+
+# ============================================================================
+# Adapter wire-format parity — the per-surface strings are preserved
+# ============================================================================
+
+
+class TestAdapterErrorFormatting:
+    def test_rest_strings_are_byte_compatible(self):
+        from api.routes.resource_ingest import _format_batch_item_error as fmt
+
+        cases = {
+            svc.KIND_PAYLOAD_TOO_LARGE: (
+                {"payload_size": 123456, "max": svc.MAX_PAYLOAD_SIZE_BYTES},
+                "Payload too large: 123456 bytes",
+            ),
+            svc.KIND_IDEMPOTENCY_INVALID: ({"message": "bad prefix"}, "bad prefix"),
+            svc.KIND_DUPLICATE_VERSION: ({"version": 3}, "Duplicate version 3"),
+            svc.KIND_DUPLICATE_IDEMPOTENCY: ({}, "Duplicate idempotency key"),
+            svc.KIND_CONSTRAINT_VIOLATION: (
+                {"constraint": "x"},
+                "Database constraint violation",
+            ),
+            svc.KIND_UNEXPECTED: ({"message": "boom"}, "boom"),
+        }
+        for kind, (detail, expected) in cases.items():
+            out = fmt(IngestItemError(index=1, kind=kind, doc_id="d1", detail=detail))
+            assert out == {"index": 1, "doc_id": "d1", "error": expected}, kind
+
+    def test_mcp_strings_are_byte_compatible(self):
+        from mcp_server.tools.resource import _format_batch_item_error as fmt
+
+        cases = {
+            svc.KIND_NOT_AN_OBJECT: ({}, "event must be an object", False),
+            svc.KIND_INVALID_OP: ({"op": "bogus"}, "Invalid op: bogus", False),
+            svc.KIND_MISSING_DOC_ID: ({}, "Missing doc_id", False),
+            svc.KIND_PAYLOAD_REQUIRED: ({}, "payload required for upsert", False),
+            svc.KIND_VERSION_NOT_INT: ({}, "version must be an integer", False),
+            svc.KIND_VERSION_TOO_SMALL_UPSERT: (
+                {},
+                "version >= 1 required for upsert",
+                False,
+            ),
+            svc.KIND_PAYLOAD_TOO_LARGE: (
+                {"payload_size": 123456, "max": svc.MAX_PAYLOAD_SIZE_BYTES},
+                f"Payload too large: 123456 bytes (max {svc.MAX_PAYLOAD_SIZE_BYTES})",
+                False,
+            ),
+            svc.KIND_IMPORTANCE_NOT_NUMBER: ({}, "importance must be a number", False),
+            svc.KIND_IMPORTANCE_OUT_OF_RANGE: (
+                {},
+                "importance must be between 0.0 and 1.0",
+                False,
+            ),
+            svc.KIND_PAYLOAD_NOT_NULL_DELETE: (
+                {},
+                "payload must be null for delete",
+                False,
+            ),
+            svc.KIND_VERSION_TOO_SMALL: ({}, "version must be >= 1", False),
+            svc.KIND_IDEMPOTENCY_INVALID: ({"message": "bad prefix"}, "bad prefix", True),
+            svc.KIND_DUPLICATE_VERSION: (
+                {"version": 3},
+                "Duplicate version for doc_id=d1",
+                False,
+            ),
+            svc.KIND_DUPLICATE_IDEMPOTENCY: ({}, "Duplicate idempotency_key", False),
+            svc.KIND_CONSTRAINT_VIOLATION: (
+                {"constraint": "x"},
+                "Unable to ingest event due to a constraint violation",
+                False,
+            ),
+        }
+        for kind, (detail, expected, has_doc_id) in cases.items():
+            out = fmt(IngestItemError(index=1, kind=kind, doc_id="d1", detail=detail))
+            assert out["index"] == 1, kind
+            assert out["error"] == expected, kind
+            assert ("doc_id" in out) is has_doc_id, kind

--- a/backend/tests/services/test_resource_ingest_service.py
+++ b/backend/tests/services/test_resource_ingest_service.py
@@ -63,6 +63,15 @@ class TestValidateEvents:
         assert errors == []
         assert valid[0].payload is None
 
+    @pytest.mark.parametrize("bad_payload", [[], "", 0, False, [1], "x"])
+    def test_delete_with_non_dict_payload_rejected(self, bad_payload):
+        # Only None or {} is accepted for delete; falsy-but-non-null shapes
+        # must not slip through a bare truthiness check (Copilot finding on
+        # PR #1268).
+        valid, errors = validate_events([{"op": "delete", "doc_id": "d1", "payload": bad_payload}])
+        assert valid == []
+        assert errors[0].kind == svc.KIND_PAYLOAD_NOT_NULL_DELETE
+
     @pytest.mark.parametrize(
         ("event", "kind"),
         [
@@ -299,19 +308,27 @@ class TestFinalizeBatch:
         async def _schedule(db_, ws, rid):
             calls.append("schedule")
 
-        with patch("api.routes.resource_ingest._schedule_indexer_for_resource", new=_schedule):
-            await svc.finalize_batch(db, workspace_id=uuid4(), resource_id="res1", created_ids=[1])
+        await svc.finalize_batch(
+            db,
+            workspace_id=uuid4(),
+            resource_id="res1",
+            created_ids=[1],
+            schedule_indexer=_schedule,
+        )
         assert calls == ["commit", "schedule", "commit"]
 
     @pytest.mark.asyncio
     async def test_no_indexer_when_nothing_created(self):
         db = AsyncMock()
         db.commit = AsyncMock()
-        with patch(
-            "api.routes.resource_ingest._schedule_indexer_for_resource",
-            new=AsyncMock(),
-        ) as mock_schedule:
-            await svc.finalize_batch(db, workspace_id=uuid4(), resource_id="res1", created_ids=[])
+        mock_schedule = AsyncMock()
+        await svc.finalize_batch(
+            db,
+            workspace_id=uuid4(),
+            resource_id="res1",
+            created_ids=[],
+            schedule_indexer=mock_schedule,
+        )
         mock_schedule.assert_not_awaited()
         db.commit.assert_awaited_once()
 
@@ -384,6 +401,14 @@ class TestAdapterErrorFormatting:
             svc.KIND_CONSTRAINT_VIOLATION: (
                 {"constraint": "x"},
                 "Unable to ingest event due to a constraint violation",
+                False,
+            ),
+            # New wire string on this surface: a per-event unexpected failure
+            # previously aborted the whole MCP call; the generic message must
+            # never leak exception text.
+            svc.KIND_UNEXPECTED: (
+                {"message": "boom"},
+                "Unexpected error ingesting event",
                 False,
             ),
         }

--- a/backend/tests/services/test_resource_ingest_service.py
+++ b/backend/tests/services/test_resource_ingest_service.py
@@ -54,6 +54,15 @@ class TestValidateEvents:
         assert errors == []
         assert valid[0].version == 5
 
+    def test_delete_with_empty_dict_payload_normalized(self):
+        # REST's Pydantic gate always accepted `payload: {}` on delete
+        # (truthiness check) and the old REST loop inserted it; the service
+        # keeps that acceptance and normalizes the payload to None. The old
+        # MCP path rejected `{}` and is deliberately relaxed to match.
+        valid, errors = validate_events([{"op": "delete", "doc_id": "d1", "payload": {}}])
+        assert errors == []
+        assert valid[0].payload is None
+
     @pytest.mark.parametrize(
         ("event", "kind"),
         [


### PR DESCRIPTION
Closes #1255

## Summary
- Extracts the duplicated batch-ingest domain pipeline into `backend/src/services/resource_ingest_service.py`: per-event validation, authoritative `resource_pk` resolution, per-event SAVEPOINT persistence with constraint classification, and the commit + post-commit indexer boundary.
- REST `ingest_batch` and MCP `handle_ingest_events` become thin adapters: they keep authentication/authorization, quota (already shared via `resource_quota_service`), wire parsing, and render their historic error strings from structured error kinds — both envelopes stay byte-compatible.
- Adds 30 characterization tests pinning the shared validation/classification semantics and both adapters' wire strings; all 62 pre-existing adapter tests pass **unmodified**.

## Implementation notes
Deliberate unifications (each documented in the service and covered by tests):
- Payload size measured in UTF-8 **bytes** on both surfaces (REST previously counted `str` characters, under-counting multibyte payloads).
- Indexer scheduled once from a single **post-commit** boundary (REST relied on the `get_db` teardown auto-commit for IndexerState; MCP scheduled before commit). Trade-off for a scheduling failure after the first commit is documented in `finalize_batch`.
- A non-IntegrityError on one event records a per-item error and keeps partial success (the MCP path previously failed the whole call).
- `importance: null` and delete `payload: {}` take the REST semantics (default 0.6 / accepted-and-normalized); the MCP path is relaxed to match.

No database migration or schema change. Single-event REST path untouched.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1255-feat-refactor-resource-unify-rest-and-mcp-bat.gate1.md
- ~/.claude/cache/gh-issue-driven/1255-feat-refactor-resource-unify-rest-and-mcp-bat.gate2.md

🤖 Generated via /gh-issue-driven:ship
