### PR TITLE
feat(mcp): get_agent_bootstrap MCP tool + REST companion (#1276)

### DIFF
--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import require_workspace_admin
+from auth.dependencies import APIKeyOrSessionUser, require_workspace_admin
 from db.base import get_db
 from models.agent import Agent
 from models.api_base import TZAwareBaseModel
@@ -477,3 +477,103 @@ async def delete_agent_binding(
     )
     await service.delete_binding(binding)
     await db.commit()
+
+
+# ============================================================================
+# Bootstrap companion (RFC-0002 P0-3, Issue #1276)
+# ============================================================================
+
+
+class BootstrapRequest(BaseModel):
+    """Body for POST /api/v1/agents/{agent_id}/bootstrap (agent_id from path).
+
+    POST-for-read follows the POST /api/v1/memory/pinned precedent.
+    """
+
+    context_id: UUID | None = None
+    session_id: str | None = Field(None, max_length=128)
+    query: str | None = Field(None, max_length=1024)
+    recall_k: int | None = None
+    pinned_cap: int | None = None
+    upcoming_until: str | None = None
+    include: list[Literal["pinned", "recall", "upcoming", "state", "policy"]] | None = None
+
+
+@router.post("/{agent_id}/bootstrap")
+async def agent_bootstrap(
+    agent_id: UUID,
+    body: BootstrapRequest,
+    user: APIKeyOrSessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> Any:
+    """Rehydrate an agent's cognitive state at session start (#1276).
+
+    Auth is ``APIKeyOrSessionUser``; the per-request agent scope (set at
+    API-key verify for agent-bound keys) drives the identity rule inside the
+    service. Component failures are fail-soft; identity/authorization failures
+    are total and fail-closed with the uniform ``agent_not_found`` /
+    ``context_not_found`` shapes.
+    """
+    from auth.agent_scope import get_agent_scope
+    from services.agent_bootstrap_service import (
+        AgentBootstrapService,
+        BootstrapError,
+        BootstrapParams,
+        parse_include,
+    )
+    from utils.exceptions import BadRequestError, NotFoundException
+
+    try:
+        params = BootstrapParams(
+            agent_id=agent_id,
+            context_id=body.context_id,
+            session_id=body.session_id,
+            query=body.query or None,
+            recall_k=body.recall_k,
+            pinned_cap=body.pinned_cap,
+            upcoming_until=body.upcoming_until,
+            include=parse_include(body.include),
+        )
+    except BootstrapError as e:
+        raise BadRequestError(message=e.message, error_code=e.code.upper()) from e
+
+    service = AgentBootstrapService(db)
+    try:
+        principal, agent = await service.resolve_principal_and_agent(
+            requested_agent_id=agent_id, user=user, agent_scope=get_agent_scope()
+        )
+        context, binding_info = await service.resolve_context(
+            agent=agent, params=params, principal=principal
+        )
+    except BootstrapError as e:
+        await db.rollback()
+        if e.code in ("agent_not_found", "context_not_found"):
+            # Uniform 404 (CWE-639) — nonexistent and not-yours are the same.
+            raise NotFoundException("Agent" if e.code == "agent_not_found" else "Context") from e
+        raise BadRequestError(message=e.message, error_code=e.code.upper()) from e
+
+    # REST recall metering: the recall component runs under the caller's plan
+    # limits; a query-carrying bootstrap that trips the limit degrades that
+    # component to rate_limited while the cheap components still return.
+    recall_metered = False
+    if params.query is not None and principal.workspace_id is not None:
+        from services.quota_service import QuotaService
+
+        try:
+            allowed, _used, _limit = await QuotaService(db).check_mcp_rate_limit(
+                principal.workspace_id
+            )
+            recall_metered = not allowed
+        except Exception:
+            recall_metered = False
+
+    envelope = await service.build_envelope(
+        agent=agent,
+        context=context,
+        binding_info=binding_info,
+        params=params,
+        principal=principal,
+        recall_metered=recall_metered,
+    )
+    await db.commit()
+    return envelope

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -575,5 +575,8 @@ async def agent_bootstrap(
         principal=principal,
         recall_metered=recall_metered,
     )
+    # #1276: record an operator (owner/admin) "on behalf of" bootstrap so it
+    # cannot masquerade as the agent's own activity (no-op for agent-bound).
+    await service.audit_on_behalf_of(agent=agent, principal=principal, session_id=params.session_id)
     await db.commit()
     return envelope

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -72,6 +72,9 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "list_agent_bindings",
         "update_agent_binding",
         "unbind_agent_context",
+        # Issue #1276: bootstrap — context_id is OPTIONAL (defaults to the
+        # agent's default binding); resolution happens in the handler.
+        "get_agent_bootstrap",
     }
 )
 
@@ -114,6 +117,11 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "get_agent",
         # Issue #1275: read-only binding listing.
         "list_agent_bindings",
+        # Issue #1276: bootstrap is a session-start read that MUST stay callable
+        # when rate-limited (like get_context_info / load_pinned). Exempt at the
+        # TOOL level; a query-CARRYING call still meters its recall component
+        # under the normal accounting inside the handler (query-less = free).
+        "get_agent_bootstrap",
     }
 )
 
@@ -128,6 +136,7 @@ _TOOL_REGISTRY: dict[str, Any] | None = None
 
 def _build_registry() -> dict[str, Any]:
     """Build tool name → handler mapping."""
+    from mcp_server.tools.agent_bootstrap import handle_get_agent_bootstrap
     from mcp_server.tools.agent_registry import (
         handle_bind_agent_context,
         handle_delete_agent,
@@ -265,6 +274,8 @@ def _build_registry() -> dict[str, Any]:
         "list_agent_bindings": handle_list_agent_bindings,
         "update_agent_binding": handle_update_agent_binding,
         "unbind_agent_context": handle_unbind_agent_context,
+        # Issue #1276 (RFC-0002 P0-3): session-start bootstrap composition.
+        "get_agent_bootstrap": handle_get_agent_bootstrap,
     }
 
 

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -24,6 +24,7 @@ TOOL_TIMEOUTS: dict[str, float] = {
     "reference": _get_timeout("reference", 10.0),
     "explore": _get_timeout("explore", 45.0),
     "get_context_info": _get_timeout("get_context_info", 15.0),
+    "get_agent_bootstrap": _get_timeout("get_agent_bootstrap", 15.0),  # #1276 (RFC-0002 P0-3)
     "list_contexts": _get_timeout("list_contexts", 10.0),
     "list_tags": _get_timeout("list_tags", 10.0),  # Issue #614
     "create_context": _get_timeout("create_context", 15.0),

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2407,6 +2407,68 @@ Returns: {status, deleted, binding_id}.""",
                 "required": ["agent_id", "binding_id"],
             },
         },
+        # Issue #1276 (RFC-0002 P0-3): session-start bootstrap composition.
+        {
+            "name": "get_agent_bootstrap",
+            "readOnly": True,
+            "description": """Rehydrate an agent's cognitive state at session start (Issue #1276).
+
+ONE call that composes existing primitives: context guide + always-load pinned
+memories + a trusted-only recall (only when `query` is supplied) + upcoming
+time memories + the agent-state lane. Pure composition — bounds, ordering, and
+trust filtering are inherited from the standalone tools, not re-specified.
+
+`agent_id` is REQUIRED. If `context_id` is omitted the agent's default binding
+is used. Each component is fail-soft: a failing component reports
+{status: error} while the rest return, with top-level `degraded: true`.
+
+Returns: {status, degraded, agent, context, instructions, components:{pinned,
+recall,upcoming,state,policy}, correlation, generated_at}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "agent_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "REQUIRED. Agent UUID from the registry.",
+                    },
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Optional; defaults to the agent's default binding.",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional opaque correlation id (<=128 chars, [A-Za-z0-9._-]).",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Optional (<=1024 chars). Enables the trusted-only recall component; omit to skip recall.",
+                    },
+                    "recall_k": {
+                        "type": "integer",
+                        "description": "Optional; forwarded to recall's k validation.",
+                    },
+                    "pinned_cap": {
+                        "type": "integer",
+                        "description": "Optional; clamped by load_pinned to [1, 1000].",
+                    },
+                    "upcoming_until": {
+                        "type": "string",
+                        "description": "Optional ISO upper bound for upcoming time memories ('from' is always now).",
+                    },
+                    "include": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["pinned", "recall", "upcoming", "state", "policy"],
+                        },
+                        "description": "Optional component selector; default all.",
+                    },
+                },
+                "required": ["agent_id"],
+            },
+        },
         # Issue #1128: zero-knowledge secret store. The server stores opaque age
         # ciphertext + public recipient keys only and NEVER decrypts. Encryption
         # and decryption happen client-side (the `kagura secret` CLI / SDK).

