### PR TITLE
feat(auth): context bindings + agent-bound member keys (#1275)

### DIFF
--- a/backend/alembic/versions/e64_1275_agent_bindings.py
+++ b/backend/alembic/versions/e64_1275_agent_bindings.py
@@ -1,0 +1,88 @@
+"""Add agent_context_bindings table — subtractive agent scoping (RFC-0002 P0-2, #1275).
+
+Purely subtractive per-context scoping for registered agents: the effective
+permission for an agent-bound request is existing RBAC decision ∩ binding
+(design contract docs/design/agent-registry-and-bindings.md). Pure additive
+migration (class 1): no existing table is touched, blue-green safe. The
+``api_keys`` ALTERs ship separately as e65 (migration class 2).
+
+CHECK literal must stay byte-identical to ``_ALL_BINDING_WRITE_POLICIES`` in
+``models/agent.py`` (drift pinned by tests/test_agent_constants.py).
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "e64_1275_agent_bindings"
+down_revision = "e63_1274_agents"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_context_bindings",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "agent_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("agents.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "context_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("can_read", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column(
+            "write_policy",
+            sa.String(length=20),
+            nullable=False,
+            server_default=sa.text("'deny'"),
+        ),
+        sa.Column("is_default", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("allowed_memory_types", postgresql.ARRAY(sa.String(length=50)), nullable=True),
+        sa.Column("allowed_source_types", postgresql.ARRAY(sa.String(length=20)), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint(
+            "write_policy IN ('deny', 'direct')",
+            name="valid_binding_write_policy",
+        ),
+    )
+    op.create_index(
+        "uq_agent_ctx_binding",
+        "agent_context_bindings",
+        ["agent_id", "context_id"],
+        unique=True,
+    )
+    # At most one bootstrap default binding per agent.
+    op.create_index(
+        "uq_agent_ctx_binding_default",
+        "agent_context_bindings",
+        ["agent_id"],
+        unique=True,
+        postgresql_where=sa.text("is_default"),
+    )
+    op.create_index(
+        "idx_agent_ctx_binding_context",
+        "agent_context_bindings",
+        ["context_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_agent_ctx_binding_context", table_name="agent_context_bindings")
+    op.drop_index("uq_agent_ctx_binding_default", table_name="agent_context_bindings")
+    op.drop_index("uq_agent_ctx_binding", table_name="agent_context_bindings")
+    op.drop_table("agent_context_bindings")

--- a/backend/alembic/versions/e65_1275_api_keys_agent.py
+++ b/backend/alembic/versions/e65_1275_api_keys_agent.py
@@ -1,0 +1,100 @@
+"""Add api_keys.agent_id — agent-bound member keys (RFC-0002 P0-2, #1275).
+
+Migration class 2 of docs/design/agent-registry-and-bindings.md: ALTERs on
+the hottest auth table, engineered so it never holds a long ACCESS EXCLUSIVE
+lock. Blue-green argument: old app versions always write ``agent_id`` NULL,
+which satisfies the new constraint.
+
+- nullable ``agent_id`` FK (ADD COLUMN of a nullable column = brief metadata
+  lock only);
+- ``ck_api_keys_agent_public_exclusion`` CHECK added ``NOT VALID`` (no table
+  scan) then validated as a separate statement (SHARE UPDATE EXCLUSIVE — does
+  not block reads/writes);
+- ``idx_api_keys_agent`` partial index built ``CONCURRENTLY``.
+
+Rerun safety (#655 hardening pattern): ``CONCURRENTLY`` and ``VALIDATE``
+run in an autocommit block; every statement is guarded (``IF NOT EXISTS`` /
+``duplicate_object`` DO-block / INVALID-leftover rebuild per e62) so a
+partial failure is re-runnable.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e65_1275_api_keys_agent"
+down_revision = "e64_1275_agent_bindings"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "idx_api_keys_agent"
+_INDEX_DDL = (
+    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
+    "ON api_keys (agent_id) WHERE agent_id IS NOT NULL"
+)
+_CHECK_NAME = "ck_api_keys_agent_public_exclusion"
+
+
+def _index_is_invalid(name: str) -> bool:
+    """True if ``name`` exists in ``pg_index`` in an INVALID state (e62 guard).
+
+    A mid-build failure of ``CREATE INDEX CONCURRENTLY`` leaves the index row
+    with ``indisvalid = false``; a retry's ``IF NOT EXISTS`` would skip it
+    without rebuilding, so the leftover must be dropped first.
+    """
+    bind = op.get_bind()
+    row = bind.execute(
+        sa.text(
+            "SELECT 1 "
+            "FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid "
+            "WHERE c.relname = :name AND i.indisvalid IS FALSE"
+        ),
+        {"name": name},
+    ).first()
+    return row is not None
+
+
+def upgrade() -> None:
+    # Step 1: nullable FK column. ADD COLUMN IF NOT EXISTS makes the step
+    # rerun-safe; a nullable column with no default is a metadata-only change.
+    # The FK constraint is named explicitly to match the ORM naming convention
+    # (``fk_api_keys_agent_id``) so the create_all/alembic drift gate sees one
+    # identical constraint instead of a PG-default ``api_keys_agent_id_fkey``.
+    op.execute(
+        sa.text(
+            "ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS agent_id UUID NULL "
+            "CONSTRAINT fk_api_keys_agent_id "
+            "REFERENCES agents(id) ON DELETE CASCADE"
+        )
+    )
+
+    # Step 2: mutual-exclusion CHECK, added NOT VALID so existing rows are not
+    # scanned under lock. DO-block guard because PG has no ADD CONSTRAINT IF
+    # NOT EXISTS for CHECK constraints (#655 pattern).
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            f"  ALTER TABLE api_keys ADD CONSTRAINT {_CHECK_NAME} "
+            "    CHECK (agent_id IS NULL OR bound_context_id IS NULL) NOT VALID; "
+            "EXCEPTION WHEN duplicate_object THEN NULL; "
+            "END $$"
+        )
+    )
+
+    # Step 3: validate + build the partial index outside a transaction.
+    # VALIDATE CONSTRAINT takes SHARE UPDATE EXCLUSIVE (no read/write block);
+    # re-running VALIDATE on an already-validated constraint is a no-op.
+    invalid = _index_is_invalid(_INDEX_NAME)
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"ALTER TABLE api_keys VALIDATE CONSTRAINT {_CHECK_NAME}"))
+        if invalid:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
+        op.execute(sa.text(_INDEX_DDL))
+
+
+def downgrade() -> None:
+    # Reverse dependency order: index → constraint → column.
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
+    op.execute(sa.text(f"ALTER TABLE api_keys DROP CONSTRAINT IF EXISTS {_CHECK_NAME}"))
+    op.execute(sa.text("ALTER TABLE api_keys DROP COLUMN IF EXISTS agent_id"))

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -275,3 +275,205 @@ async def delete_agent(
     )
     await service.delete_agent(agent)
     await db.commit()
