### PR TITLE
feat(agents): Agent Registry — agents table + CRUD (#1274)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -11,6 +11,7 @@ from logging.config import fileConfig
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
+import models.agent  # noqa: F401  # Issue #1274: Agent Registry (RFC-0002 P0-1)
 import models.analysis  # noqa: F401  # Issue #494: Memory Broadlistening tables
 import models.auth  # noqa: F401
 import models.config  # noqa: F401

--- a/backend/alembic/versions/e63_1274_agents.py
+++ b/backend/alembic/versions/e63_1274_agents.py
@@ -1,0 +1,87 @@
+"""Add agents table — Agent Registry (RFC-0002 P0-1, #1274).
+
+Workspace-scoped registry of AI agents; the anchor for P0-2..P0-5 (bindings,
+agent-bound keys, bootstrap, correlation, access events). Pure additive
+migration (migration class 1 of docs/design/agent-registry-and-bindings.md):
+no existing table is touched, blue-green safe by the house definition. The
+``api_keys`` ALTERs are deliberately NOT here — they ship with P0-2 (#1275)
+as migration class 2.
+
+CHECK literals must stay byte-identical to the module-level tuples in
+``models/agent.py`` (the valid_delivery_mode drift-pin pattern, #886);
+drift is pinned by tests/test_agent_constants.py.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "e63_1274_agents"
+down_revision = "e62_1245_assign_mem_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agents",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("owner_user_id", sa.String(length=255), nullable=False),
+        sa.Column("framework", sa.String(length=100), nullable=True),
+        sa.Column("environment", sa.String(length=100), nullable=True),
+        sa.Column("version", sa.String(length=100), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+        sa.Column(
+            "enforcement_mode",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'enforce'"),
+        ),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "status IN ('active', 'suspended', 'retired')",
+            name="valid_agent_status",
+        ),
+        sa.CheckConstraint(
+            "enforcement_mode IN ('shadow', 'enforce')",
+            name="valid_agent_enforcement",
+        ),
+    )
+    op.create_index(
+        "uq_agents_workspace_name",
+        "agents",
+        ["workspace_id", "name"],
+        unique=True,
+    )
+    op.create_index(
+        "idx_agents_workspace",
+        "agents",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_agents_workspace", table_name="agents")
+    op.drop_index("uq_agents_workspace_name", table_name="agents")
+    op.drop_table("agents")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -499,6 +499,7 @@ from api.routes import (  # noqa: E402
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
     admin_sleep,  # Issue #247: Manual Sleep Maintenance trigger
     agent_state,  # Issue #906: REST surface for the agent session-state lane
+    agents,  # Issue #1274: Agent Registry CRUD (RFC-0002 P0-1)
     analyses,  # Issue #496: Memory Analysis API endpoints
     api_keys,
     attachments,  # Issue #330 → deprecated by #555 (returns HTTP 410 Gone)
@@ -570,6 +571,10 @@ app.include_router(share_keys.recall_router, prefix="/api/v1")
 
 # Issue #1128: zero-knowledge secret store (owner/admin management + member fetch).
 app.include_router(secrets.router, prefix="/api/v1")
+
+# Issue #1274 (RFC-0002 P0-1): Agent Registry — owner/admin-gated CRUD over
+# the workspace-scoped agents table (kill switch + enforcement ramp).
+app.include_router(agents.router, prefix="/api/v1")
 
 # Admin routes (Issue #43 - User management and system-wide stats)
 app.include_router(admin.router, prefix="/api/v1")

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -118,11 +118,18 @@ class AgentListResponse(BaseModel):
 
 
 def _actor(user: dict) -> tuple[str, str | None, UUID, dict[str, Any]]:
-    """Extract (user_id, email, workspace_id, audit-base-metadata) from auth."""
+    """Extract (user_id, email, workspace_id, audit-base-metadata) from auth.
+
+    ``via`` discriminates on the ``api_key_workspace_id`` KEY (present on
+    every API-key principal dict, including global keys where its value is
+    None) rather than on ``api_key_prefix`` truthiness — a programmatic call
+    whose prefix did not surface must still be attributed as ``api_key``,
+    not misclassified as ``session`` (Copilot review, PR #1279).
+    """
     user_id = user["user_id"]
     workspace_id = UUID(str(user["current_workspace_id"]))
     metadata: dict[str, Any] = {
-        "via": "api_key" if user.get("api_key_prefix") else "session",
+        "via": "api_key" if "api_key_workspace_id" in user else "session",
     }
     if user.get("api_key_prefix"):
         metadata["key_prefix"] = user["api_key_prefix"]

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -1,0 +1,270 @@
+"""Agent Registry REST routes (RFC-0002 P0-1, Issue #1274).
+
+Owner/admin-gated CRUD over the workspace-scoped ``agents`` table. The flat
+``/api/v1/agents`` namespace matches the F2 bootstrap companion
+(``POST /api/v1/agents/{agent_id}/bootstrap``, P0-3); the workspace boundary
+comes from the authenticated principal's active workspace, mirroring the
+other workspace-surface routes.
+
+Every mutation writes an ``audit_logs`` row via the security-mutation lane
+(``services.agent_registry_service.add_agent_audit_row``) and commits it
+atomically with the mutation. ``enforce`` → ``shadow`` transitions are
+recorded under the distinct ``agent_enforcement_widened`` action.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import require_workspace_admin
+from db.base import get_db
+from models.agent import Agent
+from models.api_base import TZAwareBaseModel
+from services.agent_registry_service import (
+    AUDIT_AGENT_DELETED,
+    AUDIT_AGENT_ENFORCEMENT_WIDENED,
+    AUDIT_AGENT_REGISTERED,
+    AUDIT_AGENT_UPDATED,
+    AgentRegistryService,
+    add_agent_audit_row,
+    enforcement_widened,
+)
+from utils.exceptions import NotFoundException, ValidationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/agents", tags=["agents"])
+
+
+# ============================================================================
+# Pydantic models
+# ============================================================================
+
+
+class AgentCreate(BaseModel):
+    """Request model for registering an agent."""
+
+    name: str = Field(..., min_length=1, max_length=255, description="Workspace-unique name")
+    description: str | None = Field(None, max_length=10_000)
+    framework: str | None = Field(
+        None, max_length=100, description="Free-form: 'claude-code', 'langgraph', ..."
+    )
+    environment: str | None = Field(
+        None, max_length=100, description="Aligned with OTel deployment.environment.name"
+    )
+    version: str | None = Field(
+        None, max_length=100, description="Agent build/prompt version (client-reported)"
+    )
+
+
+class AgentUpdate(BaseModel):
+    """Request model for a partial agent update.
+
+    Only fields explicitly present in the request body are applied
+    (``exclude_unset``), so ``null`` clears a metadata field while an absent
+    key leaves it untouched.
+    """
+
+    name: str | None = Field(None, min_length=1, max_length=255)
+    description: str | None = Field(None, max_length=10_000)
+    framework: str | None = Field(None, max_length=100)
+    environment: str | None = Field(None, max_length=100)
+    version: str | None = Field(None, max_length=100)
+    status: Literal["active", "suspended", "retired"] | None = Field(
+        None, description="Lifecycle kill switch (fail-closed for bound keys, P0-2)"
+    )
+    enforcement_mode: Literal["shadow", "enforce"] | None = Field(
+        None, description="Binding enforcement ramp; enforce→shadow is audited as widening"
+    )
+
+
+class AgentResponse(TZAwareBaseModel):
+    """Response model for one registry row."""
+
+    id: UUID
+    workspace_id: UUID
+    name: str
+    description: str | None = None
+    owner_user_id: str
+    framework: str | None = None
+    environment: str | None = None
+    version: str | None = None
+    status: str
+    enforcement_mode: str
+    last_seen_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class AgentListResponse(BaseModel):
+    """Response model for the workspace agent listing."""
+
+    agents: list[AgentResponse]
+    count: int
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+def _actor(user: dict) -> tuple[str, str | None, UUID, dict[str, Any]]:
+    """Extract (user_id, email, workspace_id, audit-base-metadata) from auth."""
+    user_id = user["user_id"]
+    workspace_id = UUID(str(user["current_workspace_id"]))
+    metadata: dict[str, Any] = {
+        "via": "api_key" if user.get("api_key_prefix") else "session",
+    }
+    if user.get("api_key_prefix"):
+        metadata["key_prefix"] = user["api_key_prefix"]
+    return user_id, user.get("email"), workspace_id, metadata
+
+
+async def _get_agent_or_404(
+    service: AgentRegistryService, workspace_id: UUID, agent_id: UUID
+) -> Agent:
+    agent = await service.get_agent(workspace_id, agent_id)
+    if agent is None:
+        # Uniform not-found inside the workspace boundary (the workspace
+        # filter in get_agent is the IDOR guard).
+        raise NotFoundException("Agent")
+    return agent
+
+
+# ============================================================================
+# Routes
+# ============================================================================
+
+
+@router.post("", response_model=AgentResponse, status_code=status.HTTP_201_CREATED)
+async def register_agent(
+    data: AgentCreate,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """Register an agent in the active workspace (owner/admin only)."""
+    user_id, email, workspace_id, metadata = _actor(user)
+    service = AgentRegistryService(db)
+    agent = await service.create_agent(
+        workspace_id=workspace_id,
+        name=data.name,
+        owner_user_id=user_id,
+        description=data.description,
+        framework=data.framework,
+        environment=data.environment,
+        version=data.version,
+    )
+    add_agent_audit_row(
+        db,
+        actor_user_id=user_id,
+        actor_email=email,
+        action=AUDIT_AGENT_REGISTERED,
+        agent_id=agent.id,
+        workspace_id=workspace_id,
+        metadata={**metadata, "agent_name": agent.name},
+    )
+    await db.commit()
+    await db.refresh(agent)
+    return agent
+
+
+@router.get("", response_model=AgentListResponse)
+async def list_agents(
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """List the active workspace's registered agents (owner/admin only)."""
+    _, _, workspace_id, _ = _actor(user)
+    agents = await AgentRegistryService(db).list_agents(workspace_id)
+    return AgentListResponse(
+        agents=[AgentResponse.model_validate(a) for a in agents],
+        count=len(agents),
+    )
+
+
+@router.get("/{agent_id}", response_model=AgentResponse)
+async def get_agent(
+    agent_id: UUID,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """Fetch one registered agent (owner/admin only)."""
+    _, _, workspace_id, _ = _actor(user)
+    return await _get_agent_or_404(AgentRegistryService(db), workspace_id, agent_id)
+
+
+@router.patch("/{agent_id}", response_model=AgentResponse)
+async def update_agent(
+    agent_id: UUID,
+    data: AgentUpdate,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """Partially update an agent, including status / enforcement transitions."""
+    user_id, email, workspace_id, metadata = _actor(user)
+    service = AgentRegistryService(db)
+    agent = await _get_agent_or_404(service, workspace_id, agent_id)
+
+    updates = data.model_dump(exclude_unset=True)
+    # `name=null` etc. are Pydantic-accepted bodies but these columns are
+    # non-nullable — reject explicitly instead of letting the service's
+    # isinstance check produce a less specific message.
+    for non_nullable in ("name", "status", "enforcement_mode"):
+        if non_nullable in updates and updates[non_nullable] is None:
+            raise ValidationError(f"'{non_nullable}' cannot be null.", field=non_nullable)
+
+    changes = await service.update_agent(agent, updates)
+    if changes:
+        widened = enforcement_widened(changes)
+        transition = changes.get("enforcement_mode") or changes.get("status")
+        add_agent_audit_row(
+            db,
+            actor_user_id=user_id,
+            actor_email=email,
+            action=AUDIT_AGENT_ENFORCEMENT_WIDENED if widened else AUDIT_AGENT_UPDATED,
+            agent_id=agent.id,
+            workspace_id=workspace_id,
+            metadata={**metadata, "agent_name": agent.name, "changes": changes},
+            old_value=transition.get("old") if transition else None,
+            new_value=transition.get("new") if transition else None,
+        )
+        await db.commit()
+        await db.refresh(agent)
+    return agent
+
+
+@router.delete("/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_agent(
+    agent_id: UUID,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Hard-delete a registry row (owner/admin only).
+
+    Operational retirement should normally use ``status='retired'``; hard
+    delete stays available and (from P0-2 on) cascades every bound key.
+    """
+    user_id, email, workspace_id, metadata = _actor(user)
+    service = AgentRegistryService(db)
+    agent = await _get_agent_or_404(service, workspace_id, agent_id)
+
+    add_agent_audit_row(
+        db,
+        actor_user_id=user_id,
+        actor_email=email,
+        action=AUDIT_AGENT_DELETED,
+        agent_id=agent.id,
+        workspace_id=workspace_id,
+        metadata={**metadata, "agent_name": agent.name},
+    )
+    await service.delete_agent(agent)
+    await db.commit()

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -116,6 +116,22 @@ class Settings(BaseSettings):
         default=60,
         description="Min seconds between contexts.last_used_at writes per context (Issue #1257)",
     )
+    # Issue #1274 (RFC-0002 P0-1): same pattern for agents.last_seen_at — the
+    # correlation/verify paths (P0-2/P0-4) mark the agent as seen, but a hot
+    # agent authenticates on every tool call, so the write is throttled to at
+    # most one per agent per window.
+    agent_last_seen_throttle_seconds: int = Field(
+        default=60,
+        description="Min seconds between agents.last_seen_at writes per agent (Issue #1274)",
+    )
+    # Issue #1274: registry rows are cheap control-plane metadata, so the cap
+    # is an anti-abuse guard (unbounded enumeration surface), not a plan knob.
+    # Applies to all plans; raise per deployment if a tenant legitimately runs
+    # a larger agent fleet.
+    max_agents_per_workspace: int = Field(
+        default=100,
+        description="Max registered agents per workspace (Issue #1274)",
+    )
     # ai-worker (kagura-chat-bridge) service auth. The worker presents this
     # as a Bearer token to GET /api/v1/workers/config (Spec 2026-06-02). Empty
     # disables the worker config endpoint (fail-closed). Use: openssl rand -hex 32.

--- a/backend/src/db/constraint_names.py
+++ b/backend/src/db/constraint_names.py
@@ -44,6 +44,14 @@ EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE = (
 # keys with the same key_name in one workspace). Created by migration a99.
 EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE = "uq_external_api_keys_workspace_key_name"
 
+# Issue #1274: unique index on agents (workspace_id, name). Created by
+# migration e63 + mirrored in models.agent.Agent.__table_args__. Used by
+# AgentRegistryService (create / rename) to close the duplicate-check→insert
+# TOCTOU race: concurrent registration of the same name loses the race at
+# flush, and the IntegrityError is mapped to the same ConflictError (409)
+# the pre-check produces; other IntegrityErrors propagate unchanged.
+AGENTS_WORKSPACE_NAME_UNIQUE = "uq_agents_workspace_name"
+
 
 def integrity_error_constraint_name(error: IntegrityError) -> str | None:
     """Return the PostgreSQL constraint name for ``error``, or ``None``.

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -59,6 +59,12 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "secret_get",
         "secret_list",
         "secret_revoke_grant",
+        # Issue #1274: Agent Registry — workspace-scoped, uses agent_id.
+        "register_agent",
+        "list_agents",
+        "get_agent",
+        "update_agent",
+        "delete_agent",
     }
 )
 
@@ -95,6 +101,10 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "secret_get",
         "secret_list",
         "secret_revoke_grant",
+        # Issue #1274: read-only registry introspection (owner/admin-gated;
+        # no embedding/LLM cost).
+        "list_agents",
+        "get_agent",
     }
 )
 
@@ -109,6 +119,13 @@ _TOOL_REGISTRY: dict[str, Any] | None = None
 
 def _build_registry() -> dict[str, Any]:
     """Build tool name → handler mapping."""
+    from mcp_server.tools.agent_registry import (
+        handle_delete_agent,
+        handle_get_agent,
+        handle_list_agents,
+        handle_register_agent,
+        handle_update_agent,
+    )
     from mcp_server.tools.analysis import (
         handle_analyze_context,
         handle_get_active_analysis,
@@ -223,6 +240,13 @@ def _build_registry() -> dict[str, Any]:
         "secret_get": handle_secret_get,
         "secret_list": handle_secret_list,
         "secret_revoke_grant": handle_secret_revoke_grant,
+        # Issue #1274 (RFC-0002 P0-1): Agent Registry — owner/admin-gated CRUD
+        # sharing AgentRegistryService with REST /api/v1/agents.
+        "register_agent": handle_register_agent,
+        "list_agents": handle_list_agents,
+        "get_agent": handle_get_agent,
+        "update_agent": handle_update_agent,
+        "delete_agent": handle_delete_agent,
     }
 
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2125,6 +2125,153 @@ Returns: {status, key, value, found}. found is false (value null) when the key i
                 "required": ["context_id"],
             },
         },
+        # Issue #1274 (RFC-0002 P0-1): Agent Registry — owner/admin-gated CRUD
+        # over the workspace-scoped agents table. Agents are resources, not
+        # principals: enforcement attaches to member keys in P0-2.
+        {
+            "name": "register_agent",
+            "description": """Register an AI agent in the workspace Agent Registry (owner/admin only, Issue #1274).
+
+An agent is a workspace-scoped registry entry (name unique per workspace) that
+anchors context bindings, agent-bound credentials, bootstrap, and audit
+correlation (RFC-0002). It is a resource, NOT a principal — it never
+authenticates by itself. New agents start with status='active' and
+enforcement_mode='enforce'.
+
+Returns: {status, agent: {id, name, status, enforcement_mode, ...}}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Workspace-unique agent name (max 255 chars).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Optional free-text description (max 10000 chars).",
+                    },
+                    "framework": {
+                        "type": "string",
+                        "description": "Optional framework tag, e.g. 'claude-code', 'langgraph' (max 100 chars).",
+                    },
+                    "environment": {
+                        "type": "string",
+                        "description": "Optional deployment environment, e.g. 'production', 'staging' (max 100 chars).",
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "Optional agent build/prompt version (max 100 chars).",
+                    },
+                },
+                "required": ["name"],
+            },
+        },
+        {
+            "name": "list_agents",
+            "readOnly": True,
+            "description": """List the workspace's registered agents (owner/admin only, Issue #1274).
+
+Returns every Agent Registry row in the active workspace, newest first,
+including status (active|suspended|retired) and enforcement_mode
+(shadow|enforce).
+
+Returns: {status, agents: [...], count}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+        {
+            "name": "get_agent",
+            "readOnly": True,
+            "description": """Fetch one registered agent by id (owner/admin only, Issue #1274).
+
+Returns: {status, agent: {id, name, status, enforcement_mode, ...}}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID from register_agent/list_agents.",
+                    },
+                },
+                "required": ["agent_id"],
+            },
+        },
+        {
+            "name": "update_agent",
+            "description": """Update a registered agent, including lifecycle transitions (owner/admin only, Issue #1274).
+
+status is the fail-closed kill switch: 'suspended'/'retired' agents cause
+every key bound to them to be rejected at verify time (P0-2). Setting
+enforcement_mode from 'enforce' to 'shadow' is an audited privilege-widening
+event (bindings stop being enforced and are only logged).
+
+Returns: {status, agent, changed: [field, ...]}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID to update.",
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "New workspace-unique name (max 255 chars).",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "New description; null clears it (max 10000 chars).",
+                    },
+                    "framework": {
+                        "type": "string",
+                        "description": "New framework tag; null clears it (max 100 chars).",
+                    },
+                    "environment": {
+                        "type": "string",
+                        "description": "New environment; null clears it (max 100 chars).",
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "New version; null clears it (max 100 chars).",
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["active", "suspended", "retired"],
+                        "description": "Lifecycle kill switch (fail-closed for bound keys).",
+                    },
+                    "enforcement_mode": {
+                        "type": "string",
+                        "enum": ["shadow", "enforce"],
+                        "description": "Binding enforcement ramp; enforce→shadow is audited as widening.",
+                    },
+                },
+                "required": ["agent_id"],
+            },
+        },
+        {
+            "name": "delete_agent",
+            "description": """Hard-delete an Agent Registry row (owner/admin only, Issue #1274).
+
+Prefer update_agent(status='retired') for operational retirement — delete is
+permanent and (from P0-2 on) cascades every API key bound to the agent
+(fail-closed).
+
+Returns: {status, deleted, agent_id}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID to delete.",
+                    },
+                },
+                "required": ["agent_id"],
+            },
+        },
         # Issue #1128: zero-knowledge secret store. The server stores opaque age
         # ciphertext + public recipient keys only and NEVER decrypts. Encryption
         # and decryption happen client-side (the `kagura secret` CLI / SDK).

--- a/backend/src/mcp_server/tools/agent_registry.py
+++ b/backend/src/mcp_server/tools/agent_registry.py
@@ -1,0 +1,291 @@
+"""MCP tools for the Agent Registry (RFC-0002 P0-1, Issue #1274).
+
+Owner/admin-gated CRUD over the workspace-scoped ``agents`` table, sharing
+``services.agent_registry_service`` with the REST surface
+(``api/routes/agents.py``). The gate sequence mirrors ``setup_resource``
+(role → validation → duplicate → plan gate → quota); validation, duplicate,
+and quota live in the service, the role gate lives here.
+
+Every mutation writes an ``audit_logs`` row via the security-mutation lane
+and commits it atomically with the mutation. ``enforce`` → ``shadow``
+transitions are recorded under the distinct ``agent_enforcement_widened``
+action.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import _error_response, _success_response
+
+# Fields accepted by update_agent, forwarded verbatim to the service (which
+# validates values and rejects unknown fields).
+_UPDATABLE_FIELDS: tuple[str, ...] = (
+    "name",
+    "description",
+    "framework",
+    "environment",
+    "version",
+    "status",
+    "enforcement_mode",
+)
+
+
+def _parse_agent_id(raw: Any) -> UUID | None:
+    """Parse an ``agent_id`` argument; None when malformed."""
+    try:
+        return UUID(str(raw))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+def _serialize_agent(agent: Any) -> dict[str, Any]:
+    """Registry row → JSON-safe dict (Z-suffixed UTC timestamps)."""
+    from utils.datetime import to_utc_iso
+
+    return {
+        "id": str(agent.id),
+        "workspace_id": str(agent.workspace_id),
+        "name": agent.name,
+        "description": agent.description,
+        "owner_user_id": agent.owner_user_id,
+        "framework": agent.framework,
+        "environment": agent.environment,
+        "version": agent.version,
+        "status": agent.status,
+        "enforcement_mode": agent.enforcement_mode,
+        "last_seen_at": to_utc_iso(agent.last_seen_at),
+        "created_at": to_utc_iso(agent.created_at),
+        "updated_at": to_utc_iso(agent.updated_at),
+    }
+
+
+async def handle_register_agent(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Register an agent in the active workspace (owner/admin only)."""
+    if "name" not in args:
+        return _error_response("missing_fields", "Missing required field: name")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+    from mcp_server.tools.resource import _check_owner_admin_role
+    from services.agent_registry_service import (
+        AUDIT_AGENT_REGISTERED,
+        AgentRegistryService,
+        add_agent_audit_row,
+    )
+    from utils.exceptions import ConflictError, QuotaExceededError, ValidationError
+
+    async for db in get_db():
+        role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+        if role_err:
+            return role_err
+
+        service = AgentRegistryService(db)
+        try:
+            agent = await service.create_agent(
+                workspace_id=workspace_id,
+                name=args["name"],
+                owner_user_id=user_id,
+                description=args.get("description"),
+                framework=args.get("framework"),
+                environment=args.get("environment"),
+                version=args.get("version"),
+            )
+        except ValidationError as e:
+            return _error_response("validation_error", e.message)
+        except ConflictError as e:
+            return _error_response("agent_name_conflict", e.message)
+        except QuotaExceededError as e:
+            return _error_response("quota_exceeded", e.message)
+
+        add_agent_audit_row(
+            db,
+            actor_user_id=user_id,
+            actor_email=None,
+            action=AUDIT_AGENT_REGISTERED,
+            agent_id=agent.id,
+            workspace_id=workspace_id,
+            metadata={"via": "mcp", "agent_name": agent.name},
+        )
+        await db.commit()
+        await db.refresh(agent)
+        return _success_response(agent=_serialize_agent(agent))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_list_agents(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List the active workspace's registered agents (owner/admin only)."""
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+    from mcp_server.tools.resource import _check_owner_admin_role
+    from services.agent_registry_service import AgentRegistryService
+
+    async for db in get_db():
+        role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+        if role_err:
+            return role_err
+
+        agents = await AgentRegistryService(db).list_agents(workspace_id)
+        return _success_response(agents=[_serialize_agent(a) for a in agents], count=len(agents))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_get_agent(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Fetch one registered agent by id (owner/admin only)."""
+    if "agent_id" not in args:
+        return _error_response("missing_fields", "Missing required field: agent_id")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+    agent_id = _parse_agent_id(args["agent_id"])
+    if agent_id is None:
+        return _error_response("validation_error", "agent_id must be a UUID.")
+
+    from db.base import get_db
+    from mcp_server.tools.resource import _check_owner_admin_role
+    from services.agent_registry_service import AgentRegistryService
+
+    async for db in get_db():
+        role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+        if role_err:
+            return role_err
+
+        agent = await AgentRegistryService(db).get_agent(workspace_id, agent_id)
+        if agent is None:
+            return _error_response("agent_not_found", "Agent not found in your workspace.")
+        return _success_response(agent=_serialize_agent(agent))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_update_agent(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Partially update an agent, including status / enforcement transitions."""
+    if "agent_id" not in args:
+        return _error_response("missing_fields", "Missing required field: agent_id")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+    agent_id = _parse_agent_id(args["agent_id"])
+    if agent_id is None:
+        return _error_response("validation_error", "agent_id must be a UUID.")
+
+    updates = {k: args[k] for k in _UPDATABLE_FIELDS if k in args}
+    if not updates:
+        return _error_response(
+            "missing_fields",
+            f"Provide at least one updatable field: {', '.join(_UPDATABLE_FIELDS)}",
+        )
+
+    from db.base import get_db
+    from mcp_server.tools.resource import _check_owner_admin_role
+    from services.agent_registry_service import (
+        AUDIT_AGENT_ENFORCEMENT_WIDENED,
+        AUDIT_AGENT_UPDATED,
+        AgentRegistryService,
+        add_agent_audit_row,
+        enforcement_widened,
+    )
+    from utils.exceptions import ConflictError, ValidationError
+
+    async for db in get_db():
+        role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+        if role_err:
+            return role_err
+
+        service = AgentRegistryService(db)
+        agent = await service.get_agent(workspace_id, agent_id)
+        if agent is None:
+            return _error_response("agent_not_found", "Agent not found in your workspace.")
+
+        try:
+            changes = await service.update_agent(agent, updates)
+        except ValidationError as e:
+            return _error_response("validation_error", e.message)
+        except ConflictError as e:
+            return _error_response("agent_name_conflict", e.message)
+
+        if changes:
+            widened = enforcement_widened(changes)
+            transition = changes.get("enforcement_mode") or changes.get("status")
+            add_agent_audit_row(
+                db,
+                actor_user_id=user_id,
+                actor_email=None,
+                action=AUDIT_AGENT_ENFORCEMENT_WIDENED if widened else AUDIT_AGENT_UPDATED,
+                agent_id=agent.id,
+                workspace_id=workspace_id,
+                metadata={"via": "mcp", "agent_name": agent.name, "changes": changes},
+                old_value=transition.get("old") if transition else None,
+                new_value=transition.get("new") if transition else None,
+            )
+            await db.commit()
+            await db.refresh(agent)
+        return _success_response(agent=_serialize_agent(agent), changed=sorted(changes))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_delete_agent(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Hard-delete a registry row (owner/admin only).
+
+    Operational retirement should normally use ``status='retired'``; from
+    P0-2 on, hard delete cascades every key bound to the agent (fail-closed).
+    """
+    if "agent_id" not in args:
+        return _error_response("missing_fields", "Missing required field: agent_id")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+    agent_id = _parse_agent_id(args["agent_id"])
+    if agent_id is None:
+        return _error_response("validation_error", "agent_id must be a UUID.")
+
+    from db.base import get_db
+    from mcp_server.tools.resource import _check_owner_admin_role
+    from services.agent_registry_service import (
+        AUDIT_AGENT_DELETED,
+        AgentRegistryService,
+        add_agent_audit_row,
+    )
+
+    async for db in get_db():
+        role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+        if role_err:
+            return role_err
+
+        service = AgentRegistryService(db)
+        agent = await service.get_agent(workspace_id, agent_id)
+        if agent is None:
+            return _error_response("agent_not_found", "Agent not found in your workspace.")
+
+        deleted_id: uuid.UUID = agent.id
+        add_agent_audit_row(
+            db,
+            actor_user_id=user_id,
+            actor_email=None,
+            action=AUDIT_AGENT_DELETED,
+            agent_id=deleted_id,
+            workspace_id=workspace_id,
+            metadata={"via": "mcp", "agent_name": agent.name},
+        )
+        await service.delete_agent(agent)
+        await db.commit()
+        return _success_response(deleted=True, agent_id=str(deleted_id))
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -8,6 +8,7 @@
 # mapper resolution. Mirrors the explicit imports in
 # ``backend/tests/conftest.py`` so production startup matches the
 # test environment's import graph (#531).
+import models.agent  # noqa: F401  # Issue #1274: Agent Registry (RFC-0002 P0-1)
 import models.agent_state  # noqa: F401  # Issue #889: agent session-state lane
 import models.analysis  # noqa: F401
 import models.file_objects  # noqa: F401  # Issue #485: file storage

--- a/backend/src/models/agent.py
+++ b/backend/src/models/agent.py
@@ -1,0 +1,119 @@
+"""Agent Registry (RFC-0002 P0-1, Issue #1274).
+
+Workspace-scoped registry of AI agents. An agent is a **resource, not a
+principal** (design invariant, ``docs/design/agent-registry-and-bindings.md``):
+it never authenticates by itself — enforcement attaches to member API keys
+that gain a nullable ``agent_id`` pointer in P0-2. This table is the anchor
+every other RFC-0002 P0 item builds on (bindings, bootstrap, correlation,
+access events).
+
+``status`` is the fail-closed kill switch: ``suspended``/``retired`` agents
+cause every key bound to them to be rejected at verify time (one row update
+beats revoking N keys). ``enforcement_mode='shadow'`` records binding
+violations as would-deny audit rows while requests proceed under legacy
+semantics — the migration ramp for binding existing, in-use keys.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+# Agent lifecycle kill switch. CHECK constraint is derived from this tuple
+# (registration order, single quotes) byte-identically to the alembic
+# migration literal — the ``valid_delivery_mode`` drift-pin pattern (#886).
+# New values are APPENDED, never reordered; drift is pinned by
+# tests/test_agent_constants.py.
+AGENT_STATUS_ACTIVE = "active"
+AGENT_STATUS_SUSPENDED = "suspended"
+AGENT_STATUS_RETIRED = "retired"
+_ALL_AGENT_STATUSES: tuple[str, ...] = (
+    AGENT_STATUS_ACTIVE,
+    AGENT_STATUS_SUSPENDED,
+    AGENT_STATUS_RETIRED,
+)
+
+# Enforcement ramp for P0-2 bindings. ``enforce`` → ``shadow`` is an audited
+# privilege-widening transition (it silently widens every key bound to the
+# agent back to full member scope).
+AGENT_ENFORCEMENT_SHADOW = "shadow"
+AGENT_ENFORCEMENT_ENFORCE = "enforce"
+_ALL_AGENT_ENFORCEMENT_MODES: tuple[str, ...] = (
+    AGENT_ENFORCEMENT_SHADOW,
+    AGENT_ENFORCEMENT_ENFORCE,
+)
+
+
+class Agent(Base):
+    """One row per registered agent, unique by ``(workspace_id, name)``.
+
+    ``id`` doubles as the OTel ``gen_ai.agent.id`` correlation anchor (P0-4);
+    ``name`` maps to ``gen_ai.agent.name``. ``framework`` / ``environment`` /
+    ``version`` are free-form client-reported metadata (open set, no CHECK).
+    """
+
+    __tablename__ = "agents"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # OAuth sub; plain string per repo convention (cf. workspaces.owner_user_id).
+    # Pseudonymized by account_erasure_service for erased subjects whose rows
+    # survive (agents in co-owned workspaces that are not hard-deleted).
+    owner_user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    framework: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    environment: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    version: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=AGENT_STATUS_ACTIVE,
+        server_default=text("'active'"),
+    )
+    enforcement_mode: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=AGENT_ENFORCEMENT_ENFORCE,
+        server_default=text("'enforce'"),
+    )
+    # Write-throttled like api_keys.last_used_at (#947) — see
+    # AgentRegistryService.touch_last_seen. Naive UTC by convention.
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # CHECKs derived from the module-level tuples (registration order,
+        # single quotes, exact whitespace), byte-identical to the alembic
+        # migration literal so create_all and the migration head never drift.
+        CheckConstraint(
+            f"status IN ({', '.join(repr(s) for s in _ALL_AGENT_STATUSES)})",
+            name="valid_agent_status",
+        ),
+        CheckConstraint(
+            f"enforcement_mode IN ({', '.join(repr(m) for m in _ALL_AGENT_ENFORCEMENT_MODES)})",
+            name="valid_agent_enforcement",
+        ),
+        Index("uq_agents_workspace_name", "workspace_id", "name", unique=True),
+        Index("idx_agents_workspace", "workspace_id"),
+    )

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -59,6 +59,11 @@ DERIVED_MOAT_TABLES: frozenset[str] = frozenset(
 
 OPERATIONAL_TABLES: frozenset[str] = frozenset(
     {
+        # Agent Registry (#1274, RFC-0002 P0-1) — control-plane metadata about
+        # agent deployments (kill switch, enforcement mode); no user knowledge
+        # content, no learned structure. Governed by the auth/security regime +
+        # GDPR erasure (workspace cascade + owner_user_id pseudonymization).
+        "agents",
         "users",
         "user_oauth_providers",
         "oauth_authorization_codes",

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -45,6 +45,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config.settings import get_settings
 from db.qdrant import delete_user_points
 from db.redis import clear_co_activations, clear_user_rate_limits, get_redis_client
+from models.agent import Agent
 from models.auth import (
     APIKey,
     AuditLog,
@@ -1019,6 +1020,14 @@ class AccountErasureService:
         # contexts/memories/edges/etc.
         counts["workspaces"] = await self._count_and_delete(
             Workspace, Workspace.owner_user_id == user_id
+        )
+
+        # Pseudonymize agents.owner_user_id (#1274, RFC-0002 P0-1) AFTER the
+        # workspace cascade so the count reflects only survivors — agents in
+        # co-owned (transferred) workspaces whose rows outlive the erased
+        # subject. Same legal-retention posture as plan_changes.changed_by.
+        counts["agents_pseudonymized"] = await self._pseudonymize_field(
+            Agent, Agent.owner_user_id, user_id
         )
 
         # Finally the user row itself.

--- a/backend/src/services/agent_registry_service.py
+++ b/backend/src/services/agent_registry_service.py
@@ -1,0 +1,345 @@
+"""Agent Registry service (RFC-0002 P0-1, Issue #1274).
+
+Workspace-scoped CRUD over the ``agents`` table, shared by the REST routes
+(``api/routes/agents.py``) and the MCP tools
+(``mcp_server/tools/agent_registry.py``). Both surfaces are owner/admin-gated
+by their own auth helpers; this service owns validation, duplicate checks,
+the anti-abuse quota, the audit-lane rows, and the ``last_seen_at`` write
+throttle.
+
+Audit convention (design doc "Audit requirements for registry/binding CRUD"):
+every mutation adds an ``audit_logs`` row via :func:`add_agent_audit_row`
+mirroring ``member_api_key_provisioned``. The row is added to the session but
+NOT committed — the caller commits it atomically with the mutation it audits.
+``enforce`` → ``shadow`` is recorded under the distinct
+``agent_enforcement_widened`` action: it silently widens every key bound to
+the agent back to full member scope (privilege-widening, containment off).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Any
+
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.settings import get_settings
+from models.agent import (
+    _ALL_AGENT_ENFORCEMENT_MODES,
+    _ALL_AGENT_STATUSES,
+    AGENT_ENFORCEMENT_ENFORCE,
+    AGENT_ENFORCEMENT_SHADOW,
+    Agent,
+)
+from utils.datetime import utcnow
+from utils.exceptions import ConflictError, QuotaExceededError, ValidationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Column-derived length caps, enforced here so overlong values return a
+# structured 422 instead of a DB-layer 500.
+_NAME_MAX_LEN = 255
+_META_MAX_LEN = 100
+_DESCRIPTION_MAX_LEN = 10_000
+
+# Free-form metadata fields updatable without transition rules (open set,
+# no CHECK — matches the DDL).
+_MUTABLE_TEXT_FIELDS: tuple[str, ...] = ("description", "framework", "environment", "version")
+
+# Audit action vocabulary (security-mutation lane).
+AUDIT_AGENT_REGISTERED = "agent_registered"
+AUDIT_AGENT_UPDATED = "agent_updated"
+AUDIT_AGENT_ENFORCEMENT_WIDENED = "agent_enforcement_widened"
+AUDIT_AGENT_DELETED = "agent_deleted"
+
+
+def validate_agent_name(name: Any) -> str:
+    """Validate and normalize an agent name. Returns the stripped name.
+
+    Raises:
+        ValidationError: If the name is not a non-empty string of at most
+            255 characters after stripping.
+    """
+    if not isinstance(name, str):
+        raise ValidationError("'name' must be a string", field="name")
+    stripped = name.strip()
+    if not stripped:
+        raise ValidationError("'name' must be a non-empty string", field="name")
+    if len(stripped) > _NAME_MAX_LEN:
+        raise ValidationError(f"'name' must be at most {_NAME_MAX_LEN} characters", field="name")
+    return stripped
+
+
+def _validate_optional_text(value: Any, field: str, max_len: int) -> str | None:
+    """Validate an optional free-form text field; None passes through."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ValidationError(f"'{field}' must be a string", field=field)
+    if len(value) > max_len:
+        raise ValidationError(f"'{field}' must be at most {max_len} characters", field=field)
+    return value
+
+
+def validate_agent_status(value: Any) -> str:
+    """Validate a ``status`` value against the CHECK tuple."""
+    if value not in _ALL_AGENT_STATUSES:
+        raise ValidationError(
+            f"'status' must be one of {list(_ALL_AGENT_STATUSES)}", field="status"
+        )
+    return value
+
+
+def validate_agent_enforcement_mode(value: Any) -> str:
+    """Validate an ``enforcement_mode`` value against the CHECK tuple."""
+    if value not in _ALL_AGENT_ENFORCEMENT_MODES:
+        raise ValidationError(
+            f"'enforcement_mode' must be one of {list(_ALL_AGENT_ENFORCEMENT_MODES)}",
+            field="enforcement_mode",
+        )
+    return value
+
+
+def add_agent_audit_row(
+    db: AsyncSession,
+    *,
+    actor_user_id: str,
+    actor_email: str | None,
+    action: str,
+    agent_id: uuid.UUID,
+    workspace_id: uuid.UUID,
+    metadata: dict[str, Any] | None = None,
+    old_value: str | None = None,
+    new_value: str | None = None,
+) -> None:
+    """Add a security-mutation ``audit_logs`` row for a registry mutation.
+
+    Mirrors ``audit_programmatic_workspace_action`` (#1164/#1165): the row is
+    added to the session but NOT committed — the caller commits atomically
+    with the audited mutation. ``old_value``/``new_value`` follow the
+    established role-transition precedent (``auth/roles.py``): short
+    non-sensitive enum values are stored raw in the hash columns.
+    """
+    from models.auth import AuditLog
+
+    db.add(
+        AuditLog(
+            user_email=actor_email or f"{actor_user_id}@api",
+            user_id=actor_user_id,
+            action=action,
+            resource=f"agent:{agent_id}",
+            old_value_hash=old_value,
+            new_value_hash=new_value,
+            user_metadata={"workspace_id": str(workspace_id), **(metadata or {})},
+        )
+    )
+    logger.info(
+        "agent_registry_mutation",
+        action=action,
+        agent_id=str(agent_id),
+        workspace_id=str(workspace_id),
+        actor_id=actor_user_id,
+    )
+
+
+class AgentRegistryService:
+    """CRUD + throttled liveness writes for the Agent Registry."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_agent(self, workspace_id: uuid.UUID, agent_id: uuid.UUID) -> Agent | None:
+        """Fetch one agent by id within the workspace boundary.
+
+        The workspace filter is the IDOR guard: a caller can never address
+        another workspace's agent even with a valid UUID.
+        """
+        result = await self.db.execute(
+            select(Agent).where(Agent.id == agent_id, Agent.workspace_id == workspace_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_agent_by_name(self, workspace_id: uuid.UUID, name: str) -> Agent | None:
+        """Fetch one agent by its workspace-unique name."""
+        result = await self.db.execute(
+            select(Agent).where(Agent.workspace_id == workspace_id, Agent.name == name)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_agents(self, workspace_id: uuid.UUID) -> list[Agent]:
+        """List all agents in the workspace, newest first."""
+        result = await self.db.execute(
+            select(Agent)
+            .where(Agent.workspace_id == workspace_id)
+            .order_by(Agent.created_at.desc(), Agent.id)
+        )
+        return list(result.scalars().all())
+
+    async def count_agents(self, workspace_id: uuid.UUID) -> int:
+        """Count registry rows in the workspace (quota input)."""
+        result = await self.db.execute(
+            select(func.count()).select_from(Agent).where(Agent.workspace_id == workspace_id)
+        )
+        return int(result.scalar_one())
+
+    async def create_agent(
+        self,
+        *,
+        workspace_id: uuid.UUID,
+        name: str,
+        owner_user_id: str,
+        description: str | None = None,
+        framework: str | None = None,
+        environment: str | None = None,
+        version: str | None = None,
+    ) -> Agent:
+        """Register an agent following the setup_resource gate sequence.
+
+        Gate order (after the surface's role check): validation → duplicate →
+        plan gate → quota. Registry rows are cheap control-plane metadata, so
+        no plan tier restricts them (the plan gate is a documented no-op); the
+        quota is the anti-abuse ``max_agents_per_workspace`` settings cap.
+
+        The row is flushed (PK assigned) but NOT committed — the caller
+        commits atomically with its audit row.
+
+        Raises:
+            ValidationError: On malformed fields.
+            ConflictError: If the name is already registered in the workspace.
+            QuotaExceededError: If the workspace hit the registry cap.
+        """
+        clean_name = validate_agent_name(name)
+        clean_description = _validate_optional_text(
+            description, "description", _DESCRIPTION_MAX_LEN
+        )
+        clean_framework = _validate_optional_text(framework, "framework", _META_MAX_LEN)
+        clean_environment = _validate_optional_text(environment, "environment", _META_MAX_LEN)
+        clean_version = _validate_optional_text(version, "version", _META_MAX_LEN)
+
+        if await self.get_agent_by_name(workspace_id, clean_name):
+            raise ConflictError(
+                f"Agent '{clean_name}' already exists in this workspace.",
+            )
+
+        # Plan gate: intentionally none — registry rows carry no embedding/LLM
+        # cost and every plan may operate agents. Quota (anti-abuse cap) still
+        # applies below.
+        max_agents = get_settings().max_agents_per_workspace
+        if await self.count_agents(workspace_id) >= max_agents:
+            raise QuotaExceededError(
+                f"Agent registry limit reached ({max_agents} per workspace).",
+                quota_type="agents",
+            )
+
+        agent = Agent(
+            workspace_id=workspace_id,
+            name=clean_name,
+            owner_user_id=owner_user_id,
+            description=clean_description,
+            framework=clean_framework,
+            environment=clean_environment,
+            version=clean_version,
+        )
+        self.db.add(agent)
+        await self.db.flush()
+        return agent
+
+    async def update_agent(
+        self, agent: Agent, updates: dict[str, Any]
+    ) -> dict[str, dict[str, Any]]:
+        """Apply a validated partial update; returns ``{field: {old, new}}``.
+
+        Recognized fields: ``name``, the free-form metadata fields, and the
+        governed transitions ``status`` / ``enforcement_mode``. Unknown fields
+        raise ValidationError so callers cannot silently write arbitrary
+        columns. No-op assignments (same value) are dropped from the change
+        set so audit rows record only real transitions.
+
+        Changes are applied to the ORM row but NOT committed — the caller
+        commits atomically with its audit row.
+        """
+        changes: dict[str, dict[str, Any]] = {}
+
+        for field, raw in updates.items():
+            if field == "name":
+                new_name = validate_agent_name(raw)
+                if new_name != agent.name:
+                    existing = await self.get_agent_by_name(agent.workspace_id, new_name)
+                    if existing and existing.id != agent.id:
+                        raise ConflictError(
+                            f"Agent '{new_name}' already exists in this workspace.",
+                        )
+                    changes["name"] = {"old": agent.name, "new": new_name}
+                    agent.name = new_name
+            elif field in _MUTABLE_TEXT_FIELDS:
+                max_len = _DESCRIPTION_MAX_LEN if field == "description" else _META_MAX_LEN
+                new_value = _validate_optional_text(raw, field, max_len)
+                if new_value != getattr(agent, field):
+                    changes[field] = {"old": getattr(agent, field), "new": new_value}
+                    setattr(agent, field, new_value)
+            elif field == "status":
+                new_status = validate_agent_status(raw)
+                if new_status != agent.status:
+                    changes["status"] = {"old": agent.status, "new": new_status}
+                    agent.status = new_status
+            elif field == "enforcement_mode":
+                new_mode = validate_agent_enforcement_mode(raw)
+                if new_mode != agent.enforcement_mode:
+                    changes["enforcement_mode"] = {
+                        "old": agent.enforcement_mode,
+                        "new": new_mode,
+                    }
+                    agent.enforcement_mode = new_mode
+            else:
+                raise ValidationError(f"Unknown agent field: '{field}'", field=field)
+
+        if changes:
+            await self.db.flush()
+        return changes
+
+    async def delete_agent(self, agent: Agent) -> None:
+        """Hard-delete a registry row (admin operation).
+
+        Operational retirement is ``status='retired'``, not row deletion —
+        but hard delete stays available for admins; in P0-2 the
+        ``api_keys.agent_id ON DELETE CASCADE`` makes it fail-closed (every
+        bound key dies with the agent). NOT committed — the caller commits
+        atomically with its audit row.
+        """
+        await self.db.delete(agent)
+        await self.db.flush()
+
+    async def touch_last_seen(self, agent_id: uuid.UUID) -> bool:
+        """Throttled ``last_seen_at`` write (mirrors api_keys #947).
+
+        At most one UPDATE per agent per
+        ``agent_last_seen_throttle_seconds`` window, so hot correlation/verify
+        paths (P0-2/P0-4) do not turn every request into a row UPDATE. Returns
+        True when a write happened. Not committed — piggybacks on the caller's
+        transaction.
+        """
+        now = utcnow().replace(tzinfo=None)
+        throttle = timedelta(seconds=get_settings().agent_last_seen_throttle_seconds)
+        result = await self.db.execute(
+            update(Agent)
+            .where(
+                Agent.id == agent_id,
+                or_(Agent.last_seen_at.is_(None), Agent.last_seen_at <= now - throttle),
+            )
+            .values(last_seen_at=now)
+        )
+        return bool(getattr(result, "rowcount", 0))
+
+
+def enforcement_widened(changes: dict[str, dict[str, Any]]) -> bool:
+    """True when the change set contains the audited ``enforce`` → ``shadow``
+    privilege-widening transition."""
+    mode_change = changes.get("enforcement_mode")
+    return bool(
+        mode_change
+        and mode_change.get("old") == AGENT_ENFORCEMENT_ENFORCE
+        and mode_change.get("new") == AGENT_ENFORCEMENT_SHADOW
+    )

--- a/backend/src/services/agent_registry_service.py
+++ b/backend/src/services/agent_registry_service.py
@@ -244,7 +244,7 @@ class AgentRegistryService:
             version=clean_version,
         )
         self.db.add(agent)
-        await self.db.flush()
+        await self._flush_mapping_duplicate_name(clean_name)
         return agent
 
     async def update_agent(
@@ -297,8 +297,36 @@ class AgentRegistryService:
                 raise ValidationError(f"Unknown agent field: '{field}'", field=field)
 
         if changes:
-            await self.db.flush()
+            await self._flush_mapping_duplicate_name(agent.name)
         return changes
+
+    async def _flush_mapping_duplicate_name(self, name: str) -> None:
+        """Flush, mapping a ``uq_agents_workspace_name`` race to ConflictError.
+
+        The pre-insert duplicate SELECT and the flush are not atomic
+        (TOCTOU): concurrent registration of the same name — e.g. replicas
+        of one agent self-registering on startup — loses the race at flush
+        with an IntegrityError that would otherwise surface as a misleading
+        503 (REST) or a raw driver string (MCP). Same posture as
+        ``setup_resource`` / ``external_keys``: recognize the constraint BY
+        NAME via db.constraint_names and re-raise as the same 409 the
+        pre-check produces; any other IntegrityError propagates unchanged.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        from db.constraint_names import (
+            AGENTS_WORKSPACE_NAME_UNIQUE,
+            integrity_error_constraint_name,
+        )
+
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            if integrity_error_constraint_name(exc) == AGENTS_WORKSPACE_NAME_UNIQUE:
+                raise ConflictError(
+                    f"Agent '{name}' already exists in this workspace.",
+                ) from exc
+            raise
 
     async def delete_agent(self, agent: Agent) -> None:
         """Hard-delete a registry row (admin operation).

--- a/backend/tests/api/test_agents_routes.py
+++ b/backend/tests/api/test_agents_routes.py
@@ -111,13 +111,32 @@ class TestRegisterAgent:
     @pytest.mark.asyncio
     async def test_api_key_actor_records_prefix(self, db, service, audit):
         service.create_agent.return_value = _fake_agent()
-        user = {**MOCK_USER, "api_key_prefix": "km_test_prefix"}
+        user = {
+            **MOCK_USER,
+            "api_key_workspace_id": WORKSPACE_ID,
+            "api_key_prefix": "km_test_prefix",
+        }
 
         await register_agent(data=AgentCreate(name="ci-bot"), user=user, db=db)
 
         metadata = audit.call_args.kwargs["metadata"]
         assert metadata["via"] == "api_key"
         assert metadata["key_prefix"] == "km_test_prefix"
+
+    @pytest.mark.asyncio
+    async def test_api_key_actor_without_prefix_still_api_key(self, db, service, audit):
+        """A programmatic principal whose prefix did not surface must not be
+        misclassified as session (Copilot review, PR #1279) — the
+        api_key_workspace_id KEY (present even when None, i.e. global keys)
+        is the discriminator."""
+        service.create_agent.return_value = _fake_agent()
+        user = {**MOCK_USER, "api_key_workspace_id": None}
+
+        await register_agent(data=AgentCreate(name="ci-bot"), user=user, db=db)
+
+        metadata = audit.call_args.kwargs["metadata"]
+        assert metadata["via"] == "api_key"
+        assert "key_prefix" not in metadata
 
 
 class TestGetAndList:

--- a/backend/tests/api/test_agents_routes.py
+++ b/backend/tests/api/test_agents_routes.py
@@ -1,0 +1,233 @@
+"""Route-surface tests for the Agent Registry REST lane (Issue #1274).
+
+Pins the REST wiring around a monkeypatched AgentRegistryService + audit
+helper. Load-bearing contracts:
+- workspace comes from the authenticated principal's active workspace, and
+  ``get_agent`` filters by it (uniform 404 inside the boundary — CWE-639);
+- every mutation writes exactly one audit row and commits atomically;
+- ``enforce`` → ``shadow`` transitions are recorded under the distinct
+  ``agent_enforcement_widened`` action;
+- a no-op PATCH writes no audit row and does not commit.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import api.routes.agents as agents_routes
+from api.routes.agents import (
+    AgentCreate,
+    AgentUpdate,
+    delete_agent,
+    get_agent,
+    list_agents,
+    register_agent,
+    update_agent,
+)
+from utils.exceptions import NotFoundException, ValidationError
+
+WORKSPACE_ID = uuid.uuid4()
+MOCK_USER = {
+    "user_id": "user-1",
+    "email": "u@example.com",
+    "current_workspace_id": str(WORKSPACE_ID),
+}
+
+
+def _fake_agent(**overrides):
+    defaults = {
+        "id": uuid.uuid4(),
+        "workspace_id": WORKSPACE_ID,
+        "name": "ci-bot",
+        "description": None,
+        "owner_user_id": "user-1",
+        "framework": None,
+        "environment": None,
+        "version": None,
+        "status": "active",
+        "enforcement_mode": "enforce",
+        "last_seen_at": None,
+        "created_at": datetime(2026, 7, 14, 0, 0, 0),
+        "updated_at": datetime(2026, 7, 14, 0, 0, 0),
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.fixture
+def db():
+    session = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def service(monkeypatch):
+    instance = MagicMock(
+        create_agent=AsyncMock(),
+        list_agents=AsyncMock(return_value=[]),
+        get_agent=AsyncMock(),
+        update_agent=AsyncMock(return_value={}),
+        delete_agent=AsyncMock(),
+    )
+    monkeypatch.setattr(agents_routes, "AgentRegistryService", MagicMock(return_value=instance))
+    return instance
+
+
+@pytest.fixture
+def audit(monkeypatch):
+    recorder = MagicMock()
+    monkeypatch.setattr(agents_routes, "add_agent_audit_row", recorder)
+    return recorder
+
+
+class TestRegisterAgent:
+    @pytest.mark.asyncio
+    async def test_creates_audits_and_commits(self, db, service, audit):
+        agent = _fake_agent()
+        service.create_agent.return_value = agent
+
+        result = await register_agent(
+            data=AgentCreate(name="ci-bot", framework="claude-code"),
+            user=MOCK_USER,
+            db=db,
+        )
+
+        assert result is agent
+        create_kwargs = service.create_agent.await_args.kwargs
+        assert create_kwargs["workspace_id"] == WORKSPACE_ID
+        assert create_kwargs["owner_user_id"] == "user-1"
+        audit.assert_called_once()
+        assert audit.call_args.kwargs["action"] == "agent_registered"
+        assert audit.call_args.kwargs["metadata"]["via"] == "session"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_api_key_actor_records_prefix(self, db, service, audit):
+        service.create_agent.return_value = _fake_agent()
+        user = {**MOCK_USER, "api_key_prefix": "km_test_prefix"}
+
+        await register_agent(data=AgentCreate(name="ci-bot"), user=user, db=db)
+
+        metadata = audit.call_args.kwargs["metadata"]
+        assert metadata["via"] == "api_key"
+        assert metadata["key_prefix"] == "km_test_prefix"
+
+
+class TestGetAndList:
+    @pytest.mark.asyncio
+    async def test_get_unknown_agent_is_uniform_404(self, db, service):
+        service.get_agent.return_value = None
+        with pytest.raises(NotFoundException) as exc:
+            await get_agent(agent_id=uuid.uuid4(), user=MOCK_USER, db=db)
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_get_scopes_lookup_to_active_workspace(self, db, service):
+        agent = _fake_agent()
+        service.get_agent.return_value = agent
+        result = await get_agent(agent_id=agent.id, user=MOCK_USER, db=db)
+        assert result is agent
+        service.get_agent.assert_awaited_once_with(WORKSPACE_ID, agent.id)
+
+    @pytest.mark.asyncio
+    async def test_list_returns_envelope(self, db, service):
+        service.list_agents.return_value = [_fake_agent()]
+        result = await list_agents(user=MOCK_USER, db=db)
+        assert result.count == 1
+        assert result.agents[0].name == "ci-bot"
+
+
+class TestUpdateAgent:
+    @pytest.mark.asyncio
+    async def test_transition_audited_with_old_new(self, db, service, audit):
+        agent = _fake_agent()
+        service.get_agent.return_value = agent
+        service.update_agent.return_value = {"status": {"old": "active", "new": "suspended"}}
+
+        await update_agent(
+            agent_id=agent.id,
+            data=AgentUpdate(status="suspended"),
+            user=MOCK_USER,
+            db=db,
+        )
+
+        kwargs = audit.call_args.kwargs
+        assert kwargs["action"] == "agent_updated"
+        assert kwargs["old_value"] == "active"
+        assert kwargs["new_value"] == "suspended"
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_enforce_to_shadow_uses_widening_action(self, db, service, audit):
+        agent = _fake_agent()
+        service.get_agent.return_value = agent
+        service.update_agent.return_value = {
+            "enforcement_mode": {"old": "enforce", "new": "shadow"}
+        }
+
+        await update_agent(
+            agent_id=agent.id,
+            data=AgentUpdate(enforcement_mode="shadow"),
+            user=MOCK_USER,
+            db=db,
+        )
+
+        assert audit.call_args.kwargs["action"] == "agent_enforcement_widened"
+
+    @pytest.mark.asyncio
+    async def test_noop_update_skips_audit_and_commit(self, db, service, audit):
+        agent = _fake_agent()
+        service.get_agent.return_value = agent
+        service.update_agent.return_value = {}
+
+        result = await update_agent(
+            agent_id=agent.id,
+            data=AgentUpdate(status="active"),
+            user=MOCK_USER,
+            db=db,
+        )
+
+        assert result is agent
+        audit.assert_not_called()
+        db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_explicit_null_name_rejected(self, db, service):
+        service.get_agent.return_value = _fake_agent()
+        with pytest.raises(ValidationError) as exc:
+            await update_agent(
+                agent_id=uuid.uuid4(),
+                data=AgentUpdate.model_construct(name=None),
+                user=MOCK_USER,
+                db=db,
+            )
+        assert exc.value.status_code == 422
+        service.update_agent.assert_not_awaited()
+
+
+class TestDeleteAgent:
+    @pytest.mark.asyncio
+    async def test_audits_before_delete_and_commits(self, db, service, audit):
+        agent = _fake_agent()
+        service.get_agent.return_value = agent
+
+        await delete_agent(agent_id=agent.id, user=MOCK_USER, db=db)
+
+        assert audit.call_args.kwargs["action"] == "agent_deleted"
+        service.delete_agent.assert_awaited_once_with(agent)
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_404_no_audit(self, db, service, audit):
+        service.get_agent.return_value = None
+        with pytest.raises(NotFoundException):
+            await delete_agent(agent_id=uuid.uuid4(), user=MOCK_USER, db=db)
+        audit.assert_not_called()
+        db.commit.assert_not_awaited()

--- a/backend/tests/mcp_server/test_agent_registry_tools.py
+++ b/backend/tests/mcp_server/test_agent_registry_tools.py
@@ -1,0 +1,265 @@
+"""Unit tests for the Agent Registry MCP handlers (Issue #1274).
+
+Pins the gate order (workspace → owner/admin role → service) and the
+arg/dispatch contract of the five ``*_agent`` handlers without a database —
+the service and role gate are mocked. DB-backed behaviour is covered by the
+service unit tests and the migration/drift integration gates.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_server.tools._helpers import _error_response
+from mcp_server.tools.agent_registry import (
+    handle_delete_agent,
+    handle_get_agent,
+    handle_list_agents,
+    handle_register_agent,
+    handle_update_agent,
+)
+
+WORKSPACE_ID = uuid.uuid4()
+
+
+def _payload(result):
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+def _fake_agent(**overrides):
+    defaults = {
+        "id": uuid.uuid4(),
+        "workspace_id": WORKSPACE_ID,
+        "name": "ci-bot",
+        "description": None,
+        "owner_user_id": "user-1",
+        "framework": None,
+        "environment": None,
+        "version": None,
+        "status": "active",
+        "enforcement_mode": "enforce",
+        "last_seen_at": None,
+        "created_at": None,
+        "updated_at": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _enter(stack, *, service, role_error=None):
+    """Enter the standard patch set; returns (service, audit recorder)."""
+
+    async def gen():
+        yield AsyncMock()
+
+    stack.enter_context(patch("db.base.get_db", new=gen))
+    stack.enter_context(
+        patch(
+            "mcp_server.tools.resource._check_owner_admin_role",
+            new=AsyncMock(return_value=role_error),
+        )
+    )
+    stack.enter_context(
+        patch(
+            "services.agent_registry_service.AgentRegistryService",
+            return_value=service,
+        )
+    )
+    audit = MagicMock()
+    stack.enter_context(patch("services.agent_registry_service.add_agent_audit_row", new=audit))
+    return service, audit
+
+
+class TestRegisterAgent:
+    @pytest.mark.asyncio
+    async def test_missing_name_returns_error(self):
+        result = await handle_register_agent(args={}, user_id="u", workspace_id=WORKSPACE_ID)
+        assert _payload(result)["error"] == "missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_returns_error(self):
+        result = await handle_register_agent(
+            args={"name": "ci-bot"}, user_id="u", workspace_id=None
+        )
+        assert _payload(result)["error"] == "workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_role_gate_short_circuits_before_service(self):
+        svc = MagicMock(create_agent=AsyncMock())
+        with ExitStack() as stack:
+            _enter(
+                stack,
+                service=svc,
+                role_error=_error_response("permission_denied", "owner/admin only"),
+            )
+            result = await handle_register_agent(
+                args={"name": "ci-bot"}, user_id="u", workspace_id=WORKSPACE_ID
+            )
+        assert _payload(result)["error"] == "permission_denied"
+        svc.create_agent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_success_audits_and_serializes(self):
+        agent = _fake_agent()
+        svc = MagicMock(create_agent=AsyncMock(return_value=agent))
+        with ExitStack() as stack:
+            _, audit = _enter(stack, service=svc)
+            result = await handle_register_agent(
+                args={"name": "ci-bot", "framework": "claude-code"},
+                user_id="user-1",
+                workspace_id=WORKSPACE_ID,
+            )
+        body = _payload(result)
+        assert body["status"] == "success"
+        assert body["agent"]["name"] == "ci-bot"
+        assert body["agent"]["enforcement_mode"] == "enforce"
+        audit.assert_called_once()
+        assert audit.call_args.kwargs["action"] == "agent_registered"
+        assert audit.call_args.kwargs["metadata"]["via"] == "mcp"
+
+    @pytest.mark.asyncio
+    async def test_duplicate_maps_to_agent_name_conflict(self):
+        from utils.exceptions import ConflictError
+
+        svc = MagicMock(create_agent=AsyncMock(side_effect=ConflictError("Agent exists")))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_register_agent(
+                args={"name": "ci-bot"}, user_id="u", workspace_id=WORKSPACE_ID
+            )
+        assert _payload(result)["error"] == "agent_name_conflict"
+
+
+class TestListAndGet:
+    @pytest.mark.asyncio
+    async def test_list_is_owner_admin_gated(self):
+        svc = MagicMock(list_agents=AsyncMock())
+        with ExitStack() as stack:
+            _enter(
+                stack,
+                service=svc,
+                role_error=_error_response("permission_denied", "owner/admin only"),
+            )
+            result = await handle_list_agents(args={}, user_id="u", workspace_id=WORKSPACE_ID)
+        assert _payload(result)["error"] == "permission_denied"
+        svc.list_agents.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_list_returns_count(self):
+        svc = MagicMock(list_agents=AsyncMock(return_value=[_fake_agent(), _fake_agent()]))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_list_agents(args={}, user_id="u", workspace_id=WORKSPACE_ID)
+        body = _payload(result)
+        assert body["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_get_malformed_uuid_rejected(self):
+        result = await handle_get_agent(
+            args={"agent_id": "not-a-uuid"}, user_id="u", workspace_id=WORKSPACE_ID
+        )
+        assert _payload(result)["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_get_unknown_agent_uniform_not_found(self):
+        svc = MagicMock(get_agent=AsyncMock(return_value=None))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_get_agent(
+                args={"agent_id": str(uuid.uuid4())},
+                user_id="u",
+                workspace_id=WORKSPACE_ID,
+            )
+        assert _payload(result)["error"] == "agent_not_found"
+
+
+class TestUpdateAgent:
+    @pytest.mark.asyncio
+    async def test_no_updatable_fields_rejected(self):
+        result = await handle_update_agent(
+            args={"agent_id": str(uuid.uuid4())}, user_id="u", workspace_id=WORKSPACE_ID
+        )
+        assert _payload(result)["error"] == "missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_widening_transition_uses_distinct_action(self):
+        agent = _fake_agent(enforcement_mode="shadow")
+        svc = MagicMock(
+            get_agent=AsyncMock(return_value=agent),
+            update_agent=AsyncMock(
+                return_value={"enforcement_mode": {"old": "enforce", "new": "shadow"}}
+            ),
+        )
+        with ExitStack() as stack:
+            _, audit = _enter(stack, service=svc)
+            result = await handle_update_agent(
+                args={"agent_id": str(agent.id), "enforcement_mode": "shadow"},
+                user_id="u",
+                workspace_id=WORKSPACE_ID,
+            )
+        body = _payload(result)
+        assert body["status"] == "success"
+        assert body["changed"] == ["enforcement_mode"]
+        assert audit.call_args.kwargs["action"] == "agent_enforcement_widened"
+        assert audit.call_args.kwargs["old_value"] == "enforce"
+        assert audit.call_args.kwargs["new_value"] == "shadow"
+
+    @pytest.mark.asyncio
+    async def test_noop_update_writes_no_audit(self):
+        agent = _fake_agent()
+        svc = MagicMock(
+            get_agent=AsyncMock(return_value=agent),
+            update_agent=AsyncMock(return_value={}),
+        )
+        with ExitStack() as stack:
+            _, audit = _enter(stack, service=svc)
+            result = await handle_update_agent(
+                args={"agent_id": str(agent.id), "status": "active"},
+                user_id="u",
+                workspace_id=WORKSPACE_ID,
+            )
+        assert _payload(result)["status"] == "success"
+        audit.assert_not_called()
+
+
+class TestDeleteAgent:
+    @pytest.mark.asyncio
+    async def test_delete_audits_then_deletes(self):
+        agent = _fake_agent()
+        svc = MagicMock(
+            get_agent=AsyncMock(return_value=agent),
+            delete_agent=AsyncMock(),
+        )
+        with ExitStack() as stack:
+            _, audit = _enter(stack, service=svc)
+            result = await handle_delete_agent(
+                args={"agent_id": str(agent.id)},
+                user_id="u",
+                workspace_id=WORKSPACE_ID,
+            )
+        body = _payload(result)
+        assert body["deleted"] is True
+        assert body["agent_id"] == str(agent.id)
+        assert audit.call_args.kwargs["action"] == "agent_deleted"
+        svc.delete_agent.assert_awaited_once_with(agent)
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_no_audit(self):
+        svc = MagicMock(get_agent=AsyncMock(return_value=None), delete_agent=AsyncMock())
+        with ExitStack() as stack:
+            _, audit = _enter(stack, service=svc)
+            result = await handle_delete_agent(
+                args={"agent_id": str(uuid.uuid4())},
+                user_id="u",
+                workspace_id=WORKSPACE_ID,
+            )
+        assert _payload(result)["error"] == "agent_not_found"
+        audit.assert_not_called()
+        svc.delete_agent.assert_not_called()

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -954,3 +954,29 @@ class TestDeletePostgresSweep:
         assert counts["context_read_attributions"] == 3
         swept_models = [call.args[0] for call in svc._count_and_delete.await_args_list]
         assert ContextReadAttribution in swept_models
+
+    @pytest.mark.asyncio
+    async def test_sweep_pseudonymizes_surviving_agents(self):
+        """#1274 (RFC-0002 P0-1): agents.owner_user_id must be pseudonymized
+        for erased subjects whose registry rows survive (agents in co-owned,
+        transferred workspaces — sole-owner workspaces cascade the rows away
+        before this step)."""
+        from models.agent import Agent
+
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=0)
+        svc._pseudonymize_field = AsyncMock(return_value=2)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        target = _user()
+
+        counts = await svc._delete_postgres(target)
+
+        assert counts["agents_pseudonymized"] == 2
+        pseudonymized = [call.args[0] for call in svc._pseudonymize_field.await_args_list]
+        assert Agent in pseudonymized
+        agent_call = next(
+            call for call in svc._pseudonymize_field.await_args_list if call.args[0] is Agent
+        )
+        assert agent_call.args[1] is Agent.owner_user_id
+        assert agent_call.args[2] == target.user_id

--- a/backend/tests/services/test_agent_registry_service.py
+++ b/backend/tests/services/test_agent_registry_service.py
@@ -154,6 +154,46 @@ class TestCreateAgent:
                 framework="x" * 101,
             )
 
+    @pytest.mark.asyncio
+    async def test_flush_race_on_unique_name_maps_to_conflict(self):
+        """TOCTOU loser at flush gets the same 409 as the pre-check.
+
+        The pre-insert SELECT and the flush are not atomic; a concurrent
+        registration of the same name fires uq_agents_workspace_name at
+        flush. The IntegrityError must map to ConflictError — not leak as a
+        503 (REST) or a raw driver string (MCP).
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        orig = Exception("duplicate key")
+        orig.constraint_name = "uq_agents_workspace_name"  # type: ignore[attr-defined]  # asyncpg shape
+        service = _service_with_mocks(
+            get_agent_by_name=AsyncMock(return_value=None),
+            count_agents=AsyncMock(return_value=0),
+        )
+        service.db.flush = AsyncMock(side_effect=IntegrityError("INSERT INTO agents ...", {}, orig))
+        with pytest.raises(ConflictError):
+            await service.create_agent(
+                workspace_id=WORKSPACE_ID, name="ci-bot", owner_user_id="user-1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_flush_unrelated_integrity_error_propagates(self):
+        """Only the named constraint maps to 409; other IntegrityErrors stay raw."""
+        from sqlalchemy.exc import IntegrityError
+
+        orig = Exception("fk violation")
+        orig.constraint_name = "agents_workspace_id_fkey"  # type: ignore[attr-defined]
+        service = _service_with_mocks(
+            get_agent_by_name=AsyncMock(return_value=None),
+            count_agents=AsyncMock(return_value=0),
+        )
+        service.db.flush = AsyncMock(side_effect=IntegrityError("INSERT INTO agents ...", {}, orig))
+        with pytest.raises(IntegrityError):
+            await service.create_agent(
+                workspace_id=WORKSPACE_ID, name="ci-bot", owner_user_id="user-1"
+            )
+
 
 # ---------------------------------------------------------------------------
 # update_agent transitions

--- a/backend/tests/services/test_agent_registry_service.py
+++ b/backend/tests/services/test_agent_registry_service.py
@@ -1,0 +1,277 @@
+"""Unit tests for AgentRegistryService (RFC-0002 P0-1, Issue #1274).
+
+Covers the pure validators, the gate order inside ``create_agent``
+(duplicate before quota), governed ``update_agent`` transitions with the
+old→new change set, the ``enforce``→``shadow`` widening detector, the
+throttled ``touch_last_seen`` write, and the audit-row helper's field
+mapping. DB access is mocked — migration/round-trip coverage lives in the
+integration gates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.agent import Agent
+from services.agent_registry_service import (
+    AUDIT_AGENT_ENFORCEMENT_WIDENED,
+    AUDIT_AGENT_REGISTERED,
+    AgentRegistryService,
+    add_agent_audit_row,
+    enforcement_widened,
+    validate_agent_enforcement_mode,
+    validate_agent_name,
+    validate_agent_status,
+)
+from utils.exceptions import ConflictError, QuotaExceededError, ValidationError
+
+WORKSPACE_ID = uuid.uuid4()
+
+
+def _make_agent(**overrides) -> Agent:
+    """Plain ORM instance (no DB) with sane defaults for update tests."""
+    defaults = {
+        "id": uuid.uuid4(),
+        "workspace_id": WORKSPACE_ID,
+        "name": "ci-bot",
+        "description": None,
+        "owner_user_id": "user-1",
+        "framework": None,
+        "environment": None,
+        "version": None,
+        "status": "active",
+        "enforcement_mode": "enforce",
+    }
+    defaults.update(overrides)
+    return Agent(**defaults)
+
+
+def _service_with_mocks(**method_overrides) -> AgentRegistryService:
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.execute = AsyncMock()
+    db.delete = AsyncMock()
+    service = AgentRegistryService(db)
+    for name, value in method_overrides.items():
+        setattr(service, name, value)
+    return service
+
+
+# ---------------------------------------------------------------------------
+# Pure validators
+# ---------------------------------------------------------------------------
+
+
+class TestValidators:
+    def test_name_stripped_and_returned(self):
+        assert validate_agent_name("  ci-bot  ") == "ci-bot"
+
+    @pytest.mark.parametrize("bad", [None, 42, "", "   ", "x" * 256])
+    def test_bad_names_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            validate_agent_name(bad)
+
+    @pytest.mark.parametrize("value", ["active", "suspended", "retired"])
+    def test_valid_statuses(self, value):
+        assert validate_agent_status(value) == value
+
+    @pytest.mark.parametrize("bad", ["deleted", "ACTIVE", "", None, 1])
+    def test_bad_statuses_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            validate_agent_status(bad)
+
+    @pytest.mark.parametrize("value", ["shadow", "enforce"])
+    def test_valid_enforcement_modes(self, value):
+        assert validate_agent_enforcement_mode(value) == value
+
+    @pytest.mark.parametrize("bad", ["off", "Enforce", "", None])
+    def test_bad_enforcement_modes_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            validate_agent_enforcement_mode(bad)
+
+
+# ---------------------------------------------------------------------------
+# create_agent gate order
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgent:
+    @pytest.mark.asyncio
+    async def test_duplicate_name_raises_conflict_before_quota(self):
+        service = _service_with_mocks(
+            get_agent_by_name=AsyncMock(return_value=_make_agent()),
+            count_agents=AsyncMock(),
+        )
+        with pytest.raises(ConflictError):
+            await service.create_agent(
+                workspace_id=WORKSPACE_ID, name="ci-bot", owner_user_id="user-1"
+            )
+        # Gate order: the duplicate check fires before the quota count.
+        service.count_agents.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_quota_cap_raises(self):
+        from config.settings import get_settings
+
+        service = _service_with_mocks(
+            get_agent_by_name=AsyncMock(return_value=None),
+            count_agents=AsyncMock(return_value=get_settings().max_agents_per_workspace),
+        )
+        with pytest.raises(QuotaExceededError):
+            await service.create_agent(
+                workspace_id=WORKSPACE_ID, name="ci-bot", owner_user_id="user-1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_success_strips_name_and_flushes(self):
+        service = _service_with_mocks(
+            get_agent_by_name=AsyncMock(return_value=None),
+            count_agents=AsyncMock(return_value=0),
+        )
+        agent = await service.create_agent(
+            workspace_id=WORKSPACE_ID,
+            name="  ci-bot  ",
+            owner_user_id="user-1",
+            framework="claude-code",
+        )
+        assert agent.name == "ci-bot"
+        assert agent.framework == "claude-code"
+        service.db.add.assert_called_once_with(agent)
+        service.db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_overlong_metadata_rejected(self):
+        service = _service_with_mocks()
+        with pytest.raises(ValidationError):
+            await service.create_agent(
+                workspace_id=WORKSPACE_ID,
+                name="ci-bot",
+                owner_user_id="user-1",
+                framework="x" * 101,
+            )
+
+
+# ---------------------------------------------------------------------------
+# update_agent transitions
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAgent:
+    @pytest.mark.asyncio
+    async def test_status_transition_recorded_old_new(self):
+        service = _service_with_mocks()
+        agent = _make_agent()
+        changes = await service.update_agent(agent, {"status": "suspended"})
+        assert changes == {"status": {"old": "active", "new": "suspended"}}
+        assert agent.status == "suspended"
+
+    @pytest.mark.asyncio
+    async def test_noop_assignment_dropped_from_change_set(self):
+        service = _service_with_mocks()
+        agent = _make_agent()
+        changes = await service.update_agent(agent, {"status": "active"})
+        assert changes == {}
+        service.db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_rejected(self):
+        service = _service_with_mocks()
+        with pytest.raises(ValidationError):
+            await service.update_agent(_make_agent(), {"owner_user_id": "attacker"})
+
+    @pytest.mark.asyncio
+    async def test_rename_checks_duplicate(self):
+        other = _make_agent(name="taken")
+        service = _service_with_mocks(get_agent_by_name=AsyncMock(return_value=other))
+        with pytest.raises(ConflictError):
+            await service.update_agent(_make_agent(), {"name": "taken"})
+
+    @pytest.mark.asyncio
+    async def test_metadata_field_cleared_with_none(self):
+        service = _service_with_mocks()
+        agent = _make_agent(framework="claude-code")
+        changes = await service.update_agent(agent, {"framework": None})
+        assert changes == {"framework": {"old": "claude-code", "new": None}}
+        assert agent.framework is None
+
+
+class TestEnforcementWidened:
+    def test_enforce_to_shadow_is_widening(self):
+        assert enforcement_widened({"enforcement_mode": {"old": "enforce", "new": "shadow"}})
+
+    def test_shadow_to_enforce_is_not_widening(self):
+        assert not enforcement_widened({"enforcement_mode": {"old": "shadow", "new": "enforce"}})
+
+    def test_unrelated_changes_are_not_widening(self):
+        assert not enforcement_widened({"status": {"old": "active", "new": "retired"}})
+        assert not enforcement_widened({})
+
+
+# ---------------------------------------------------------------------------
+# touch_last_seen throttle
+# ---------------------------------------------------------------------------
+
+
+class TestTouchLastSeen:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_row_written(self):
+        service = _service_with_mocks()
+        service.db.execute = AsyncMock(return_value=SimpleNamespace(rowcount=1))
+        assert await service.touch_last_seen(uuid.uuid4()) is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_throttled(self):
+        # Inside the throttle window the WHERE clause matches no row.
+        service = _service_with_mocks()
+        service.db.execute = AsyncMock(return_value=SimpleNamespace(rowcount=0))
+        assert await service.touch_last_seen(uuid.uuid4()) is False
+
+
+# ---------------------------------------------------------------------------
+# Audit-row helper
+# ---------------------------------------------------------------------------
+
+
+class TestAuditRow:
+    def test_row_fields_mirror_security_mutation_lane(self):
+        db = MagicMock()
+        agent_id = uuid.uuid4()
+        add_agent_audit_row(
+            db,
+            actor_user_id="user-1",
+            actor_email=None,
+            action=AUDIT_AGENT_REGISTERED,
+            agent_id=agent_id,
+            workspace_id=WORKSPACE_ID,
+            metadata={"via": "mcp", "agent_name": "ci-bot"},
+        )
+        row = db.add.call_args[0][0]
+        assert row.action == AUDIT_AGENT_REGISTERED
+        assert row.resource == f"agent:{agent_id}"
+        assert row.user_id == "user-1"
+        # Email fallback mirrors audit_programmatic_workspace_action.
+        assert row.user_email == "user-1@api"
+        assert row.user_metadata["workspace_id"] == str(WORKSPACE_ID)
+        assert row.user_metadata["via"] == "mcp"
+
+    def test_transition_values_recorded_in_hash_columns(self):
+        db = MagicMock()
+        add_agent_audit_row(
+            db,
+            actor_user_id="user-1",
+            actor_email="u@example.com",
+            action=AUDIT_AGENT_ENFORCEMENT_WIDENED,
+            agent_id=uuid.uuid4(),
+            workspace_id=WORKSPACE_ID,
+            old_value="enforce",
+            new_value="shadow",
+        )
+        row = db.add.call_args[0][0]
+        assert row.user_email == "u@example.com"
+        # Raw enum values per the roles.py transition precedent.
+        assert row.old_value_hash == "enforce"
+        assert row.new_value_hash == "shadow"

--- a/backend/tests/test_agent_constants.py
+++ b/backend/tests/test_agent_constants.py
@@ -1,0 +1,75 @@
+"""Regression tests for #1274: Agent Registry constant + CHECK invariants.
+
+The ``agents`` CHECK constraints are derived from ordered Python tuples
+(``_ALL_AGENT_STATUSES`` / ``_ALL_AGENT_ENFORCEMENT_MODES``) so
+``Base.metadata.create_all()`` (tests, fresh dev DBs) produces CHECK strings
+byte-identical to the alembic migration literal (``e63_1274_agents``) —
+the ``valid_delivery_mode`` drift-pin pattern (#886).
+
+Adding a value requires THREE coordinated edits (caught here if any are
+missed): (1) add the named constant, (2) APPEND it to the tuple (never
+reorder), (3) update the expected literal below — plus an alembic migration
+that ALTERs the prod CHECK.
+"""
+
+from models.agent import (
+    _ALL_AGENT_ENFORCEMENT_MODES,
+    _ALL_AGENT_STATUSES,
+    AGENT_ENFORCEMENT_ENFORCE,
+    AGENT_ENFORCEMENT_SHADOW,
+    AGENT_STATUS_ACTIVE,
+    AGENT_STATUS_RETIRED,
+    AGENT_STATUS_SUSPENDED,
+    Agent,
+)
+
+
+def test_all_agent_statuses_tuple_matches_constants() -> None:
+    """Registration order is fixed (active, suspended, retired)."""
+    assert _ALL_AGENT_STATUSES == (
+        AGENT_STATUS_ACTIVE,
+        AGENT_STATUS_SUSPENDED,
+        AGENT_STATUS_RETIRED,
+    )
+
+
+def test_all_agent_enforcement_modes_tuple_matches_constants() -> None:
+    """Registration order is fixed (shadow, enforce) — matches the DDL literal."""
+    assert _ALL_AGENT_ENFORCEMENT_MODES == (
+        AGENT_ENFORCEMENT_SHADOW,
+        AGENT_ENFORCEMENT_ENFORCE,
+    )
+
+
+def test_agent_constant_values() -> None:
+    """The design-fixed value set (docs/design/agent-registry-and-bindings.md)."""
+    assert AGENT_STATUS_ACTIVE == "active"
+    assert AGENT_STATUS_SUSPENDED == "suspended"
+    assert AGENT_STATUS_RETIRED == "retired"
+    assert AGENT_ENFORCEMENT_SHADOW == "shadow"
+    assert AGENT_ENFORCEMENT_ENFORCE == "enforce"
+
+
+def test_valid_agent_status_check_matches_migration_literal() -> None:
+    """``valid_agent_status`` CHECK text is byte-identical to e63_1274_agents."""
+    expected = "status IN ('active', 'suspended', 'retired')"
+    check = next(
+        c for c in Agent.__table_args__ if getattr(c, "name", None) == "valid_agent_status"
+    )
+    assert check.sqltext.text == expected
+
+
+def test_valid_agent_enforcement_check_matches_migration_literal() -> None:
+    """``valid_agent_enforcement`` CHECK text is byte-identical to e63_1274_agents."""
+    expected = "enforcement_mode IN ('shadow', 'enforce')"
+    check = next(
+        c for c in Agent.__table_args__ if getattr(c, "name", None) == "valid_agent_enforcement"
+    )
+    assert check.sqltext.text == expected
+
+
+def test_agents_is_classified_operational() -> None:
+    """#1274 two-sided closure: the creating PR classifies the table."""
+    from models.data_boundary import OPERATIONAL_TABLES
+
+    assert "agents" in OPERATIONAL_TABLES


### PR DESCRIPTION
Closes #1274 (RFC-0002 P0-1)

Implements the Agent Registry per the signed-off F1 design contract
([docs/design/agent-registry-and-bindings.md](https://github.com/kagura-ai/memory-cloud/blob/main/docs/design/agent-registry-and-bindings.md), #1258). Foundation for P0-2..P0-5 (#1275-#1278).

## What

- **`agents` table** (migration `e63_1274_agents`, pure additive, chains from `e62`): workspace-scoped registry with `status` kill switch (`active|suspended|retired`) and `enforcement_mode` ramp (`shadow|enforce`). CHECK constraints derived byte-identically from module-level Python tuples (`valid_delivery_mode` drift-pin pattern, #886); unique `(workspace_id, name)`; symmetric downgrade.
- **`AgentRegistryService`**: shared by REST + MCP. `setup_resource` gate order (validation → duplicate → plan gate → quota); governed `status`/`enforcement_mode` transitions returning old→new change sets; duplicate-check→flush TOCTOU race closed by recognizing `uq_agents_workspace_name` BY NAME via `db/constraint_names` and mapping to the same 409 (setup_resource / external_keys precedent); `last_seen_at` write-throttled like `api_keys.last_used_at` (#947, `agent_last_seen_throttle_seconds`).
- **REST `/api/v1/agents`** CRUD — owner/admin via `require_workspace_admin`; canonical exceptions only (raw-HTTPException guard stays at baseline); `TZAwareBaseModel` responses.
- **MCP tools** `register_agent` / `list_agents` / `get_agent` / `update_agent` / `delete_agent` — owner/admin via `_check_owner_admin_role`; read-only pair rate-limit-exempt.
- **Audit (security-mutation lane)**: every mutation writes an `audit_logs` row atomically with the mutation; `enforce`→`shadow` recorded under the distinct **`agent_enforcement_widened`** action with old/new values (privilege-widening per the design contract). Session mutations are audited too (stronger than the #1164 programmatic-only lane — deliberate for a privilege surface).
- **Data boundary + erasure (two-sided closure in the creating PR)**: `agents` classified in `data_boundary.OPERATIONAL_TABLES`; `agents.owner_user_id` pseudonymized in `account_erasure_service` for rows surviving the workspace cascade.

## Deliberately NOT here (P0-2, #1275)

`agent_context_bindings`, `api_keys.agent_id` ALTERs (migration class 2: `NOT VALID` + `VALIDATE`, `CREATE INDEX CONCURRENTLY`), verify-path kill-switch wiring, and the full erasure CASCADE integration scenario (requires the `api_keys.agent_id` FK).

## Tests

- `tests/test_agent_constants.py` — CHECK-literal byte-identity pins + data-boundary classification
- `tests/services/test_agent_registry_service.py` — validators, gate order, transitions, TOCTOU mapping (both directions), throttle, audit-row fields
- `tests/api/test_agents_routes.py` — role/workspace scoping, audit actions, no-op PATCH writes nothing
- `tests/mcp_server/test_agent_registry_tools.py` — gate order, arg contract, widening action
- erasure sweep pin for `agents_pseudonymized`

Local suite 5257+ passed; migration round-trip (incl. `downgrade -1`) + create_all/alembic drift gates green; ruff clean; pyright 0 new errors.

## Gates

- Gate1: green (/ask → CIO lens; design-contract anchors verified)
- Inner review: 1 warning (TOCTOU race surfacing) — fixed in a3423c8
- Gate2: cso green / qa-lead green / cto green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
