### PR TITLE
feat(api): session/run/trace correlation + identity precedence (#1277)

### DIFF
--- a/backend/src/api/correlation.py
+++ b/backend/src/api/correlation.py
@@ -25,6 +25,10 @@ from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 # OTel GenAI baggage keys (published attribute names; vendor key for run).
 BAGGAGE_AGENT_ID = "gen_ai.agent.id"
 BAGGAGE_SESSION_ID = "gen_ai.conversation.id"
@@ -82,8 +86,18 @@ def validate_correlation_token(value: Any) -> str | None:
     (advisory data, never a request failure).
     """
     if not isinstance(value, str) or not value or len(value) > _CORRELATION_TOKEN_MAX_LEN:
+        # Structured warning on drop (design F4 §validation) — advisory, never
+        # a request failure. Never log the token verbatim (it may, despite the
+        # opacity contract, carry client PII); log only its length/type.
+        logger.warning(
+            "correlation_token_dropped",
+            reason="length_or_type",
+            length=len(value) if isinstance(value, str) else None,
+            value_type=type(value).__name__,
+        )
         return None
     if not _CORRELATION_TOKEN_RE.match(value):
+        logger.warning("correlation_token_dropped", reason="charset", length=len(value))
         return None
     return value
 
@@ -97,9 +111,14 @@ def parse_traceparent(header: str | None) -> tuple[str, str] | None:
         return None
     m = _TRACEPARENT_RE.match(header.strip())
     if not m:
+        # Advisory: a malformed traceparent (e.g. from a misconfigured proxy)
+        # is dropped and the server generates its own ids — but log it so the
+        # misconfiguration is diagnosable (design F4 §validation).
+        logger.warning("traceparent_invalid", reason="malformed")
         return None
     trace_id, span_id = m.group("trace_id"), m.group("span_id")
     if trace_id == "0" * 32 or span_id == "0" * 16:
+        logger.warning("traceparent_invalid", reason="all_zero_id")
         return None
     return trace_id, span_id
 
@@ -193,11 +212,9 @@ def _hash_claim(claim: str) -> str:
     from config.settings import get_settings
     from utils.hashing import hmac_sha256_hex
 
-    settings = get_settings()
-    key = getattr(settings, "audit_hmac_key", None) or getattr(
-        settings, "api_key_secret", "kagura-audit"
-    )
-    return hmac_sha256_hex(claim, key)
+    # audit_hmac_key is a required Settings field with a non-empty default —
+    # use it directly (utils.hashing's contract: never a hard-coded constant).
+    return hmac_sha256_hex(claim, get_settings().audit_hmac_key)
 
 
 async def verify_baggage_agent_claim(

--- a/backend/src/api/correlation.py
+++ b/backend/src/api/correlation.py
@@ -1,0 +1,340 @@
+"""Agent correlation context (RFC-0002 P0-4, Issue #1277).
+
+Parses W3C Trace Context (``traceparent``) + ``baggage`` into a per-request
+contextvar so audit/usage writers can stamp joinable correlation identifiers
+(``agent_id``, ``session_id``, ``run_id``, ``trace_id``, ``span_id``) without
+threading parameters through handler signatures — a sibling of the #963
+MCP key-workspace-scope contextvar (design F4,
+``docs/design/agent-otel-correlation.md``).
+
+**Correlation is observability, never authorization.** Headers/baggage are
+advisory: nothing here grants or denies access. Invalid values are dropped
+(never a request failure); missing ``traceparent`` triggers server-side ID
+generation so every audit row is correlatable.
+
+Identity precedence (normative): credential-bound ``agent_id`` (verified key)
+> explicit bootstrap arg > baggage claim. A claim never outranks a credential
+— see :func:`resolve_agent_correlation`.
+"""
+
+from __future__ import annotations
+
+import re
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+from uuid import UUID
+
+# OTel GenAI baggage keys (published attribute names; vendor key for run).
+BAGGAGE_AGENT_ID = "gen_ai.agent.id"
+BAGGAGE_SESSION_ID = "gen_ai.conversation.id"
+BAGGAGE_SESSION_ID_ALIAS = "session.id"
+BAGGAGE_RUN_ID = "kagura.agent.run.id"
+
+# policy_decision stamped on rows whose agent_id came from a *verified baggage
+# claim* on an agent-UNBOUND credential (attribution without containment).
+POLICY_DECISION_UNBOUND = "unbound"
+
+_CORRELATION_TOKEN_MAX_LEN = 128
+_CORRELATION_TOKEN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+# traceparent: version(2)-trace_id(32)-parent_id(16)-flags(2), all lowercase hex.
+_TRACEPARENT_RE = re.compile(
+    r"^(?P<version>[0-9a-f]{2})-(?P<trace_id>[0-9a-f]{32})-"
+    r"(?P<span_id>[0-9a-f]{16})-(?P<flags>[0-9a-f]{2})$"
+)
+
+
+@dataclass
+class CorrelationContext:
+    """Per-request correlation identifiers (all optional except the always-set
+    server-generated trace/span)."""
+
+    trace_id: str
+    span_id: str
+    session_id: str | None = None
+    run_id: str | None = None
+    # Raw baggage agent-id claim (unresolved). Resolution to the audit
+    # ``agent_id`` column + policy_decision happens once the credential
+    # identity is known (resolve_agent_correlation).
+    agent_claim: str | None = None
+
+
+_correlation: ContextVar[CorrelationContext | None] = ContextVar("correlation", default=None)
+
+
+def set_correlation(ctx: CorrelationContext | None) -> None:
+    _correlation.set(ctx)
+
+
+def get_correlation() -> CorrelationContext | None:
+    return _correlation.get()
+
+
+# ---------------------------------------------------------------------------
+# Parsing / validation
+# ---------------------------------------------------------------------------
+
+
+def validate_correlation_token(value: Any) -> str | None:
+    """Validate an opaque ``session_id`` / ``run_id`` token; None if invalid.
+
+    Charset ``[A-Za-z0-9._-]``, length ≤128 (design F4). Invalid = dropped
+    (advisory data, never a request failure).
+    """
+    if not isinstance(value, str) or not value or len(value) > _CORRELATION_TOKEN_MAX_LEN:
+        return None
+    if not _CORRELATION_TOKEN_RE.match(value):
+        return None
+    return value
+
+
+def parse_traceparent(header: str | None) -> tuple[str, str] | None:
+    """Parse a W3C ``traceparent`` header → ``(trace_id, span_id)`` or None.
+
+    Rejects the all-zero trace/span ids (invalid per the spec).
+    """
+    if not header:
+        return None
+    m = _TRACEPARENT_RE.match(header.strip())
+    if not m:
+        return None
+    trace_id, span_id = m.group("trace_id"), m.group("span_id")
+    if trace_id == "0" * 32 or span_id == "0" * 16:
+        return None
+    return trace_id, span_id
+
+
+def parse_baggage(header: str | None) -> dict[str, str]:
+    """Parse a W3C ``baggage`` header into a flat ``{key: value}`` dict.
+
+    Best-effort: malformed entries are skipped, per-entry properties (after
+    ``;``) are ignored. Never raises.
+    """
+    result: dict[str, str] = {}
+    if not header:
+        return result
+    for entry in header.split(","):
+        entry = entry.strip()
+        if not entry or "=" not in entry:
+            continue
+        key, _, value = entry.partition("=")
+        # Strip any per-member properties after ';'.
+        value = value.split(";", 1)[0].strip()
+        key = key.strip()
+        if key and value:
+            result[key] = value
+    return result
+
+
+def generate_trace_id() -> str:
+    """Generate a random 32-hex W3C trace-id (server-side, when none arrives)."""
+    import secrets
+
+    return secrets.token_hex(16)
+
+
+def generate_span_id() -> str:
+    """Generate a random 16-hex W3C span-id."""
+    import secrets
+
+    return secrets.token_hex(8)
+
+
+def build_correlation_from_headers(
+    *,
+    traceparent: str | None,
+    baggage: str | None,
+) -> CorrelationContext:
+    """Assemble the per-request CorrelationContext from raw headers.
+
+    - ``trace_id``/``span_id`` from ``traceparent`` when valid, else generated.
+    - ``session_id``/``run_id`` from baggage after token validation (invalid →
+      dropped).
+    - ``agent_claim`` = the raw baggage ``gen_ai.agent.id`` (unresolved).
+    """
+    tp = parse_traceparent(traceparent)
+    if tp is not None:
+        trace_id, span_id = tp
+    else:
+        trace_id, span_id = generate_trace_id(), generate_span_id()
+
+    bag = parse_baggage(baggage)
+    session_id = validate_correlation_token(
+        bag.get(BAGGAGE_SESSION_ID) or bag.get(BAGGAGE_SESSION_ID_ALIAS)
+    )
+    run_id = validate_correlation_token(bag.get(BAGGAGE_RUN_ID))
+    agent_claim = bag.get(BAGGAGE_AGENT_ID) or None
+
+    return CorrelationContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        session_id=session_id,
+        run_id=run_id,
+        agent_claim=agent_claim,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Identity precedence + claim verification (normative, design F4)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ResolvedAgentCorrelation:
+    """Outcome of applying the identity-precedence rules to a request."""
+
+    agent_id: UUID | None  # what an audit row's agent_id column should hold
+    policy_decision: str | None  # 'unbound' for verified-claim-on-unbound-cred
+    unverified_agent_claim_hash: str | None  # keyed hash, never verbatim
+    correlation_conflict: bool  # explicit arg disagreed with baggage (unbound cred)
+
+
+def _hash_claim(claim: str) -> str:
+    from config.settings import get_settings
+    from utils.hashing import hmac_sha256_hex
+
+    settings = get_settings()
+    key = getattr(settings, "audit_hmac_key", None) or getattr(
+        settings, "api_key_secret", "kagura-audit"
+    )
+    return hmac_sha256_hex(claim, key)
+
+
+async def verify_baggage_agent_claim(
+    db: Any, *, claimed_agent_id: UUID, member_user_id: str, workspace_id: UUID
+) -> bool:
+    """Rule 2 predicate: a baggage ``gen_ai.agent.id`` claim verifies IFF the
+    claimed agent is bound (via ``api_keys.agent_id``) to the SAME member row
+    as the authenticated credential, in the same workspace.
+
+    Confines attribution to agents demonstrably operated by the same
+    authenticated service member — the answer to claim-forgery, not an
+    instance of it.
+    """
+    from sqlalchemy import select
+
+    from models.agent import Agent
+    from models.auth import APIKey
+
+    # The claimed agent must exist in the workspace ...
+    agent = (
+        await db.execute(
+            select(Agent.id).where(Agent.id == claimed_agent_id, Agent.workspace_id == workspace_id)
+        )
+    ).scalar_one_or_none()
+    if agent is None:
+        return False
+    # ... and the authenticated member must hold at least one non-revoked
+    # api_key bound to that agent (same-member proof).
+    key = (
+        await db.execute(
+            select(APIKey.id).where(
+                APIKey.agent_id == claimed_agent_id,
+                APIKey.user_id == member_user_id,
+                APIKey.revoked_at.is_(None),
+            )
+        )
+    ).first()
+    return key is not None
+
+
+async def resolve_agent_correlation(
+    db: Any,
+    *,
+    credential_agent_id: UUID | None,
+    explicit_agent_id: UUID | None,
+    member_user_id: str | None,
+    workspace_id: UUID | None,
+    correlation: CorrelationContext | None = None,
+) -> ResolvedAgentCorrelation:
+    """Apply the normative precedence to determine the audit ``agent_id``.
+
+    Precedence: credential-bound ``agent_id`` > explicit arg > baggage claim.
+
+    - **Credential-bound** (Rule 1): the credential wins unconditionally; any
+      disagreeing explicit arg / baggage claim is recorded ONLY as a keyed-hash
+      ``unverified_agent_claim`` — never precedence-resolved in favor of the
+      claim.
+    - **Agent-unbound credential** (Rules 2/5): an explicit arg wins over
+      baggage (``correlation_conflict`` when they disagree); a baggage claim is
+      trusted into ``agent_id`` IFF :func:`verify_baggage_agent_claim` passes,
+      and such rows are stamped ``policy_decision='unbound'``. An unverified
+      claim is keyed-hashed only.
+    """
+    baggage_claim_raw = correlation.agent_claim if correlation else None
+
+    # --- Credential-bound: Rule 1 controls unconditionally. --------------
+    if credential_agent_id is not None:
+        disagreeing: str | None = None
+        if explicit_agent_id is not None and explicit_agent_id != credential_agent_id:
+            disagreeing = str(explicit_agent_id)
+        elif baggage_claim_raw and baggage_claim_raw != str(credential_agent_id):
+            disagreeing = baggage_claim_raw
+        return ResolvedAgentCorrelation(
+            agent_id=credential_agent_id,
+            policy_decision=None,
+            unverified_agent_claim_hash=_hash_claim(disagreeing) if disagreeing else None,
+            correlation_conflict=False,
+        )
+
+    # --- Agent-unbound credential. ---------------------------------------
+    if member_user_id is None or workspace_id is None:
+        # Cannot verify anything — keep any raw claim as a hash only.
+        return ResolvedAgentCorrelation(
+            agent_id=None,
+            policy_decision=None,
+            unverified_agent_claim_hash=_hash_claim(baggage_claim_raw)
+            if baggage_claim_raw
+            else None,
+            correlation_conflict=False,
+        )
+
+    # Rule 5: explicit arg wins over baggage; conflict flagged when they differ.
+    conflict = bool(
+        explicit_agent_id is not None
+        and baggage_claim_raw
+        and baggage_claim_raw != str(explicit_agent_id)
+    )
+    candidate = explicit_agent_id
+    candidate_raw = str(explicit_agent_id) if explicit_agent_id is not None else baggage_claim_raw
+
+    if candidate is None:
+        # Only a baggage claim — parse it to a UUID.
+        candidate = _coerce_uuid(baggage_claim_raw)
+    if candidate is None:
+        return ResolvedAgentCorrelation(
+            agent_id=None,
+            policy_decision=None,
+            unverified_agent_claim_hash=_hash_claim(candidate_raw) if candidate_raw else None,
+            correlation_conflict=conflict,
+        )
+
+    verified = await verify_baggage_agent_claim(
+        db, claimed_agent_id=candidate, member_user_id=member_user_id, workspace_id=workspace_id
+    )
+    if verified:
+        # Attribution without containment — stamp 'unbound'.
+        return ResolvedAgentCorrelation(
+            agent_id=candidate,
+            policy_decision=POLICY_DECISION_UNBOUND,
+            unverified_agent_claim_hash=None,
+            correlation_conflict=conflict,
+        )
+    # Rule 3: unverified claim never reaches agent_id — keyed hash only.
+    return ResolvedAgentCorrelation(
+        agent_id=None,
+        policy_decision=None,
+        unverified_agent_claim_hash=_hash_claim(candidate_raw) if candidate_raw else None,
+        correlation_conflict=conflict,
+    )
+
+
+def _coerce_uuid(value: Any) -> UUID | None:
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except (ValueError, TypeError):
+        return None

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -299,6 +299,15 @@ from api.middleware.request_logger import RequestLoggingMiddleware  # noqa: E402
 app.add_middleware(RequestLoggingMiddleware)
 logger.info("request_logging_middleware_registered")
 
+# Correlation Middleware (RFC-0002 P0-4, Issue #1277)
+# Parses W3C traceparent + baggage into the per-request correlation contextvar
+# for audit/usage stamping. Added last so it runs outermost (the correlation
+# context is available to every inner layer, including the request logger).
+from api.middleware.correlation import CorrelationMiddleware  # noqa: E402
+
+app.add_middleware(CorrelationMiddleware)
+logger.info("correlation_middleware_registered")
+
 
 # ============================================================================
 # Exception Handlers

--- a/backend/src/api/middleware/correlation.py
+++ b/backend/src/api/middleware/correlation.py
@@ -1,0 +1,40 @@
+"""Correlation middleware (RFC-0002 P0-4, Issue #1277).
+
+Parses W3C Trace Context (``traceparent``) + ``baggage`` from every
+``/api/v1/*`` request into the per-request correlation contextvar, as a
+sibling of ``RequestLoggingMiddleware``. Advisory-only: a malformed header
+never fails the request (missing/invalid → server-generated trace/span,
+dropped tokens). The contextvar is reset after the response so a value from
+one request can never bleed into another (defense in depth on top of ASGI
+per-request task isolation).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from api.correlation import build_correlation_from_headers, set_correlation
+
+
+class CorrelationMiddleware(BaseHTTPMiddleware):
+    """Populate the correlation contextvar from trace headers per request."""
+
+    async def dispatch(self, request: Request, call_next: Callable) -> Response:
+        # Reset first so a leaked value can never survive into this request,
+        # then parse (advisory — never raises).
+        set_correlation(None)
+        try:
+            ctx = build_correlation_from_headers(
+                traceparent=request.headers.get("traceparent"),
+                baggage=request.headers.get("baggage"),
+            )
+            set_correlation(ctx)
+        except Exception:  # pragma: no cover - defensive; correlation is advisory
+            set_correlation(None)
+        try:
+            return await call_next(request)
+        finally:
+            set_correlation(None)

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -426,6 +426,26 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
 
         set_mcp_key_workspace_scope(api_key_workspace_id)
 
+        # RFC-0002 P0-4 (#1277): parse W3C traceparent + baggage into the
+        # per-request correlation contextvar at the same auth seam (sibling of
+        # the #963 key-workspace scope). Advisory-only — never fails the
+        # request; missing/invalid headers → server-generated trace/span.
+        from api.correlation import build_correlation_from_headers, set_correlation
+
+        def _hdr(name: bytes) -> str | None:
+            raw = headers.get(name)
+            return raw.decode("utf-8", "replace") if isinstance(raw, bytes) else raw
+
+        try:
+            set_correlation(
+                build_correlation_from_headers(
+                    traceparent=_hdr(b"traceparent"),
+                    baggage=_hdr(b"baggage"),
+                )
+            )
+        except Exception:  # pragma: no cover - defensive; correlation is advisory
+            set_correlation(None)
+
         # Issue #169: For workspace-scoped API keys, use workspace_id from key; otherwise get from user
         if api_key_workspace_id:
             workspace_id = api_key_workspace_id

--- a/backend/src/services/agent_bootstrap_service.py
+++ b/backend/src/services/agent_bootstrap_service.py
@@ -299,13 +299,7 @@ class AgentBootstrapService:
             "context": context_block,
             "instructions": instructions,
             "components": components,
-            "correlation": {
-                "agent_id": str(agent.id),
-                "session_id": params.session_id,
-                # P0-4 (#1277) populates trace/span from the correlation lane.
-                "trace_id": None,
-                "span_id": None,
-            },
+            "correlation": self._correlation_block(agent, params),
             "generated_at": to_utc_iso(utcnow()),
         }
 
@@ -333,6 +327,24 @@ class AgentBootstrapService:
         except Exception as exc:  # fail-soft per component; savepoint rolled back
             logger.error(f"bootstrap_component_failed: {name}: {exc}", exc_info=True)
             return {"status": STATUS_ERROR, "error": "component_error"}
+
+    def _correlation_block(self, agent: Any, params: BootstrapParams) -> dict[str, Any]:
+        """Build the correlation block, populating trace/span from the P0-4
+        (#1277) per-request correlation context when present.
+
+        ``session_id`` prefers the explicit bootstrap arg (functional input),
+        falling back to the baggage-derived session id.
+        """
+        from api.correlation import get_correlation
+
+        corr = get_correlation()
+        return {
+            "agent_id": str(agent.id),
+            "session_id": params.session_id or (corr.session_id if corr else None),
+            "run_id": corr.run_id if corr else None,
+            "trace_id": corr.trace_id if corr else None,
+            "span_id": corr.span_id if corr else None,
+        }
 
     async def audit_on_behalf_of(
         self, *, agent: Any, principal: BootstrapPrincipal, session_id: str | None

--- a/backend/tests/api/test_correlation.py
+++ b/backend/tests/api/test_correlation.py
@@ -1,0 +1,233 @@
+"""Unit tests for agent correlation parsing + identity precedence (Issue #1277).
+
+Pins the W3C traceparent/baggage parsers, token validation + server-side
+generation, and — the load-bearing part — the normative identity-precedence
+rules (F4): a claim never outranks a credential; baggage claims verify only
+via same-member binding and stamp policy_decision='unbound'; unverified
+claims reach only a keyed-hash metadata field, never the agent_id column.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.correlation import (
+    POLICY_DECISION_UNBOUND,
+    CorrelationContext,
+    build_correlation_from_headers,
+    parse_baggage,
+    parse_traceparent,
+    resolve_agent_correlation,
+    validate_correlation_token,
+)
+
+WORKSPACE_ID = uuid.uuid4()
+CRED_AGENT = uuid.uuid4()
+OTHER_AGENT = uuid.uuid4()
+VALID_TP = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+
+class TestTraceparent:
+    def test_valid(self):
+        assert parse_traceparent(VALID_TP) == (
+            "4bf92f3577b34da6a3ce929d0e0e4736",
+            "00f067aa0ba902b7",
+        )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            None,
+            "",
+            "garbage",
+            "00-4bf9-00f067aa0ba902b7-01",  # short trace
+            "00-" + "0" * 32 + "-00f067aa0ba902b7-01",  # all-zero trace
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-" + "0" * 16 + "-01",  # all-zero span
+            "00-4BF92F3577B34DA6A3CE929D0E0E4736-00f067aa0ba902b7-01",  # uppercase
+        ],
+    )
+    def test_invalid_returns_none(self, bad):
+        assert parse_traceparent(bad) is None
+
+
+class TestBaggage:
+    def test_parses_keys_and_strips_properties(self):
+        bag = parse_baggage(
+            "gen_ai.agent.id=a1,gen_ai.conversation.id=s1;meta=x, kagura.agent.run.id=r1"
+        )
+        assert bag["gen_ai.agent.id"] == "a1"
+        assert bag["gen_ai.conversation.id"] == "s1"
+        assert bag["kagura.agent.run.id"] == "r1"
+
+    def test_malformed_entries_skipped(self):
+        assert parse_baggage("no-equals,=noval,k=v") == {"k": "v"}
+
+    def test_none(self):
+        assert parse_baggage(None) == {}
+
+
+class TestTokenValidation:
+    @pytest.mark.parametrize("ok", ["sess-1", "a.b_c-D9", "x" * 128])
+    def test_valid(self, ok):
+        assert validate_correlation_token(ok) == ok
+
+    @pytest.mark.parametrize("bad", [None, "", "x" * 129, "has space", "sess/1", "sess:1", 42])
+    def test_invalid_dropped(self, bad):
+        assert validate_correlation_token(bad) is None
+
+
+class TestBuild:
+    def test_generates_ids_when_no_traceparent(self):
+        c = build_correlation_from_headers(traceparent=None, baggage=None)
+        assert len(c.trace_id) == 32 and len(c.span_id) == 16
+        assert c.session_id is None and c.run_id is None
+
+    def test_session_alias_accepted(self):
+        c = build_correlation_from_headers(traceparent=None, baggage="session.id=s2")
+        assert c.session_id == "s2"
+
+    def test_invalid_session_token_dropped(self):
+        c = build_correlation_from_headers(
+            traceparent=None, baggage="gen_ai.conversation.id=has space"
+        )
+        assert c.session_id is None
+
+
+# ---------------------------------------------------------------------------
+# Identity precedence (the normative core)
+# ---------------------------------------------------------------------------
+
+
+class TestPrecedence:
+    @pytest.mark.asyncio
+    async def test_credential_bound_always_wins_over_disagreeing_baggage(self):
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=str(OTHER_AGENT))
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=CRED_AGENT,
+            explicit_agent_id=None,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+            correlation=corr,
+        )
+        # Credential wins; the disagreeing claim is only a keyed hash.
+        assert res.agent_id == CRED_AGENT
+        assert res.unverified_agent_claim_hash is not None
+        assert res.policy_decision is None
+
+    @pytest.mark.asyncio
+    async def test_credential_bound_disagreeing_explicit_arg_hashed_not_used(self):
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=CRED_AGENT,
+            explicit_agent_id=OTHER_AGENT,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+        )
+        assert res.agent_id == CRED_AGENT
+        assert res.unverified_agent_claim_hash is not None
+
+    @pytest.mark.asyncio
+    async def test_unbound_credential_verified_claim_stamps_unbound(self, monkeypatch):
+        # Same-member verification passes → claim populates agent_id + 'unbound'.
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=True),
+        )
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=str(OTHER_AGENT))
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=None,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+            correlation=corr,
+        )
+        assert res.agent_id == OTHER_AGENT
+        assert res.policy_decision == POLICY_DECISION_UNBOUND
+
+    @pytest.mark.asyncio
+    async def test_unbound_credential_unverified_claim_hashed_only(self, monkeypatch):
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=False),
+        )
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=str(OTHER_AGENT))
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=None,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+            correlation=corr,
+        )
+        assert res.agent_id is None  # never reaches the column
+        assert res.unverified_agent_claim_hash is not None
+        assert res.policy_decision is None
+
+    @pytest.mark.asyncio
+    async def test_unbound_credential_explicit_vs_baggage_sets_conflict(self, monkeypatch):
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=True),
+        )
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=str(uuid.uuid4()))
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=OTHER_AGENT,  # disagrees with baggage claim
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+            correlation=corr,
+        )
+        # Rule 5: explicit wins; conflict flagged.
+        assert res.agent_id == OTHER_AGENT
+        assert res.correlation_conflict is True
+
+
+class TestVerifyPredicate:
+    @pytest.mark.asyncio
+    async def test_verifies_only_same_member_bound_agent(self):
+        from api.correlation import verify_baggage_agent_claim
+
+        db = MagicMock()
+        # agent exists in workspace, and a same-member non-revoked key is bound.
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=OTHER_AGENT)),
+                MagicMock(first=MagicMock(return_value=(1,))),
+            ]
+        )
+        assert await verify_baggage_agent_claim(
+            db, claimed_agent_id=OTHER_AGENT, member_user_id="m", workspace_id=WORKSPACE_ID
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_no_same_member_key(self):
+        from api.correlation import verify_baggage_agent_claim
+
+        db = MagicMock()
+        db.execute = AsyncMock(
+            side_effect=[
+                MagicMock(scalar_one_or_none=MagicMock(return_value=OTHER_AGENT)),
+                MagicMock(first=MagicMock(return_value=None)),
+            ]
+        )
+        assert not await verify_baggage_agent_claim(
+            db, claimed_agent_id=OTHER_AGENT, member_user_id="m", workspace_id=WORKSPACE_ID
+        )
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_agent_not_in_workspace(self):
+        from api.correlation import verify_baggage_agent_claim
+
+        db = MagicMock()
+        db.execute = AsyncMock(
+            return_value=MagicMock(scalar_one_or_none=MagicMock(return_value=None))
+        )
+        assert not await verify_baggage_agent_claim(
+            db, claimed_agent_id=OTHER_AGENT, member_user_id="m", workspace_id=WORKSPACE_ID
+        )


### PR DESCRIPTION
Closes #1277 (RFC-0002 P0-4)

W3C Trace Context (`traceparent`) + `baggage` parsing into a per-request correlation contextvar on both surfaces, per the signed-off F4 contract ([docs/design/agent-otel-correlation.md](https://github.com/kagura-ai/memory-cloud/blob/main/docs/design/agent-otel-correlation.md)). **Correlation columns semantics only** — no `agent_sessions` table, no server-side span emission (both P1). **Correlation is observability, never authorization.**

## What

- **`api/correlation.py`** — `CorrelationContext` contextvar + parsers:
  - W3C `traceparent` (rejects all-zero ids + uppercase + malformed), `baggage`, `session_id`/`run_id` charset (`[A-Za-z0-9._-]`) + length (≤128) validation (invalid **dropped** with a structured warning — advisory, never a request failure), server-side `trace_id`/`span_id` generation when no `traceparent` arrives.
  - OTel GenAI mapping: `agent_id`→`gen_ai.agent.id`, `session_id`→`gen_ai.conversation.id` (+`session.id` alias), `run_id`→`kagura.agent.run.id` (tracked vendor gap), trace/span from `traceparent`.
- **Identity precedence** (normative) — `resolve_agent_correlation()`: credential-bound `agent_id` **>** explicit bootstrap arg **>** baggage claim.
  - **Rule 1** — a claim NEVER outranks a credential; a disagreeing explicit arg / baggage claim is recorded only as a keyed **HMAC** hash (`unverified_agent_claim`), never precedence-resolved in its favor.
  - **Rule 2** — for an agent-**unbound** credential, a baggage claim reaches the `agent_id` column **iff** `verify_baggage_agent_claim` passes (claimed agent bound via `api_keys.agent_id` to the **same member**, non-revoked key, same workspace) and the row is stamped `policy_decision='unbound'`.
  - **Rule 3** — an unverified claim reaches only the keyed-hash metadata, never `agent_id`.
  - **Rule 5** — explicit arg beats baggage; `correlation_conflict` flagged.
- **Transport** — parsed at the MCP auth seam (sibling of the #963 key-scope contextvar) and via `CorrelationMiddleware` (outermost, reset per request) for REST `/api/v1/*`. IDs ride headers/baggage — **no per-tool parameter changes**; the frozen `additionalProperties:false` MCP surface is untouched.
- **Bootstrap** — `get_agent_bootstrap`'s correlation block now populates `trace_id`/`span_id`/`run_id` from the contextvar (was null); `session_id` prefers the explicit arg.

## Tests

`test_correlation.py` — traceparent/baggage parsers, token validation + server-side generation, and the full **identity-precedence matrix** (credential/explicit/baggage × verified/unverified/conflict) + the verify predicate (same-member/same-workspace/non-revoked). Full local suite **5406 passed**; ruff clean; pyright 0 new errors.

## Consumed by

P0-5 (#1278) stores these correlation columns on `memory_access_events`. A `kagura.agent.run.id` vendor-gap tracking issue will be filed.

## Gates

- Inner review: verified all 8 F4 identity-precedence invariants hold (no forged claim can reach `agent_id`); 1 finding (missing structured warning on dropped correlation data, an F4 §validation MUST) — fixed in `dc2ddac`.
- Gate2: cso / qa-lead / cto all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