+
+
+# ============================================================================
+# Context bindings (RFC-0002 P0-2, Issue #1275)
+# ============================================================================
+
+
+class BindingCreate(BaseModel):
+    """Request model for binding an agent to a context (subtractive scoping)."""
+
+    context_id: UUID
+    can_read: bool = True
+    write_policy: Literal["deny", "direct"] = "deny"
+    is_default: bool = Field(False, description="Bootstrap default binding (max one per agent)")
+    allowed_memory_types: list[str] | None = Field(None, description="NULL = all types; [] = none")
+    allowed_source_types: list[str] | None = Field(
+        None, description="Values from the memories.source_type set; NULL = all; [] = none"
+    )
+
+
+class BindingUpdate(BaseModel):
+    """Partial binding update (``context_id`` is immutable — recreate to re-target)."""
+
+    can_read: bool | None = None
+    write_policy: Literal["deny", "direct"] | None = None
+    is_default: bool | None = None
+    allowed_memory_types: list[str] | None = None
+    allowed_source_types: list[str] | None = None
+
+
+class BindingResponse(TZAwareBaseModel):
+    """Response model for one binding row."""
+
+    id: UUID
+    agent_id: UUID
+    context_id: UUID
+    can_read: bool
+    write_policy: str
+    is_default: bool
+    allowed_memory_types: list[str] | None = None
+    allowed_source_types: list[str] | None = None
+    created_by: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BindingListResponse(BaseModel):
+    """Response model for an agent's binding listing."""
+
+    bindings: list[BindingResponse]
+    count: int
+
+
+def _binding_service(db: AsyncSession):
+    from services.agent_binding_service import AgentBindingService
+
+    return AgentBindingService(db)
+
+
+@router.post(
+    "/{agent_id}/bindings", response_model=BindingResponse, status_code=status.HTTP_201_CREATED
+)
+async def create_agent_binding(
+    agent_id: UUID,
+    data: BindingCreate,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """Bind an agent to a context (owner/admin only, purely subtractive)."""
+    from services.agent_binding_service import AUDIT_BINDING_CREATED
+
+    user_id, email, workspace_id, metadata = _actor(user)
+    agent = await _get_agent_or_404(AgentRegistryService(db), workspace_id, agent_id)
+
+    binding = await _binding_service(db).create_binding(
+        agent=agent,
+        context_id=data.context_id,
+        created_by=user_id,
+        can_read=data.can_read,
+        write_policy=data.write_policy,
+        is_default=data.is_default,
+        allowed_memory_types=data.allowed_memory_types,
+        allowed_source_types=data.allowed_source_types,
+    )
+    add_agent_audit_row(
+        db,
+        actor_user_id=user_id,
+        actor_email=email,
+        action=AUDIT_BINDING_CREATED,
+        agent_id=agent.id,
+        workspace_id=workspace_id,
+        metadata={
+            **metadata,
+            "agent_name": agent.name,
+            "context_id": str(data.context_id),
+            "binding_id": str(binding.id),
+            "can_read": binding.can_read,
+            "write_policy": binding.write_policy,
+            "is_default": binding.is_default,
+        },
+    )
+    await db.commit()
+    await db.refresh(binding)
+    return binding
+
+
+@router.get("/{agent_id}/bindings", response_model=BindingListResponse)
+async def list_agent_bindings(
+    agent_id: UUID,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """List an agent's context bindings (owner/admin only)."""
+    _, _, workspace_id, _ = _actor(user)
+    agent = await _get_agent_or_404(AgentRegistryService(db), workspace_id, agent_id)
+    bindings = await _binding_service(db).list_bindings(agent)
+    return BindingListResponse(
+        bindings=[BindingResponse.model_validate(b) for b in bindings],
+        count=len(bindings),
+    )
+
+
+@router.patch("/{agent_id}/bindings/{binding_id}", response_model=BindingResponse)
+async def update_agent_binding(
+    agent_id: UUID,
+    binding_id: UUID,
+    data: BindingUpdate,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """Partially update a binding (owner/admin only)."""
+    from services.agent_binding_service import AUDIT_BINDING_UPDATED
+
+    user_id, email, workspace_id, metadata = _actor(user)
+    service = _binding_service(db)
+    agent = await _get_agent_or_404(AgentRegistryService(db), workspace_id, agent_id)
+    binding = await service.get_binding(agent, binding_id)
+    if binding is None:
+        raise NotFoundException("Binding")
+
+    updates = data.model_dump(exclude_unset=True)
+    for non_nullable in ("can_read", "write_policy", "is_default"):
+        if non_nullable in updates and updates[non_nullable] is None:
+            raise ValidationError(f"'{non_nullable}' cannot be null.", field=non_nullable)
+
+    changes = await service.update_binding(binding, updates)
+    if changes:
+        add_agent_audit_row(
+            db,
+            actor_user_id=user_id,
+            actor_email=email,
+            action=AUDIT_BINDING_UPDATED,
+            agent_id=agent.id,
+            workspace_id=workspace_id,
+            metadata={
+                **metadata,
+                "agent_name": agent.name,
+                "context_id": str(binding.context_id),
+                "binding_id": str(binding.id),
+                "changes": changes,
+            },
+        )
+        await db.commit()
+        await db.refresh(binding)
+    return binding
+
+
+@router.delete("/{agent_id}/bindings/{binding_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_agent_binding(
+    agent_id: UUID,
+    binding_id: UUID,
+    user: dict = Depends(require_workspace_admin),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Delete a binding (owner/admin only) — the agent loses that context."""
+    from services.agent_binding_service import AUDIT_BINDING_DELETED
+
+    user_id, email, workspace_id, metadata = _actor(user)
+    service = _binding_service(db)
+    agent = await _get_agent_or_404(AgentRegistryService(db), workspace_id, agent_id)
+    binding = await service.get_binding(agent, binding_id)
+    if binding is None:
+        raise NotFoundException("Binding")
+
+    add_agent_audit_row(
+        db,
+        actor_user_id=user_id,
+        actor_email=email,
+        action=AUDIT_BINDING_DELETED,
+        agent_id=agent.id,
+        workspace_id=workspace_id,
+        metadata={
+            **metadata,
+            "agent_name": agent.name,
+            "context_id": str(binding.context_id),
+            "binding_id": str(binding.id),
+        },
+    )
+    await service.delete_binding(binding)
+    await db.commit()

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -14,6 +14,7 @@ Endpoints:
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.api_keys import APIKeyManager, apply_zero_knowledge_hide
@@ -273,6 +274,17 @@ async def _owner_provisioned_mint(
         )
     except ValueError as e:
         raise BadRequestError(message=str(e)) from e
+    except IntegrityError as e:
+        # Issue #1275: a concurrent agent hard-delete between create_key's
+        # active-agent check and the INSERT flush violates the api_keys.agent_id
+        # FK. Fail-closed (no key minted), but surface it as a clean 400 rather
+        # than letting the SQLAlchemy handler map it to a 503/500 (code-review).
+        await db.rollback()
+        raise BadRequestError(
+            message="Agent binding is no longer valid (the agent may have been "
+            "deleted or suspended concurrently). Retry the mint.",
+            error_code="AGENT-001",
+        ) from e
 
 
 @router.get("/{user_id}/credentials", response_model=MemberCredentialsResponse)

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -221,6 +221,10 @@ async def _owner_provisioned_mint(
             workspace_id=workspace_id,
             expires_days=data.expires_days,
             auto_hide_minutes=0,  # visibility_expires_at = now
+            # Issue #1275: optional agent binding. Mint-time gates (agent
+            # exists, same workspace, active) live in create_key and surface
+            # as ValueError → 400 below.
+            agent_id=data.agent_id,
         )
         # Force-hide immediately so plaintext is never re-revealed via GET, and
         # null the encrypted-at-rest copy too (Migration-035 zero-knowledge). The
@@ -245,6 +249,9 @@ async def _owner_provisioned_mint(
             metadata={
                 "minted_key_prefix": new_key.key_prefix,  # the MINTED key
                 "expires_days": data.expires_days,
+                # Issue #1275: record the agent binding in the existing audit
+                # metadata (design contract: "Mint records agent_id").
+                **({"agent_id": str(data.agent_id)} if data.agent_id else {}),
             },
         )
         await db.commit()
@@ -572,6 +579,15 @@ async def create_api_key(
     if data.expires_days is not None:
         raise BadRequestError(
             message="expires_days is only supported for owner-provisioned keys "
+            "(via a workspace-owner API key), not session self-mint."
+        )
+
+    # Issue #1275: agent binding is owner-provisioned-only — agent workloads
+    # authenticate with provisioned service-member keys, never with a session
+    # user's self-minted key. Reject explicitly (same posture as expires_days).
+    if data.agent_id is not None:
+        raise BadRequestError(
+            message="agent_id is only supported for owner-provisioned keys "
             "(via a workspace-owner API key), not session self-mint."
         )
 

--- a/backend/src/auth/agent_scope.py
+++ b/backend/src/auth/agent_scope.py
@@ -1,0 +1,66 @@
+"""Per-request agent scope for binding enforcement (RFC-0002 P0-2, #1275).
+
+When a request authenticates with an agent-bound member API key
+(``api_keys.agent_id`` set), the verified agent identity and its
+``enforcement_mode`` are recorded here so the context-resolution chokepoints
+(``PermissionService.resolve_context_for_workspace_read`` /
+``check_context_access`` / ``get_accessible_contexts`` and the MCP
+``_resolve_context`` write path) can apply the **purely subtractive** binding
+intersection without threading a parameter through every call site — the
+same per-request contextvar pattern as the #963 MCP key-workspace scope.
+
+The scope is ``None`` for every non-agent authentication (session, OAuth,
+global/workspace member keys without ``agent_id``), which makes the binding
+filter a structural no-op there — the backward-compat matrix's
+"byte-for-byte unchanged" guarantee. Fail-open is impossible by construction:
+a set scope can only *remove* access the underlying RBAC decision granted.
+
+ContextVar isolation: each ASGI request runs in its own task context, so a
+scope set for one request can never leak into another; the auth adapters
+(REST dependencies, MCP transport) also reset it explicitly per request as
+defense in depth.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class AgentScope:
+    """Verified agent identity attached to the current request's credential."""
+
+    agent_id: UUID
+    enforcement_mode: str
+
+
+_agent_scope: ContextVar[AgentScope | None] = ContextVar("agent_scope", default=None)
+
+
+def set_agent_scope(scope: AgentScope | None) -> None:
+    """Set (or clear) the current request's agent scope."""
+    _agent_scope.set(scope)
+
+
+def get_agent_scope() -> AgentScope | None:
+    """Read the current request's agent scope (None = not an agent credential)."""
+    return _agent_scope.get()
+
+
+def set_agent_scope_from_verified(verified: Any) -> None:
+    """Set the scope from a ``VerifiedKey``-shaped object (or clear it).
+
+    Accepts anything exposing ``agent_id`` / ``agent_enforcement_mode`` so the
+    auth adapters do not need to import ``auth.api_keys`` (and duck-typing
+    keeps test doubles cheap). A verified key without an agent binding clears
+    the scope.
+    """
+    agent_id = getattr(verified, "agent_id", None)
+    mode = getattr(verified, "agent_enforcement_mode", None)
+    if verified is None or agent_id is None or mode is None:
+        set_agent_scope(None)
+        return
+    set_agent_scope(AgentScope(agent_id=agent_id, enforcement_mode=mode))

--- a/backend/src/auth/agent_scope.py
+++ b/backend/src/auth/agent_scope.py
@@ -60,7 +60,18 @@ def set_agent_scope_from_verified(verified: Any) -> None:
     """
     agent_id = getattr(verified, "agent_id", None)
     mode = getattr(verified, "agent_enforcement_mode", None)
-    if verified is None or agent_id is None or mode is None:
+    if verified is None or agent_id is None:
+        # Not an agent-bound credential — clear any stale scope.
         set_agent_scope(None)
         return
+    if mode is None:
+        # An agent-bound key (agent_id set) with no enforcement_mode is an
+        # anomaly — verify_key only sets agent_id for an ACTIVE agent whose
+        # mode is a NOT-NULL/CHECK-constrained column, so this can only arise
+        # from a bug, partial select, or test double. Fail CLOSED: default to
+        # ``enforce``, which with no bindings is default-deny — never silently
+        # widen the key to full member scope (code-review hardening).
+        from models.agent import AGENT_ENFORCEMENT_ENFORCE
+
+        mode = AGENT_ENFORCEMENT_ENFORCE
     set_agent_scope(AgentScope(agent_id=agent_id, enforcement_mode=mode))

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -52,6 +52,14 @@ class VerifiedKey(NamedTuple):
             authenticated principal (``api_key_prefix``) so audit trails for
             programmatic member-management actions attribute the specific
             acting key, not just the owner user_id.
+        agent_id: Issue #1275 (RFC-0002 P0-2): the agent this key is bound
+            to, already verified ``active`` (suspended/retired agents are
+            rejected at verify time — fail-closed kill switch). None for
+            unbound keys.
+        agent_enforcement_mode: The bound agent's ``enforcement_mode``
+            (``shadow`` | ``enforce``), read in the same verify-time lookup
+            so the binding chokepoints need no second agents query. None for
+            unbound keys.
     """
 
     id: int
@@ -59,6 +67,8 @@ class VerifiedKey(NamedTuple):
     workspace_id: UUID | None
     bound_context_id: UUID | None
     key_prefix: str | None = None
+    agent_id: UUID | None = None
+    agent_enforcement_mode: str | None = None
 
 
 def apply_zero_knowledge_hide(key: APIKey) -> None:
@@ -114,6 +124,7 @@ class APIKeyManager:
         workspace_id: UUID | None = None,
         bound_context_id: UUID | None = None,
         auto_hide_minutes: int = 10,
+        agent_id: UUID | None = None,
     ) -> tuple[str, APIKey]:
         """Create a new API key.
 
@@ -135,6 +146,13 @@ class APIKeyManager:
                 (Issue #626). The context must satisfy ``is_public=True`` at
                 creation time. Mutually exclusive with ``workspace_id``.
             auto_hide_minutes: Minutes until key is auto-hidden (default: 10)
+            agent_id: Issue #1275 (RFC-0002 P0-2): bind the key to a
+                registered agent. Requires ``workspace_id`` (an agent-bound
+                key with the global-key shape is rejected at mint) and the
+                agent MUST belong to the same workspace — PostgreSQL cannot
+                express this cross-table invariant in a CHECK, so it is
+                enforced here and re-asserted defensively at verify. Mutually
+                exclusive with ``bound_context_id``.
 
         Returns:
             ``(plaintext_key, new_api_key_row)`` — the plaintext is only ever
@@ -143,13 +161,43 @@ class APIKeyManager:
 
         Raises:
             ValueError: If name already exists for user, if both scoping
-                params are supplied, or if the bound context is not public.
+                params are supplied, if the bound context is not public, or
+                if the agent binding is malformed (missing/mismatched
+                workspace, unknown agent, or a non-active agent).
         """
         if workspace_id is not None and bound_context_id is not None:
             raise ValueError(
                 "workspace_id and bound_context_id are mutually exclusive — "
                 "a key cannot be both workspace-scoped and public-bound"
             )
+
+        # Issue #1275: agent-bound mint gates. Fail-closed at mint so an
+        # invalid binding never reaches the verify path.
+        if agent_id is not None:
+            if bound_context_id is not None:
+                raise ValueError(
+                    "agent_id and bound_context_id are mutually exclusive — "
+                    "a key cannot be both agent-bound and public-bound"
+                )
+            if workspace_id is None:
+                raise ValueError(
+                    "agent-bound keys must be workspace-scoped — a global key cannot carry agent_id"
+                )
+            from models.agent import AGENT_STATUS_ACTIVE, Agent
+
+            agent_result = await self.db.execute(select(Agent).where(Agent.id == agent_id))
+            agent = agent_result.scalar_one_or_none()
+            if agent is None:
+                raise ValueError(f"Agent {agent_id} not found")
+            if agent.workspace_id != workspace_id:
+                raise ValueError(
+                    "agent and key workspace mismatch — the agent must belong "
+                    "to the key's workspace"
+                )
+            if agent.status != AGENT_STATUS_ACTIVE:
+                raise ValueError(
+                    f"agent is '{agent.status}' — keys can only be minted for active agents"
+                )
 
         # Validate the bound context exists and is public at creation time.
         # Subsequent flips of context.is_public are handled at request time
@@ -213,6 +261,7 @@ class APIKeyManager:
             user_id=user_id,
             workspace_id=workspace_id,  # Issue #169
             bound_context_id=bound_context_id,  # Issue #626
+            agent_id=agent_id,  # Issue #1275
             expires_at=expires_at,
             visibility_expires_at=visibility_expires_at,  # Migration 034
             plaintext_encrypted=plaintext_encrypted,  # Migration 035
@@ -227,6 +276,7 @@ class APIKeyManager:
             user_id=user_id,
             workspace_id=str(workspace_id) if workspace_id else None,
             bound_context_id=str(bound_context_id) if bound_context_id else None,
+            agent_id=str(agent_id) if agent_id else None,
         )
 
         return api_key, new_key
@@ -276,6 +326,44 @@ class APIKeyManager:
             if utcnow() > key_record.expires_at:
                 return None
 
+        # Issue #1275 (RFC-0002 P0-2): agent-bound key gates. Only bound keys
+        # pay the extra agents SELECT — unbound keys (every credential
+        # existing before P0-2) stay byte-for-byte on the pre-#1275 path.
+        agent_enforcement_mode: str | None = None
+        if key_record.agent_id is not None:
+            from models.agent import AGENT_STATUS_ACTIVE, Agent
+
+            agent_result = await self.db.execute(
+                select(Agent).where(Agent.id == key_record.agent_id)
+            )
+            agent = agent_result.scalar_one_or_none()
+            # Fail-closed kill switch: a suspended/retired (or somehow
+            # missing) agent invalidates every key bound to it — one row
+            # update beats revoking N keys.
+            if agent is None or agent.status != AGENT_STATUS_ACTIVE:
+                logger.warning(
+                    "api_key_rejected_agent_kill_switch",
+                    key_prefix=key_record.key_prefix,
+                    agent_id=str(key_record.agent_id),
+                    agent_status=agent.status if agent else "missing",
+                )
+                return None
+            # Defensive re-assert of the mint-time invariant (PostgreSQL
+            # cannot express the cross-table workspace equality in a CHECK).
+            if agent.workspace_id != key_record.workspace_id:
+                logger.warning(
+                    "api_key_rejected_agent_workspace_mismatch",
+                    key_prefix=key_record.key_prefix,
+                    agent_id=str(agent.id),
+                )
+                return None
+            agent_enforcement_mode = agent.enforcement_mode
+
+            # Agent liveness signal — throttled like last_used_at below.
+            from services.agent_registry_service import AgentRegistryService
+
+            await AgentRegistryService(self.db).touch_last_seen(agent.id)
+
         # Update last_used_at — throttled (#947). This runs on EVERY auth (one
         # per MCP tool call), so writing the row each time is hot-row
         # write-amplification. Skip the write while the stored timestamp is
@@ -295,6 +383,8 @@ class APIKeyManager:
             workspace_id=key_record.workspace_id,
             bound_context_id=key_record.bound_context_id,
             key_prefix=key_record.key_prefix,
+            agent_id=key_record.agent_id,
+            agent_enforcement_mode=agent_enforcement_mode,
         )
 
     async def list_keys(

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -261,6 +261,12 @@ async def verify_api_key(api_key: str) -> VerifiedKey | None:
                 await db.commit()
             except Exception as commit_err:
                 logger.warning("api_key_last_used_commit_failed", error=str(commit_err))
+            # Issue #1275: surface the verified agent binding (if any) to the
+            # per-request scope so the context chokepoints can apply the
+            # subtractive binding intersection. No-op (clears) for unbound keys.
+            from auth.agent_scope import set_agent_scope_from_verified
+
+            set_agent_scope_from_verified(verified)
             return verified
     except Exception:
         # Silent failure - return None on any error
@@ -399,6 +405,11 @@ async def verify_api_key_user(
                 "they are only valid on /api/v1/public/{context_id}/* endpoints"
             ),
         )
+
+    # Issue #1275: record the verified agent binding for the chokepoints.
+    from auth.agent_scope import set_agent_scope_from_verified
+
+    set_agent_scope_from_verified(result)
 
     return await _build_api_key_user_dict(
         result.user_id, result.workspace_id, db, api_key_prefix=result.key_prefix
@@ -558,6 +569,11 @@ async def get_user_from_api_key_or_session(
                         "they are only valid on /api/v1/public/{context_id}/* endpoints"
                     ),
                 )
+            # Issue #1275: record the verified agent binding for the chokepoints.
+            from auth.agent_scope import set_agent_scope_from_verified
+
+            set_agent_scope_from_verified(result)
+
             return await _build_api_key_user_dict(
                 result.user_id, result.workspace_id, db, api_key_prefix=result.key_prefix
             )

--- a/backend/src/db/constraint_names.py
+++ b/backend/src/db/constraint_names.py
@@ -52,6 +52,13 @@ EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE = "uq_external_api_keys_workspace_ke
 # the pre-check produces; other IntegrityErrors propagate unchanged.
 AGENTS_WORKSPACE_NAME_UNIQUE = "uq_agents_workspace_name"
 
+# Issue #1275: agent_context_bindings unique indexes (migration e64 +
+# models.agent.AgentContextBinding.__table_args__). Same TOCTOU posture as
+# above — AgentBindingService maps flush-time races on these names to the
+# 409 the pre-checks produce.
+AGENT_CTX_BINDING_UNIQUE = "uq_agent_ctx_binding"
+AGENT_CTX_BINDING_DEFAULT_UNIQUE = "uq_agent_ctx_binding_default"
+
 
 def integrity_error_constraint_name(error: IntegrityError) -> str | None:
     """Return the PostgreSQL constraint name for ``error``, or ``None``.

--- a/backend/src/mcp_server/auth.py
+++ b/backend/src/mcp_server/auth.py
@@ -56,6 +56,14 @@ async def authenticate_mcp_request(
         >>> user_id, context_id, workspace_id = await authenticate_mcp_request("Bearer api_key_...")
         >>> # Returns: ("user_12345", None, UUID("...")) for workspace-scoped API key
     """
+    # Issue #1275: reset the per-request agent scope BEFORE any auth branch —
+    # session/OAuth paths never carry an agent binding, and the API-key branch
+    # (auth.dependencies.verify_api_key) re-sets it when the key is
+    # agent-bound. Defense in depth against a stale scope in reused contexts.
+    from auth.agent_scope import set_agent_scope
+
+    set_agent_scope(None)
+
     # Try session cookie first (Issue #155: Claude Web UI support)
     # Issue #245: context_id is no longer returned from auth (now required in tool args)
     if not authorization_header and cookie_header:

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -65,6 +65,13 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "get_agent",
         "update_agent",
         "delete_agent",
+        # Issue #1275: binding CRUD — bind's context_id is a binding TARGET
+        # selector (like describe_binding), not a memory-context to resolve;
+        # the handlers validate presence themselves.
+        "bind_agent_context",
+        "list_agent_bindings",
+        "update_agent_binding",
+        "unbind_agent_context",
     }
 )
 
@@ -105,6 +112,8 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         # no embedding/LLM cost).
         "list_agents",
         "get_agent",
+        # Issue #1275: read-only binding listing.
+        "list_agent_bindings",
     }
 )
 