--- a/backend/src/mcp_server/tools/agent_bootstrap.py
+++ b/backend/src/mcp_server/tools/agent_bootstrap.py
@@ -1,0 +1,143 @@
+"""MCP tool: get_agent_bootstrap (RFC-0002 P0-3, Issue #1276).
+
+Session-start composition tool — resolves the agent + its default (or
+supplied) context, then composes context guide, pinned memories, a
+trusted-only recall (only when a query is supplied), upcoming time memories,
+and the agent-state lane into one fail-soft envelope. Pure composition of
+existing primitives via ``AgentBootstrapService`` — no parallel retrieval
+path (F2 design, ``docs/design/agent-bootstrap-contract.md``).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import (
+    _error_response,
+    _log_tool_usage,
+    _success_response,
+    execute_with_timeout,
+)
+
+
+def _parse_uuid(raw: Any) -> UUID | None:
+    try:
+        return UUID(str(raw))
+    except (ValueError, AttributeError, TypeError):
+        return None
+
+
+async def handle_get_agent_bootstrap(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Rehydrate an agent's cognitive state at session start (owner/agent gated)."""
+    if "agent_id" not in args:
+        return _error_response("missing_fields", "Missing required field: agent_id")
+    agent_id = _parse_uuid(args["agent_id"])
+    if agent_id is None:
+        return _error_response("invalid_arguments", "agent_id must be a UUID.")
+
+    from auth.agent_scope import get_agent_scope
+    from db.base import get_db
+    from services.agent_bootstrap_service import (
+        AgentBootstrapService,
+        BootstrapError,
+        BootstrapParams,
+        parse_include,
+        validate_query,
+        validate_session_id,
+    )
+
+    # Argument validation (before opening a session) → structured errors.
+    try:
+        context_id = _parse_uuid(args["context_id"]) if args.get("context_id") else None
+        if args.get("context_id") and context_id is None:
+            return _error_response("invalid_arguments", "context_id must be a UUID.")
+        params = BootstrapParams(
+            agent_id=agent_id,
+            context_id=context_id,
+            session_id=validate_session_id(args.get("session_id")),
+            query=validate_query(args.get("query")),
+            recall_k=args.get("recall_k"),
+            pinned_cap=args.get("pinned_cap"),
+            upcoming_until=args.get("upcoming_until"),
+            include=parse_include(args.get("include")),
+        )
+    except BootstrapError as e:
+        return _error_response(e.code, e.message)
+
+    # The MCP session carries user_id + workspace; build the principal dict the
+    # service reads (agent scope carries the agent-bound identity).
+    user = {
+        "user_id": user_id,
+        "current_workspace_id": workspace_id,
+        "api_key_workspace_id": workspace_id,
+    }
+    agent_scope = get_agent_scope()
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            service = AgentBootstrapService(db)
+            principal, agent = await service.resolve_principal_and_agent(
+                requested_agent_id=agent_id, user=user, agent_scope=agent_scope
+            )
+            context, binding_info = await service.resolve_context(
+                agent=agent, params=params, principal=principal
+            )
+
+            # Rate-limit exemption is scoped to query-LESS calls: this tool is in
+            # _RATE_LIMIT_EXEMPT_TOOLS (a query-less bootstrap is Postgres-only,
+            # like get_context_info / load_pinned). A query-CARRYING bootstrap
+            # meters its recall component under the normal MCP rate accounting;
+            # on limit that component degrades to rate_limited while the cheap
+            # components still return (a session-start tool must stay callable).
+            recall_metered = False
+            if params.query is not None and workspace_id is not None:
+                from mcp_server.tools import _check_rate_limit
+
+                try:
+                    allowed, _used, _limit = await _check_rate_limit(workspace_id)
+                    recall_metered = not allowed
+                except Exception:
+                    recall_metered = False
+
+            envelope = await execute_with_timeout(
+                service.build_envelope(
+                    agent=agent,
+                    context=context,
+                    binding_info=binding_info,
+                    params=params,
+                    principal=principal,
+                    recall_metered=recall_metered,
+                ),
+                operation_name="get_agent_bootstrap",
+            )
+
+            await _log_tool_usage(
+                db, user_id, "get_agent_bootstrap", start_time, 200, context.id, workspace_id
+            )
+            await db.commit()
+            return _success_response(**{k: v for k, v in envelope.items() if k != "status"})
+
+        except BootstrapError as e:
+            await db.rollback()
+            await _log_tool_usage(
+                db, user_id, "get_agent_bootstrap", start_time, 404, None, workspace_id
+            )
+            return _error_response(e.code, e.message)
+        except Exception as e:  # pragma: no cover - defensive
+            await db.rollback()
+            await _log_tool_usage(
+                db, user_id, "get_agent_bootstrap", start_time, 500, None, workspace_id
+            )
+            from mcp_server.tools._helpers import logger
+
+            logger.error(f"get_agent_bootstrap_failed: {e}", exc_info=True)
+            return _error_response("internal_error", "Failed to build agent bootstrap.")
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/agent_bootstrap.py
+++ b/backend/src/mcp_server/tools/agent_bootstrap.py
@@ -118,6 +118,12 @@ async def handle_get_agent_bootstrap(
                 operation_name="get_agent_bootstrap",
             )
 
