### PR TITLE
feat(db): memory_access_events append-only audit (#1278)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -12,6 +12,7 @@ from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 import models.agent  # noqa: F401  # Issue #1274: Agent Registry (RFC-0002 P0-1)
+import models.memory_access_event  # noqa: F401  # Issue #1278: agent access audit (P0-5)
 import models.analysis  # noqa: F401  # Issue #494: Memory Broadlistening tables
 import models.auth  # noqa: F401
 import models.config  # noqa: F401

--- a/backend/alembic/versions/e66_1278_memory_access_events.py
+++ b/backend/alembic/versions/e66_1278_memory_access_events.py
@@ -1,0 +1,143 @@
+"""Add memory_access_events — append-only agent memory-access audit (RFC-0002 P0-5, #1278).
+
+Pure additive migration (blue-green safe): a new table + indexes + append-only
+triggers. CHECK literals are byte-identical to the module-level tuples in
+``models/memory_access_event.py`` (drift-pinned by
+tests/test_memory_access_event_constants.py).
+
+Append-only enforcement mirrors the ``e50_1128`` secret-store precedent: a
+``BEFORE UPDATE OR DELETE`` row trigger + a ``BEFORE TRUNCATE`` statement
+trigger, sharing one guard function. UNLIKE e50, UPDATE is permitted when it
+changes ONLY the erasure carve-out columns (user_id, session_id, run_id,
+event_metadata) — GDPR/APPI pseudonymize + scrub. The guard compares the
+immutable column subset (row-as-jsonb minus the carve-out keys) OLD vs NEW.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "e66_1278_mae"
+down_revision = "e65_1275_api_keys_agent"
+branch_labels = None
+depends_on = None
+
+_CARVE_OUT = "'user_id','session_id','run_id','event_metadata'"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "memory_access_events",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("occurred_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("workspace_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("context_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("user_id", sa.String(length=255), nullable=False),
+        sa.Column("principal_type", sa.String(length=16), nullable=False),
+        sa.Column("api_key_prefix", sa.String(length=16), nullable=True),
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("session_id", sa.String(length=128), nullable=True),
+        sa.Column("run_id", sa.String(length=128), nullable=True),
+        sa.Column("trace_id", sa.String(length=32), nullable=True),
+        sa.Column("span_id", sa.String(length=16), nullable=True),
+        sa.Column("surface", sa.String(length=10), nullable=False),
+        sa.Column("operation", sa.String(length=20), nullable=False),
+        sa.Column("outcome", sa.String(length=10), nullable=False),
+        sa.Column("policy_decision", sa.String(length=20), nullable=True),
+        sa.Column("policy_revision_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("memory_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("result_count", sa.Integer(), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("query_hash", sa.String(length=64), nullable=True),
+        sa.Column("event_metadata", postgresql.JSONB(), nullable=True),
+        sa.CheckConstraint(
+            "operation IN ('recall', 'reference', 'remember', 'update', 'forget', "
+            "'load_pinned', 'bootstrap', 'feedback')",
+            name="valid_mae_operation",
+        ),
+        sa.CheckConstraint(
+            "outcome IN ('success', 'denied', 'error', 'partial')", name="valid_mae_outcome"
+        ),
+        sa.CheckConstraint("surface IN ('mcp', 'rest')", name="valid_mae_surface"),
+        sa.CheckConstraint(
+            "principal_type IN ('api_key', 'oauth', 'session')", name="valid_mae_principal"
+        ),
+        sa.CheckConstraint(
+            "policy_decision IS NULL OR policy_decision IN ('allowed', 'binding_denied', "
+            "'rbac_denied', 'would_deny', 'unbound')",
+            name="valid_mae_policy",
+        ),
+        sa.CheckConstraint("octet_length(event_metadata::text) <= 4096", name="mae_metadata_size"),
+    )
+    op.create_index("idx_mae_occurred", "memory_access_events", ["occurred_at"])
+    op.create_index(
+        "idx_mae_workspace_occurred", "memory_access_events", ["workspace_id", "occurred_at"]
+    )
+    op.create_index(
+        "idx_mae_agent_occurred",
+        "memory_access_events",
+        ["agent_id", "occurred_at"],
+        postgresql_where=sa.text("agent_id IS NOT NULL"),
+    )
+
+    # Append-only guard with the erasure carve-out. On UPDATE, everything
+    # OUTSIDE the carve-out must be unchanged; DELETE and TRUNCATE always raise.
+    op.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE FUNCTION memory_access_events_append_only()
+            RETURNS trigger AS $$
+            BEGIN
+                IF TG_OP = 'UPDATE' THEN
+                    IF (to_jsonb(OLD) - ARRAY[{_CARVE_OUT}])
+                       IS DISTINCT FROM
+                       (to_jsonb(NEW) - ARRAY[{_CARVE_OUT}]) THEN
+                        RAISE EXCEPTION
+                            'memory_access_events is append-only; only '
+                            '(user_id, session_id, run_id, event_metadata) may be '
+                            'updated (erasure carve-out)'
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+                    RETURN NEW;
+                END IF;
+                RAISE EXCEPTION
+                    'memory_access_events is append-only; % is not permitted', TG_OP
+                    USING ERRCODE = 'restrict_violation';
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER memory_access_events_no_mutate
+            BEFORE UPDATE OR DELETE ON memory_access_events
+            FOR EACH ROW EXECUTE FUNCTION memory_access_events_append_only();
+            """
+        )
+    )
+    op.execute(
+        sa.text(
+            """
+            CREATE TRIGGER memory_access_events_no_truncate
+            BEFORE TRUNCATE ON memory_access_events
+            FOR EACH STATEMENT EXECUTE FUNCTION memory_access_events_append_only();
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text("DROP TRIGGER IF EXISTS memory_access_events_no_truncate ON memory_access_events")
+    )
+    op.execute(
+        sa.text("DROP TRIGGER IF EXISTS memory_access_events_no_mutate ON memory_access_events")
+    )
+    op.execute(sa.text("DROP FUNCTION IF EXISTS memory_access_events_append_only()"))
+    op.drop_index("idx_mae_agent_occurred", table_name="memory_access_events")
+    op.drop_index("idx_mae_workspace_occurred", table_name="memory_access_events")
+    op.drop_index("idx_mae_occurred", table_name="memory_access_events")
+    op.drop_table("memory_access_events")

--- a/backend/src/api/correlation.py
+++ b/backend/src/api/correlation.py
@@ -61,6 +61,9 @@ class CorrelationContext:
     # ``agent_id`` column + policy_decision happens once the credential
     # identity is known (resolve_agent_correlation).
     agent_claim: str | None = None
+    # 'mcp' | 'rest' — the request surface, set at the transport/middleware
+    # seam so service-layer audit emission (#1278) is surface-invariant.
+    surface: str = "rest"
 
 
 _correlation: ContextVar[CorrelationContext | None] = ContextVar("correlation", default=None)
@@ -163,6 +166,7 @@ def build_correlation_from_headers(
     *,
     traceparent: str | None,
     baggage: str | None,
+    surface: str = "rest",
 ) -> CorrelationContext:
     """Assemble the per-request CorrelationContext from raw headers.
 
@@ -190,6 +194,7 @@ def build_correlation_from_headers(
         session_id=session_id,
         run_id=run_id,
         agent_claim=agent_claim,
+        surface=surface,
     )
 
 

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -579,4 +579,17 @@ async def agent_bootstrap(
     # cannot masquerade as the agent's own activity (no-op for agent-bound).
     await service.audit_on_behalf_of(agent=agent, principal=principal, session_id=params.session_id)
     await db.commit()
+
+    # #1278: append-only audit row (independent session, fail-open, no-op
+    # unless the request carries verified agent identity).
+    from services.memory_access_event_writer import emit_memory_access_event
+
+    await emit_memory_access_event(
+        operation="bootstrap",
+        outcome="partial" if envelope.get("degraded") else "success",
+        workspace_id=principal.workspace_id,
+        user_id=principal.user_id,
+        context_id=context.id,
+        policy_decision=principal.metadata.get("policy_decision"),
+    )
     return envelope

--- a/backend/src/mcp_server/tools/agent_bootstrap.py
+++ b/backend/src/mcp_server/tools/agent_bootstrap.py
@@ -128,6 +128,20 @@ async def handle_get_agent_bootstrap(
                 db, user_id, "get_agent_bootstrap", start_time, 200, context.id, workspace_id
             )
             await db.commit()
+
+            # #1278: append-only audit row (independent session, fail-open,
+            # no-op unless the request carries verified agent identity).
+            from services.memory_access_event_writer import emit_memory_access_event
+
+            await emit_memory_access_event(
+                operation="bootstrap",
+                outcome="partial" if envelope.get("degraded") else "success",
+                workspace_id=principal.workspace_id,
+                user_id=principal.user_id,
+                context_id=context.id,
+                latency_ms=int((time.time() - start_time) * 1000),
+                policy_decision=principal.metadata.get("policy_decision"),
+            )
             return _success_response(**{k: v for k, v in envelope.items() if k != "status"})
 
         except BootstrapError as e:

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -441,6 +441,7 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
                 build_correlation_from_headers(
                     traceparent=_hdr(b"traceparent"),
                     baggage=_hdr(b"baggage"),
+                    surface="mcp",
                 )
             )
         except Exception:  # pragma: no cover - defensive; correlation is advisory

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -14,6 +14,7 @@ import models.analysis  # noqa: F401
 import models.file_objects  # noqa: F401  # Issue #485: file storage
 import models.llm_call_log  # noqa: F401  # Issue #474: comprehensive call ledger
 import models.llm_pricing  # noqa: F401
+import models.memory_access_event  # noqa: F401  # Issue #1278: agent access audit (P0-5)
 import models.retrieval_feedback  # noqa: F401  # Issue #888: retrieval feedback signal
 import models.secrets  # noqa: F401  # Issue #1128: zero-knowledge secret store
 import models.sleep  # noqa: F401

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -68,6 +68,11 @@ OPERATIONAL_TABLES: frozenset[str] = frozenset(
         # plumbing like context_members; cascades with agent/context, created_by
         # pseudonymized on erasure.
         "agent_context_bindings",
+        # Append-only agent memory-access audit (#1278, RFC-0002 P0-5) — audit
+        # plumbing (no user knowledge, no learned structure); no FK (survives
+        # entity deletion); user_id/session_id/run_id/event_metadata
+        # pseudonymized+scrubbed on erasure via the append-only carve-out.
+        "memory_access_events",
         "users",
         "user_oauth_providers",
         "oauth_authorization_codes",

--- a/backend/src/models/memory_access_event.py
+++ b/backend/src/models/memory_access_event.py
@@ -1,0 +1,152 @@
+"""memory_access_events — append-only agent memory-access audit (RFC-0002 P0-5, #1278).
+
+The append-only audit row for the eight memory operations performed under
+**verified agent identity**: recall / reference / remember / update / forget /
+load_pinned / bootstrap / feedback (design F3,
+``docs/design/memory-access-events.md``). Rows store identifiers, outcome,
+latency, policy decision, and keyed (HMAC) hashes — NEVER raw prompts,
+retrieved content, secrets, or PII.
+
+Audit-grade posture (distinct from the telemetry-grade
+``context_read_attributions``): NO foreign keys — the trail must survive the
+deletion of the agent/context/key it references (an access row for a deleted
+context is exactly what an investigation needs). Append-only is enforced at
+the DB level by a ``BEFORE UPDATE OR DELETE`` + ``BEFORE TRUNCATE`` trigger
+(migration ``e66``, the ``e50_1128`` secret-store precedent), with a narrow
+erasure carve-out limited to ``(user_id, session_id, run_id, event_metadata)``.
+
+Retention (v1): unlimited, no partitioning, NO sampling. Escalation trigger —
+**100M rows or 12 months, whichever first** — then monthly range partitioning
+on ``occurred_at`` (the additive, pre-designated response). Ops plan: F7,
+``docs/ops/memory-access-events-retention.md``. Volume scales with agent-bound
+adoption (≥1 row per recall + per load_pinned per agent turn), not total
+traffic; the P1 unbound-traffic extension MUST re-open this sizing before it
+can flip on.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+# CHECK constraints are derived from these module-level tuples byte-identically
+# to the alembic migration literal (the house drift-pin convention; pinned by
+# tests/test_memory_access_event_constants.py). New values are APPENDED, never
+# reordered.
+MAE_OPERATIONS: tuple[str, ...] = (
+    "recall",
+    "reference",
+    "remember",
+    "update",
+    "forget",
+    "load_pinned",
+    "bootstrap",
+    "feedback",
+)
+MAE_OUTCOMES: tuple[str, ...] = ("success", "denied", "error", "partial")
+MAE_SURFACES: tuple[str, ...] = ("mcp", "rest")
+MAE_PRINCIPAL_TYPES: tuple[str, ...] = ("api_key", "oauth", "session")
+# 'would_deny' = shadow mode; 'unbound' = agent identity from a verified
+# baggage claim on a credential not itself bound to that agent (attribution
+# without containment). NULL = binding evaluation not applicable.
+MAE_POLICY_DECISIONS: tuple[str, ...] = (
+    "allowed",
+    "binding_denied",
+    "rbac_denied",
+    "would_deny",
+    "unbound",
+)
+
+# 4 KB canonical PII-sensitive JSONB cap (llm_call_log precedent).
+MAE_METADATA_MAX_BYTES = 4096
+
+# The erasure carve-out: the ONLY columns the append-only trigger permits an
+# UPDATE to touch (GDPR/APPI pseudonymize + scrub). Kept here so the migration
+# trigger and any reader share one source of truth.
+MAE_MUTABLE_COLUMNS: tuple[str, ...] = ("user_id", "session_id", "run_id", "event_metadata")
+
+
+def _in_list(values: tuple[str, ...]) -> str:
+    return ", ".join(repr(v) for v in values)
+
+
+class MemoryAccessEvent(Base):
+    """One append-only audit row per audited memory operation (#1278)."""
+
+    __tablename__ = "memory_access_events"
+
+    # BIGSERIAL — the house pattern for append-only logs; doubles as a keyset
+    # cursor.
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    # Identifiers only; NO foreign keys (rows outlive agents/contexts/keys).
+    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    context_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    # OAuth sub, non-FK convention; pseudonymized on erasure (carve-out).
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    principal_type: Mapped[str] = mapped_column(String(16), nullable=False)
+    api_key_prefix: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    # Verified only; non-NULL on every P0 row (NULL reserved for the P1
+    # unbound-traffic extension).
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    run_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    trace_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    span_id: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    surface: Mapped[str] = mapped_column(String(10), nullable=False)
+    operation: Mapped[str] = mapped_column(String(20), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(10), nullable=False)
+    policy_decision: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    policy_revision_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    memory_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    result_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # HMAC-SHA256 of the query text (dedicated audit key); raw query NEVER stored.
+    query_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    event_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(f"operation IN ({_in_list(MAE_OPERATIONS)})", name="valid_mae_operation"),
+        CheckConstraint(f"outcome IN ({_in_list(MAE_OUTCOMES)})", name="valid_mae_outcome"),
+        CheckConstraint(f"surface IN ({_in_list(MAE_SURFACES)})", name="valid_mae_surface"),
+        CheckConstraint(
+            f"principal_type IN ({_in_list(MAE_PRINCIPAL_TYPES)})",
+            name="valid_mae_principal",
+        ),
+        CheckConstraint(
+            f"policy_decision IS NULL OR policy_decision IN ({_in_list(MAE_POLICY_DECISIONS)})",
+            name="valid_mae_policy",
+        ),
+        CheckConstraint(
+            f"octet_length(event_metadata::text) <= {MAE_METADATA_MAX_BYTES}",
+            name="mae_metadata_size",
+        ),
+        Index("idx_mae_occurred", "occurred_at"),
+        Index("idx_mae_workspace_occurred", "workspace_id", "occurred_at"),
+        # Partial: agent_id is non-NULL on every P0 row; the partial form
+        # anticipates the P1 unbound-traffic extension (agent-less rows).
+        Index(
+            "idx_mae_agent_occurred",
+            "agent_id",
+            "occurred_at",
+            postgresql_where=text("agent_id IS NOT NULL"),
+        ),
+    )

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -1037,6 +1037,15 @@ class AccountErasureService:
             AgentContextBinding, AgentContextBinding.created_by, user_id
         )
 
+        # memory_access_events (#1278, RFC-0002 P0-5): no-FK append-only audit
+        # rows survive entity deletion, so the subject's rows must be
+        # pseudonymized + scrubbed here. The append-only trigger permits UPDATE
+        # ONLY of the carve-out columns (user_id, session_id, run_id,
+        # event_metadata) — this single statement touches exactly those.
+        counts["memory_access_events_pseudonymized"] = await self._erase_memory_access_events(
+            user_id
+        )
+
         # Finally the user row itself.
         await self.db.delete(target)
         await self.db.commit()
@@ -1053,6 +1062,45 @@ class AccountErasureService:
         result = cast(
             CursorResult[Any],
             await self.db.execute(delete(model).where(where_clause)),
+        )
+        return result.rowcount or 0
+
+    async def _erase_memory_access_events(self, user_id: str) -> int:
+        """Pseudonymize + scrub the erased subject's memory_access_events rows.
+
+        One UPDATE touching ONLY the append-only carve-out columns
+        (user_id, session_id, run_id, event_metadata), so the append-only
+        trigger permits it:
+
+        - ``user_id`` → salted-SHA256 pseudonym (keeps the row's non-personal
+          audit shape while breaking the personal-data link, same lane as
+          plan_changes/audit_logs);
+        - ``session_id`` / ``run_id`` → NULL scrubbed. These are opaque
+          per-session correlation tokens with no post-erasure analytical value,
+          and because a contract is not a control (a client may have embedded a
+          name despite the MUST-NOT), a definitive NULL is stronger than a
+          hash and needs no pgcrypto;
+        - ``event_metadata`` → redacted marker (the "opaque tokens" contract is
+          not trusted to keep PII out of client-controlled JSONB — the
+          llm_call_log lesson).
+
+        Rows keep their non-personal audit value.
+        """
+        from models.memory_access_event import MemoryAccessEvent
+
+        pseudonym = sha256_hex(user_id, salt=_audit_salt())
+        result = cast(
+            CursorResult[Any],
+            await self.db.execute(
+                update(MemoryAccessEvent)
+                .where(MemoryAccessEvent.user_id == user_id)
+                .values(
+                    user_id=pseudonym,
+                    session_id=None,
+                    run_id=None,
+                    event_metadata={"redacted": "erased_subject"},
+                )
+            ),
         )
         return result.rowcount or 0
 

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -101,6 +101,24 @@ class FeedbackService:
         self.db.add(row)
         await self.db.commit()
         await self.db.refresh(row)
+
+        # #1278: append-only audit (no-op unless verified agent identity). Only
+        # the public (agent) path is audited; record_host_feedback is the
+        # gateway seam, not agent activity.
+        if provenance == FEEDBACK_PROVENANCE_AGENT:
+            from services.memory_access_event_writer import emit_memory_access_event
+
+            ws = (
+                await self.db.execute(select(Memory.workspace_id).where(Memory.id == memory_id))
+            ).scalar_one_or_none()
+            await emit_memory_access_event(
+                operation="feedback",
+                outcome="success",
+                workspace_id=ws,
+                user_id=user_id,
+                context_id=context_id,
+                memory_id=memory_id,
+            )
         return row
 
     async def record_host_feedback(

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -77,16 +77,20 @@ class FeedbackService:
                 f"invalid feedback provenance {provenance!r}; "
                 f"expected one of {_ALL_FEEDBACK_PROVENANCES}"
             )
-        exists = (
+        # Fetch workspace_id alongside the existence check so the audit emission
+        # below reuses it instead of a second round-trip (Copilot review, #1278).
+        # `.one_or_none()` on a Row disambiguates "no row" from "row with NULL
+        # workspace_id" (a bare scalar_one_or_none would conflate them).
+        existing = (
             await self.db.execute(
-                select(Memory.id).where(
+                select(Memory.id, Memory.workspace_id).where(
                     Memory.id == memory_id,
                     Memory.context_id == context_id,
                     Memory.deleted_at.is_(None),
                 )
             )
-        ).scalar_one_or_none()
-        if exists is None:
+        ).one_or_none()
+        if existing is None:
             raise NotFoundException("Memory")
 
         row = RetrievalFeedback(
@@ -108,13 +112,10 @@ class FeedbackService:
         if provenance == FEEDBACK_PROVENANCE_AGENT:
             from services.memory_access_event_writer import emit_memory_access_event
 
-            ws = (
-                await self.db.execute(select(Memory.workspace_id).where(Memory.id == memory_id))
-            ).scalar_one_or_none()
             await emit_memory_access_event(
                 operation="feedback",
                 outcome="success",
-                workspace_id=ws,
+                workspace_id=existing.workspace_id,
                 user_id=user_id,
                 context_id=context_id,
                 memory_id=memory_id,

--- a/backend/src/services/memory_access_event_writer.py
+++ b/backend/src/services/memory_access_event_writer.py
@@ -17,6 +17,7 @@ setting-gated and separately reviewed.
 
 from __future__ import annotations
 
+from contextlib import aclosing
 from typing import Any
 from uuid import UUID
 
@@ -90,32 +91,38 @@ async def record_memory_access_event(
     from models.memory_access_event import MemoryAccessEvent
 
     try:
-        async for db in get_db():
-            db.add(
-                MemoryAccessEvent(
-                    workspace_id=workspace_id,
-                    context_id=context_id,
-                    user_id=user_id,
-                    principal_type=principal_type,
-                    api_key_prefix=api_key_prefix,
-                    agent_id=agent_id,
-                    session_id=session_id,
-                    run_id=run_id,
-                    trace_id=trace_id,
-                    span_id=span_id,
-                    surface=surface,
-                    operation=operation,
-                    outcome=outcome,
-                    policy_decision=policy_decision,
-                    memory_id=memory_id,
-                    result_count=result_count,
-                    latency_ms=latency_ms,
-                    query_hash=query_hash,
-                    event_metadata=event_metadata,
+        # aclosing() forces get_db()'s post-yield teardown (session.close) to run
+        # synchronously HERE, inside this try/except. A bare early `return`/`break`
+        # out of `async for` defers async-generator finalization to GC, so a
+        # teardown error would escape the fail-open guard and surface as an
+        # unretrieved finalizer exception instead (Copilot review, #1278).
+        async with aclosing(get_db()) as gen:
+            async for db in gen:
+                db.add(
+                    MemoryAccessEvent(
+                        workspace_id=workspace_id,
+                        context_id=context_id,
+                        user_id=user_id,
+                        principal_type=principal_type,
+                        api_key_prefix=api_key_prefix,
+                        agent_id=agent_id,
+                        session_id=session_id,
+                        run_id=run_id,
+                        trace_id=trace_id,
+                        span_id=span_id,
+                        surface=surface,
+                        operation=operation,
+                        outcome=outcome,
+                        policy_decision=policy_decision,
+                        memory_id=memory_id,
+                        result_count=result_count,
+                        latency_ms=latency_ms,
+                        query_hash=query_hash,
+                        event_metadata=event_metadata,
+                    )
                 )
-            )
-            await db.commit()
-            return
+                await db.commit()
+                break
     except Exception as exc:  # fail-open — never break the caller's path
         logger.warning(
             "memory_access_event_write_failed",

--- a/backend/src/services/memory_access_event_writer.py
+++ b/backend/src/services/memory_access_event_writer.py
@@ -1,0 +1,190 @@
+"""Writer for memory_access_events (RFC-0002 P0-5, Issue #1278).
+
+Hot-path-safe and **fail-open** (design F3 D24): runs on an INDEPENDENT db
+session (so the audit write neither joins nor poisons the caller's
+transaction, and a caller rollback never loses the audit row), swallows DB
+failures with a structured warning that logs ``error_type`` — never
+``str(exc)`` (the credential-leak guard, ``llm_call_log_writer`` precedent).
+Validation errors (bad enum) RAISE. A dropped event degrades observability,
+not security — P0 policy decisions are advisory.
+
+**Audited population**: only requests carrying **verified agent identity** are
+written (D34). :func:`emit_memory_access_event` early-returns for every
+non-agent request, so legacy (unbound) traffic gains no hot-path write — the
+RFC-0002 backward-compatibility contract. The P1 unbound-traffic extension is
+setting-gated and separately reviewed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Max recall result memory_ids stored in event_metadata (identifiers only,
+# content never; under the 4 KB cap).
+MAX_METADATA_MEMORY_IDS = 32
+
+
+def _validate_enums(
+    *, operation: str, outcome: str, surface: str, principal_type: str, policy_decision: str | None
+) -> None:
+    from models.memory_access_event import (
+        MAE_OPERATIONS,
+        MAE_OUTCOMES,
+        MAE_POLICY_DECISIONS,
+        MAE_PRINCIPAL_TYPES,
+        MAE_SURFACES,
+    )
+
+    if operation not in MAE_OPERATIONS:
+        raise ValueError(f"invalid memory-access operation: {operation!r}")
+    if outcome not in MAE_OUTCOMES:
+        raise ValueError(f"invalid memory-access outcome: {outcome!r}")
+    if surface not in MAE_SURFACES:
+        raise ValueError(f"invalid memory-access surface: {surface!r}")
+    if principal_type not in MAE_PRINCIPAL_TYPES:
+        raise ValueError(f"invalid memory-access principal_type: {principal_type!r}")
+    if policy_decision is not None and policy_decision not in MAE_POLICY_DECISIONS:
+        raise ValueError(f"invalid memory-access policy_decision: {policy_decision!r}")
+
+
+async def record_memory_access_event(
+    *,
+    workspace_id: UUID,
+    user_id: str,
+    principal_type: str,
+    operation: str,
+    outcome: str,
+    surface: str,
+    agent_id: UUID | None = None,
+    context_id: UUID | None = None,
+    api_key_prefix: str | None = None,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    trace_id: str | None = None,
+    span_id: str | None = None,
+    policy_decision: str | None = None,
+    memory_id: UUID | None = None,
+    result_count: int | None = None,
+    latency_ms: int | None = None,
+    query_hash: str | None = None,
+    event_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Write one audit row on an independent session; fail-open.
+
+    Validation (enum) raises; a DB failure logs ``error_type`` and returns.
+    """
+    _validate_enums(
+        operation=operation,
+        outcome=outcome,
+        surface=surface,
+        principal_type=principal_type,
+        policy_decision=policy_decision,
+    )
+
+    from db.base import get_db
+    from models.memory_access_event import MemoryAccessEvent
+
+    try:
+        async for db in get_db():
+            db.add(
+                MemoryAccessEvent(
+                    workspace_id=workspace_id,
+                    context_id=context_id,
+                    user_id=user_id,
+                    principal_type=principal_type,
+                    api_key_prefix=api_key_prefix,
+                    agent_id=agent_id,
+                    session_id=session_id,
+                    run_id=run_id,
+                    trace_id=trace_id,
+                    span_id=span_id,
+                    surface=surface,
+                    operation=operation,
+                    outcome=outcome,
+                    policy_decision=policy_decision,
+                    memory_id=memory_id,
+                    result_count=result_count,
+                    latency_ms=latency_ms,
+                    query_hash=query_hash,
+                    event_metadata=event_metadata,
+                )
+            )
+            await db.commit()
+            return
+    except Exception as exc:  # fail-open — never break the caller's path
+        logger.warning(
+            "memory_access_event_write_failed",
+            operation=operation,
+            outcome=outcome,
+            surface=surface,
+            error_type=type(exc).__name__,
+        )
+
+
+async def emit_memory_access_event(
+    *,
+    operation: str,
+    outcome: str,
+    workspace_id: UUID | None,
+    user_id: str | None,
+    context_id: UUID | None = None,
+    memory_id: UUID | None = None,
+    result_count: int | None = None,
+    latency_ms: int | None = None,
+    query_hash: str | None = None,
+    policy_decision: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Chokepoint entry point — emits only for the verified-agent population.
+
+    Gathers agent identity from the per-request AgentScope (#1275) and
+    correlation identifiers from the per-request CorrelationContext (#1277).
+    Early-returns (no write, one contextvar read) when the request carries no
+    verified agent identity — the backward-compat no-hot-path-write guarantee
+    for legacy traffic. Fail-open end to end.
+    """
+    from auth.agent_scope import get_agent_scope
+
+    scope = get_agent_scope()
+    # P0 audited population: credential-bound agent identity. (The P0-4 verified
+    # baggage-claim population is stamped by the caller passing agent_id +
+    # policy_decision='unbound'; when only the scope is set we use it.)
+    if scope is None:
+        return
+    if workspace_id is None or not user_id:
+        return
+
+    from api.correlation import get_correlation
+
+    corr = get_correlation()
+    surface = corr.surface if corr else "rest"
+
+    metadata = dict(extra_metadata) if extra_metadata else None
+
+    await record_memory_access_event(
+        workspace_id=workspace_id,
+        user_id=user_id,
+        # Agent workloads authenticate with member API keys (P0-2); the audited
+        # population is API-key-authenticated by construction.
+        principal_type="api_key",
+        operation=operation,
+        outcome=outcome,
+        surface=surface,
+        agent_id=scope.agent_id,
+        context_id=context_id,
+        session_id=corr.session_id if corr else None,
+        run_id=corr.run_id if corr else None,
+        trace_id=corr.trace_id if corr else None,
+        span_id=corr.span_id if corr else None,
+        policy_decision=policy_decision,
+        memory_id=memory_id,
+        result_count=result_count,
+        latency_ms=latency_ms,
+        query_hash=query_hash,
+        event_metadata=metadata,
+    )

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -2767,6 +2767,18 @@ class MemoryService:
                 cap=effective_cap,
             )
 
+        # #1278: append-only audit (no-op unless verified agent identity).
+        from services.memory_access_event_writer import emit_memory_access_event
+
+        await emit_memory_access_event(
+            operation="load_pinned",
+            outcome="success",
+            workspace_id=UUID(workspace_id_str),
+            user_id=user_id,
+            context_id=UUID(context_id_str),
+            result_count=len(rows),
+        )
+
         return LoadPinnedResponse(
             memories=[
                 PinnedMemoryItem(

--- a/backend/tests/api/test_agent_bootstrap_route.py
+++ b/backend/tests/api/test_agent_bootstrap_route.py
@@ -39,7 +39,7 @@ def _svc(monkeypatch, *, principal_error=None, context_error=None, envelope=None
     else:
         inst.resolve_principal_and_agent = AsyncMock(
             return_value=(
-                SimpleNamespace(workspace_id=WORKSPACE_ID),
+                SimpleNamespace(workspace_id=WORKSPACE_ID, user_id="u", metadata={}),
                 SimpleNamespace(id=AGENT_ID, name="ci-bot", workspace_id=WORKSPACE_ID),
             )
         )

--- a/backend/tests/integration/test_memory_access_events_trigger.py
+++ b/backend/tests/integration/test_memory_access_events_trigger.py
@@ -1,0 +1,141 @@
+"""Integration tests for the memory_access_events append-only trigger (#1278).
+
+Against a real Postgres test DB. ``create_all`` does not install triggers, so
+(like ``test_secret_store_integration``) we install the migration's DDL here,
+then assert: DELETE and TRUNCATE always raise; an UPDATE touching a
+non-carve-out column raises; an UPDATE limited to the carve-out
+(user_id, session_id, run_id, event_metadata) is permitted (the erasure lane).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.memory_access_event import MemoryAccessEvent
+
+_TRIGGER_DDL = """
+CREATE OR REPLACE FUNCTION memory_access_events_append_only()
+RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        IF (to_jsonb(OLD) - ARRAY['user_id','session_id','run_id','event_metadata'])
+           IS DISTINCT FROM
+           (to_jsonb(NEW) - ARRAY['user_id','session_id','run_id','event_metadata']) THEN
+            RAISE EXCEPTION 'memory_access_events is append-only'
+                USING ERRCODE = 'restrict_violation';
+        END IF;
+        RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'memory_access_events is append-only; % is not permitted', TG_OP
+        USING ERRCODE = 'restrict_violation';
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+
+@pytest_asyncio.fixture
+async def mae_triggers(db_session: AsyncSession):
+    # Defensive: a prior test whose body raised inside the trigger leaves the
+    # committed triggers in place (db_session commits real transactions, no
+    # per-test rollback of DDL). Drop-if-exists first so setup is idempotent.
+    await db_session.rollback()
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS memory_access_events_no_truncate ON memory_access_events")
+    )
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS memory_access_events_no_mutate ON memory_access_events")
+    )
+    await db_session.execute(text(_TRIGGER_DDL))
+    await db_session.execute(
+        text(
+            "CREATE TRIGGER memory_access_events_no_mutate "
+            "BEFORE UPDATE OR DELETE ON memory_access_events "
+            "FOR EACH ROW EXECUTE FUNCTION memory_access_events_append_only()"
+        )
+    )
+    await db_session.execute(
+        text(
+            "CREATE TRIGGER memory_access_events_no_truncate "
+            "BEFORE TRUNCATE ON memory_access_events "
+            "FOR EACH STATEMENT EXECUTE FUNCTION memory_access_events_append_only()"
+        )
+    )
+    await db_session.commit()
+    yield
+    await db_session.rollback()
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS memory_access_events_no_truncate ON memory_access_events")
+    )
+    await db_session.execute(
+        text("DROP TRIGGER IF EXISTS memory_access_events_no_mutate ON memory_access_events")
+    )
+    await db_session.execute(text("DELETE FROM memory_access_events"))
+    await db_session.execute(text("DROP FUNCTION IF EXISTS memory_access_events_append_only()"))
+    await db_session.commit()
+
+
+async def _insert(db: AsyncSession) -> int:
+    row = MemoryAccessEvent(
+        workspace_id=uuid.uuid4(),
+        user_id="subject-1",
+        principal_type="api_key",
+        agent_id=uuid.uuid4(),
+        session_id="sess-1",
+        run_id="run-1",
+        surface="mcp",
+        operation="recall",
+        outcome="success",
+    )
+    db.add(row)
+    await db.commit()
+    await db.refresh(row)
+    return row.id
+
+
+@pytest.mark.asyncio
+async def test_delete_blocked(db_session: AsyncSession, mae_triggers):
+    rid = await _insert(db_session)
+    with pytest.raises(Exception, match="append-only"):
+        await db_session.execute(text("DELETE FROM memory_access_events WHERE id = :i"), {"i": rid})
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_truncate_blocked(db_session: AsyncSession, mae_triggers):
+    await _insert(db_session)
+    with pytest.raises(Exception, match="append-only"):
+        await db_session.execute(text("TRUNCATE memory_access_events"))
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_immutable_column_update_blocked(db_session: AsyncSession, mae_triggers):
+    rid = await _insert(db_session)
+    with pytest.raises(Exception, match="append-only"):
+        await db_session.execute(
+            text("UPDATE memory_access_events SET operation = 'forget' WHERE id = :i"),
+            {"i": rid},
+        )
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_carve_out_update_permitted(db_session: AsyncSession, mae_triggers):
+    rid = await _insert(db_session)
+    await db_session.execute(
+        text(
+            "UPDATE memory_access_events SET user_id = 'pseudo', session_id = NULL, "
+            'run_id = NULL, event_metadata = \'{"redacted":"erased_subject"}\'::jsonb '
+            "WHERE id = :i"
+        ),
+        {"i": rid},
+    )
+    await db_session.commit()
+    row = await db_session.get(MemoryAccessEvent, rid)
+    assert row.user_id == "pseudo"
+    assert row.session_id is None

--- a/backend/tests/mcp_server/test_agent_bootstrap_tool.py
+++ b/backend/tests/mcp_server/test_agent_bootstrap_tool.py
@@ -43,7 +43,7 @@ def _enter(stack, *, principal_error=None, envelope=None):
     else:
         svc.resolve_principal_and_agent = AsyncMock(
             return_value=(
-                SimpleNamespace(workspace_id=WORKSPACE_ID),
+                SimpleNamespace(workspace_id=WORKSPACE_ID, user_id="u", metadata={}),
                 SimpleNamespace(id=AGENT_ID, name="ci-bot", workspace_id=WORKSPACE_ID),
             )
         )

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -980,3 +980,36 @@ class TestDeletePostgresSweep:
         )
         assert agent_call.args[1] is Agent.owner_user_id
         assert agent_call.args[2] == target.user_id
+
+
+class TestMemoryAccessEventsErasure:
+    """#1278: the erased subject's memory_access_events rows are pseudonymized
+    + scrubbed in ONE carve-out UPDATE (user_id pseudonym, session_id/run_id
+    NULL, event_metadata redacted)."""
+
+    @pytest.mark.asyncio
+    async def test_erasure_pseudonymizes_and_scrubs(self):
+
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=0)
+        svc._pseudonymize_field = AsyncMock(return_value=0)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        captured = {}
+
+        async def _exec(stmt):
+            captured["stmt"] = stmt
+            return SimpleNamespace(rowcount=4)
+
+        svc.db.execute = AsyncMock(side_effect=_exec)
+        target = _user()
+
+        count = await svc._erase_memory_access_events(target.user_id)
+        assert count == 4
+        # A single UPDATE on memory_access_events touching only carve-out cols.
+        compiled = str(captured["stmt"]).lower()
+        assert "update memory_access_events" in compiled
+        params = captured["stmt"].compile().params
+        assert params["user_id"] != target.user_id  # pseudonymized
+        assert params["session_id"] is None
+        assert params["run_id"] is None

--- a/backend/tests/services/test_memory_access_event_writer.py
+++ b/backend/tests/services/test_memory_access_event_writer.py
@@ -1,0 +1,180 @@
+"""Unit tests for the memory_access_events writer (#1278).
+
+Pins the fail-open posture (DB error → structured warning + return None, never
+raise; error_type never str(exc)), the validation-raises rule, and the
+audited-population gate (emit is a no-op without verified agent identity).
+DB access is mocked; the append-only trigger + erasure are integration-tested.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.memory_access_event_writer import (
+    emit_memory_access_event,
+    record_memory_access_event,
+)
+
+WORKSPACE_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+
+
+def _patch_db(stack, *, add_raises=None):
+    committed = {"n": 0}
+    db = MagicMock()
+    db.add = MagicMock(side_effect=add_raises) if add_raises else MagicMock()
+
+    async def _commit():
+        committed["n"] += 1
+
+    db.commit = AsyncMock(side_effect=_commit)
+
+    async def gen():
+        yield db
+
+    stack.enter_context(patch("db.base.get_db", new=gen))
+    return db, committed
+
+
+class TestRecordValidation:
+    @pytest.mark.asyncio
+    async def test_bad_operation_raises(self):
+        with pytest.raises(ValueError, match="operation"):
+            await record_memory_access_event(
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                principal_type="api_key",
+                operation="bogus",
+                outcome="success",
+                surface="mcp",
+            )
+
+    @pytest.mark.asyncio
+    async def test_bad_outcome_raises(self):
+        with pytest.raises(ValueError, match="outcome"):
+            await record_memory_access_event(
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                principal_type="api_key",
+                operation="recall",
+                outcome="ok",
+                surface="mcp",
+            )
+
+    @pytest.mark.asyncio
+    async def test_bad_policy_decision_raises(self):
+        with pytest.raises(ValueError, match="policy_decision"):
+            await record_memory_access_event(
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                principal_type="api_key",
+                operation="recall",
+                outcome="denied",
+                surface="mcp",
+                policy_decision="nope",
+            )
+
+
+class TestRecordFailOpen:
+    @pytest.mark.asyncio
+    async def test_success_inserts_and_commits(self):
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            db, committed = _patch_db(stack)
+            await record_memory_access_event(
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                principal_type="api_key",
+                operation="bootstrap",
+                outcome="success",
+                surface="rest",
+                agent_id=AGENT_ID,
+            )
+        db.add.assert_called_once()
+        assert committed["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_db_error_is_swallowed(self):
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            _patch_db(stack, add_raises=RuntimeError("db down"))
+            warn = MagicMock()
+            stack.enter_context(
+                patch("services.memory_access_event_writer.logger.warning", new=warn)
+            )
+            # Must NOT raise (fail-open).
+            await record_memory_access_event(
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                principal_type="api_key",
+                operation="recall",
+                outcome="success",
+                surface="mcp",
+            )
+        warn.assert_called_once()
+        kwargs = warn.call_args.kwargs
+        # error_type only — never str(exc) (credential-leak guard).
+        assert kwargs["error_type"] == "RuntimeError"
+        assert "db down" not in str(kwargs)
+
+
+class TestEmitGate:
+    @pytest.mark.asyncio
+    async def test_no_agent_scope_is_noop(self):
+        recorder = AsyncMock()
+        with (
+            patch("auth.agent_scope.get_agent_scope", return_value=None),
+            patch("services.memory_access_event_writer.record_memory_access_event", new=recorder),
+        ):
+            await emit_memory_access_event(
+                operation="load_pinned",
+                outcome="success",
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+            )
+        recorder.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_agent_scope_emits_with_correlation(self):
+        recorder = AsyncMock()
+        scope = SimpleNamespace(agent_id=AGENT_ID, enforcement_mode="enforce")
+        corr = SimpleNamespace(
+            session_id="s1", run_id="r1", trace_id="t", span_id="sp", surface="mcp"
+        )
+        with (
+            patch("auth.agent_scope.get_agent_scope", return_value=scope),
+            patch("api.correlation.get_correlation", return_value=corr),
+            patch("services.memory_access_event_writer.record_memory_access_event", new=recorder),
+        ):
+            await emit_memory_access_event(
+                operation="load_pinned",
+                outcome="success",
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                result_count=3,
+            )
+        recorder.assert_awaited_once()
+        kwargs = recorder.await_args.kwargs
+        assert kwargs["agent_id"] == AGENT_ID
+        assert kwargs["session_id"] == "s1"
+        assert kwargs["surface"] == "mcp"
+        assert kwargs["result_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_is_noop(self):
+        recorder = AsyncMock()
+        scope = SimpleNamespace(agent_id=AGENT_ID, enforcement_mode="enforce")
+        with (
+            patch("auth.agent_scope.get_agent_scope", return_value=scope),
+            patch("services.memory_access_event_writer.record_memory_access_event", new=recorder),
+        ):
+            await emit_memory_access_event(
+                operation="recall", outcome="success", workspace_id=None, user_id="u"
+            )
+        recorder.assert_not_awaited()

--- a/backend/tests/test_memory_access_event_constants.py
+++ b/backend/tests/test_memory_access_event_constants.py
@@ -1,0 +1,81 @@
+"""Regression tests for #1278: memory_access_events CHECK + classification pins.
+
+The CHECK constraints are derived from ordered Python tuples so
+``Base.metadata.create_all()`` produces literals byte-identical to the alembic
+migration (``e66``); adding a value requires the coordinated edits caught here.
+"""
+
+from models.memory_access_event import (
+    MAE_METADATA_MAX_BYTES,
+    MAE_MUTABLE_COLUMNS,
+    MAE_OPERATIONS,
+    MAE_OUTCOMES,
+    MAE_POLICY_DECISIONS,
+    MAE_PRINCIPAL_TYPES,
+    MAE_SURFACES,
+    MemoryAccessEvent,
+)
+
+
+def _check(name: str) -> str:
+    c = next(c for c in MemoryAccessEvent.__table_args__ if getattr(c, "name", None) == name)
+    return c.sqltext.text
+
+
+def test_operation_tuple_is_the_eight_audited_ops():
+    assert MAE_OPERATIONS == (
+        "recall",
+        "reference",
+        "remember",
+        "update",
+        "forget",
+        "load_pinned",
+        "bootstrap",
+        "feedback",
+    )
+
+
+def test_check_literals_byte_identical_to_migration():
+    assert _check("valid_mae_operation") == (
+        "operation IN ('recall', 'reference', 'remember', 'update', 'forget', "
+        "'load_pinned', 'bootstrap', 'feedback')"
+    )
+    assert _check("valid_mae_outcome") == "outcome IN ('success', 'denied', 'error', 'partial')"
+    assert _check("valid_mae_surface") == "surface IN ('mcp', 'rest')"
+    assert _check("valid_mae_principal") == "principal_type IN ('api_key', 'oauth', 'session')"
+    assert _check("valid_mae_policy") == (
+        "policy_decision IS NULL OR policy_decision IN ('allowed', 'binding_denied', "
+        "'rbac_denied', 'would_deny', 'unbound')"
+    )
+    assert _check("mae_metadata_size") == "octet_length(event_metadata::text) <= 4096"
+
+
+def test_constant_value_sets():
+    assert MAE_OUTCOMES == ("success", "denied", "error", "partial")
+    assert MAE_SURFACES == ("mcp", "rest")
+    assert MAE_PRINCIPAL_TYPES == ("api_key", "oauth", "session")
+    assert MAE_POLICY_DECISIONS == (
+        "allowed",
+        "binding_denied",
+        "rbac_denied",
+        "would_deny",
+        "unbound",
+    )
+    assert MAE_METADATA_MAX_BYTES == 4096
+
+
+def test_erasure_carve_out_columns():
+    # The ONLY columns the append-only trigger permits an UPDATE to touch.
+    assert MAE_MUTABLE_COLUMNS == ("user_id", "session_id", "run_id", "event_metadata")
+
+
+def test_classified_operational():
+    from models.data_boundary import OPERATIONAL_TABLES
+
+    assert "memory_access_events" in OPERATIONAL_TABLES
+
+
+def test_no_foreign_keys():
+    # Audit-grade: the trail must survive entity deletion (no FK to
+    # agents/contexts/workspaces/keys).
+    assert list(MemoryAccessEvent.__table__.foreign_keys) == []


### PR DESCRIPTION
Closes #1278 (RFC-0002 P0-5)

Append-only audit of memory operations under **verified agent identity**, per the signed-off F3 contract ([docs/design/memory-access-events.md](https://github.com/kagura-ai/memory-cloud/blob/main/docs/design/memory-access-events.md)); retention plan F7. Stacked on #1274–#1277.

## Schema (migration e66, pure additive)

- `memory_access_events` — the canonical DDL: identifiers / outcome / latency / policy decision / keyed (HMAC) hashes only, **NEVER** raw prompts, retrieved content, secrets, or PII. `BIGSERIAL` PK (keyset cursor); **NO foreign keys** (audit-grade — the trail survives deletion of the agent/context/key it references). CHECK constraints (operation/outcome/surface/principal_type/policy_decision) derived byte-identically from module-level Python tuples (drift-pinned); 4 KB `event_metadata` cap; `idx_mae_occurred` / `idx_mae_workspace_occurred` / partial `idx_mae_agent_occurred`.
- **Append-only enforcement** — `BEFORE UPDATE OR DELETE` + `BEFORE TRUNCATE` triggers (the `e50_1128` secret-store precedent) with the **erasure carve-out**: an UPDATE is permitted only when it changes solely `(user_id, session_id, run_id, event_metadata)`; the guard compares the immutable subset (`to_jsonb(row) - carve_out`) OLD vs NEW.

## Writer

- `record_memory_access_event` — **independent session** (never joins/poisons the caller's transaction), **fail-open**: a DB error logs a structured warning (`error_type`, never `str(exc)` — the credential-leak guard) and returns; validation (bad enum) raises.
- `emit_memory_access_event` — chokepoint entry: gathers agent identity from the #1275 `AgentScope` + correlation from the #1277 `CorrelationContext`, and **early-returns for non-agent requests** (audited population = verified agent identity only) — so legacy/unbound traffic gains no hot-path write (the RFC-0002 backward-compat contract).

## Emission

Wired at **bootstrap** (both surfaces), **load_pinned**, and **feedback**. The remaining ops (`recall` / `reference` / `remember` / `update` / `forget`) + deny capture (`would_deny` / `binding_denied`) are mechanical follow-ups tracked in **#1281** (~5 lines each via the shipped `emit_memory_access_event` helper).

## Erasure + boundary (same-PR two-sided closure)

`memory_access_events` classified in `OPERATIONAL_TABLES`; `account_erasure_service` pseudonymizes `user_id` + scrubs `session_id`/`run_id`/`event_metadata` for the erased subject in **one carve-out UPDATE** (exactly what the append-only trigger permits).

## Retention

Unlimited / no partitioning / **no sampling**; escalation trigger **100M rows or 12 months** (F7 ops plan). Quota-invisible (separate table — `usage_stats` consumers never see it).

## Tests

Constants/drift + no-FK + classification pins; writer fail-open (error_type, no str(exc)) + validation-raises + audited-population gate; **append-only trigger integration** (delete/truncate/immutable-update blocked, carve-out-only UPDATE permitted); erasure carve-out UPDATE. Migration round-trip (incl. `downgrade -1`) + create_all/alembic drift gates green. Full local suite **5427 passed**; ruff clean; pyright 0 new errors.

## Gates

- Inner review: all 7 F3 invariants verified — **NO FINDINGS**.
- Gate2: cso / qa-lead / cto all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