@@ -120,11 +129,15 @@ _TOOL_REGISTRY: dict[str, Any] | None = None
 def _build_registry() -> dict[str, Any]:
     """Build tool name → handler mapping."""
     from mcp_server.tools.agent_registry import (
+        handle_bind_agent_context,
         handle_delete_agent,
         handle_get_agent,
+        handle_list_agent_bindings,
         handle_list_agents,
         handle_register_agent,
+        handle_unbind_agent_context,
         handle_update_agent,
+        handle_update_agent_binding,
     )
     from mcp_server.tools.analysis import (
         handle_analyze_context,
@@ -247,6 +260,11 @@ def _build_registry() -> dict[str, Any]:
         "get_agent": handle_get_agent,
         "update_agent": handle_update_agent,
         "delete_agent": handle_delete_agent,
+        # Issue #1275 (RFC-0002 P0-2): subtractive context bindings.
+        "bind_agent_context": handle_bind_agent_context,
+        "list_agent_bindings": handle_list_agent_bindings,
+        "update_agent_binding": handle_update_agent_binding,
+        "unbind_agent_context": handle_unbind_agent_context,
     }
 
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2272,6 +2272,141 @@ Returns: {status, deleted, agent_id}.""",
                 "required": ["agent_id"],
             },
         },
+        # Issue #1275 (RFC-0002 P0-2): subtractive context bindings for
+        # registered agents. A binding can only REMOVE access the underlying
+        # member credential already has — never grant.
+        {
+            "name": "bind_agent_context",
+            "description": """Bind an agent to a context — purely subtractive scoping (owner/admin only, Issue #1275).
+
+The effective permission for an agent-bound request is the existing RBAC
+decision ∩ binding: can_read gates reads, write_policy ('deny'|'direct')
+gates writes. Under enforcement_mode='enforce', contexts WITHOUT a binding
+row are denied for the agent (default-deny); under 'shadow', violations are
+only logged. NULL type filters = unrestricted; [] = deny-all.
+
+Returns: {status, binding: {id, context_id, can_read, write_policy, is_default, ...}}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID from register_agent/list_agents.",
+                    },
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Context to bind (must belong to the agent's workspace).",
+                    },
+                    "can_read": {
+                        "type": "boolean",
+                        "description": "Whether the agent may read this context (default: true).",
+                    },
+                    "write_policy": {
+                        "type": "string",
+                        "enum": ["deny", "direct"],
+                        "description": "Write gate (default: 'deny'). 'staged' is reserved for a later phase.",
+                    },
+                    "is_default": {
+                        "type": "boolean",
+                        "description": "Mark as the agent's bootstrap default binding (max one per agent).",
+                    },
+                    "allowed_memory_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional memory-type filter. Omit/null = all types; [] = none.",
+                    },
+                    "allowed_source_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional source-type filter (memories.source_type values). Omit/null = all; [] = none.",
+                    },
+                },
+                "required": ["agent_id", "context_id"],
+            },
+        },
+        {
+            "name": "list_agent_bindings",
+            "readOnly": True,
+            "description": """List an agent's context bindings (owner/admin only, Issue #1275).
+
+Returns: {status, bindings: [...], count}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID.",
+                    },
+                },
+                "required": ["agent_id"],
+            },
+        },
+        {
+            "name": "update_agent_binding",
+            "description": """Update a binding's scoping fields (owner/admin only, Issue #1275).
+
+context_id is immutable — unbind and re-bind to re-target. Changes are
+audited with old→new values.
+
+Returns: {status, binding, changed: [field, ...]}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID.",
+                    },
+                    "binding_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Binding UUID from list_agent_bindings.",
+                    },
+                    "can_read": {"type": "boolean"},
+                    "write_policy": {"type": "string", "enum": ["deny", "direct"]},
+                    "is_default": {"type": "boolean"},
+                    "allowed_memory_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "null = all types; [] = none.",
+                    },
+                    "allowed_source_types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "null = all; [] = none.",
+                    },
+                },
+                "required": ["agent_id", "binding_id"],
+            },
+        },
+        {
+            "name": "unbind_agent_context",
+            "description": """Delete a binding — the agent loses that context (owner/admin only, Issue #1275).
+
+Under enforcement_mode='enforce' the agent's requests against the unbound
+context are denied afterwards (uniform context_not_found).
+
+Returns: {status, deleted, binding_id}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Agent UUID.",
+                    },
+                    "binding_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Binding UUID to delete.",
+                    },
+                },
+                "required": ["agent_id", "binding_id"],
+            },
+        },
         # Issue #1128: zero-knowledge secret store. The server stores opaque age
         # ciphertext + public recipient keys only and NEVER decrypts. Encryption
         # and decryption happen client-side (the `kagura secret` CLI / SDK).

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -225,6 +225,34 @@ async def _resolve_context(
         )
         raise _ContextNotFoundError(context_id, "Context not found or you don't have access to it.")
 
+    # Issue #1275 (RFC-0002 P0-2): subtractive agent-binding WRITE gate for the
+    # MCP write tools (remember / update_memory / forget resolve via this
+    # helper). The read path inherits the same filter from
+    # resolve_context_for_workspace_read. Applied strictly last, so it can
+    # only remove access; no-op unless the request authenticated with an
+    # agent-bound key. Deny is the same uniform context_not_found shape.
+    from auth.agent_scope import get_agent_scope
+
+    scope = get_agent_scope()
+    if scope is not None:
+        from services.agent_binding_service import ACCESS_WRITE, AgentBindingService
+
+        allowed, decision = await AgentBindingService(db).evaluate_context_access(
+            scope, context_id, ACCESS_WRITE
+        )
+        if not allowed:
+            logger.warning(
+                "context_write_denied: reason=agent_binding decision=%s context_id=%s "
+                "agent_id=%s user_id=%s",
+                decision,
+                str(context_id),
+                str(scope.agent_id),
+                user_id,
+            )
+            raise _ContextNotFoundError(
+                context_id, "Context not found or you don't have access to it."
+            )
+
     return context
 
 

--- a/backend/src/mcp_server/tools/agent_registry.py
+++ b/backend/src/mcp_server/tools/agent_registry.py
@@ -289,3 +289,266 @@ async def handle_delete_agent(
         return _success_response(deleted=True, agent_id=str(deleted_id))
 
     return _error_response("internal_error", "Database session unavailable")
+
+
+# ============================================================================
+# Context bindings (RFC-0002 P0-2, Issue #1275)
+# ============================================================================
+
+# Binding fields accepted by bind/update, forwarded to the service (which
+# validates values and rejects unknown fields).
+_BINDING_UPDATABLE_FIELDS: tuple[str, ...] = (
+    "can_read",
+    "write_policy",
+    "is_default",
+    "allowed_memory_types",
+    "allowed_source_types",
+)
+
+
+def _serialize_binding(binding: Any) -> dict[str, Any]:
+    """Binding row → JSON-safe dict (Z-suffixed UTC timestamps)."""
+    from utils.datetime import to_utc_iso
+
+    return {
+        "id": str(binding.id),
+        "agent_id": str(binding.agent_id),
+        "context_id": str(binding.context_id),
+        "can_read": binding.can_read,
+        "write_policy": binding.write_policy,
+        "is_default": binding.is_default,
+        "allowed_memory_types": binding.allowed_memory_types,
+        "allowed_source_types": binding.allowed_source_types,
+        "created_by": binding.created_by,
+        "created_at": to_utc_iso(binding.created_at),
+        "updated_at": to_utc_iso(binding.updated_at),
+    }
+
+
+async def _resolve_agent_for_binding_op(db: Any, user_id: str, workspace_id: UUID, args: dict):
+    """Shared preamble: role gate + agent lookup. Returns (agent, error)."""
+    from mcp_server.tools.resource import _check_owner_admin_role
+    from services.agent_registry_service import AgentRegistryService
+
+    role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+    if role_err:
+        return None, role_err
+    agent_id = _parse_agent_id(args["agent_id"])
+    if agent_id is None:
+        return None, _error_response("validation_error", "agent_id must be a UUID.")
+    agent = await AgentRegistryService(db).get_agent(workspace_id, agent_id)
+    if agent is None:
+        return None, _error_response("agent_not_found", "Agent not found in your workspace.")
+    return agent, None
+
+
+async def handle_bind_agent_context(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Bind an agent to a context (owner/admin only, purely subtractive)."""
+    for field in ("agent_id", "context_id"):
+        if field not in args:
+            return _error_response("missing_fields", f"Missing required field: {field}")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+    context_id = _parse_agent_id(args["context_id"])
+    if context_id is None:
+        return _error_response("validation_error", "context_id must be a UUID.")
+
+    from db.base import get_db
+    from services.agent_binding_service import (
+        AUDIT_BINDING_CREATED,
+        AgentBindingService,
+    )
+    from services.agent_registry_service import add_agent_audit_row
+    from utils.exceptions import ConflictError, NotFoundException, ValidationError
+
+    async for db in get_db():
+        agent, err = await _resolve_agent_for_binding_op(db, user_id, workspace_id, args)
+        if err:
+            return err
+
+        try:
+            binding = await AgentBindingService(db).create_binding(
+                agent=agent,
+                context_id=context_id,
+                created_by=user_id,
+                can_read=args.get("can_read", True),
+                write_policy=args.get("write_policy", "deny"),
+                is_default=args.get("is_default", False),
+                allowed_memory_types=args.get("allowed_memory_types"),
+                allowed_source_types=args.get("allowed_source_types"),
+            )
+        except ValidationError as e:
+            return _error_response("validation_error", e.message)
+        except NotFoundException:
+            return _error_response(
+                "context_not_found", "Context not found in the agent's workspace."
+            )
+        except ConflictError as e:
+            return _error_response("binding_conflict", e.message)
+
+        add_agent_audit_row(
+            db,
+            actor_user_id=user_id,
+            actor_email=None,
+            action=AUDIT_BINDING_CREATED,
+            agent_id=agent.id,
+            workspace_id=workspace_id,
+            metadata={
+                "via": "mcp",
+                "agent_name": agent.name,
+                "context_id": str(context_id),
+                "binding_id": str(binding.id),
+                "can_read": binding.can_read,
+                "write_policy": binding.write_policy,
+                "is_default": binding.is_default,
+            },
+        )
+        await db.commit()
+        await db.refresh(binding)
+        return _success_response(binding=_serialize_binding(binding))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_list_agent_bindings(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List an agent's context bindings (owner/admin only)."""
+    if "agent_id" not in args:
+        return _error_response("missing_fields", "Missing required field: agent_id")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+    from services.agent_binding_service import AgentBindingService
+
+    async for db in get_db():
+        agent, err = await _resolve_agent_for_binding_op(db, user_id, workspace_id, args)
+        if err:
+            return err
+        bindings = await AgentBindingService(db).list_bindings(agent)
+        return _success_response(
+            bindings=[_serialize_binding(b) for b in bindings], count=len(bindings)
+        )
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_update_agent_binding(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Partially update a binding (owner/admin only)."""
+    for field in ("agent_id", "binding_id"):
+        if field not in args:
+            return _error_response("missing_fields", f"Missing required field: {field}")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+    binding_id = _parse_agent_id(args["binding_id"])
+    if binding_id is None:
+        return _error_response("validation_error", "binding_id must be a UUID.")
+
+    updates = {k: args[k] for k in _BINDING_UPDATABLE_FIELDS if k in args}
+    if not updates:
+        return _error_response(
+            "missing_fields",
+            f"Provide at least one updatable field: {', '.join(_BINDING_UPDATABLE_FIELDS)}",
+        )
+
+    from db.base import get_db
+    from services.agent_binding_service import (
+        AUDIT_BINDING_UPDATED,
+        AgentBindingService,
+    )
+    from services.agent_registry_service import add_agent_audit_row
+    from utils.exceptions import ConflictError, ValidationError
+
+    async for db in get_db():
+        agent, err = await _resolve_agent_for_binding_op(db, user_id, workspace_id, args)
+        if err:
+            return err
+        service = AgentBindingService(db)
+        binding = await service.get_binding(agent, binding_id)
+        if binding is None:
+            return _error_response("binding_not_found", "Binding not found for this agent.")
+
+        try:
+            changes = await service.update_binding(binding, updates)
+        except ValidationError as e:
+            return _error_response("validation_error", e.message)
+        except ConflictError as e:
+            return _error_response("binding_conflict", e.message)
+
+        if changes:
+            add_agent_audit_row(
+                db,
+                actor_user_id=user_id,
+                actor_email=None,
+                action=AUDIT_BINDING_UPDATED,
+                agent_id=agent.id,
+                workspace_id=workspace_id,
+                metadata={
+                    "via": "mcp",
+                    "agent_name": agent.name,
+                    "context_id": str(binding.context_id),
+                    "binding_id": str(binding.id),
+                    "changes": changes,
+                },
+            )
+            await db.commit()
+            await db.refresh(binding)
+        return _success_response(binding=_serialize_binding(binding), changed=sorted(changes))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_unbind_agent_context(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Delete a binding (owner/admin only) — the agent loses that context."""
+    for field in ("agent_id", "binding_id"):
+        if field not in args:
+            return _error_response("missing_fields", f"Missing required field: {field}")
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+    binding_id = _parse_agent_id(args["binding_id"])
+    if binding_id is None:
+        return _error_response("validation_error", "binding_id must be a UUID.")
+
+    from db.base import get_db
+    from services.agent_binding_service import (
+        AUDIT_BINDING_DELETED,
+        AgentBindingService,
+    )
+    from services.agent_registry_service import add_agent_audit_row
+
+    async for db in get_db():
+        agent, err = await _resolve_agent_for_binding_op(db, user_id, workspace_id, args)
+        if err:
+            return err
+        service = AgentBindingService(db)
+        binding = await service.get_binding(agent, binding_id)
+        if binding is None:
+            return _error_response("binding_not_found", "Binding not found for this agent.")
+
+        deleted_id = binding.id
+        add_agent_audit_row(
+            db,
+            actor_user_id=user_id,
+            actor_email=None,
+            action=AUDIT_BINDING_DELETED,
+            agent_id=agent.id,
+            workspace_id=workspace_id,
+            metadata={
+                "via": "mcp",
+                "agent_name": agent.name,
+                "context_id": str(binding.context_id),
+                "binding_id": str(deleted_id),
+            },
+        )
+        await service.delete_binding(binding)
+        await db.commit()
+        return _success_response(deleted=True, binding_id=str(deleted_id))
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/state.py
+++ b/backend/src/mcp_server/tools/state.py
@@ -84,6 +84,16 @@ async def handle_set_state(
         if perm_error:
             return perm_error
 
+        # Issue #1275: agent-state is a WRITE against the context — apply the
+        # subtractive binding gate so a read-only-bound agent (can_read=true,
+        # write_policy='deny') cannot mutate state in a context whose binding
+        # forbids writes. _resolve_context_for_read above only checks the READ
+        # side. No-op for non-agent credentials (code-review).
+        from services.agent_binding_service import ACCESS_WRITE, agent_binding_permits
+
+        if not await agent_binding_permits(db, context_id, ACCESS_WRITE):
+            return _ContextNotFoundError(context_id, "Context not found.").to_response()
+
         await AgentStateService(db).set_state(context_id, key, value, ttl_seconds=ttl_seconds)
         # Use the helper's standard {"status":"success"} envelope (consistent
         # with get_state and the rest of the MCP tools / tests).

--- a/backend/src/models/agent.py
+++ b/backend/src/models/agent.py
@@ -19,8 +19,18 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, func, text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
@@ -47,6 +57,16 @@ AGENT_ENFORCEMENT_ENFORCE = "enforce"
 _ALL_AGENT_ENFORCEMENT_MODES: tuple[str, ...] = (
     AGENT_ENFORCEMENT_SHADOW,
     AGENT_ENFORCEMENT_ENFORCE,
+)
+
+# Binding write policy (P0-2, #1275). ``'staged'`` is reserved for P1 — CHECK
+# tuples are append-only by house convention, so adding it later is a cheap
+# migration. Same drift-pin discipline as the agent tuples above.
+BINDING_WRITE_POLICY_DENY = "deny"
+BINDING_WRITE_POLICY_DIRECT = "direct"
+_ALL_BINDING_WRITE_POLICIES: tuple[str, ...] = (
+    BINDING_WRITE_POLICY_DENY,
+    BINDING_WRITE_POLICY_DIRECT,
 )
 
 
@@ -116,4 +136,84 @@ class Agent(Base):
         ),
         Index("uq_agents_workspace_name", "workspace_id", "name", unique=True),
         Index("idx_agents_workspace", "workspace_id"),
+    )
+
+
+class AgentContextBinding(Base):
+    """Purely subtractive per-context scoping for one agent (P0-2, #1275).
+
+    The effective permission for an agent-bound request is *existing
+    PermissionService decision ∩ binding* — a binding can never grant access
+    the underlying member row does not have (design invariant 2,
+    ``docs/design/agent-registry-and-bindings.md``). The agent's **read set**
+    is the rows with ``can_read = true``; its **write set** is the rows with
+    ``write_policy = 'direct'``. No binding row for a context = deny under
+    ``enforce`` (default-deny applies only to newly bound agents).
+
+    NULL/[] array semantics are fixed: ``NULL`` = unrestricted, ``[]`` =
+    deny-all — deliberately NOT reproducing the role-dependent
+    ``allowed_context_ids`` NULL asymmetry. ``is_default`` is the single
+    source of truth for the bootstrap default binding (at most one per agent,
+    guaranteed by the partial unique index).
+    """
+
+    __tablename__ = "agent_context_bindings"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    context_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    can_read: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default=text("true")
+    )
+    write_policy: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=BINDING_WRITE_POLICY_DENY,
+        server_default=text("'deny'"),
+    )
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
+    # NULL = all types allowed; [] = none. Memory types are an open vocabulary
+    # (no CHECK); source types take values from the memories.source_type set,
+    # validated at the service layer.
+    allowed_memory_types: Mapped[list[str] | None] = mapped_column(ARRAY(String(50)), nullable=True)
+    allowed_source_types: Mapped[list[str] | None] = mapped_column(ARRAY(String(20)), nullable=True)
+    # OAuth sub of the binding author; pseudonymized by account_erasure_service
+    # for erased subjects whose rows survive.
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"write_policy IN ({', '.join(repr(p) for p in _ALL_BINDING_WRITE_POLICIES)})",
+            name="valid_binding_write_policy",
+        ),
+        Index("uq_agent_ctx_binding", "agent_id", "context_id", unique=True),
+        # At most one bootstrap default binding per agent.
+        Index(
+            "uq_agent_ctx_binding_default",
+            "agent_id",
+            unique=True,
+            postgresql_where=text("is_default"),
+        ),
+        Index("idx_agent_ctx_binding_context", "context_id"),
     )

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -312,6 +312,19 @@ class APIKey(Base):
         nullable=True,
     )
 
+    # Issue #1275 (RFC-0002 P0-2): agent-bound member key. ON DELETE CASCADE,
+    # not SET NULL — SET NULL would silently widen a dead agent's keys back to
+    # full member scope (privilege escalation by deletion); CASCADE is also
+    # what the account-erasure workspace hard-delete path relies on. Mutually
+    # exclusive with bound_context_id (CHECK below). Key↔agent workspace
+    # consistency is enforced at mint time in the service layer and
+    # re-asserted defensively at verify.
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agents.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
@@ -333,9 +346,23 @@ class APIKey(Base):
         Index("idx_revoked", "revoked_at"),
         Index("idx_expires", "expires_at"),
         Index("idx_api_keys_bound_context_id", "bound_context_id"),