+            # #1276: record an operator (owner/admin) "on behalf of" bootstrap
+            # so it cannot masquerade as the agent's own activity (no-op for
+            # agent-bound calls). Committed atomically with the usage row.
+            await service.audit_on_behalf_of(
+                agent=agent, principal=principal, session_id=params.session_id
+            )
             await _log_tool_usage(
                 db, user_id, "get_agent_bootstrap", start_time, 200, context.id, workspace_id
             )

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -261,22 +261,18 @@ async def handle_recall_upcoming(
     if "context_id" not in args:
         return _error_response("missing_fields", "Missing required field: context_id")
 
-    from sqlalchemy import select
-
     from db.base import get_db
-    from models.memory import Memory
+    from services.time_memory import clamp_upcoming_k, query_upcoming_time_memories
     from utils.time_trigger import TriggerValidationError, parse_query_bound
 
     # Validate inputs up front (before opening a DB session) so a malformed
     # argument is a structured validation_error, not an unhandled crash.
+    # #1276: the coerce+clamp is hoisted into the shared time_memory helper so
+    # the tool and get_agent_bootstrap share one implementation.
     try:
-        raw_k = args.get("k", 20)
-        k = int(raw_k)
+        k = clamp_upcoming_k(args.get("k", 20))
     except (TypeError, ValueError):
         return _error_response("validation_error", f"k must be an integer, got {args.get('k')!r}")
-    # Clamp into [1, 100]: a missing lower bound let k<=0 through as LIMIT 0
-    # (always empty) or LIMIT -1 (no cap, bypassing the 100 ceiling).
-    k = max(1, min(k, 100))
 
     try:
         # Re-normalize bounds to fixed-width ISO (and resolve 'now') so the
@@ -296,31 +292,9 @@ async def handle_recall_upcoming(
             # A01), mirroring handle_recall.
             current_context = await _resolve_context_for_read(db, user_id, current_context_id)
 
-            query = (
-                select(Memory)
-                .where(Memory.deleted_at.is_(None))
-                .where(Memory.type == "time")
-                .where(Memory.context_id == current_context_id)
+            results = await query_upcoming_time_memories(
+                db, current_context_id, q_from=q_from, q_until=q_until, k=k
             )
-            # Window overlap: stored [trigger_from, trigger_until] overlaps the
-            # query window [q_from, q_until] iff trigger_until >= q_from AND
-            # trigger_from <= q_until.
-            if q_from is not None:
-                query = query.where(Memory.trigger_until >= q_from)
-            if q_until is not None:
-                query = query.where(Memory.trigger_from <= q_until)
-            query = query.order_by(Memory.trigger_from.asc()).limit(k)
-
-            rows = (await db.execute(query)).scalars().all()
-            results = [
-                {
-                    "memory_id": str(m.id),
-                    "summary": m.summary,
-                    "type": m.type,
-                    "details": m.details,
-                }
-                for m in rows
-            ]
             await _log_tool_usage(
                 db, user_id, "recall_upcoming", start_time, 200, current_context_id, workspace_id
             )

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -138,6 +138,22 @@ class AgentBindingService:
         )
         return result.scalar_one_or_none()
 
+    async def get_binding_for_context(
+        self, agent_id: uuid.UUID, context_id: uuid.UUID
+    ) -> AgentContextBinding | None:
+        """Fetch the binding row for one (agent, context) pair, or None.
+
+        Used by bootstrap (#1276) to read the ``is_default`` descriptor of an
+        explicitly-supplied ``context_id``.
+        """
+        result = await self.db.execute(
+            select(AgentContextBinding).where(
+                AgentContextBinding.agent_id == agent_id,
+                AgentContextBinding.context_id == context_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def create_binding(
         self,
         *,
@@ -360,3 +376,46 @@ class AgentBindingService:
             )
         )
         return set(result.scalars().all())
+
+    async def resolve_default_binding(
+        self, agent_id: uuid.UUID
+    ) -> tuple[AgentContextBinding | None, str]:
+        """Resolve the agent's default binding for bootstrap (#1276, F2).
+
+        Returns ``(binding, outcome)`` where outcome ∈
+        {``"default"``, ``"sole"``, ``"none"``, ``"ambiguous"``}:
+
+        - the row with ``is_default = true`` (``"default"``), else
+        - the agent's SOLE binding when exactly one exists (``"sole"``), else
+        - ``(None, "none")`` when the agent has no bindings, or
+        - ``(None, "ambiguous")`` when it has ≥2 bindings and no default.
+
+        The caller maps ``none``/``ambiguous`` to ``context_id_required``
+        WITHOUT enumerating bindings (no existence oracle — F2 normative).
+        """
+        default_result = await self.db.execute(
+            select(AgentContextBinding).where(
+                AgentContextBinding.agent_id == agent_id,
+                AgentContextBinding.is_default.is_(True),
+            )
+        )
+        default = default_result.scalar_one_or_none()
+        if default is not None:
+            return default, "default"
+
+        rows = (
+            (
+                await self.db.execute(
+                    select(AgentContextBinding)
+                    .where(AgentContextBinding.agent_id == agent_id)
+                    .limit(2)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if len(rows) == 1:
+            return rows[0], "sole"
+        if len(rows) == 0:
+            return None, "none"
+        return None, "ambiguous"

--- a/backend/src/services/agent_bootstrap_service.py
+++ b/backend/src/services/agent_bootstrap_service.py
@@ -314,13 +314,58 @@ class AgentBootstrapService:
     # ------------------------------------------------------------------
 
     async def _component(self, name: str, fn: Any) -> dict[str, Any]:
-        """Run one component fail-soft: {status: ok, ...} or {status: error}."""
+        """Run one component fail-soft: {status: ok, ...} or {status: error}.
+
+        Each component runs inside a SAVEPOINT (``begin_nested``): a genuine
+        Postgres-level error in one component (lock timeout, transient blip)
+        rolls back ONLY that component's partial work and leaves the shared
+        session usable, so the remaining components — and the final commit —
+        do not hit ``PendingRollbackError``. Without the savepoint, a single
+        component's DB error would poison the transaction and deny the agent
+        everything, defeating the fail-soft design (the ``get_db()``
+        auto-commit trap; inner code review). The #1255 per-event SAVEPOINT
+        pattern.
+        """
         try:
-            body = await fn()
+            async with self.db.begin_nested():
+                body = await fn()
             return {"status": STATUS_OK, **body}
-        except Exception as exc:  # fail-soft per component
+        except Exception as exc:  # fail-soft per component; savepoint rolled back
             logger.error(f"bootstrap_component_failed: {name}: {exc}", exc_info=True)
             return {"status": STATUS_ERROR, "error": "component_error"}
+
+    async def audit_on_behalf_of(
+        self, *, agent: Any, principal: BootstrapPrincipal, session_id: str | None
+    ) -> None:
+        """Write the on-behalf-of audit row for an operator bootstrap (#1276).
+
+        F2 normative: a non-agent (owner/admin) credential bootstrapping an
+        agent MUST record ``on_behalf_of`` + ``principal_type`` so operator
+        activity is distinguishable from the agent's own and cannot masquerade
+        as it. No-op for agent-bound calls (``on_behalf_of`` is None — the
+        activity IS the agent's, covered by usage + correlation). Added to the
+        session but NOT committed — the caller commits atomically.
+        """
+        if not principal.on_behalf_of:
+            return
+        from services.agent_registry_service import (
+            AUDIT_AGENT_BOOTSTRAP_ON_BEHALF,
+            add_agent_audit_row,
+        )
+
+        add_agent_audit_row(
+            self.db,
+            actor_user_id=principal.user_id,
+            actor_email=None,
+            action=AUDIT_AGENT_BOOTSTRAP_ON_BEHALF,
+            agent_id=agent.id,
+            workspace_id=principal.workspace_id,
+            metadata={
+                "principal_type": principal.principal_type,
+                "on_behalf_of": principal.on_behalf_of,
+                "session_id": session_id,
+            },
+        )
 
     async def _context_and_instructions(self, context: Any) -> tuple[dict[str, Any], str]:
         from sqlalchemy import select

--- a/backend/src/services/agent_bootstrap_service.py
+++ b/backend/src/services/agent_bootstrap_service.py
@@ -1,0 +1,476 @@
+"""Agent bootstrap composition service (RFC-0002 P0-3, Issue #1276).
+
+``get_agent_bootstrap`` is the single session-start call that rehydrates an
+agent's cognitive state by **composing existing primitives** — it adds no
+parallel retrieval path and no second scoring surface (F2 design invariant 1,
+``docs/design/agent-bootstrap-contract.md``). Each component delegates to the
+exact service chokepoint the standalone primitive uses, so bounds, ordering,
+trust filtering, ranking, and IDOR posture are inherited, not re-specified.
+
+Shared by the MCP tool (``mcp_server/tools/agent_bootstrap.py``) and the REST
+companion (``POST /api/v1/agents/{agent_id}/bootstrap``).
+
+Total, fail-closed errors (identity/authorization) raise ``BootstrapError``;
+component failures are fail-soft — a failing component yields
+``{"status": "error", ...}`` for that component only, with top-level
+``degraded: true``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.datetime import to_utc_iso, utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Component health vocabulary (per-component; distinct from the top-level
+# house envelope status which stays "success").
+STATUS_OK = "ok"
+STATUS_ERROR = "error"
+STATUS_SKIPPED = "skipped"
+
+_ALL_COMPONENTS = ("pinned", "recall", "upcoming", "state", "policy")
+_QUERY_MAX_LEN = 1024
+_SESSION_ID_MAX_LEN = 128
+
+
+class BootstrapError(Exception):
+    """A total, fail-closed bootstrap failure (identity/authorization/args).
+
+    ``code`` is the snake_case ``_error_response`` code the surfaces render;
+    ``message`` is the generic caller-facing string (never leaks existence).
+    """
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+@dataclass
+class BootstrapParams:
+    """Validated request parameters (surface-agnostic)."""
+
+    agent_id: UUID
+    context_id: UUID | None = None
+    session_id: str | None = None
+    query: str | None = None
+    recall_k: int | None = None
+    pinned_cap: int | None = None
+    upcoming_until: str | None = None
+    include: tuple[str, ...] = _ALL_COMPONENTS
+
+
+@dataclass
+class BootstrapPrincipal:
+    """Who is bootstrapping — an agent-bound key, or an owner/admin operator."""
+
+    user_id: str
+    workspace_id: UUID
+    principal_type: str  # "agent" | "owner" | "admin"
+    on_behalf_of: str | None = None  # set for non-agent (operator) bootstraps
+    # The pure API-key workspace scope (#963), forwarded to the resolver.
+    key_workspace_id: UUID | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+def parse_include(raw: Any) -> tuple[str, ...]:
+    """Validate the optional ``include`` selector; default = all components."""
+    if raw is None:
+        return _ALL_COMPONENTS
+    if not isinstance(raw, list) or not all(isinstance(v, str) for v in raw):
+        raise BootstrapError("invalid_arguments", "'include' must be a list of strings.")
+    unknown = sorted(set(raw) - set(_ALL_COMPONENTS))
+    if unknown:
+        raise BootstrapError(
+            "invalid_arguments",
+            f"'include' has unknown components {unknown} (valid: {list(_ALL_COMPONENTS)}).",
+        )
+    # Preserve declared order, dedup.
+    return tuple(c for c in _ALL_COMPONENTS if c in raw)
+
+
+def validate_session_id(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or len(raw) > _SESSION_ID_MAX_LEN:
+        raise BootstrapError(
+            "invalid_arguments",
+            f"'session_id' must be a string of at most {_SESSION_ID_MAX_LEN} chars.",
+        )
+    if raw and not all(c.isalnum() or c in "._-" for c in raw):
+        raise BootstrapError("invalid_arguments", "'session_id' allows only [A-Za-z0-9._-].")
+    return raw or None
+
+
+def validate_query(raw: Any) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str) or len(raw) > _QUERY_MAX_LEN:
+        raise BootstrapError(
+            "invalid_arguments",
+            f"'query' must be a string of at most {_QUERY_MAX_LEN} chars.",
+        )
+    return raw or None
+
+
+class AgentBootstrapService:
+    """Compose the agent bootstrap envelope from existing primitives."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def resolve_principal_and_agent(
+        self,
+        *,
+        requested_agent_id: UUID,
+        user: dict,
+        agent_scope: Any,
+    ) -> tuple[BootstrapPrincipal, Any]:
+        """Apply the F2 identity rule and resolve the agent (fail-closed).
+
+        ``agent_scope`` is the per-request AgentScope (or None). Raises
+        ``BootstrapError('agent_not_found')`` uniformly for both "no such
+        agent" and "not yours" (no existence oracle).
+        """
+        from services.agent_registry_service import AgentRegistryService
+
+        user_id = user.get("user_id")
+        if not user_id:
+            raise BootstrapError("agent_not_found", "Agent not found.")
+
+        if agent_scope is not None:
+            # Agent-bound key: the requested agent MUST equal the key's agent.
+            if requested_agent_id != agent_scope.agent_id:
+                raise BootstrapError("agent_not_found", "Agent not found.")
+            workspace_id = _coerce_uuid(user.get("current_workspace_id"))
+            key_workspace_id = _coerce_uuid(user.get("api_key_workspace_id"))
+            if workspace_id is None:
+                raise BootstrapError("agent_not_found", "Agent not found.")
+            agent = await AgentRegistryService(self.db).get_agent(workspace_id, requested_agent_id)
+            if agent is None:
+                raise BootstrapError("agent_not_found", "Agent not found.")
+            return (
+                BootstrapPrincipal(
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    principal_type="agent",
+                    key_workspace_id=key_workspace_id,
+                    metadata={"principal_type": "agent"},
+                ),
+                agent,
+            )
+
+        # Non-agent credential: only a workspace owner/admin may bootstrap an
+        # agent of their workspace (e.g. for testing), recorded as on_behalf_of.
+        workspace_id = _coerce_uuid(user.get("current_workspace_id"))
+        if workspace_id is None:
+            raise BootstrapError("agent_not_found", "Agent not found.")
+        agent = await AgentRegistryService(self.db).get_agent(workspace_id, requested_agent_id)
+        if agent is None:
+            raise BootstrapError("agent_not_found", "Agent not found.")
+
+        from services.permission_service import PermissionService
+        from utils.exceptions import AuthorizationError
+
+        try:
+            member = await PermissionService(self.db).check_workspace_admin(user_id, workspace_id)
+        except AuthorizationError as exc:
+            # Not owner/admin — uniform agent_not_found (no existence oracle).
+            raise BootstrapError("agent_not_found", "Agent not found.") from exc
+
+        role = getattr(member, "role", "admin")
+        principal_type = "owner" if str(role) in ("owner", "WorkspaceRole.OWNER") else "admin"
+        return (
+            BootstrapPrincipal(
+                user_id=user_id,
+                workspace_id=workspace_id,
+                principal_type=principal_type,
+                on_behalf_of=user_id,
+                key_workspace_id=_coerce_uuid(user.get("api_key_workspace_id")),
+                metadata={"principal_type": principal_type, "on_behalf_of": user_id},
+            ),
+            agent,
+        )
+
+    async def resolve_context(
+        self, *, agent: Any, params: BootstrapParams, principal: BootstrapPrincipal
+    ) -> tuple[Any, dict[str, Any]]:
+        """Resolve the bootstrap context + its binding descriptor (fail-closed).
+
+        Returns ``(context, binding_info)`` where binding_info is
+        ``{context_id, is_default}``. Raises ``BootstrapError`` with
+        ``context_id_required`` / ``context_not_found`` per F2.
+        """
+        from services.agent_binding_service import AgentBindingService
+        from services.permission_service import PermissionService
+        from utils.exceptions import NotFoundException
+
+        binding_service = AgentBindingService(self.db)
+        context_id = params.context_id
+        is_default = False
+
+        if context_id is None:
+            binding, outcome = await binding_service.resolve_default_binding(agent.id)
+            if binding is None:
+                # none / ambiguous — do NOT enumerate bindings (no oracle).
+                raise BootstrapError(
+                    "context_id_required",
+                    "context_id is required — the agent has no default binding.",
+                )
+            context_id = binding.context_id
+            is_default = binding.is_default
+        else:
+            existing = await binding_service.get_binding_for_context(agent.id, context_id)
+            is_default = bool(existing and existing.is_default)
+
+        # Authorization is additive on the existing chain: uniform-404 resolver
+        # first (with #963 key-workspace forwarding + allowed_context_ids), and
+        # the AgentContextBinding intersection is applied inside it because the
+        # per-request agent scope is set — it MAY narrow, MUST NOT widen.
+        try:
+            context = await PermissionService(self.db).resolve_context_for_workspace_read(
+                user_id=principal.user_id,
+                context_id=context_id,
+                key_workspace_id=principal.key_workspace_id,
+            )
+        except NotFoundException as exc:
+            raise BootstrapError("context_not_found", "Context not found.") from exc
+
+        return context, {"context_id": str(context_id), "is_default": is_default}
+
+    async def build_envelope(
+        self,
+        *,
+        agent: Any,
+        context: Any,
+        binding_info: dict[str, Any],
+        params: BootstrapParams,
+        principal: BootstrapPrincipal,
+        recall_metered: bool,
+    ) -> dict[str, Any]:
+        """Compose the response envelope with per-component fail-soft.
+
+        ``recall_metered`` is True when the recall component (query present)
+        exceeded the caller's rate budget — the component degrades to
+        ``rate_limited`` while the cheap components still return.
+        """
+        components: dict[str, Any] = {}
+        degraded = False
+
+        # context block + instructions (byte-compatible with get_context_info).
+        context_block, instructions = await self._context_and_instructions(context)
+
+        include = set(params.include)
+
+        if "pinned" in include:
+            components["pinned"] = await self._component(
+                "pinned", lambda: self._pinned(context, principal)
+            )
+        if "recall" in include:
+            components["recall"] = await self._recall_component(
+                context, params, principal, recall_metered
+            )
+        if "upcoming" in include:
+            components["upcoming"] = await self._component(
+                "upcoming", lambda: self._upcoming(context, params)
+            )
+        if "state" in include:
+            components["state"] = await self._component("state", lambda: self._state(context))
+        if "policy" in include:
+            components["policy"] = {"status": STATUS_SKIPPED, "reason": "no_policy_bundle"}
+
+        degraded = any(c.get("status") == STATUS_ERROR for c in components.values())
+
+        return {
+            "status": "success",
+            "degraded": degraded,
+            "agent": {
+                "agent_id": str(agent.id),
+                "name": agent.name,
+                "binding": binding_info,
+            },
+            "context": context_block,
+            "instructions": instructions,
+            "components": components,
+            "correlation": {
+                "agent_id": str(agent.id),
+                "session_id": params.session_id,
+                # P0-4 (#1277) populates trace/span from the correlation lane.
+                "trace_id": None,
+                "span_id": None,
+            },
+            "generated_at": to_utc_iso(utcnow()),
+        }
+
+    # ------------------------------------------------------------------
+    # Components
+    # ------------------------------------------------------------------
+
+    async def _component(self, name: str, fn: Any) -> dict[str, Any]:
+        """Run one component fail-soft: {status: ok, ...} or {status: error}."""
+        try:
+            body = await fn()
+            return {"status": STATUS_OK, **body}
+        except Exception as exc:  # fail-soft per component
+            logger.error(f"bootstrap_component_failed: {name}: {exc}", exc_info=True)
+            return {"status": STATUS_ERROR, "error": "component_error"}
+
+    async def _context_and_instructions(self, context: Any) -> tuple[dict[str, Any], str]:
+        from sqlalchemy import select
+
+        from config.settings import get_settings
+        from mcp_server.tools._constants import KAGURA_MEMORY_INSTRUCTIONS
+        from models.config import ContextSearchConfig
+
+        settings = get_settings()
+        config = (
+            await self.db.execute(
+                select(ContextSearchConfig).where(ContextSearchConfig.context_id == context.id)
+            )
+        ).scalar_one_or_none()
+
+        usage_guide = context.usage_guide or (
+            "No usage guide provided. Please add usage guidelines in the context settings."
+        )
+        context_block = {
+            "id": str(context.id),
+            "name": context.name,
+            "display_name": context.display_name,
+            "summary": context.summary
+            or "No summary provided. Please add a summary in the context settings.",
+            "usage_guide": usage_guide,
+            "is_private": context.is_private,
+            "is_locked": context.is_locked,
+            "embedding_model": config.embedding_model if config else settings.embedding_model,
+            "embedding_dimensions": config.embedding_dimensions
+            if config
+            else settings.embedding_dimensions,
+        }
+        # instructions = context usage_guide, blank line, standard instructions
+        # (the get_context_info precedent — usage_guide first).
+        instructions = f"{usage_guide}\n\n{KAGURA_MEMORY_INSTRUCTIONS}"
+        return context_block, instructions
+
+    async def _pinned(self, context: Any, principal: BootstrapPrincipal) -> dict[str, Any]:
+        from services.memory_service import MemoryService
+
+        result = await MemoryService(self.db).load_pinned(
+            user_id=principal.user_id,
+            current_context_id=context.id,
+            current_workspace_id=principal.workspace_id,
+            cap=None,  # inherit the load_pinned default clamp
+        )
+        return {
+            "memories": [
+                {
+                    "memory_id": str(m.memory_id),
+                    "summary": m.summary,
+                    "context_summary": m.context_summary,
+                    "type": m.type,
+                    "importance": m.importance,
+                    "delivery_mode": m.delivery_mode,
+                }
+                for m in result.memories
+            ],
+            "total_available": result.total_available,
+            "truncated": result.truncated,
+            "cap": result.cap,
+        }
+
+    async def _recall_component(
+        self,
+        context: Any,
+        params: BootstrapParams,
+        principal: BootstrapPrincipal,
+        recall_metered: bool,
+    ) -> dict[str, Any]:
+        # Server never fabricates a query — absent query = skipped, even when
+        # include explicitly names recall (F2 normative).
+        if params.query is None:
+            return {"status": STATUS_SKIPPED, "reason": "no_query"}
+        if recall_metered:
+            return {"status": STATUS_ERROR, "error": "rate_limited"}
+        return await self._component("recall", lambda: self._recall(context, params, principal))
+
+    async def _recall(
+        self, context: Any, params: BootstrapParams, principal: BootstrapPrincipal
+    ) -> dict[str, Any]:
+        from config.settings import get_settings
+        from models.schemas import RecallRequest
+        from services.memory_service import MemoryService
+        from utils.hashing import hmac_sha256_hex
+
+        # Trusted-tier-only recall — bootstrap output is behaviour-establishing
+        # (OWASP LLM01/LLM03); not configurable in v1 (F2 invariant 3).
+        request = RecallRequest(
+            query=params.query,
+            k=params.recall_k if params.recall_k is not None else 5,
+            filters={"trust_tier": "trusted"},
+        )
+        result = await MemoryService(self.db).recall(
+            request,
+            user_id=principal.user_id,
+            current_context_id=context.id,
+            current_workspace_id=principal.workspace_id,
+            context_workspace_id=context.workspace_id,
+        )
+        results_data = [
+            {
+                "memory_id": str(r.memory_id),
+                "summary": r.summary,
+                "context_summary": r.context_summary,
+                "type": r.type,
+                "importance": r.importance,
+                "scope": r.scope,
+                "score": r.score,
+                "tags": r.tags,
+                "created_at": to_utc_iso(r.created_at),
+                "updated_at": to_utc_iso(r.updated_at),
+                "superseded_by": str(r.superseded_by) if r.superseded_by else None,
+                "contradicts": [str(c) for c in r.contradicts],
+            }
+            for r in result.results
+        ]
+        # query_hash never leaks the raw query — correlation only.
+        query_hash = hmac_sha256_hex(params.query or "", get_settings().api_key_secret)
+        return {
+            "query_hash": query_hash,
+            "results": results_data,
+            "k": request.k,
+            "trust_filter": "trusted",
+        }
+
+    async def _upcoming(self, context: Any, params: BootstrapParams) -> dict[str, Any]:
+        from services.time_memory import query_upcoming_time_memories
+        from utils.time_trigger import parse_query_bound
+
+        q_from = parse_query_bound("now")
+        q_until = parse_query_bound(params.upcoming_until) if params.upcoming_until else None
+        results = await query_upcoming_time_memories(
+            self.db, context.id, q_from=q_from, q_until=q_until, k=20
+        )
+        return {"results": results, "from": q_from, "until": q_until}
+
+    async def _state(self, context: Any) -> dict[str, Any]:
+        from services.agent_state_service import AgentStateService
+
+        states = await AgentStateService(self.db).list_state(context.id)
+        return {"states": states, "count": len(states)}
+
+
+def _coerce_uuid(value: Any) -> UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError):
+        return None

--- a/backend/src/services/agent_registry_service.py
+++ b/backend/src/services/agent_registry_service.py
@@ -54,6 +54,10 @@ AUDIT_AGENT_REGISTERED = "agent_registered"
 AUDIT_AGENT_UPDATED = "agent_updated"
 AUDIT_AGENT_ENFORCEMENT_WIDENED = "agent_enforcement_widened"
 AUDIT_AGENT_DELETED = "agent_deleted"
+# Issue #1276: an owner/admin operator bootstrapping an agent "on behalf of"
+# (non-agent credential) — recorded so operator activity is distinguishable
+# from the agent's own and cannot masquerade as it (F2 normative).
+AUDIT_AGENT_BOOTSTRAP_ON_BEHALF = "agent_bootstrap_on_behalf_of"
 
 
 def validate_agent_name(name: Any) -> str:

--- a/backend/src/services/time_memory.py
+++ b/backend/src/services/time_memory.py
@@ -1,0 +1,79 @@
+"""Shared Time Memory (``type='time'``) window query (#877, hoisted for #1276).
+
+The upcoming-window overlap query historically lived inline in the
+``recall_upcoming`` MCP handler. F2 (``get_agent_bootstrap``) composes the same
+query, so it is hoisted here as the single implementation both the standalone
+tool and the bootstrap service consume — the ``AgentStateService`` dual-surface
+pattern. Same predicate, same clamps, no second implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Clamp bounds shared by every caller — a missing lower bound let k<=0 through
+# as LIMIT 0 (always empty) or LIMIT -1 (no cap, bypassing the ceiling).
+UPCOMING_K_DEFAULT = 20
+UPCOMING_K_MIN = 1
+UPCOMING_K_MAX = 100
+
+
+def clamp_upcoming_k(raw_k: Any) -> int:
+    """Coerce + clamp the ``k`` argument into ``[1, 100]`` (default 20).
+
+    Raises ``ValueError`` on a non-integer so the caller can surface a
+    structured ``validation_error`` (matches the pre-hoist handler behavior).
+    """
+    if raw_k is None:
+        raw_k = UPCOMING_K_DEFAULT
+    k = int(raw_k)  # may raise ValueError/TypeError → caller maps to 422
+    return max(UPCOMING_K_MIN, min(k, UPCOMING_K_MAX))
+
+
+async def query_upcoming_time_memories(
+    db: AsyncSession,
+    context_id: UUID,
+    *,
+    q_from: str | None,
+    q_until: str | None,
+    k: int,
+) -> list[dict[str, Any]]:
+    """Return the context's Time Memories whose window overlaps ``[q_from, q_until]``.
+
+    ``q_from`` / ``q_until`` are fixed-width ISO strings (or None = unbounded)
+    already normalized by ``utils.time_trigger.parse_query_bound``; the
+    ``trigger_from`` / ``trigger_until`` columns are TEXT fixed-width ISO so the
+    lexical comparison equals a chronological one. Soonest-first, capped at
+    ``k``. Result rows are byte-compatible with the ``recall_upcoming`` handler
+    (``memory_id`` / ``summary`` / ``type`` / ``details``).
+    """
+    from models.memory import Memory
+
+    query = (
+        select(Memory)
+        .where(Memory.deleted_at.is_(None))
+        .where(Memory.type == "time")
+        .where(Memory.context_id == context_id)
+    )
+    # Window overlap: stored [trigger_from, trigger_until] overlaps the query
+    # window [q_from, q_until] iff trigger_until >= q_from AND trigger_from <= q_until.
+    if q_from is not None:
+        query = query.where(Memory.trigger_until >= q_from)
+    if q_until is not None:
+        query = query.where(Memory.trigger_from <= q_until)
+    query = query.order_by(Memory.trigger_from.asc()).limit(k)
+
+    rows = (await db.execute(query)).scalars().all()
+    return [
+        {
+            "memory_id": str(m.id),
+            "summary": m.summary,
+            "type": m.type,
+            "details": m.details,
+        }
+        for m in rows
+    ]

--- a/backend/tests/api/test_agent_bootstrap_route.py
+++ b/backend/tests/api/test_agent_bootstrap_route.py
@@ -55,6 +55,7 @@ def _svc(monkeypatch, *, principal_error=None, context_error=None, envelope=None
     inst.build_envelope = AsyncMock(
         return_value=envelope or {"status": "success", "degraded": False, "components": {}}
     )
+    inst.audit_on_behalf_of = AsyncMock()
     monkeypatch.setattr(
         "services.agent_bootstrap_service.AgentBootstrapService",
         MagicMock(return_value=inst),
@@ -65,9 +66,7 @@ def _svc(monkeypatch, *, principal_error=None, context_error=None, envelope=None
 @pytest.mark.asyncio
 async def test_success_returns_envelope(db, monkeypatch):
     _svc(monkeypatch)
-    result = await agent_bootstrap(
-        agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db
-    )
+    result = await agent_bootstrap(agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db)
     assert result["status"] == "success"
     db.commit.assert_awaited_once()
 

--- a/backend/tests/api/test_agent_bootstrap_route.py
+++ b/backend/tests/api/test_agent_bootstrap_route.py
@@ -1,0 +1,94 @@
+"""Route-surface tests for the agent bootstrap REST companion (Issue #1276).
+
+Pins the identity/authorization → HTTP mapping (uniform 404 for
+agent_not_found / context_not_found; 400 for context_id_required) and the
+success envelope pass-through. Composition is covered by the service tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes.agents import BootstrapRequest, agent_bootstrap
+from utils.exceptions import BadRequestError, NotFoundException
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+CONTEXT_ID = uuid.uuid4()
+USER = {"user_id": "u", "current_workspace_id": WORKSPACE_ID, "api_key_workspace_id": WORKSPACE_ID}
+
+
+@pytest.fixture
+def db():
+    d = MagicMock()
+    d.commit = AsyncMock()
+    d.rollback = AsyncMock()
+    return d
+
+
+def _svc(monkeypatch, *, principal_error=None, context_error=None, envelope=None):
+    from services.agent_bootstrap_service import BootstrapError
+
+    inst = MagicMock()
+    if principal_error:
+        inst.resolve_principal_and_agent = AsyncMock(side_effect=BootstrapError(*principal_error))
+    else:
+        inst.resolve_principal_and_agent = AsyncMock(
+            return_value=(
+                SimpleNamespace(workspace_id=WORKSPACE_ID),
+                SimpleNamespace(id=AGENT_ID, name="ci-bot", workspace_id=WORKSPACE_ID),
+            )
+        )
+    if context_error:
+        inst.resolve_context = AsyncMock(side_effect=BootstrapError(*context_error))
+    else:
+        inst.resolve_context = AsyncMock(
+            return_value=(
+                SimpleNamespace(id=CONTEXT_ID, workspace_id=WORKSPACE_ID),
+                {"context_id": str(CONTEXT_ID), "is_default": True},
+            )
+        )
+    inst.build_envelope = AsyncMock(
+        return_value=envelope or {"status": "success", "degraded": False, "components": {}}
+    )
+    monkeypatch.setattr(
+        "services.agent_bootstrap_service.AgentBootstrapService",
+        MagicMock(return_value=inst),
+    )
+    return inst
+
+
+@pytest.mark.asyncio
+async def test_success_returns_envelope(db, monkeypatch):
+    _svc(monkeypatch)
+    result = await agent_bootstrap(
+        agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db
+    )
+    assert result["status"] == "success"
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_agent_not_found_is_404(db, monkeypatch):
+    _svc(monkeypatch, principal_error=("agent_not_found", "Agent not found."))
+    with pytest.raises(NotFoundException):
+        await agent_bootstrap(agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db)
+    db.rollback.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_context_not_found_is_404(db, monkeypatch):
+    _svc(monkeypatch, context_error=("context_not_found", "Context not found."))
+    with pytest.raises(NotFoundException):
+        await agent_bootstrap(agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db)
+
+
+@pytest.mark.asyncio
+async def test_context_id_required_is_400(db, monkeypatch):
+    _svc(monkeypatch, context_error=("context_id_required", "context_id is required."))
+    with pytest.raises(BadRequestError):
+        await agent_bootstrap(agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db)

--- a/backend/tests/mcp_server/test_agent_bootstrap_tool.py
+++ b/backend/tests/mcp_server/test_agent_bootstrap_tool.py
@@ -63,6 +63,7 @@ def _enter(stack, *, principal_error=None, envelope=None):
             "correlation": {},
         }
     )
+    svc.audit_on_behalf_of = AsyncMock()
     stack.enter_context(
         patch("services.agent_bootstrap_service.AgentBootstrapService", return_value=svc)
     )

--- a/backend/tests/mcp_server/test_agent_bootstrap_tool.py
+++ b/backend/tests/mcp_server/test_agent_bootstrap_tool.py
@@ -1,0 +1,125 @@
+"""Handler tests for the get_agent_bootstrap MCP tool (Issue #1276).
+
+Pins the arg/dispatch contract, the total-error → _error_response mapping,
+and the success envelope shaping. The composition logic itself is covered by
+tests/services/test_agent_bootstrap_service.py.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_server.tools.agent_bootstrap import handle_get_agent_bootstrap
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+CONTEXT_ID = uuid.uuid4()
+
+
+def _payload(result):
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+def _enter(stack, *, principal_error=None, envelope=None):
+    async def gen():
+        yield AsyncMock()
+
+    stack.enter_context(patch("db.base.get_db", new=gen))
+    stack.enter_context(patch("mcp_server.tools.agent_bootstrap._log_tool_usage", new=AsyncMock()))
+    stack.enter_context(patch("auth.agent_scope.get_agent_scope", return_value=None))
+
+    from services.agent_bootstrap_service import BootstrapError
+
+    svc = MagicMock()
+    if principal_error:
+        svc.resolve_principal_and_agent = AsyncMock(side_effect=BootstrapError(*principal_error))
+    else:
+        svc.resolve_principal_and_agent = AsyncMock(
+            return_value=(
+                SimpleNamespace(workspace_id=WORKSPACE_ID),
+                SimpleNamespace(id=AGENT_ID, name="ci-bot", workspace_id=WORKSPACE_ID),
+            )
+        )
+    svc.resolve_context = AsyncMock(
+        return_value=(
+            SimpleNamespace(id=CONTEXT_ID, workspace_id=WORKSPACE_ID),
+            {"context_id": str(CONTEXT_ID), "is_default": True},
+        )
+    )
+    svc.build_envelope = AsyncMock(
+        return_value=envelope
+        or {
+            "status": "success",
+            "degraded": False,
+            "agent": {"agent_id": str(AGENT_ID)},
+            "components": {},
+            "correlation": {},
+        }
+    )
+    stack.enter_context(
+        patch("services.agent_bootstrap_service.AgentBootstrapService", return_value=svc)
+    )
+    return svc
+
+
+class TestArgValidation:
+    @pytest.mark.asyncio
+    async def test_missing_agent_id(self):
+        result = await handle_get_agent_bootstrap(args={}, user_id="u", workspace_id=WORKSPACE_ID)
+        assert _payload(result)["error"] == "missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_malformed_agent_id(self):
+        result = await handle_get_agent_bootstrap(
+            args={"agent_id": "nope"}, user_id="u", workspace_id=WORKSPACE_ID
+        )
+        assert _payload(result)["error"] == "invalid_arguments"
+
+    @pytest.mark.asyncio
+    async def test_bad_include_rejected(self):
+        result = await handle_get_agent_bootstrap(
+            args={"agent_id": str(AGENT_ID), "include": ["bogus"]},
+            user_id="u",
+            workspace_id=WORKSPACE_ID,
+        )
+        assert _payload(result)["error"] == "invalid_arguments"
+
+
+class TestDispatch:
+    @pytest.mark.asyncio
+    async def test_agent_not_found_maps_error(self):
+        with ExitStack() as stack:
+            _enter(stack, principal_error=("agent_not_found", "Agent not found."))
+            result = await handle_get_agent_bootstrap(
+                args={"agent_id": str(AGENT_ID)}, user_id="u", workspace_id=WORKSPACE_ID
+            )
+        assert _payload(result)["error"] == "agent_not_found"
+
+    @pytest.mark.asyncio
+    async def test_success_returns_envelope(self):
+        with ExitStack() as stack:
+            _enter(stack)
+            result = await handle_get_agent_bootstrap(
+                args={"agent_id": str(AGENT_ID)}, user_id="u", workspace_id=WORKSPACE_ID
+            )
+        body = _payload(result)
+        assert body["status"] == "success"
+        assert body["agent"]["agent_id"] == str(AGENT_ID)
+        assert "degraded" in body
+
+    @pytest.mark.asyncio
+    async def test_queryless_call_does_not_meter(self):
+        with ExitStack() as stack:
+            svc = _enter(stack)
+            await handle_get_agent_bootstrap(
+                args={"agent_id": str(AGENT_ID)}, user_id="u", workspace_id=WORKSPACE_ID
+            )
+        # recall_metered must be False for a query-less call.
+        assert svc.build_envelope.await_args.kwargs["recall_metered"] is False

--- a/backend/tests/services/test_agent_bootstrap_service.py
+++ b/backend/tests/services/test_agent_bootstrap_service.py
@@ -1,0 +1,406 @@
+"""Unit tests for AgentBootstrapService (RFC-0002 P0-3, Issue #1276).
+
+Pins the F2 identity rule (agent-bound equality → uniform agent_not_found;
+non-agent → owner/admin only, on_behalf_of recorded), default-binding
+resolution (no enumeration oracle), the per-component fail-soft envelope
+(pinned/recall/upcoming/state/policy), the recall skip-without-query and
+trusted-only invariants, and the rate_limited degrade. DB access is mocked;
+composition byte-compat is covered by the primitives' own tests.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.agent_bootstrap_service import (
+    STATUS_ERROR,
+    STATUS_OK,
+    STATUS_SKIPPED,
+    AgentBootstrapService,
+    BootstrapError,
+    BootstrapParams,
+    BootstrapPrincipal,
+    parse_include,
+    validate_query,
+    validate_session_id,
+)
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+CONTEXT_ID = uuid.uuid4()
+
+
+def _scope(agent_id=AGENT_ID):
+    return SimpleNamespace(agent_id=agent_id, enforcement_mode="enforce")
+
+
+def _agent():
+    return SimpleNamespace(id=AGENT_ID, name="ci-bot", workspace_id=WORKSPACE_ID)
+
+
+def _context():
+    return SimpleNamespace(
+        id=CONTEXT_ID,
+        workspace_id=WORKSPACE_ID,
+        name="ctx",
+        display_name="Ctx",
+        summary="s",
+        usage_guide="use me",
+        is_private=False,
+        is_locked=False,
+    )
+
+
+def _agent_user():
+    return {
+        "user_id": "u",
+        "current_workspace_id": WORKSPACE_ID,
+        "api_key_workspace_id": WORKSPACE_ID,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Argument validators
+# ---------------------------------------------------------------------------
+
+
+class TestValidators:
+    def test_include_default_all(self):
+        assert parse_include(None) == ("pinned", "recall", "upcoming", "state", "policy")
+
+    def test_include_preserves_canonical_order_and_dedups(self):
+        assert parse_include(["state", "pinned", "state"]) == ("pinned", "state")
+
+    def test_include_unknown_rejected(self):
+        with pytest.raises(BootstrapError):
+            parse_include(["pinned", "bogus"])
+
+    @pytest.mark.parametrize("bad", ["x" * 129, "has space", 42])
+    def test_session_id_rejected(self, bad):
+        with pytest.raises(BootstrapError):
+            validate_session_id(bad)
+
+    def test_session_id_ok(self):
+        assert validate_session_id("run.1-2_3") == "run.1-2_3"
+
+    def test_query_too_long_rejected(self):
+        with pytest.raises(BootstrapError):
+            validate_query("x" * 1025)
+
+
+# ---------------------------------------------------------------------------
+# Identity rule
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityRule:
+    @pytest.mark.asyncio
+    async def test_agent_key_mismatch_uniform_not_found(self):
+        svc = AgentBootstrapService(MagicMock())
+        with pytest.raises(BootstrapError) as e:
+            await svc.resolve_principal_and_agent(
+                requested_agent_id=uuid.uuid4(),  # != scope.agent_id
+                user=_agent_user(),
+                agent_scope=_scope(),
+            )
+        assert e.value.code == "agent_not_found"
+
+    @pytest.mark.asyncio
+    async def test_agent_key_match_resolves_principal(self):
+        svc = AgentBootstrapService(MagicMock())
+        with patch(
+            "services.agent_registry_service.AgentRegistryService.get_agent",
+            new=AsyncMock(return_value=_agent()),
+        ):
+            principal, agent = await svc.resolve_principal_and_agent(
+                requested_agent_id=AGENT_ID, user=_agent_user(), agent_scope=_scope()
+            )
+        assert principal.principal_type == "agent"
+        assert principal.on_behalf_of is None
+        assert agent.id == AGENT_ID
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_agent_not_found(self):
+        svc = AgentBootstrapService(MagicMock())
+        with patch(
+            "services.agent_registry_service.AgentRegistryService.get_agent",
+            new=AsyncMock(return_value=None),
+        ):
+            with pytest.raises(BootstrapError) as e:
+                await svc.resolve_principal_and_agent(
+                    requested_agent_id=AGENT_ID, user=_agent_user(), agent_scope=_scope()
+                )
+        assert e.value.code == "agent_not_found"
+
+    @pytest.mark.asyncio
+    async def test_non_agent_owner_records_on_behalf_of(self):
+        svc = AgentBootstrapService(MagicMock())
+        with (
+            patch(
+                "services.agent_registry_service.AgentRegistryService.get_agent",
+                new=AsyncMock(return_value=_agent()),
+            ),
+            patch(
+                "services.permission_service.PermissionService.check_workspace_admin",
+                new=AsyncMock(return_value=SimpleNamespace(role="owner")),
+            ),
+        ):
+            principal, _ = await svc.resolve_principal_and_agent(
+                requested_agent_id=AGENT_ID, user=_agent_user(), agent_scope=None
+            )
+        assert principal.principal_type == "owner"
+        assert principal.on_behalf_of == "u"
+        assert principal.metadata["on_behalf_of"] == "u"
+
+    @pytest.mark.asyncio
+    async def test_non_agent_non_admin_uniform_not_found(self):
+        from utils.exceptions import AuthorizationError
+
+        svc = AgentBootstrapService(MagicMock())
+        with (
+            patch(
+                "services.agent_registry_service.AgentRegistryService.get_agent",
+                new=AsyncMock(return_value=_agent()),
+            ),
+            patch(
+                "services.permission_service.PermissionService.check_workspace_admin",
+                new=AsyncMock(side_effect=AuthorizationError()),
+            ),
+        ):
+            with pytest.raises(BootstrapError) as e:
+                await svc.resolve_principal_and_agent(
+                    requested_agent_id=AGENT_ID, user=_agent_user(), agent_scope=None
+                )
+        assert e.value.code == "agent_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Default-binding resolution
+# ---------------------------------------------------------------------------
+
+
+class TestContextResolution:
+    def _principal(self):
+        return BootstrapPrincipal(user_id="u", workspace_id=WORKSPACE_ID, principal_type="agent")
+
+    @pytest.mark.asyncio
+    async def test_no_default_binding_context_id_required(self):
+        svc = AgentBootstrapService(MagicMock())
+        with patch(
+            "services.agent_binding_service.AgentBindingService.resolve_default_binding",
+            new=AsyncMock(return_value=(None, "none")),
+        ):
+            with pytest.raises(BootstrapError) as e:
+                await svc.resolve_context(
+                    agent=_agent(),
+                    params=BootstrapParams(agent_id=AGENT_ID),
+                    principal=self._principal(),
+                )
+        assert e.value.code == "context_id_required"
+        # No enumeration oracle — message must not list bindings.
+        assert "binding" not in e.value.message.lower() or "default" in e.value.message.lower()
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_bindings_context_id_required(self):
+        svc = AgentBootstrapService(MagicMock())
+        with patch(
+            "services.agent_binding_service.AgentBindingService.resolve_default_binding",
+            new=AsyncMock(return_value=(None, "ambiguous")),
+        ):
+            with pytest.raises(BootstrapError) as e:
+                await svc.resolve_context(
+                    agent=_agent(),
+                    params=BootstrapParams(agent_id=AGENT_ID),
+                    principal=self._principal(),
+                )
+        assert e.value.code == "context_id_required"
+
+    @pytest.mark.asyncio
+    async def test_default_binding_resolves_context(self):
+        svc = AgentBootstrapService(MagicMock())
+        binding = SimpleNamespace(context_id=CONTEXT_ID, is_default=True)
+        with (
+            patch(
+                "services.agent_binding_service.AgentBindingService.resolve_default_binding",
+                new=AsyncMock(return_value=(binding, "default")),
+            ),
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                new=AsyncMock(return_value=_context()),
+            ),
+        ):
+            context, info = await svc.resolve_context(
+                agent=_agent(),
+                params=BootstrapParams(agent_id=AGENT_ID),
+                principal=self._principal(),
+            )
+        assert context.id == CONTEXT_ID
+        assert info == {"context_id": str(CONTEXT_ID), "is_default": True}
+
+    @pytest.mark.asyncio
+    async def test_binding_denied_context_maps_to_context_not_found(self):
+        from utils.exceptions import NotFoundException
+
+        svc = AgentBootstrapService(MagicMock())
+        with (
+            patch(
+                "services.agent_binding_service.AgentBindingService.get_binding_for_context",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                new=AsyncMock(side_effect=NotFoundException("Context")),
+            ),
+        ):
+            with pytest.raises(BootstrapError) as e:
+                await svc.resolve_context(
+                    agent=_agent(),
+                    params=BootstrapParams(agent_id=AGENT_ID, context_id=CONTEXT_ID),
+                    principal=self._principal(),
+                )
+        assert e.value.code == "context_not_found"
+
+
+# ---------------------------------------------------------------------------
+# Envelope composition + fail-soft
+# ---------------------------------------------------------------------------
+
+
+class TestEnvelope:
+    def _principal(self):
+        return BootstrapPrincipal(user_id="u", workspace_id=WORKSPACE_ID, principal_type="agent")
+
+    async def _build(self, svc, params, recall_metered=False):
+        return await svc.build_envelope(
+            agent=_agent(),
+            context=_context(),
+            binding_info={"context_id": str(CONTEXT_ID), "is_default": True},
+            params=params,
+            principal=self._principal(),
+            recall_metered=recall_metered,
+        )
+
+    def _patch_components(self, stack, *, pinned=None, recall=None, upcoming=None, state=None):
+        # Patch each component's private helper to return a body dict.
+
+        patches = {
+            "_pinned": pinned
+            if pinned is not None
+            else {"memories": [], "total_available": 0, "truncated": False, "cap": 100},
+            "_upcoming": upcoming
+            if upcoming is not None
+            else {"results": [], "from": "now", "until": None},
+            "_state": state if state is not None else {"states": {}, "count": 0},
+        }
+        for name, body in patches.items():
+            stack.enter_context(
+                patch.object(AgentBootstrapService, name, new=AsyncMock(return_value=body))
+            )
+
+    @pytest.mark.asyncio
+    async def test_query_absent_recall_skipped(self):
+        import contextlib
+
+        svc = AgentBootstrapService(MagicMock())
+        with contextlib.ExitStack() as stack:
+            self._patch_components(stack)
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_context_and_instructions",
+                    new=AsyncMock(return_value=({"id": str(CONTEXT_ID)}, "guide\n\ninstr")),
+                )
+            )
+            env = await self._build(svc, BootstrapParams(agent_id=AGENT_ID, query=None))
+        assert env["components"]["recall"]["status"] == STATUS_SKIPPED
+        assert env["components"]["recall"]["reason"] == "no_query"
+        assert env["degraded"] is False
+        assert env["instructions"] == "guide\n\ninstr"
+
+    @pytest.mark.asyncio
+    async def test_query_present_but_rate_limited_degrades_recall_only(self):
+        import contextlib
+
+        svc = AgentBootstrapService(MagicMock())
+        with contextlib.ExitStack() as stack:
+            self._patch_components(stack)
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_context_and_instructions",
+                    new=AsyncMock(return_value=({"id": str(CONTEXT_ID)}, "g")),
+                )
+            )
+            env = await self._build(
+                svc, BootstrapParams(agent_id=AGENT_ID, query="hi"), recall_metered=True
+            )
+        assert env["components"]["recall"] == {"status": STATUS_ERROR, "error": "rate_limited"}
+        # Cheap components still return.
+        assert env["components"]["pinned"]["status"] == STATUS_OK
+        assert env["components"]["state"]["status"] == STATUS_OK
+
+    @pytest.mark.asyncio
+    async def test_component_error_sets_degraded_but_others_return(self):
+        import contextlib
+
+        svc = AgentBootstrapService(MagicMock())
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_pinned",
+                    new=AsyncMock(side_effect=RuntimeError("qdrant down")),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_upcoming",
+                    new=AsyncMock(return_value={"results": [], "from": "now", "until": None}),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_state",
+                    new=AsyncMock(return_value={"states": {}, "count": 0}),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_context_and_instructions",
+                    new=AsyncMock(return_value=({"id": str(CONTEXT_ID)}, "g")),
+                )
+            )
+            env = await self._build(
+                svc,
+                BootstrapParams(
+                    agent_id=AGENT_ID, query=None, include=("pinned", "upcoming", "state")
+                ),
+            )
+        assert env["components"]["pinned"] == {"status": STATUS_ERROR, "error": "component_error"}
+        assert env["components"]["upcoming"]["status"] == STATUS_OK
+        assert env["degraded"] is True
+
+    @pytest.mark.asyncio
+    async def test_include_selector_limits_components(self):
+        import contextlib
+
+        svc = AgentBootstrapService(MagicMock())
+        with contextlib.ExitStack() as stack:
+            self._patch_components(stack)
+            stack.enter_context(
+                patch.object(
+                    AgentBootstrapService,
+                    "_context_and_instructions",
+                    new=AsyncMock(return_value=({"id": str(CONTEXT_ID)}, "g")),
+                )
+            )
+            env = await self._build(svc, BootstrapParams(agent_id=AGENT_ID, include=("state",)))
+        assert set(env["components"]) == {"state"}
+        assert env["correlation"]["agent_id"] == str(AGENT_ID)