+        # Issue #1275: partial index over only the agent-bound rows so the
+        # verify-path agent lookup and per-agent key listings stay
+        # proportional to bound keys, not the table.
+        Index(
+            "idx_api_keys_agent",
+            "agent_id",
+            postgresql_where=text("agent_id IS NOT NULL"),
+        ),
         CheckConstraint(
             "bound_context_id IS NULL OR workspace_id IS NULL",
             name="ck_api_keys_binding_workspace_exclusion",
+        ),
+        # Issue #1275: agent binding and public binding are mutually
+        # exclusive, extending the exclusion precedent above.
+        CheckConstraint(
+            "agent_id IS NULL OR bound_context_id IS NULL",
+            name="ck_api_keys_agent_public_exclusion",
         ),
     )
 

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -64,6 +64,10 @@ OPERATIONAL_TABLES: frozenset[str] = frozenset(
         # content, no learned structure. Governed by the auth/security regime +
         # GDPR erasure (workspace cascade + owner_user_id pseudonymization).
         "agents",
+        # Subtractive agent scoping rows (#1275, RFC-0002 P0-2) — authorization
+        # plumbing like context_members; cascades with agent/context, created_by
+        # pseudonymized on erasure.
+        "agent_context_bindings",
         "users",
         "user_oauth_providers",
         "oauth_authorization_codes",

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1426,6 +1426,12 @@ class CreateAPIKeyRequest(BaseModel):
     # 400 if omitted for the programmatic path); session self-mint leaves it None
     # (unchanged — no expiry, as today). 1–3650 days mirrors /api/v1/config/api-keys.
     expires_days: int | None = Field(default=None, ge=1, le=3650)
+    # Issue #1275 (RFC-0002 P0-2): bind the minted key to a registered agent.
+    # Owner-provisioned path only (the route rejects it on session self-mint);
+    # the agent must belong to the same workspace and be active (mint-time
+    # gates in APIKeyManager.create_key). Mutually exclusive with
+    # bound_context_id.
+    agent_id: UUID | None = None
 
 
 class RegenerateAPIKeyResponse(BaseModel):

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -45,7 +45,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config.settings import get_settings
 from db.qdrant import delete_user_points
 from db.redis import clear_co_activations, clear_user_rate_limits, get_redis_client
-from models.agent import Agent
+from models.agent import Agent, AgentContextBinding
 from models.auth import (
     APIKey,
     AuditLog,
@@ -1028,6 +1028,13 @@ class AccountErasureService:
         # subject. Same legal-retention posture as plan_changes.changed_by.
         counts["agents_pseudonymized"] = await self._pseudonymize_field(
             Agent, Agent.owner_user_id, user_id
+        )
+
+        # Same for agent_context_bindings.created_by (#1275, RFC-0002 P0-2):
+        # binding rows cascade with their agent/context, but bindings authored
+        # by the erased subject on surviving agents must drop the personal link.
+        counts["agent_bindings_pseudonymized"] = await self._pseudonymize_field(
+            AgentContextBinding, AgentContextBinding.created_by, user_id
         )
 
         # Finally the user row itself.

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -95,6 +95,31 @@ def _validate_write_policy(value: Any) -> str:
     return value
 
 
+async def agent_binding_permits(db: AsyncSession, context_id: uuid.UUID, access: str) -> bool:
+    """Reusable subtractive gate for the per-request agent scope.
+
+    Returns True when the request is not an agent credential (scope None) or
+    the binding allows / shadow-permits the access; False only on a hard
+    ``binding_denied``. This is the single lever the memory-access chokepoints
+    (``PermissionService.can_access_memory`` for memory-id-addressed ops,
+    ``MemoryService._get_context_isolation_params`` for the declared-context
+    write/read path) call so agent-bound REST **and** MCP requests get the
+    same intersection the context-resolution chokepoints already apply —
+    closing the "MemoryService authorizes via its own RBAC path, not the
+    named chokepoint" gap (Copilot/inner review of #1275). No-op cost for
+    every non-agent credential (one contextvar read).
+    """
+    from auth.agent_scope import get_agent_scope
+
+    scope = get_agent_scope()
+    if scope is None:
+        return True
+    allowed, _decision = await AgentBindingService(db).evaluate_context_access(
+        scope, context_id, access
+    )
+    return allowed
+
+
 class AgentBindingService:
     """CRUD + subtractive evaluation over ``agent_context_bindings``."""
 

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -1,0 +1,346 @@
+"""Agent context-binding service (RFC-0002 P0-2, Issue #1275).
+
+Owns the ``agent_context_bindings`` CRUD (shared by the REST nested routes
+and the MCP tools) and the **subtractive** binding evaluation the context
+chokepoints call. Design invariants
+(``docs/design/agent-registry-and-bindings.md``):
+
+- A binding can only *remove* access the underlying RBAC decision granted —
+  the evaluation returns allow/deny; it never grants.
+- No binding row for a context = deny under ``enforce`` (default-deny applies
+  only to newly bound agents); under ``shadow`` the request proceeds and the
+  violation is logged as a would-deny (the durable ``memory_access_events``
+  row lands with P0-5, #1278).
+- ``contexts.workspace_id == agents.workspace_id`` is validated at binding
+  create — a cross-workspace binding row would be inert under the subtractive
+  rule, but it is dead weight and a confusing admin surface.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.agent_scope import AgentScope
+from models.agent import (
+    _ALL_BINDING_WRITE_POLICIES,
+    AGENT_ENFORCEMENT_SHADOW,
+    Agent,
+    AgentContextBinding,
+)
+from utils.exceptions import ConflictError, NotFoundException, ValidationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Binding evaluation decisions — vocabulary aligned with the
+# memory_access_events.decision CHECK set (F3 design, lands with P0-5).
+DECISION_ALLOWED = "allowed"
+DECISION_BINDING_DENIED = "binding_denied"
+DECISION_WOULD_DENY = "would_deny"
+
+# Access kinds the chokepoints evaluate.
+ACCESS_READ = "read"
+ACCESS_WRITE = "write"
+
+# Audit action vocabulary (security-mutation lane, extends the P0-1 set).
+AUDIT_BINDING_CREATED = "agent_binding_created"
+AUDIT_BINDING_UPDATED = "agent_binding_updated"
+AUDIT_BINDING_DELETED = "agent_binding_deleted"
+
+_ARRAY_FIELDS = ("allowed_memory_types", "allowed_source_types")
+_ARRAY_VALUE_MAX_LEN = {"allowed_memory_types": 50, "allowed_source_types": 20}
+_ARRAY_MAX_ITEMS = 100
+
+
+def _validate_type_array(value: Any, field: str) -> list[str] | None:
+    """Validate a NULL-vs-[] typed filter array.
+
+    ``None`` = unrestricted, ``[]`` = deny-all (fixed semantics — deliberately
+    NOT the role-dependent ``allowed_context_ids`` asymmetry). Memory types
+    are an open vocabulary; ``allowed_source_types`` values are checked
+    against the canonical ``memories.source_type`` set.
+    """
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(v, str) and v for v in value):
+        raise ValidationError(f"'{field}' must be null or a list of non-empty strings", field=field)
+    if len(value) > _ARRAY_MAX_ITEMS:
+        raise ValidationError(f"'{field}' must have at most {_ARRAY_MAX_ITEMS} items", field=field)
+    max_len = _ARRAY_VALUE_MAX_LEN[field]
+    if any(len(v) > max_len for v in value):
+        raise ValidationError(f"'{field}' values must be at most {max_len} characters", field=field)
+    if field == "allowed_source_types":
+        from models.memory import _ALL_SOURCE_TYPES
+
+        unknown = sorted(set(value) - set(_ALL_SOURCE_TYPES))
+        if unknown:
+            raise ValidationError(
+                f"'{field}' contains unknown source types: {unknown} "
+                f"(valid: {list(_ALL_SOURCE_TYPES)})",
+                field=field,
+            )
+    return value
+
+
+def _validate_write_policy(value: Any) -> str:
+    if value not in _ALL_BINDING_WRITE_POLICIES:
+        raise ValidationError(
+            f"'write_policy' must be one of {list(_ALL_BINDING_WRITE_POLICIES)}",
+            field="write_policy",
+        )
+    return value
+
+
+class AgentBindingService:
+    """CRUD + subtractive evaluation over ``agent_context_bindings``."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    # ------------------------------------------------------------------
+    # CRUD (owner/admin surfaces)
+    # ------------------------------------------------------------------
+
+    async def list_bindings(self, agent: Agent) -> list[AgentContextBinding]:
+        result = await self.db.execute(
+            select(AgentContextBinding)
+            .where(AgentContextBinding.agent_id == agent.id)
+            .order_by(AgentContextBinding.created_at.desc(), AgentContextBinding.id)
+        )
+        return list(result.scalars().all())
+
+    async def get_binding(self, agent: Agent, binding_id: uuid.UUID) -> AgentContextBinding | None:
+        result = await self.db.execute(
+            select(AgentContextBinding).where(
+                AgentContextBinding.id == binding_id,
+                AgentContextBinding.agent_id == agent.id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def create_binding(
+        self,
+        *,
+        agent: Agent,
+        context_id: uuid.UUID,
+        created_by: str,
+        can_read: bool = True,
+        write_policy: str = "deny",
+        is_default: bool = False,
+        allowed_memory_types: list[str] | None = None,
+        allowed_source_types: list[str] | None = None,
+    ) -> AgentContextBinding:
+        """Create a binding after validating the workspace boundary.
+
+        Flushed but NOT committed — the caller commits atomically with its
+        audit row. The two unique indexes are recognized BY NAME on the flush
+        so TOCTOU losers get the same 409 as the pre-checks.
+
+        Raises:
+            ValidationError: malformed fields.
+            NotFoundException: context missing / cross-workspace (uniform —
+                does not confirm foreign contexts exist).
+            ConflictError: duplicate (agent, context) binding, or a second
+                default binding for the agent.
+        """
+        from models.auth import Context
+
+        if not isinstance(can_read, bool):
+            raise ValidationError("'can_read' must be a boolean", field="can_read")
+        if not isinstance(is_default, bool):
+            raise ValidationError("'is_default' must be a boolean", field="is_default")
+        clean_policy = _validate_write_policy(write_policy)
+        clean_memory_types = _validate_type_array(allowed_memory_types, "allowed_memory_types")
+        clean_source_types = _validate_type_array(allowed_source_types, "allowed_source_types")
+
+        # Workspace-boundary validation (design-normative). Uniform 404 so a
+        # cross-workspace probe cannot confirm a foreign context exists.
+        ctx_result = await self.db.execute(
+            select(Context).where(Context.id == context_id, Context.deleted_at.is_(None))
+        )
+        context = ctx_result.scalar_one_or_none()
+        if context is None or context.workspace_id != agent.workspace_id:
+            raise NotFoundException("Context", str(context_id))
+
+        existing = await self.db.execute(
+            select(AgentContextBinding.id).where(
+                AgentContextBinding.agent_id == agent.id,
+                AgentContextBinding.context_id == context_id,
+            )
+        )
+        if existing.scalar_one_or_none():
+            raise ConflictError("A binding for this (agent, context) pair already exists.")
+
+        if is_default:
+            default_row = await self.db.execute(
+                select(AgentContextBinding.id).where(
+                    AgentContextBinding.agent_id == agent.id,
+                    AgentContextBinding.is_default.is_(True),
+                )
+            )
+            if default_row.scalar_one_or_none():
+                raise ConflictError(
+                    "This agent already has a default binding — unset it first "
+                    "(is_default is the single source of truth for bootstrap)."
+                )
+
+        binding = AgentContextBinding(
+            agent_id=agent.id,
+            context_id=context_id,
+            can_read=can_read,
+            write_policy=clean_policy,
+            is_default=is_default,
+            allowed_memory_types=clean_memory_types,
+            allowed_source_types=clean_source_types,
+            created_by=created_by,
+        )
+        self.db.add(binding)
+        await self._flush_mapping_conflicts()
+        return binding
+
+    async def update_binding(
+        self, binding: AgentContextBinding, updates: dict[str, Any]
+    ) -> dict[str, dict[str, Any]]:
+        """Apply a validated partial update; returns ``{field: {old, new}}``.
+
+        ``context_id`` is immutable (delete + recreate to re-target). No-op
+        assignments are dropped so audit rows record only real transitions.
+        Flushed but NOT committed.
+        """
+        changes: dict[str, dict[str, Any]] = {}
+
+        for field, raw in updates.items():
+            if field == "can_read" or field == "is_default":
+                if not isinstance(raw, bool):
+                    raise ValidationError(f"'{field}' must be a boolean", field=field)
+                if raw != getattr(binding, field):
+                    if field == "is_default" and raw:
+                        default_row = await self.db.execute(
+                            select(AgentContextBinding.id).where(
+                                AgentContextBinding.agent_id == binding.agent_id,
+                                AgentContextBinding.is_default.is_(True),
+                                AgentContextBinding.id != binding.id,
+                            )
+                        )
+                        if default_row.scalar_one_or_none():
+                            raise ConflictError(
+                                "This agent already has a default binding — unset it first."
+                            )
+                    changes[field] = {"old": getattr(binding, field), "new": raw}
+                    setattr(binding, field, raw)
+            elif field == "write_policy":
+                new_policy = _validate_write_policy(raw)
+                if new_policy != binding.write_policy:
+                    changes[field] = {"old": binding.write_policy, "new": new_policy}
+                    binding.write_policy = new_policy
+            elif field in _ARRAY_FIELDS:
+                new_value = _validate_type_array(raw, field)
+                if new_value != getattr(binding, field):
+                    changes[field] = {"old": getattr(binding, field), "new": new_value}
+                    setattr(binding, field, new_value)
+            else:
+                raise ValidationError(f"Unknown binding field: '{field}'", field=field)
+
+        if changes:
+            await self._flush_mapping_conflicts()
+        return changes
+
+    async def delete_binding(self, binding: AgentContextBinding) -> None:
+        """Delete a binding row. NOT committed (caller commits with audit)."""
+        await self.db.delete(binding)
+        await self.db.flush()
+
+    async def _flush_mapping_conflicts(self) -> None:
+        """Flush, mapping binding unique-index races to the pre-check 409s."""
+        from sqlalchemy.exc import IntegrityError
+
+        from db.constraint_names import (
+            AGENT_CTX_BINDING_DEFAULT_UNIQUE,
+            AGENT_CTX_BINDING_UNIQUE,
+            integrity_error_constraint_name,
+        )
+
+        try:
+            await self.db.flush()
+        except IntegrityError as exc:
+            constraint = integrity_error_constraint_name(exc)
+            if constraint == AGENT_CTX_BINDING_UNIQUE:
+                raise ConflictError(
+                    "A binding for this (agent, context) pair already exists."
+                ) from exc
+            if constraint == AGENT_CTX_BINDING_DEFAULT_UNIQUE:
+                raise ConflictError(
+                    "This agent already has a default binding — unset it first."
+                ) from exc
+            raise
+
+    # ------------------------------------------------------------------
+    # Subtractive evaluation (chokepoints)
+    # ------------------------------------------------------------------
+
+    async def evaluate_context_access(
+        self, scope: AgentScope, context_id: uuid.UUID, access: str
+    ) -> tuple[bool, str]:
+        """Evaluate the binding intersection for one context.
+
+        Returns ``(allowed, decision)`` where decision ∈ {allowed,
+        binding_denied, would_deny}. ``would_deny`` means the binding would
+        deny but ``enforcement_mode='shadow'`` lets the request proceed under
+        legacy semantics (the migration ramp) — callers MUST treat it as
+        allowed. This function can only subtract: it is called strictly AFTER
+        the existing RBAC decision allowed the request.
+        """
+        result = await self.db.execute(
+            select(AgentContextBinding).where(
+                AgentContextBinding.agent_id == scope.agent_id,
+                AgentContextBinding.context_id == context_id,
+            )
+        )
+        binding = result.scalar_one_or_none()
+
+        if binding is not None:
+            permitted = (
+                binding.can_read if access == ACCESS_READ else (binding.write_policy == "direct")
+            )
+        else:
+            # No row = not in the agent's binding set: default-deny (applies
+            # only to newly bound agents — unbound keys never reach here).
+            permitted = False
+
+        if permitted:
+            return True, DECISION_ALLOWED
+
+        if scope.enforcement_mode == AGENT_ENFORCEMENT_SHADOW:
+            # Shadow ramp: proceed, but record the violation. The durable
+            # would_deny row lands in memory_access_events with P0-5 (#1278).
+            logger.warning(
+                "agent_binding_would_deny",
+                agent_id=str(scope.agent_id),
+                context_id=str(context_id),
+                access=access,
+                bound=binding is not None,
+            )
+            return True, DECISION_WOULD_DENY
+
+        logger.warning(
+            "agent_binding_denied",
+            agent_id=str(scope.agent_id),
+            context_id=str(context_id),
+            access=access,
+            bound=binding is not None,
+        )
+        return False, DECISION_BINDING_DENIED
+
+    async def readable_context_ids(self, agent_id: uuid.UUID) -> set[uuid.UUID]:
+        """The agent's read set — for enumeration-surface intersection."""
+        result = await self.db.execute(
+            select(AgentContextBinding.context_id).where(
+                AgentContextBinding.agent_id == agent_id,
+                AgentContextBinding.can_read.is_(True),
+            )
+        )
+        return set(result.scalars().all())

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -52,38 +52,29 @@ AUDIT_BINDING_UPDATED = "agent_binding_updated"
 AUDIT_BINDING_DELETED = "agent_binding_deleted"
 
 _ARRAY_FIELDS = ("allowed_memory_types", "allowed_source_types")
-_ARRAY_VALUE_MAX_LEN = {"allowed_memory_types": 50, "allowed_source_types": 20}
-_ARRAY_MAX_ITEMS = 100
 
 
 def _validate_type_array(value: Any, field: str) -> list[str] | None:
-    """Validate a NULL-vs-[] typed filter array.
+    """Validate a type/source filter array — RESERVED, enforcement deferred.
 
-    ``None`` = unrestricted, ``[]`` = deny-all (fixed semantics — deliberately
-    NOT the role-dependent ``allowed_context_ids`` asymmetry). Memory types
-    are an open vocabulary; ``allowed_source_types`` values are checked
-    against the canonical ``memories.source_type`` set.
+    The ``allowed_memory_types`` / ``allowed_source_types`` columns are
+    forward-provisioned in the F1 DDL, but per-memory type/source enforcement
+    is materially larger than the context-level binding gate (it must filter
+    each recall/reference/write by the memory's own type) and lands in a
+    follow-up (#1281). To avoid a **fail-open** — an admin setting a restriction
+    that is silently ignored, a false sense of containment — CRUD rejects any
+    non-NULL value for now. ``NULL`` (= all types, the P0-2-enforced value) is
+    the only accepted value. Code-review of #1275. (Same "provisioned-but-
+    reserved" posture as ``write_policy='staged'``.)
     """
     if value is None:
         return None
-    if not isinstance(value, list) or not all(isinstance(v, str) and v for v in value):
-        raise ValidationError(f"'{field}' must be null or a list of non-empty strings", field=field)
-    if len(value) > _ARRAY_MAX_ITEMS:
-        raise ValidationError(f"'{field}' must have at most {_ARRAY_MAX_ITEMS} items", field=field)
-    max_len = _ARRAY_VALUE_MAX_LEN[field]
-    if any(len(v) > max_len for v in value):
-        raise ValidationError(f"'{field}' values must be at most {max_len} characters", field=field)
-    if field == "allowed_source_types":
-        from models.memory import _ALL_SOURCE_TYPES
-
-        unknown = sorted(set(value) - set(_ALL_SOURCE_TYPES))
-        if unknown:
-            raise ValidationError(
-                f"'{field}' contains unknown source types: {unknown} "
-                f"(valid: {list(_ALL_SOURCE_TYPES)})",
-                field=field,
-            )
-    return value
+    raise ValidationError(
+        f"'{field}' is reserved: per-type binding filters are provisioned but "
+        "not yet enforced — set it to null (all types) for now. Type/source "
+        "filtering ships in a follow-up (#1281).",
+        field=field,
+    )
 
 
 def _validate_write_policy(value: Any) -> str:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -159,26 +159,43 @@ class MemoryService:
         self.context_service = ContextService(db)
 
     async def _get_context_isolation_params(
-        self, user_id: str, context_id: UUID | None
+        self, user_id: str, context_id: UUID | None, *, access: str = "read"
     ) -> tuple[Context | None, str | None, str | None]:
         """Extract workspace_id and context_id for 3-level isolation (performance optimization).
 
         Single Collection Migration: Helper to avoid duplicate context fetches.
 
+        Issue #1275 (RFC-0002 P0-2): this resolves the *declared* context for
+        the remember (write) / recall (read) / forget-by-context (write)
+        paths — a route that does not pass through
+        ``PermissionService.resolve_context_for_workspace_read``. Apply the
+        same subtractive agent-binding gate here so agent-bound REST/MCP
+        requests cannot write into (or read from) a binding-denied context via
+        these paths. Callers on a WRITE path MUST pass ``access="write"``.
+        No-op for non-agent credentials; deny raises the uniform
+        ``NotFoundException("Context")`` matching ``get_context``.
+
         Args:
             user_id: User ID
             context_id: Context ID
+            access: ``"read"`` (default) or ``"write"`` — the binding gate.
 
         Returns:
             Tuple of (context_object, workspace_id_str, context_id_str)
 
         Raises:
-            NotFoundException: If context not found
+            NotFoundException: If context not found or the binding denies it.
         """
         if not context_id:
             return None, None, None
 
         context = await self.context_service.get_context(user_id, context_id)
+
+        from services.agent_binding_service import agent_binding_permits
+
+        if not await agent_binding_permits(self.db, context_id, access):
+            raise NotFoundException("Context", str(context_id))
+
         return context, str(context.workspace_id), str(context_id)
 
     @staticmethod
@@ -295,9 +312,11 @@ class MemoryService:
                 current_workspace_id, raise_on_exceeded=True
             )
 
-        # Single Collection Migration: Extract isolation params (optimized)
+        # Single Collection Migration: Extract isolation params (optimized).
+        # Issue #1275: remember is a WRITE — gate the declared context against
+        # the agent binding (no-op for non-agent credentials).
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id
+            user_id, current_context_id, access="write"
         )
 
         # Validate required parameters
@@ -499,6 +518,7 @@ class MemoryService:
             memory_user_id=MemoryAuthorId(memory.user_id),
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
+            access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
         )
         if not can_access:
             raise NotFoundException("Memory", str(request.memory_id))
@@ -686,6 +706,7 @@ class MemoryService:
             memory_user_id=MemoryAuthorId(memory.user_id),
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
+            access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
         )
         if not can_access:
             raise NotFoundException("Memory", str(memory_id))
@@ -2782,9 +2803,11 @@ class MemoryService:
         Returns:
             ForgetResponse with deleted count and IDs
         """
-        # Single Collection Migration: Extract isolation params (optimized)
+        # Single Collection Migration: Extract isolation params (optimized).
+        # Issue #1275: forget is a WRITE — gate the declared context against
+        # the agent binding (no-op for non-agent credentials).
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id
+            user_id, current_context_id, access="write"
         )
 
         deleted_ids = []
@@ -2803,6 +2826,7 @@ class MemoryService:
                     memory_user_id=MemoryAuthorId(memory.user_id),
                     workspace_id=memory.workspace_id,
                     context_id=memory.context_id,
+                    access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
                 )
 
                 if not can_access:

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -896,6 +896,7 @@ class PermissionService:
         memory_user_id: MemoryAuthorId,
         workspace_id: UUID,
         context_id: UUID,
+        access: str = "read",
     ) -> bool:
         """Check if user can access a memory based on workspace membership and context privacy.
 
@@ -903,18 +904,38 @@ class PermissionService:
         1. Private context (is_private=true): Only creator can access
         2. Shared context (is_private=false): Workspace members can access
 
+        Issue #1275 (RFC-0002 P0-2): this is the memory-id-addressed access
+        chokepoint (reference / update / forget-by-id / explore authorize the
+        memory's *own* stored ``context_id`` here). After the base RBAC
+        decision allows, the purely subtractive agent-binding intersection is
+        applied for agent-bound credentials, so a binding-denied context is
+        unreachable even by memory_id. Callers on a WRITE path (update /
+        forget) MUST pass ``access="write"`` so a ``can_read``-only binding
+        cannot be used to mutate. No-op for non-agent credentials.
+
         Args:
             user_id: Requesting user ID
             memory_user_id: Memory creator's user ID
             workspace_id: Workspace ID
             context_id: Context ID
+            access: ``"read"`` (default) or ``"write"`` — the binding gate.
 
         Returns:
             True if user can access, False otherwise
         """
-        # Owner can always access their own memories
+
+        async def _binding_ok() -> bool:
+            # The subtractive agent-binding gate applies to EVERY caller,
+            # including the memory owner (an agent bound-denied to a context
+            # must not reach its own memories there via memory_id).
+            from services.agent_binding_service import agent_binding_permits
+
+            return await agent_binding_permits(self.db, context_id, access)
+
+        # Owner can always access their own memories (RBAC), but the binding
+        # still subtracts.
         if user_id == memory_user_id:
-            return True
+            return await _binding_ok()
 
         # Check if context is shared
         from services.context_service import ContextService
@@ -926,5 +947,7 @@ class PermissionService:
             # Private context: only creator can access
             return False
 
-        # Shared context: check workspace membership
-        return await self.is_workspace_member(user_id, workspace_id)
+        # Shared context: check workspace membership, then the binding.
+        if not await self.is_workspace_member(user_id, workspace_id):
+            return False
+        return await _binding_ok()

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -401,7 +401,51 @@ class PermissionService:
             )
             raise NotFoundException("Context", str(context_id))
 
+        # Issue #1275 (RFC-0002 P0-2): purely subtractive agent-binding
+        # intersection — applied strictly AFTER every existing gate passed, so
+        # it can only remove access. No-op for non-agent credentials (scope is
+        # None). ``required_role`` semantics: viewer = read helper default;
+        # writers pass admin/owner. WorkspaceRole is a StrEnum, so the
+        # comparison holds for both str and enum callers.
+        access = "read" if required_role == WorkspaceRole.VIEWER else "write"
+        await self._apply_agent_binding_filter(context_id, access=access, user_id=user_id)
+
         return context
+
+    async def _apply_agent_binding_filter(
+        self, context_id: UUID, *, access: str, user_id: str
+    ) -> None:
+        """Deny with the uniform 404 when the agent binding subtracts access.
+
+        Reads the per-request agent scope (#1275, set at API-key verify for
+        agent-bound keys only) and evaluates the binding intersection. Both
+        read and write denies surface as ``context_not_found`` — confirming
+        the context exists but is write-forbidden would leak the CWE-639
+        signal the uniform-404 posture removes. Shadow-mode violations are
+        logged and allowed (``would_deny``, the enforcement ramp).
+        """
+        from auth.agent_scope import get_agent_scope
+
+        scope = get_agent_scope()
+        if scope is None:
+            return
+
+        from services.agent_binding_service import AgentBindingService
+
+        allowed, decision = await AgentBindingService(self.db).evaluate_context_access(
+            scope, context_id, access
+        )
+        if not allowed:
+            logger.warning(
+                "context_access_denied",
+                reason="agent_binding",
+                decision=decision,
+                access=access,
+                context_id=str(context_id),
+                agent_id=str(scope.agent_id),
+                user_id=user_id,
+            )
+            raise NotFoundException("Context", str(context_id))
 
     async def check_workspace_owner(self, user_id: str, workspace_id: UUID) -> WorkspaceMember:
         """Check if user is workspace owner.
@@ -471,6 +515,12 @@ class PermissionService:
         2. Workspace viewer → Read-only access (bypass context membership)
         3. Workspace member → Requires explicit context membership
 
+        Issue #1275 (RFC-0002 P0-2): after the RBAC decision allows, the
+        purely subtractive agent-binding intersection is applied for
+        agent-bound credentials (no-op otherwise). A binding deny — read OR
+        write — surfaces as the uniform ``context_not_found`` 404 per the
+        design contract, not a 403 that would confirm existence.
+
         Args:
             user_id: User ID
             context_id: Context ID
@@ -483,12 +533,39 @@ class PermissionService:
             ContextMember row keeps its own role.
 
         Raises:
-            NotFoundException: 404 if the context does not exist.
+            NotFoundException: 404 if the context does not exist, or the
+                agent binding subtracts access (#1275).
             AuthorizationError: 403 if user doesn't have required access.
                 Message is the uniform ``"Insufficient permissions"`` —
                 per-deny-path messages were intentionally stripped to remove
                 a CWE-639 enumeration vector. Use structured logs / sentry
                 breadcrumbs for the deny reason.
+        """
+        context, effective_role = await self._check_context_access_rbac(
+            user_id, context_id, required_role
+        )
+
+        # ContextRole is a str-comparable enum here only via its value set;
+        # normalize the same way the RBAC core does.
+        required = (
+            required_role if isinstance(required_role, ContextRole) else ContextRole(required_role)
+        )
+        access = "read" if required == ContextRole.VIEWER else "write"
+        await self._apply_agent_binding_filter(context_id, access=access, user_id=user_id)
+
+        return context, effective_role
+
+    async def _check_context_access_rbac(
+        self,
+        user_id: str,
+        context_id: UUID,
+        required_role: ContextRole | str = ContextRole.VIEWER,
+    ) -> tuple[Context, ContextRole]:
+        """The pre-#1275 RBAC decision core of ``check_context_access``.
+
+        Kept verbatim so the binding intersection is a strict wrapper — the
+        backward-compat matrix's "byte-for-byte unchanged without agent_id"
+        guarantee reduces to "this method did not change".
         """
         from sqlalchemy import select
 
@@ -656,6 +733,12 @@ class PermissionService:
         hid every shared context from viewers (UX-visible: contexts list
         was empty for viewer even when shared contexts existed).
 
+        Issue #1275 (RFC-0002 P0-2): for ``enforce``-mode agent credentials
+        the enumeration surface is intersected with the agent's binding read
+        set — a membership-driven listing must not disclose contexts the
+        binding subtracts. ``shadow``-mode agents keep the full membership
+        view (the enforcement ramp changes nothing observable).
+
         Args:
             user_id: User ID
             workspace_id: Workspace ID
@@ -663,6 +746,26 @@ class PermissionService:
         Returns:
             List of accessible contexts
         """
+        contexts = await self._get_accessible_contexts_rbac(user_id, workspace_id)
+
+        from auth.agent_scope import get_agent_scope
+        from models.agent import AGENT_ENFORCEMENT_ENFORCE
+
+        scope = get_agent_scope()
+        if scope is None or scope.enforcement_mode != AGENT_ENFORCEMENT_ENFORCE or not contexts:
+            return contexts
+
+        from services.agent_binding_service import AgentBindingService
+
+        readable = await AgentBindingService(self.db).readable_context_ids(scope.agent_id)
+        return [c for c in contexts if c.id in readable]
+
+    async def _get_accessible_contexts_rbac(
+        self,
+        user_id: str,
+        workspace_id: UUID,
+    ) -> list[Context]:
+        """The pre-#1275 membership-driven listing (see get_accessible_contexts)."""
         from sqlalchemy import select
 
         # Check workspace membership (viewer is the floor — the per-role

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -749,10 +749,18 @@ class PermissionService:
         contexts = await self._get_accessible_contexts_rbac(user_id, workspace_id)
 
         from auth.agent_scope import get_agent_scope
-        from models.agent import AGENT_ENFORCEMENT_ENFORCE
+        from models.agent import AGENT_ENFORCEMENT_SHADOW
 
         scope = get_agent_scope()
-        if scope is None or scope.enforcement_mode != AGENT_ENFORCEMENT_ENFORCE or not contexts:
+        if scope is None or not contexts:
+            return contexts
+        # shadow is the only mode that keeps the full membership view (the
+        # enforcement ramp — would_deny is logged, not applied). enforce AND
+        # any unexpected mode fall through to the intersection so an
+        # unrecognized enforcement_mode fails CLOSED, matching
+        # evaluate_context_access which denies on a non-shadow mode
+        # (code-review: the two paths must not disagree).
+        if scope.enforcement_mode == AGENT_ENFORCEMENT_SHADOW:
             return contexts
 
         from services.agent_binding_service import AgentBindingService

--- a/backend/tests/api/test_member_credentials_owner_key.py
+++ b/backend/tests/api/test_member_credentials_owner_key.py
@@ -399,3 +399,58 @@ class TestGetMemberCredentialsNonMember:
 
         r = client.get(LIST_URL)
         assert r.status_code == 404, r.text
+
+
+class TestAgentBoundMint:
+    """RFC-0002 P0-2 (#1275): owner-provisioned mint accepts agent_id."""
+
+    def test_agent_id_plumbed_and_audited(self, client, owner_gate, monkeypatch):
+        fake_db = _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+        mgr, _ = _mock_manager(monkeypatch)
+        agent_id = uuid.uuid4()
+
+        r = client.post(
+            MINT_URL,
+            json={"name": "agent-key", "expires_days": 30, "agent_id": str(agent_id)},
+        )
+
+        assert r.status_code == 201, r.text
+        assert mgr.create_key.await_args.kwargs["agent_id"] == agent_id
+        from models.auth import AuditLog
+
+        audit_rows = [
+            c.args[0] for c in fake_db.add.call_args_list if isinstance(c.args[0], AuditLog)
+        ]
+        assert audit_rows[0].user_metadata["agent_id"] == str(agent_id)
+
+    def test_mint_gate_valueerror_maps_to_400(self, client, owner_gate, monkeypatch):
+        """create_key's mint gates (unknown agent / cross-workspace / non-active)
+        raise ValueError, which the route maps to a clean 400."""
+        _override(_api_key_owner())
+        _mock_member_service(monkeypatch, target_role="member")
+        mgr, _ = _mock_manager(monkeypatch)
+        mgr.create_key = AsyncMock(side_effect=ValueError("agent and key workspace mismatch"))
+
+        r = client.post(
+            MINT_URL,
+            json={"name": "k", "expires_days": 30, "agent_id": str(uuid.uuid4())},
+        )
+
+        assert r.status_code == 400
+
+    def test_session_self_mint_rejects_agent_id(self, client, monkeypatch):
+        """agent_id is owner-provisioned-only — session self-mint 400s
+        (same posture as expires_days)."""
+        _override(
+            {
+                "user_id": "target-user",
+                "sub": "target-user",  # session principal marker
+                "email": "t@example.com",
+                "role": "user",
+                "current_workspace_id": _WS,
+            }
+        )
+        r = client.post(MINT_URL, json={"name": "k", "agent_id": str(uuid.uuid4())})
+        assert r.status_code == 400
+        assert "owner-provisioned" in r.json()["message"]

--- a/backend/tests/auth/test_agent_bound_keys.py
+++ b/backend/tests/auth/test_agent_bound_keys.py
@@ -1,0 +1,207 @@
+"""Unit tests for agent-bound key mint/verify gates (RFC-0002 P0-2, #1275).
+
+Pins the verify-time fail-closed kill switch (suspended/retired/missing
+agent → key rejected), the defensive workspace re-assert, the VerifiedKey
+agent fields, the mint-time gates in ``create_key``, and the per-request
+agent-scope propagation helpers. DB access is mocked.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auth.agent_scope import (
+    AgentScope,
+    get_agent_scope,
+    set_agent_scope,
+    set_agent_scope_from_verified,
+)
+from auth.api_keys import APIKeyManager, VerifiedKey
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+
+
+def _key_record(**overrides):
+    defaults = {
+        "id": 7,
+        "key_hash": "0" * 64,
+        "key_prefix": "kagura_test_pref",
+        "user_id": "svc-member",
+        "workspace_id": WORKSPACE_ID,
+        "bound_context_id": None,
+        "agent_id": AGENT_ID,
+        "revoked_at": None,
+        "expires_at": None,
+        "last_used_at": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _agent_row(**overrides):
+    defaults = {
+        "id": AGENT_ID,
+        "workspace_id": WORKSPACE_ID,
+        "status": "active",
+        "enforcement_mode": "enforce",
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _manager(execute_rows: list) -> APIKeyManager:
+    """Manager whose db.execute yields the given scalar rows in order."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.execute = AsyncMock(
+        side_effect=[MagicMock(scalar_one_or_none=MagicMock(return_value=r)) for r in execute_rows]
+    )
+    return APIKeyManager(db)
+
+
+def _patch_hash(key_record):
+    """Make _hash_key deterministic so the constant-time compare passes."""
+    return patch.object(APIKeyManager, "_hash_key", return_value=key_record.key_hash)
+
+
+class TestVerifyKeyKillSwitch:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", ["suspended", "retired"])
+    async def test_non_active_agent_rejects_key(self, status):
+        key = _key_record()
+        manager = _manager([key, _agent_row(status=status)])
+        with _patch_hash(key):
+            assert await manager.verify_key("kagura_x") is None
+
+    @pytest.mark.asyncio
+    async def test_missing_agent_rejects_key(self):
+        key = _key_record()
+        manager = _manager([key, None])
+        with _patch_hash(key):
+            assert await manager.verify_key("kagura_x") is None
+
+    @pytest.mark.asyncio
+    async def test_workspace_mismatch_rejects_key(self):
+        key = _key_record()
+        manager = _manager([key, _agent_row(workspace_id=uuid.uuid4())])
+        with _patch_hash(key):
+            assert await manager.verify_key("kagura_x") is None
+
+    @pytest.mark.asyncio
+    async def test_active_agent_returns_agent_fields_and_touches_liveness(self):
+        key = _key_record()
+        agent = _agent_row(enforcement_mode="shadow")
+        manager = _manager([key, agent])
+        with (
+            _patch_hash(key),
+            patch(
+                "services.agent_registry_service.AgentRegistryService.touch_last_seen",
+                new=AsyncMock(return_value=True),
+            ) as touch,
+        ):
+            verified = await manager.verify_key("kagura_x")
+        assert verified is not None
+        assert verified.agent_id == AGENT_ID
+        assert verified.agent_enforcement_mode == "shadow"
+        touch.assert_awaited_once_with(AGENT_ID)
+
+    @pytest.mark.asyncio
+    async def test_unbound_key_never_queries_agents(self):
+        """Backward-compat: keys without agent_id stay on the pre-#1275 path
+        (exactly one SELECT — the key lookup)."""
+        key = _key_record(agent_id=None)
+        manager = _manager([key])
+        with _patch_hash(key):
+            verified = await manager.verify_key("kagura_x")
+        assert verified is not None
+        assert verified.agent_id is None
+        assert verified.agent_enforcement_mode is None
+        assert manager.db.execute.await_count == 1
+
+
+class TestCreateKeyMintGates:
+    @pytest.mark.asyncio
+    async def test_agent_requires_workspace_scope(self):
+        manager = _manager([])
+        with pytest.raises(ValueError, match="workspace-scoped"):
+            await manager.create_key(name="k", user_id="u", workspace_id=None, agent_id=AGENT_ID)
+
+    @pytest.mark.asyncio
+    async def test_agent_and_public_binding_mutually_exclusive(self):
+        manager = _manager([])
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await manager.create_key(
+                name="k",
+                user_id="u",
+                bound_context_id=uuid.uuid4(),
+                agent_id=AGENT_ID,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_agent_rejected(self):
+        manager = _manager([None])
+        with pytest.raises(ValueError, match="not found"):
+            await manager.create_key(
+                name="k", user_id="u", workspace_id=WORKSPACE_ID, agent_id=AGENT_ID
+            )
+
+    @pytest.mark.asyncio
+    async def test_cross_workspace_agent_rejected(self):
+        manager = _manager([_agent_row(workspace_id=uuid.uuid4())])
+        with pytest.raises(ValueError, match="workspace mismatch"):
+            await manager.create_key(
+                name="k", user_id="u", workspace_id=WORKSPACE_ID, agent_id=AGENT_ID
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_active_agent_rejected_at_mint(self):
+        manager = _manager([_agent_row(status="retired")])
+        with pytest.raises(ValueError, match="active agents"):
+            await manager.create_key(
+                name="k", user_id="u", workspace_id=WORKSPACE_ID, agent_id=AGENT_ID
+            )
+
+
+class TestAgentScopePropagation:
+    def teardown_method(self):
+        set_agent_scope(None)
+
+    def test_default_scope_is_none(self):
+        set_agent_scope(None)
+        assert get_agent_scope() is None
+
+    def test_verified_agent_key_sets_scope(self):
+        verified = VerifiedKey(
+            id=1,
+            user_id="u",
+            workspace_id=WORKSPACE_ID,
+            bound_context_id=None,
+            key_prefix="kagura_test_pref",
+            agent_id=AGENT_ID,
+            agent_enforcement_mode="enforce",
+        )
+        set_agent_scope_from_verified(verified)
+        scope = get_agent_scope()
+        assert scope == AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce")
+
+    def test_unbound_key_clears_scope(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        verified = VerifiedKey(
+            id=1,
+            user_id="u",
+            workspace_id=WORKSPACE_ID,
+            bound_context_id=None,
+            key_prefix="kagura_test_pref",
+        )
+        set_agent_scope_from_verified(verified)
+        assert get_agent_scope() is None
+
+    def test_none_clears_scope(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        set_agent_scope_from_verified(None)
+        assert get_agent_scope() is None

--- a/backend/tests/auth/test_agent_bound_keys.py
+++ b/backend/tests/auth/test_agent_bound_keys.py
@@ -205,3 +205,21 @@ class TestAgentScopePropagation:
         set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
         set_agent_scope_from_verified(None)
         assert get_agent_scope() is None
+
+    def test_agent_id_without_mode_fails_closed_to_enforce(self):
+        """code-review hardening: an agent-bound key (agent_id set) with a
+        missing enforcement_mode is an anomaly — it must default to enforce
+        (fail-closed, default-deny with no bindings), never clear the scope
+        into unrestricted member access."""
+        verified = VerifiedKey(
+            id=1,
+            user_id="u",
+            workspace_id=WORKSPACE_ID,
+            bound_context_id=None,
+            key_prefix="kagura_test_pref",
+            agent_id=AGENT_ID,
+            agent_enforcement_mode=None,
+        )
+        set_agent_scope_from_verified(verified)
+        scope = get_agent_scope()
+        assert scope == AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce")

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -303,6 +303,7 @@ class TestVerifyKeyTimingSafeComparison:
             user_id="user-1",
             workspace_id=None,
             bound_context_id=None,
+            agent_id=None,  # #1275: unbound key (pre-P0-2 shape)
             key_prefix="kagura_test",
             key_hash=key_hash,
             revoked_at=None,
@@ -348,6 +349,7 @@ class TestVerifyKeyLastUsedThrottle:
             user_id="user-1",
             workspace_id=None,
             bound_context_id=None,
+            agent_id=None,  # #1275: unbound key (pre-P0-2 shape)
             key_prefix="kagura_test",
             # Must match sha256_hex of the key passed in _verify() so the
             # #964 constant-time gate accepts the row and the throttle path runs.

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -302,3 +302,176 @@ class TestPartialUniqueIndexRace:
         service = AccountErasureService(db_session)
         with pytest.raises(ErasureAlreadyInProgressError):
             await service.request_self_service_erasure(user_id=target_user_id)
+
+
+# ---------------------------------------------------------------------------
+# RFC-0002 P0-2 (#1275): agent registry / binding / agent-bound key CASCADE
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def agent_erasure_scenario(db_session: AsyncSession):
+    """The F1 sign-off erasure scenario (docs/design/agent-registry-and-bindings.md).
+
+    Validates the CASCADE ordering the design doc's ON DELETE CASCADE choice
+    exists for: the workspace hard-delete must take the agent, BOTH
+    agent-bound key rows (including a soft-revoked forensics row — the shape
+    a RESTRICT FK would abort a legally mandated erasure on), and the binding
+    row with it.
+
+    Deviation from the doc's literal step 2: a lingering service *member*
+    would (correctly) trip the pre-existing WorkspaceTransferRequiredError
+    guard before the hard-delete path is reachable, so the key rows here
+    belong to a departed service identity whose membership row is already
+    gone while its (revoked/live) key rows linger — exactly the retention
+    shape that motivates CASCADE over RESTRICT.
+    """
+    from models.agent import Agent, AgentContextBinding
+    from models.auth import Context
+
+    target_user_id = f"agent_owner_{uuid4().hex[:8]}"
+    target_email = f"agent-owner-{uuid4().hex[:6]}@example.com"
+    member_user_id = f"svc_member_{uuid4().hex[:8]}"
+
+    target = User(
+        email=target_email,
+        user_id=target_user_id,
+        name="Agent Owner",
+        role="user",
+        is_initial_admin=False,
+        auth_method="oauth",
+        auth_provider="google",
+    )
+    db_session.add(target)
+    await db_session.flush()
+
+    workspace = Workspace(
+        id=uuid4(),
+        name=f"ws-agent-{uuid4().hex[:8]}",
+        plan_name="free",
+        owner_user_id=target_user_id,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+    )
+    db_session.add(workspace)
+    await db_session.flush()
+
+    # Sole membership: the owner only. A lingering non-admin member would
+    # trip WorkspaceTransferRequiredError before the hard-delete path (the
+    # cascade under test) is reachable — see fixture docstring.
+    db_session.add(
+        WorkspaceMember(
+            workspace_id=workspace.id,
+            user_id=target_user_id,
+            role=WorkspaceRole.OWNER,
+        )
+    )
+
+    agent = Agent(
+        workspace_id=workspace.id,
+        name="erasure-ci-agent",
+        owner_user_id=target_user_id,
+    )
+    db_session.add(agent)
+    await db_session.flush()
+
+    context = Context(
+        id=uuid4(),
+        workspace_id=workspace.id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=target_user_id,
+    )
+    db_session.add(context)
+    await db_session.flush()
+
+    binding = AgentContextBinding(
+        agent_id=agent.id,
+        context_id=context.id,
+        can_read=True,
+        write_policy="direct",
+        is_default=True,
+        created_by=target_user_id,
+    )
+    db_session.add(binding)
+
+    # K: live agent-bound member key (owner-provisioned shape: member user,
+    # workspace-scoped, mandatory expiry semantics are a route concern).
+    key_live = APIKey(
+        key_hash=sha256_hex(f"kagura_agent_{uuid4().hex}"),
+        key_prefix="kagura_agent_xx",
+        name="agent-key-live",
+        user_id=member_user_id,
+        workspace_id=workspace.id,
+        agent_id=agent.id,
+    )
+    # K2: soft-revoked agent-bound key — the forensics-retained row shape.
+    from utils.datetime import utcnow
+
+    key_revoked = APIKey(
+        key_hash=sha256_hex(f"kagura_agent_{uuid4().hex}"),
+        key_prefix="kagura_agent_yy",
+        name="agent-key-revoked",
+        user_id=member_user_id,
+        workspace_id=workspace.id,
+        agent_id=agent.id,
+        revoked_at=utcnow().replace(tzinfo=None),
+    )
+    db_session.add_all([key_live, key_revoked])
+    await db_session.commit()
+
+    yield {
+        "target_user_id": target_user_id,
+        "workspace_id": workspace.id,
+        "agent_id": agent.id,
+        "context_id": context.id,
+        "binding_id": binding.id,
+        "key_live_id": key_live.id,
+        "key_revoked_id": key_revoked.id,
+    }
+
+
+class TestAgentErasureCascade:
+    """F1 sign-off scenario: workspace hard-delete cascades the agent lane."""
+
+    @pytest.mark.asyncio
+    async def test_sole_owner_erasure_cascades_agents_keys_bindings(
+        self,
+        db_session: AsyncSession,
+        agent_erasure_scenario,
+        patched_external_stores,
+    ):
+        from models.agent import Agent, AgentContextBinding
+
+        s = agent_erasure_scenario
+        service = AccountErasureService(db_session)
+
+        request = await service.admin_force_erase(
+            target_user_id=s["target_user_id"],
+            initiator_user_id="admin-runner",
+            reason_code=REASON_USER_REQUEST_VIA_SUPPORT,
+            reason_detail="integration test (RFC-0002 F1 scenario)",
+        )
+        # Completed without FK violations.
+        assert request.status == STATUS_COMPLETE
+
+        # Sole-owner workspace was hard-deleted...
+        result = await db_session.execute(
+            select(Workspace).where(Workspace.id == s["workspace_id"])
+        )
+        assert result.scalar_one_or_none() is None
+
+        # ...and the cascade took the agent, BOTH keys (incl. the
+        # soft-revoked forensics row — the shape RESTRICT would trip on),
+        # and the binding with it. No orphans remain.
+        result = await db_session.execute(select(Agent).where(Agent.id == s["agent_id"]))
+        assert result.scalar_one_or_none() is None
+
+        result = await db_session.execute(
+            select(APIKey).where(APIKey.id.in_([s["key_live_id"], s["key_revoked_id"]]))
+        )
+        assert result.scalars().all() == []
+
+        result = await db_session.execute(
+            select(AgentContextBinding).where(AgentContextBinding.id == s["binding_id"])
+        )
+        assert result.scalar_one_or_none() is None

--- a/backend/tests/mcp_server/test_state_tools.py
+++ b/backend/tests/mcp_server/test_state_tools.py
@@ -27,7 +27,7 @@ def _payload(result):
     return json.loads(result[0].text)
 
 
-def _enter(stack, *, service, resolve_raises=None, viewer_error=None):
+def _enter(stack, *, service, resolve_raises=None, viewer_error=None, binding_permits=True):
     """Enter the standard patch set and return the mocked service."""
 
     async def gen():
@@ -40,6 +40,15 @@ def _enter(stack, *, service, resolve_raises=None, viewer_error=None):
         patch(
             "mcp_server.tools.state._check_viewer_permission",
             new=AsyncMock(return_value=viewer_error),
+        )
+    )
+    # #1275: set_state applies the WRITE binding gate. Default permits (no
+    # agent scope); tests pass binding_permits=False to simulate a
+    # write-denied agent binding.
+    stack.enter_context(
+        patch(
+            "services.agent_binding_service.agent_binding_permits",
+            new=AsyncMock(return_value=binding_permits),
         )
     )
     stack.enter_context(
@@ -103,6 +112,22 @@ class TestSetState:
                 workspace_id=uuid4(),
             )
         assert _payload(result)["error"] == "validation_error"
+        svc.set_state.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_denied_agent_binding_blocks_set_state(self):
+        """#1275 code-review: set_state is a WRITE — a read-only-bound agent
+        (write_policy='deny') must be blocked with the uniform
+        context_not_found, not slip through the read-side gate."""
+        svc = MagicMock(set_state=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc, binding_permits=False)
+            result = await handle_set_state(
+                args={"context_id": CTX, "key": "k", "value": 1},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "context_not_found"
         svc.set_state.assert_not_called()
 
     @pytest.mark.asyncio

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -84,33 +84,18 @@ def _service(execute_results: list | None = None) -> AgentBindingService:
 
 
 class TestTypeArrayValidation:
+    """#1275 code-review: the type/source filter columns are provisioned but
+    per-type enforcement is deferred to a follow-up. To avoid a fail-open
+    (a silently-ignored restriction), CRUD accepts only NULL for now."""
+
     def test_null_means_unrestricted(self):
         assert _validate_type_array(None, "allowed_memory_types") is None
 
-    def test_empty_list_means_deny_all(self):
-        assert _validate_type_array([], "allowed_memory_types") == []
-
-    def test_memory_types_are_open_vocabulary(self):
-        assert _validate_type_array(["learning", "メモ"], "allowed_memory_types") == [
-            "learning",
-            "メモ",
-        ]
-
-    def test_source_types_checked_against_canonical_set(self):
-        with pytest.raises(ValidationError):
-            _validate_type_array(["not-a-source-type"], "allowed_source_types")
-
-    def test_known_source_types_pass(self):
-        from models.memory import _ALL_SOURCE_TYPES
-
-        assert _validate_type_array(list(_ALL_SOURCE_TYPES[:2]), "allowed_source_types") == list(
-            _ALL_SOURCE_TYPES[:2]
-        )
-
-    @pytest.mark.parametrize("bad", ["str", 42, [1], [""], [None]])
-    def test_malformed_arrays_rejected(self, bad):
-        with pytest.raises(ValidationError):
-            _validate_type_array(bad, "allowed_memory_types")
+    @pytest.mark.parametrize("reserved", [[], ["learning"], ["file"], ["a", "b"], "str", 42])
+    @pytest.mark.parametrize("field", ["allowed_memory_types", "allowed_source_types"])
+    def test_non_null_rejected_as_reserved(self, reserved, field):
+        with pytest.raises(ValidationError, match="reserved"):
+            _validate_type_array(reserved, field)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -1,0 +1,292 @@
+"""Unit tests for AgentBindingService (RFC-0002 P0-2, Issue #1275).
+
+Pins the subtractive evaluation matrix (read/write × bound/unbound ×
+enforce/shadow), the create/update validations (workspace boundary,
+duplicate, single default, array semantics incl. the source-type
+vocabulary), and the TOCTOU race mapping. DB access is mocked; the
+migration/drift/cascade coverage lives in the integration gates.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auth.agent_scope import AgentScope
+from models.agent import Agent, AgentContextBinding
+from services.agent_binding_service import (
+    ACCESS_READ,
+    ACCESS_WRITE,
+    DECISION_ALLOWED,
+    DECISION_BINDING_DENIED,
+    DECISION_WOULD_DENY,
+    AgentBindingService,
+    _validate_type_array,
+)
+from utils.exceptions import ConflictError, NotFoundException, ValidationError
+
+WORKSPACE_ID = uuid.uuid4()
+
+
+def _agent(**overrides) -> Agent:
+    defaults = {
+        "id": uuid.uuid4(),
+        "workspace_id": WORKSPACE_ID,
+        "name": "ci-bot",
+        "owner_user_id": "user-1",
+        "status": "active",
+        "enforcement_mode": "enforce",
+    }
+    defaults.update(overrides)
+    return Agent(**defaults)
+
+
+def _binding(**overrides) -> AgentContextBinding:
+    defaults = {
+        "id": uuid.uuid4(),
+        "agent_id": uuid.uuid4(),
+        "context_id": uuid.uuid4(),
+        "can_read": True,
+        "write_policy": "deny",
+        "is_default": False,
+        "allowed_memory_types": None,
+        "allowed_source_types": None,
+        "created_by": "user-1",
+    }
+    defaults.update(overrides)
+    return AgentContextBinding(**defaults)
+
+
+def _scope(agent_id=None, mode="enforce") -> AgentScope:
+    return AgentScope(agent_id=agent_id or uuid.uuid4(), enforcement_mode=mode)
+
+
+def _service(execute_results: list | None = None) -> AgentBindingService:
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.delete = AsyncMock()
+    if execute_results is not None:
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=r)) for r in execute_results
+            ]
+        )
+    else:
+        db.execute = AsyncMock()
+    return AgentBindingService(db)
+
+
+# ---------------------------------------------------------------------------
+# Array validation
+# ---------------------------------------------------------------------------
+
+
+class TestTypeArrayValidation:
+    def test_null_means_unrestricted(self):
+        assert _validate_type_array(None, "allowed_memory_types") is None
+
+    def test_empty_list_means_deny_all(self):
+        assert _validate_type_array([], "allowed_memory_types") == []
+
+    def test_memory_types_are_open_vocabulary(self):
+        assert _validate_type_array(["learning", "メモ"], "allowed_memory_types") == [
+            "learning",
+            "メモ",
+        ]
+
+    def test_source_types_checked_against_canonical_set(self):
+        with pytest.raises(ValidationError):
+            _validate_type_array(["not-a-source-type"], "allowed_source_types")
+
+    def test_known_source_types_pass(self):
+        from models.memory import _ALL_SOURCE_TYPES
+
+        assert _validate_type_array(list(_ALL_SOURCE_TYPES[:2]), "allowed_source_types") == list(
+            _ALL_SOURCE_TYPES[:2]
+        )
+
+    @pytest.mark.parametrize("bad", ["str", 42, [1], [""], [None]])
+    def test_malformed_arrays_rejected(self, bad):
+        with pytest.raises(ValidationError):
+            _validate_type_array(bad, "allowed_memory_types")
+
+
+# ---------------------------------------------------------------------------
+# create_binding validations
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBinding:
+    @pytest.mark.asyncio
+    async def test_cross_workspace_context_uniform_404(self):
+        agent = _agent()
+        foreign_context = MagicMock(workspace_id=uuid.uuid4())  # != agent.workspace_id
+        service = _service(execute_results=[foreign_context])
+        with pytest.raises(NotFoundException):
+            await service.create_binding(agent=agent, context_id=uuid.uuid4(), created_by="user-1")
+
+    @pytest.mark.asyncio
+    async def test_missing_context_uniform_404(self):
+        service = _service(execute_results=[None])
+        with pytest.raises(NotFoundException):
+            await service.create_binding(
+                agent=_agent(), context_id=uuid.uuid4(), created_by="user-1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_duplicate_pair_conflicts(self):
+        agent = _agent()
+        same_ws_context = MagicMock(workspace_id=agent.workspace_id)
+        service = _service(execute_results=[same_ws_context, uuid.uuid4()])
+        with pytest.raises(ConflictError):
+            await service.create_binding(agent=agent, context_id=uuid.uuid4(), created_by="user-1")
+
+    @pytest.mark.asyncio
+    async def test_second_default_conflicts(self):
+        agent = _agent()
+        same_ws_context = MagicMock(workspace_id=agent.workspace_id)
+        # context lookup → ok, duplicate check → none, default check → existing
+        service = _service(execute_results=[same_ws_context, None, uuid.uuid4()])
+        with pytest.raises(ConflictError):
+            await service.create_binding(
+                agent=agent, context_id=uuid.uuid4(), created_by="user-1", is_default=True
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_success_flushes_row(self):
+        agent = _agent()
+        same_ws_context = MagicMock(workspace_id=agent.workspace_id)
+        service = _service(execute_results=[same_ws_context, None])
+        binding = await service.create_binding(
+            agent=agent,
+            context_id=uuid.uuid4(),
+            created_by="user-1",
+            write_policy="direct",
+        )
+        assert binding.write_policy == "direct"
+        assert binding.created_by == "user-1"
+        service.db.add.assert_called_once_with(binding)
+        service.db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_bad_write_policy_rejected(self):
+        with pytest.raises(ValidationError):
+            await _service().create_binding(
+                agent=_agent(),
+                context_id=uuid.uuid4(),
+                created_by="user-1",
+                write_policy="staged",  # reserved for P1
+            )
+
+    @pytest.mark.asyncio
+    async def test_flush_race_maps_to_conflict(self):
+        from sqlalchemy.exc import IntegrityError
+
+        agent = _agent()
+        same_ws_context = MagicMock(workspace_id=agent.workspace_id)
+        service = _service(execute_results=[same_ws_context, None])
+        orig = Exception("duplicate key")
+        orig.constraint_name = "uq_agent_ctx_binding"  # type: ignore[attr-defined]
+        service.db.flush = AsyncMock(side_effect=IntegrityError("INSERT", {}, orig))
+        with pytest.raises(ConflictError):
+            await service.create_binding(agent=agent, context_id=uuid.uuid4(), created_by="user-1")
+
+
+# ---------------------------------------------------------------------------
+# update_binding
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateBinding:
+    @pytest.mark.asyncio
+    async def test_transition_recorded_old_new(self):
+        service = _service()
+        binding = _binding()
+        changes = await service.update_binding(binding, {"write_policy": "direct"})
+        assert changes == {"write_policy": {"old": "deny", "new": "direct"}}
+        assert binding.write_policy == "direct"
+
+    @pytest.mark.asyncio
+    async def test_noop_dropped(self):
+        service = _service()
+        changes = await service.update_binding(_binding(), {"can_read": True})
+        assert changes == {}
+        service.db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_rejected(self):
+        with pytest.raises(ValidationError):
+            await _service().update_binding(_binding(), {"context_id": uuid.uuid4()})
+
+    @pytest.mark.asyncio
+    async def test_promoting_second_default_conflicts(self):
+        service = _service(execute_results=[uuid.uuid4()])  # another default exists
+        with pytest.raises(ConflictError):
+            await service.update_binding(_binding(is_default=False), {"is_default": True})
+
+
+# ---------------------------------------------------------------------------
+# Subtractive evaluation matrix
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateContextAccess:
+    async def _evaluate(self, binding, scope, access):
+        service = _service(execute_results=[binding])
+        return await service.evaluate_context_access(scope, uuid.uuid4(), access)
+
+    @pytest.mark.asyncio
+    async def test_bound_readable_read_allowed(self):
+        allowed, decision = await self._evaluate(
+            _binding(can_read=True), _scope(mode="enforce"), ACCESS_READ
+        )
+        assert (allowed, decision) == (True, DECISION_ALLOWED)
+
+    @pytest.mark.asyncio
+    async def test_bound_read_false_enforce_denied(self):
+        allowed, decision = await self._evaluate(
+            _binding(can_read=False), _scope(mode="enforce"), ACCESS_READ
+        )
+        assert (allowed, decision) == (False, DECISION_BINDING_DENIED)
+
+    @pytest.mark.asyncio
+    async def test_write_requires_direct_policy(self):
+        allowed, decision = await self._evaluate(
+            _binding(write_policy="deny"), _scope(mode="enforce"), ACCESS_WRITE
+        )
+        assert (allowed, decision) == (False, DECISION_BINDING_DENIED)
+
+        allowed, decision = await self._evaluate(
+            _binding(write_policy="direct"), _scope(mode="enforce"), ACCESS_WRITE
+        )
+        assert (allowed, decision) == (True, DECISION_ALLOWED)
+
+    @pytest.mark.asyncio
+    async def test_unbound_context_enforce_default_deny(self):
+        allowed, decision = await self._evaluate(None, _scope(mode="enforce"), ACCESS_READ)
+        assert (allowed, decision) == (False, DECISION_BINDING_DENIED)
+
+    @pytest.mark.asyncio
+    async def test_unbound_context_shadow_proceeds_as_would_deny(self):
+        allowed, decision = await self._evaluate(None, _scope(mode="shadow"), ACCESS_READ)
+        assert (allowed, decision) == (True, DECISION_WOULD_DENY)
+
+    @pytest.mark.asyncio
+    async def test_bound_write_deny_shadow_proceeds_as_would_deny(self):
+        allowed, decision = await self._evaluate(
+            _binding(write_policy="deny"), _scope(mode="shadow"), ACCESS_WRITE
+        )
+        assert (allowed, decision) == (True, DECISION_WOULD_DENY)
+
+
+class TestReadableContextIds:
+    @pytest.mark.asyncio
+    async def test_returns_read_set(self):
+        ids = [uuid.uuid4(), uuid.uuid4()]
+        db = MagicMock()
+        scalars = MagicMock(all=MagicMock(return_value=ids))
+        db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=scalars)))
+        service = AgentBindingService(db)
+        assert await service.readable_context_ids(uuid.uuid4()) == set(ids)

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -177,3 +177,97 @@ class TestMcpWritePathGate:
             result = await _resolve_context(MagicMock(), "u", context.id)
         assert result is context
         instance.evaluate_context_access.assert_not_awaited()
+
+
+class TestCanAccessMemoryBindingGate:
+    """#1275: can_access_memory is the memory-id-addressed chokepoint —
+    binding subtracts even for the memory owner, honors the access kind, and
+    shadow mode proceeds."""
+
+    @pytest.mark.asyncio
+    async def test_no_scope_owner_unchanged(self):
+        perm = _perm()
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with patcher:
+            ok = await perm.can_access_memory(
+                user_id="u", memory_user_id="u", workspace_id=WORKSPACE_ID, context_id=uuid.uuid4()
+            )
+        assert ok is True
+        instance.evaluate_context_access.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_owner_still_subtracted_by_binding(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        perm = _perm()
+        patcher, _ = _patch_binding_service(False, "binding_denied")
+        with patcher:
+            ok = await perm.can_access_memory(
+                user_id="u", memory_user_id="u", workspace_id=WORKSPACE_ID, context_id=uuid.uuid4()
+            )
+        # Owner passes RBAC but the binding denies — the agent cannot reach
+        # even its own memory in a bound-denied context.
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_write_access_kind_forwarded(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        perm = _perm()
+        patcher, instance = _patch_binding_service(True, "allowed")
+        with patcher:
+            await perm.can_access_memory(
+                user_id="u",
+                memory_user_id="u",
+                workspace_id=WORKSPACE_ID,
+                context_id=uuid.uuid4(),
+                access="write",
+            )
+        assert instance.evaluate_context_access.await_args.args[2] == "write"
+
+    @pytest.mark.asyncio
+    async def test_shadow_would_deny_permits(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="shadow"))
+        perm = _perm()
+        patcher, _ = _patch_binding_service(True, "would_deny")
+        with patcher:
+            ok = await perm.can_access_memory(
+                user_id="u", memory_user_id="u", workspace_id=WORKSPACE_ID, context_id=uuid.uuid4()
+            )
+        assert ok is True
+
+
+class TestMemoryServiceDeclaredContextGate:
+    """#1275: MemoryService._get_context_isolation_params applies the binding
+    gate on the declared-context write/read path (remember / recall / forget)."""
+
+    def _service(self, context):
+        from services.memory_service import MemoryService
+
+        svc = MemoryService.__new__(MemoryService)
+        svc.db = MagicMock()
+        svc.context_service = MagicMock(get_context=AsyncMock(return_value=context))
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_no_scope_passes(self):
+        context = SimpleNamespace(id=uuid.uuid4(), workspace_id=WORKSPACE_ID)
+        svc = self._service(context)
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with patcher:
+            ctx, ws, cid = await svc._get_context_isolation_params("u", context.id, access="write")
+        assert ctx is context
+        instance.evaluate_context_access.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_write_binding_deny_raises_context_404(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        context = SimpleNamespace(id=uuid.uuid4(), workspace_id=WORKSPACE_ID)
+        svc = self._service(context)
+        patcher, _ = _patch_binding_service(False, "binding_denied")
+        with patcher, pytest.raises(NotFoundException):
+            await svc._get_context_isolation_params("u", context.id, access="write")
+
+    @pytest.mark.asyncio
+    async def test_none_context_short_circuits(self):
+        svc = self._service(None)
+        result = await svc._get_context_isolation_params("u", None, access="write")
+        assert result == (None, None, None)

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -147,6 +147,21 @@ class TestEnumerationIntersection:
         assert result == contexts
         instance.readable_context_ids.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_unknown_mode_fails_closed_intersects(self):
+        """code-review: an unrecognized enforcement_mode must fail CLOSED
+        (intersect), matching evaluate_context_access which denies on a
+        non-shadow mode — the two paths must not disagree."""
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="future_mode"))
+        perm = _perm()
+        contexts = self._contexts()
+        perm._get_accessible_contexts_rbac = AsyncMock(return_value=contexts)
+        patcher, instance = _patch_binding_service(True, "allowed")
+        instance.readable_context_ids = AsyncMock(return_value={contexts[1].id})
+        with patcher:
+            result = await perm.get_accessible_contexts("u", WORKSPACE_ID)
+        assert result == [contexts[1]]
+
 
 class TestMcpWritePathGate:
     @pytest.mark.asyncio

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -1,0 +1,179 @@
+"""Chokepoint tests for the subtractive agent-binding filter (#1275).
+
+Pins the load-bearing contracts of the RFC-0002 P0-2 enforcement wiring:
+
+- **Backward-compat**: with no agent scope (every pre-P0-2 credential) the
+  filter is a structural no-op — AgentBindingService is never constructed,
+  so the RBAC chokepoints stay byte-for-byte on their old path.
+- Binding deny surfaces as the uniform ``context_not_found`` 404 (never a
+  403 that would confirm existence) on reads AND writes.
+- ``shadow`` mode proceeds (would_deny is allowed).
+- ``check_context_access`` derives access from the required ContextRole
+  (viewer → read, editor/owner → write).
+- Enumeration (``get_accessible_contexts``) intersects with the binding
+  read set ONLY in enforce mode.
+- The MCP write path (``_resolve_context``) applies the write gate with the
+  same uniform deny shape.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from auth.agent_scope import AgentScope, set_agent_scope
+from services.permission_service import PermissionService
+from utils.exceptions import NotFoundException
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+
+
+@pytest.fixture(autouse=True)
+def _clean_scope():
+    set_agent_scope(None)
+    yield
+    set_agent_scope(None)
+
+
+def _perm() -> PermissionService:
+    return PermissionService(MagicMock())
+
+
+def _patch_binding_service(allowed: bool, decision: str):
+    instance = MagicMock(
+        evaluate_context_access=AsyncMock(return_value=(allowed, decision)),
+        readable_context_ids=AsyncMock(return_value=set()),
+    )
+    return (
+        patch(
+            "services.agent_binding_service.AgentBindingService",
+            return_value=instance,
+        ),
+        instance,
+    )
+
+
+class TestApplyAgentBindingFilter:
+    @pytest.mark.asyncio
+    async def test_no_scope_is_structural_noop(self):
+        """Pre-P0-2 credentials must never construct the binding service."""
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with patcher:
+            await _perm()._apply_agent_binding_filter(uuid.uuid4(), access="read", user_id="u")
+        instance.evaluate_context_access.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_enforce_deny_raises_uniform_404(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        patcher, _ = _patch_binding_service(False, "binding_denied")
+        with patcher, pytest.raises(NotFoundException):
+            await _perm()._apply_agent_binding_filter(uuid.uuid4(), access="read", user_id="u")
+
+    @pytest.mark.asyncio
+    async def test_shadow_would_deny_passes(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="shadow"))
+        patcher, _ = _patch_binding_service(True, "would_deny")
+        with patcher:
+            await _perm()._apply_agent_binding_filter(uuid.uuid4(), access="write", user_id="u")
+
+
+class TestCheckContextAccessWrapper:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("required_role", "expected_access"),
+        [("viewer", "read"), ("editor", "write"), ("owner", "write")],
+    )
+    async def test_access_kind_derived_from_required_role(self, required_role, expected_access):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        perm = _perm()
+        context = SimpleNamespace(id=uuid.uuid4())
+        perm._check_context_access_rbac = AsyncMock(return_value=(context, "owner"))
+        perm._apply_agent_binding_filter = AsyncMock()
+
+        result, _ = await perm.check_context_access("u", context.id, required_role)
+
+        assert result is context
+        kwargs = perm._apply_agent_binding_filter.await_args.kwargs
+        assert kwargs["access"] == expected_access
+
+    @pytest.mark.asyncio
+    async def test_binding_deny_is_404_even_for_writes(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        perm = _perm()
+        perm._check_context_access_rbac = AsyncMock(
+            return_value=(SimpleNamespace(id=uuid.uuid4()), "owner")
+        )
+        patcher, _ = _patch_binding_service(False, "binding_denied")
+        with patcher, pytest.raises(NotFoundException):
+            await perm.check_context_access("u", uuid.uuid4(), "editor")
+
+
+class TestEnumerationIntersection:
+    def _contexts(self):
+        return [SimpleNamespace(id=uuid.uuid4()), SimpleNamespace(id=uuid.uuid4())]
+
+    @pytest.mark.asyncio
+    async def test_no_scope_returns_full_membership_view(self):
+        perm = _perm()
+        contexts = self._contexts()
+        perm._get_accessible_contexts_rbac = AsyncMock(return_value=contexts)
+        assert await perm.get_accessible_contexts("u", WORKSPACE_ID) == contexts
+
+    @pytest.mark.asyncio
+    async def test_enforce_mode_intersects_with_read_set(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        perm = _perm()
+        contexts = self._contexts()
+        perm._get_accessible_contexts_rbac = AsyncMock(return_value=contexts)
+        patcher, instance = _patch_binding_service(True, "allowed")
+        instance.readable_context_ids = AsyncMock(return_value={contexts[0].id})
+        with patcher:
+            result = await perm.get_accessible_contexts("u", WORKSPACE_ID)
+        assert result == [contexts[0]]
+
+    @pytest.mark.asyncio
+    async def test_shadow_mode_keeps_full_view(self):
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="shadow"))
+        perm = _perm()
+        contexts = self._contexts()
+        perm._get_accessible_contexts_rbac = AsyncMock(return_value=contexts)
+        patcher, instance = _patch_binding_service(True, "allowed")
+        with patcher:
+            result = await perm.get_accessible_contexts("u", WORKSPACE_ID)
+        assert result == contexts
+        instance.readable_context_ids.assert_not_awaited()
+
+
+class TestMcpWritePathGate:
+    @pytest.mark.asyncio
+    async def test_write_deny_raises_uniform_context_not_found(self):
+        from mcp_server.tools._helpers import _ContextNotFoundError, _resolve_context
+
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        context = SimpleNamespace(id=uuid.uuid4(), workspace_id=WORKSPACE_ID)
+        service = MagicMock(get_context=AsyncMock(return_value=context))
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with (
+            patch("services.context_service.ContextService", return_value=service),
+            patcher,
+            pytest.raises(_ContextNotFoundError),
+        ):
+            await _resolve_context(MagicMock(), "u", context.id)
+        instance.evaluate_context_access.assert_awaited_once()
+        assert instance.evaluate_context_access.await_args.args[2] == "write"
+
+    @pytest.mark.asyncio
+    async def test_no_scope_write_path_unchanged(self):
+        from mcp_server.tools._helpers import _resolve_context
+
+        context = SimpleNamespace(id=uuid.uuid4(), workspace_id=WORKSPACE_ID)
+        service = MagicMock(get_context=AsyncMock(return_value=context))
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with patch("services.context_service.ContextService", return_value=service), patcher:
+            result = await _resolve_context(MagicMock(), "u", context.id)
+        assert result is context
+        instance.evaluate_context_access.assert_not_awaited()

--- a/backend/tests/test_agent_constants.py
+++ b/backend/tests/test_agent_constants.py
@@ -73,3 +73,52 @@ def test_agents_is_classified_operational() -> None:
     from models.data_boundary import OPERATIONAL_TABLES
 
     assert "agents" in OPERATIONAL_TABLES
+
+
+def test_all_binding_write_policies_tuple_matches_constants() -> None:
+    """Registration order is fixed (deny, direct); 'staged' is reserved for P1."""
+    from models.agent import (
+        _ALL_BINDING_WRITE_POLICIES,
+        BINDING_WRITE_POLICY_DENY,
+        BINDING_WRITE_POLICY_DIRECT,
+    )
+
+    assert _ALL_BINDING_WRITE_POLICIES == (
+        BINDING_WRITE_POLICY_DENY,
+        BINDING_WRITE_POLICY_DIRECT,
+    )
+    assert BINDING_WRITE_POLICY_DENY == "deny"
+    assert BINDING_WRITE_POLICY_DIRECT == "direct"
+
+
+def test_valid_binding_write_policy_check_matches_migration_literal() -> None:
+    """``valid_binding_write_policy`` CHECK text is byte-identical to e64."""
+    from models.agent import AgentContextBinding
+
+    expected = "write_policy IN ('deny', 'direct')"
+    check = next(
+        c
+        for c in AgentContextBinding.__table_args__
+        if getattr(c, "name", None) == "valid_binding_write_policy"
+    )
+    assert check.sqltext.text == expected
+
+
+def test_agent_context_bindings_is_classified_operational() -> None:
+    """#1275 two-sided closure: the creating PR classifies the table."""
+    from models.data_boundary import OPERATIONAL_TABLES
+
+    assert "agent_context_bindings" in OPERATIONAL_TABLES
+
+
+def test_api_keys_agent_exclusion_check_matches_migration_literal() -> None:
+    """``ck_api_keys_agent_public_exclusion`` matches the e65 literal."""
+    from models.auth import APIKey
+
+    expected = "agent_id IS NULL OR bound_context_id IS NULL"
+    check = next(
+        c
+        for c in APIKey.__table_args__
+        if getattr(c, "name", None) == "ck_api_keys_agent_public_exclusion"
+    )
+    assert check.sqltext.text == expected

--- a/docs/ops/agent-credential-runbook.md
+++ b/docs/ops/agent-credential-runbook.md
@@ -12,10 +12,12 @@
 
 This runbook covers the full operational lifecycle of a **workload credential** — the API key
 an agent process authenticates with — as the system exists **today**. Everything in the
-numbered procedures is shipped, verified behavior. Blocks marked **[P0-2]** describe what
-changes when agent-bound keys (`api_keys.agent_id`) land; blocks marked **[P0-3]** describe
-the bootstrap contract (F2, #1259); blocks marked **[P1]** describe the deferred DLP item.
-None of the marked blocks are implemented yet.
+numbered procedures is shipped, verified behavior. Blocks marked **[P0-2]** describe
+agent-bound keys (`api_keys.agent_id`) — **shipped with #1275**: mint accepts `agent_id`
+(owner-provisioned path only), verify rejects keys whose agent is `suspended`/`retired`, and
+the fleet kill switch in section 6 is live. Blocks marked **[P0-3]** describe the bootstrap
+contract (F2, #1259); blocks marked **[P1]** describe the deferred DLP item — those two are
+not implemented yet.
 
 ## Scope and non-goals
 


### PR DESCRIPTION
Closes #1275 (RFC-0002 P0-2)

One vertical slice — bindings + agent-bound credentials ship together because binding enforcement is unreachable until a key can carry `agent_id`. Implements the signed-off F1 contract ([docs/design/agent-registry-and-bindings.md](https://github.com/kagura-ai/memory-cloud/blob/main/docs/design/agent-registry-and-bindings.md)). Stacked on #1274.

## Schema (two migration classes, per the plan)

- **e64** (pure additive): `agent_context_bindings` — purely subtractive per-context scoping; partial unique `(agent_id) WHERE is_default`; `NULL`=unrestricted / `[]`=deny-all array semantics; `write_policy deny|direct` (`staged` reserved for P1; CHECK derived byte-identically from the module tuple, drift-pinned).
- **e65** (`api_keys` ALTERs): nullable `agent_id` FK `ON DELETE CASCADE` (named `fk_api_keys_agent_id` to match the ORM convention so the drift gate sees one identical constraint); `ck_api_keys_agent_public_exclusion` added `NOT VALID` then `VALIDATE`d, and `idx_api_keys_agent` built `CONCURRENTLY`, all in an autocommit block with #655 rerun guards (INVALID-leftover rebuild per e62).

## Verify-time enforcement (`auth/api_keys.py`)

- `VerifiedKey` gains `agent_id` + `agent_enforcement_mode` (appended, defaulted — unbound keys stay byte-for-byte on the pre-#1275 path, one SELECT).
- **Fail-closed kill switch**: `suspended`/`retired`/missing agent rejects every bound key at verify; workspace consistency re-asserted defensively; throttled `agents.last_seen_at` liveness touch.
- **Mint gates**: agent must exist, be active, and share the key's workspace; agent-bound global-key shape rejected; mutually exclusive with `bound_context_id`.

## Purely-subtractive intersection (`existing RBAC decision ∩ binding`)

Per-request `AgentScope` contextvar (`auth/agent_scope.py`, the #963 pattern) set at API-key verify on REST + reset on MCP; `None` for every other credential, so the filter is a **structural** no-op there (RBAC cores extracted verbatim as `_check_context_access_rbac` / `_get_accessible_contexts_rbac`; the filter is a strict wrapper). Applied at:

- **Context-resolution chokepoints**: `resolve_context_for_workspace_read`, `check_context_access`, `get_accessible_contexts` (enumeration intersected in `enforce` mode), and MCP `_resolve_context[_for_read]` (incl. cross-context recall, per context).
- **Memory-access chokepoints** (found by inner review — the memory routes authorize on a different path): `can_access_memory` for memory-id-addressed ops (reference/update/forget-by-id/explore; the binding subtracts even for the memory owner; writes pass `access="write"` so a `can_read`-only binding cannot mutate) and `_get_context_isolation_params` for the declared-context remember/recall/forget path.

Deny — read **and** write — is the uniform `context_not_found` 404 (CWE-639). `shadow` mode logs `would_deny` and proceeds (the durable audit row lands with P0-5, #1278).

## Surfaces

- REST `/api/v1/agents/{id}/bindings` CRUD + MCP `bind_agent_context` / `list_agent_bindings` / `update_agent_binding` / `unbind_agent_context` — owner/admin-gated, audited via the security-mutation lane, TOCTOU races on both unique indexes mapped by name to the pre-check 409.
- Owner-provisioned mint accepts `agent_id` (session self-mint rejects it); minted `agent_id` recorded in the audit metadata.
- F5 runbook `[P0-2]` callouts activated.

## Erasure

`agent_context_bindings` classified operational; `created_by` pseudonymized; **F1 CASCADE integration scenario** added (workspace hard-delete takes the agent + live and soft-revoked bound keys + binding rows — the shape `RESTRICT` would abort a mandated erasure on).

## Tests

`test_agent_binding_service` (evaluation matrix, validations, TOCTOU), `test_agent_bound_keys` (kill switch, mint gates, scope propagation), `test_permission_agent_binding` (chokepoint no-op-without-scope, uniform-404, enumeration intersection, MCP write gate, `can_access_memory` + `_get_context_isolation_params` gates), `test_agent_constants` (CHECK/exclusion drift pins), owner-key mint `agent_id` plumbing, erasure CASCADE. Full local suite **5334 passed**; migration round-trip (incl. `downgrade -1`) + create_all/alembic drift gates green; ruff clean; pyright 0 new errors.

## Gates

- Inner review: 2 critical bypasses (REST memory writes + memory-id ops skipped the binding filter) — fixed in `06f4b0e` with regression pins.
- Gate2: cso green / qa-lead green / cto green (remaining named surfaces — cross-context recall / public_search / share keys / graph — verified covered or not agent-reachable).

## Deliberately NOT here

`write_policy='staged'` (P1); the Phase-C strictness default flip (stays `false`); the durable `memory_access_events` `would_deny` rows (P0-5, #1278).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