--- a/backend/tests/services/test_agent_bootstrap_service.py
+++ b/backend/tests/services/test_agent_bootstrap_service.py
@@ -265,9 +265,61 @@ class TestContextResolution:
         assert e.value.code == "context_not_found"
 
 
+class TestAuditOnBehalfOf:
+    """#1276 code-review: operator (owner/admin) bootstraps MUST persist an
+    on_behalf_of audit row; agent-bound calls must not."""
+
+    @pytest.mark.asyncio
+    async def test_operator_bootstrap_writes_audit_row(self):
+        db = MagicMock()
+        svc = AgentBootstrapService(db)
+        principal = BootstrapPrincipal(
+            user_id="op",
+            workspace_id=WORKSPACE_ID,
+            principal_type="owner",
+            on_behalf_of="op",
+        )
+        recorder = MagicMock()
+        with patch("services.agent_registry_service.add_agent_audit_row", new=recorder):
+            await svc.audit_on_behalf_of(agent=_agent(), principal=principal, session_id="s1")
+        recorder.assert_called_once()
+        kwargs = recorder.call_args.kwargs
+        assert kwargs["action"] == "agent_bootstrap_on_behalf_of"
+        assert kwargs["metadata"]["on_behalf_of"] == "op"
+        assert kwargs["metadata"]["principal_type"] == "owner"
+
+    @pytest.mark.asyncio
+    async def test_agent_bootstrap_writes_no_audit_row(self):
+        db = MagicMock()
+        svc = AgentBootstrapService(db)
+        principal = BootstrapPrincipal(
+            user_id="u", workspace_id=WORKSPACE_ID, principal_type="agent"
+        )
+        recorder = MagicMock()
+        with patch("services.agent_registry_service.add_agent_audit_row", new=recorder):
+            await svc.audit_on_behalf_of(agent=_agent(), principal=principal, session_id=None)
+        recorder.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # Envelope composition + fail-soft
 # ---------------------------------------------------------------------------
+
+
+def _savepoint_db() -> MagicMock:
+    """A db mock whose begin_nested() is a working async context manager,
+    so _component's per-component SAVEPOINT wrapper runs under test."""
+
+    class _SP:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    db = MagicMock()
+    db.begin_nested = MagicMock(side_effect=lambda: _SP())
+    return db
 
 
 class TestEnvelope:
@@ -305,7 +357,7 @@ class TestEnvelope:
     async def test_query_absent_recall_skipped(self):
         import contextlib
 
-        svc = AgentBootstrapService(MagicMock())
+        svc = AgentBootstrapService(_savepoint_db())
         with contextlib.ExitStack() as stack:
             self._patch_components(stack)
             stack.enter_context(
@@ -325,7 +377,7 @@ class TestEnvelope:
     async def test_query_present_but_rate_limited_degrades_recall_only(self):
         import contextlib
 
-        svc = AgentBootstrapService(MagicMock())
+        svc = AgentBootstrapService(_savepoint_db())
         with contextlib.ExitStack() as stack:
             self._patch_components(stack)
             stack.enter_context(
@@ -347,7 +399,7 @@ class TestEnvelope:
     async def test_component_error_sets_degraded_but_others_return(self):
         import contextlib
 
-        svc = AgentBootstrapService(MagicMock())
+        svc = AgentBootstrapService(_savepoint_db())
         with contextlib.ExitStack() as stack:
             stack.enter_context(
                 patch.object(
@@ -391,7 +443,7 @@ class TestEnvelope:
     async def test_include_selector_limits_components(self):
         import contextlib
 
-        svc = AgentBootstrapService(MagicMock())
+        svc = AgentBootstrapService(_savepoint_db())
         with contextlib.ExitStack() as stack:
             self._patch_components(stack)
             stack.enter_context(


### PR DESCRIPTION
Closes #1276 (RFC-0002 P0-3)

`get_agent_bootstrap` — the single session-start call that rehydrates an agent's cognitive state, per the signed-off F2 contract ([docs/design/agent-bootstrap-contract.md](https://github.com/kagura-ai/memory-cloud/blob/main/docs/design/agent-bootstrap-contract.md)). Stacked on #1274/#1275.

## What

**Pure composition** (`AgentBootstrapService`) — every component delegates to the exact chokepoint the standalone primitive uses, so bounds, ordering, trust filtering, ranking and IDOR posture are **inherited, not re-specified**. No parallel retrieval path, no second scoring surface.

| Component | Delegated primitive | Notes |
|---|---|---|
| `context` + `instructions` | context row + search-config + `KAGURA_MEMORY_INSTRUCTIONS` | usage_guide first, blank-line, standard instructions |
| `pinned` | `MemoryService.load_pinned` | cap clamp inherited |
| `recall` | `MemoryService.recall`, `filters={"trust_tier":"trusted"}` | **query-gated** (skipped when absent — server never fabricates a query); `query_hash` (HMAC) never leaks the raw query |
| `upcoming` | `services.time_memory.query_upcoming_time_memories` | **hoisted** — one implementation shared with `recall_upcoming` |
| `state` | `AgentStateService.list_state` | |
| `policy` | P1 pointer | `skipped` in P0 |

## Invariants

- **Identity** (F2): agent-bound key ⇒ requested `agent_id` MUST equal the key's agent → uniform `agent_not_found` (no existence oracle). Non-agent creds ⇒ owner/admin only, recorded with an `agent_bootstrap_on_behalf_of` audit row (`on_behalf_of` + `principal_type`) so operator activity can't masquerade as the agent's.
- **Authorization additive**: `resolve_context_for_workspace_read` (uniform 404 + #963 key-workspace forwarding) THEN the binding intersection (via the per-request agent scope from #1275; MAY narrow, MUST NOT widen).
- **Default-binding resolution**: `is_default` or sole binding; none / ≥2-with-no-default → `context_id_required` **without enumerating bindings**.
- **Fail-soft components**: a failing component → `{status: error}` + top-level `degraded: true`; each runs in a **SAVEPOINT** so one component's DB error can't poison the shared session and deny the rest. Identity/auth failures are total + fail-closed with `db.rollback`.
- **Rate limit**: exempt at the tool level (query-less = free, Postgres-only), but a query-carrying call meters its recall component under normal accounting, degrading that component to `rate_limited` while the cheap components still return.

## Surfaces

MCP `get_agent_bootstrap` (readOnly, strict `additionalProperties:false` schema, `TOOL_TIMEOUTS` entry, one billable usage row, registered context-optional + rate-exempt) + REST `POST /api/v1/agents/{agent_id}/bootstrap` (`APIKeyOrSessionUser`).

## Tests

Service (identity matrix, default-binding no-oracle, per-component fail-soft, savepoint isolation, recall skip/trusted, rate_limited degrade, on-behalf-of audit), MCP handler, REST route, tool-schema-policy. `recall_upcoming` hoist verified byte-preserving by its unchanged existing tests. Full local suite **5374 passed**; ruff clean; pyright 0 new errors.

## Follow-up

SDK parity for `get_agent_bootstrap` to be filed in `kagura-memory-python-sdk` (proxy forwards `/mcp` transparently; `client.py`/`cli.py` are per-tool explicit).

## Gates

- Inner review: 2 criticals (session-poisoning fail-soft + un-persisted on-behalf-of audit) — fixed in `60bbd6a` with regression pins.
- Gate2: cso / qa-lead / cto all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
