### PR TITLE
chore(auth): P0-2 fast-follow hardening subset (#1281)

### DIFF
--- a/backend/alembic/versions/e67_1281_agent_key_workspace.py
+++ b/backend/alembic/versions/e67_1281_agent_key_workspace.py
@@ -1,0 +1,46 @@
+"""api_keys: agent_id IS NOT NULL implies workspace_id IS NOT NULL (#1281 item 4).
+
+Structural backstop for the RFC-0002 P0-2 invariant that an agent-bound member
+key is always workspace-scoped. It was already enforced at mint (service layer)
+and re-asserted fail-closed at verify; this makes it a single-table DB CHECK so
+the guarantee cannot drift on a direct write or a future code path.
+
+Added ``NOT VALID`` (no scan under lock) then ``VALIDATE`` as a separate
+statement (SHARE UPDATE EXCLUSIVE — does not block reads/writes), mirroring the
+e65 ``ck_api_keys_agent_public_exclusion`` addition. Fresh feature: no
+pre-existing rows can violate it (every minted agent key already carries
+``workspace_id``), so VALIDATE is a formality that also guards against a bad
+backfill.
+
+Rerun safety (#655 pattern): the ADD is a ``duplicate_object``-guarded DO block;
+VALIDATE runs in an autocommit block and is a no-op once validated.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e67_1281_agent_ws"
+down_revision = "e66_1278_mae"
+branch_labels = None
+depends_on = None
+
+_CHECK_NAME = "ck_api_keys_agent_requires_workspace"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            f"  ALTER TABLE api_keys ADD CONSTRAINT {_CHECK_NAME} "
+            "    CHECK (agent_id IS NULL OR workspace_id IS NOT NULL) NOT VALID; "
+            "EXCEPTION WHEN duplicate_object THEN NULL; "
+            "END $$"
+        )
+    )
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"ALTER TABLE api_keys VALIDATE CONSTRAINT {_CHECK_NAME}"))
+
+
+def downgrade() -> None:
+    op.execute(sa.text(f"ALTER TABLE api_keys DROP CONSTRAINT IF EXISTS {_CHECK_NAME}"))

--- a/backend/src/api/correlation.py
+++ b/backend/src/api/correlation.py
@@ -88,6 +88,11 @@ def validate_correlation_token(value: Any) -> str | None:
     Charset ``[A-Za-z0-9._-]``, length ≤128 (design F4). Invalid = dropped
     (advisory data, never a request failure).
     """
+    if value is None:
+        # Absent baggage key (bag.get(...) -> None) is the overwhelmingly common
+        # case, not an anomaly — drop silently. Only a *present* malformed value
+        # warrants the structured drop warning below (Copilot review, #1277).
+        return None
     if not isinstance(value, str) or not value or len(value) > _CORRELATION_TOKEN_MAX_LEN:
         # Structured warning on drop (design F4 §validation) — advisory, never
         # a request failure. Never log the token verbatim (it may, despite the

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -292,8 +292,10 @@ app.add_middleware(RateLimitMiddleware)
 logger.info("rate_limit_middleware_registered")
 
 # Request Logging Middleware (Issue #48, #50)
-# Must be added LAST (so it runs outermost — records after all other middleware)
-# Execution order: RequestLogger → RateLimit → Session → Route handler → (response logged)
+# Added after RateLimit (so it runs outside it) but BEFORE CorrelationMiddleware,
+# so the correlation context is already set when request/response logging runs.
+# It is no longer the outermost layer — CorrelationMiddleware (added last) is.
+# Execution order (outermost→inner): Correlation → RequestLogger → RateLimit → Session → Route handler
 from api.middleware.request_logger import RequestLoggingMiddleware  # noqa: E402
 
 app.add_middleware(RequestLoggingMiddleware)

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -520,6 +520,8 @@ async def agent_bootstrap(
         BootstrapError,
         BootstrapParams,
         parse_include,
+        validate_query,
+        validate_session_id,
     )
     from utils.exceptions import BadRequestError, NotFoundException
 
@@ -527,8 +529,12 @@ async def agent_bootstrap(
         params = BootstrapParams(
             agent_id=agent_id,
             context_id=body.context_id,
-            session_id=body.session_id,
-            query=body.query or None,
+            # #1281 item 6: reuse the shared MCP validators so the REST surface
+            # enforces the same session_id charset ([A-Za-z0-9._-]) and query
+            # limits as the tool contract — Pydantic max_length alone let spaces
+            # and other chars through. Both raise BootstrapError (caught below).
+            session_id=validate_session_id(body.session_id),
+            query=validate_query(body.query),
             recall_k=body.recall_k,
             pinned_cap=body.pinned_cap,
             upcoming_until=body.upcoming_until,

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -51,7 +51,7 @@ from services.analysis.preview import (
     estimate_cost,
 )
 from tasks.analysis_tasks import cancel_run_task, register_run_task, run_analysis_task
-from utils.exceptions import ConflictError, ValidationError
+from utils.exceptions import ConflictError, NotFoundException, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -308,11 +308,12 @@ async def _verify_context_in_workspace(
     # #1281 item 5: subtractive agent-binding gate (REST parity with the MCP
     # analysis surface). Contains an agent-bound credential to its bound
     # contexts even when the underlying role is broad; no-op for non-agent
-    # credentials; deny is the same uniform 404 (no existence leak).
+    # credentials; deny is the same uniform 404 (no existence leak). Raise the
+    # canonical NotFoundException (not a raw HTTPException) per the house rule.
     from services.agent_binding_service import agent_binding_permits
 
     if not await agent_binding_permits(db, context_id, "read"):
-        raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+        raise NotFoundException("Context", str(context_id))
 
 
 def _params_from_body(body: AnalysisPreviewRequest) -> AnalysisParams:

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -305,6 +305,15 @@ async def _verify_context_in_workspace(
     ):
         raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
 
+    # #1281 item 5: subtractive agent-binding gate (REST parity with the MCP
+    # analysis surface). Contains an agent-bound credential to its bound
+    # contexts even when the underlying role is broad; no-op for non-agent
+    # credentials; deny is the same uniform 404 (no existence leak).
+    from services.agent_binding_service import agent_binding_permits
+
+    if not await agent_binding_permits(db, context_id, "read"):
+        raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
 
 def _params_from_body(body: AnalysisPreviewRequest) -> AnalysisParams:
     """Convert a request body to the orchestrator's ``AnalysisParams``.

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -121,6 +121,9 @@ async def remember(
             client=user.get("client", "web"),
             current_context_id=context_id,
             current_workspace_id=user.get("current_workspace_id"),  # NEW: Issue #146
+            # Issue #963/#1281 item 2: confine a workspace-scoped key to its own
+            # workspace (pure key scope; None for OAuth/session/global-key).
+            key_workspace_id=user.get("api_key_workspace_id"),
         )
     except ValueError as e:
         # MemoryService raises ValueError as its "bad request" signal (e.g. an
@@ -279,6 +282,8 @@ async def load_pinned(
             current_context_id=context_uuid,
             current_workspace_id=user.get("current_workspace_id"),
             cap=request.cap,
+            # Issue #963/#1281 item 2: pure key scope (None unless workspace-scoped key).
+            key_workspace_id=user.get("api_key_workspace_id"),
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
@@ -376,6 +381,10 @@ async def forget(
         request,
         user_id=user["user_id"],
         current_context_id=None,  # Issue #246: current_context_id removed
+        # Issue #963/#1281 item 2: pure key scope. Inert while current_context_id
+        # is None (the isolation helper short-circuits), wired for symmetry so the
+        # confinement holds the moment forget regains a declared context.
+        key_workspace_id=user.get("api_key_workspace_id"),
     )
 
     return result

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -111,6 +111,13 @@ async def get_current_user(request: Request) -> dict:
         async def get_me(user: dict = Depends(get_current_user)):
             return user
     """
+    # Issue #1281 item 3: symmetric agent-scope reset (mirrors the MCP transport
+    # and get_user_from_api_key_or_session). Session auth never carries an agent
+    # scope; make that explicit and stale-proof.
+    from auth.agent_scope import set_agent_scope
+
+    set_agent_scope(None)
+
     # SessionMiddleware sets request.state.user if logged in
     if not hasattr(request.state, "user") or request.state.user is None:
         logger.warning("unauthorized_access_attempt", path=request.url.path)
@@ -512,6 +519,16 @@ async def get_user_from_api_key_or_session(
             context_id = user.get("current_context_id")
             return await save_memory(user["user_id"], context_id, ...)
     """
+    # Issue #1281 item 3: reset the per-request agent scope up-front, symmetric
+    # with the MCP transport (mcp_server/auth.py sets it None before auth). ASGI
+    # already isolates the contextvar per request, so this is defense-in-depth —
+    # it guarantees a non-agent credential (OAuth/session/global key) never
+    # observes a stale scope even if that isolation assumption breaks. The
+    # agent-key branch below re-sets it via set_agent_scope_from_verified.
+    from auth.agent_scope import set_agent_scope
+
+    set_agent_scope(None)
+
     # Priority 0: OAuth Bearer. The prefix check skips the OAuth DB
     # lookup for ``kagura_*`` API keys (and vice versa), so each Bearer
     # request hits only one of the two stores.

--- a/backend/src/mcp_server/tools/agent_bootstrap.py
+++ b/backend/src/mcp_server/tools/agent_bootstrap.py
@@ -146,8 +146,13 @@ async def handle_get_agent_bootstrap(
 
         except BootstrapError as e:
             await db.rollback()
+            # #1281 item 6: distinguish client-argument errors (400) from
+            # not-found / authorization denials (404) in usage_stats so analytics
+            # can tell them apart. The caller still gets the uniform
+            # _error_response(code) either way (no disclosure change).
+            status_code = 404 if e.code in ("agent_not_found", "context_not_found") else 400
             await _log_tool_usage(
-                db, user_id, "get_agent_bootstrap", start_time, 404, None, workspace_id
+                db, user_id, "get_agent_bootstrap", start_time, status_code, None, workspace_id
             )
             return _error_response(e.code, e.message)
         except Exception as e:  # pragma: no cover - defensive

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -125,6 +125,21 @@ async def _verify_context_in_workspace_mcp(
             f"Context {context_id} not found or you don't have access to it.",
             context_id=str(context_id),
         )
+
+    # #1281 item 5: subtractive agent-binding gate on the analysis surfaces
+    # (analyze_context / get_cluster / get_analysis all funnel through here).
+    # The workspace boundary above is necessary but not sufficient for an
+    # agent-bound credential — the binding must contain it to its bound
+    # contexts even when the underlying role is broad. No-op for non-agent
+    # credentials; deny is the same uniform context_not_found shape (no leak).
+    from services.agent_binding_service import agent_binding_permits
+
+    if not await agent_binding_permits(db, context_id, "read"):
+        return _error_response(
+            "context_not_found",
+            f"Context {context_id} not found or you don't have access to it.",
+            context_id=str(context_id),
+        )
     return None
 
 

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -448,6 +448,22 @@ async def handle_get_analysis(
                     f"Analysis run {run_id} not found.",
                     run_id=str(run_id),
                 )
+            # #1281 item 5: this handler is run_id-addressed (no context_id in
+            # args), so the shared _verify_context_in_workspace_mcp gate doesn't
+            # run. Gate on the run's own context_id (already loaded on the row;
+            # agent_binding_permits is a no-op contextvar read for non-agent
+            # creds). Deny → the same uniform run_not_found (no existence leak).
+            from services.agent_binding_service import agent_binding_permits
+
+            if not await agent_binding_permits(db, row.context_id, "read"):
+                await _log_tool_usage(
+                    db, user_id, "get_analysis", start_time, 404, workspace_id=workspace_id
+                )
+                return _error_response(
+                    "run_not_found",
+                    f"Analysis run {run_id} not found.",
+                    run_id=str(run_id),
+                )
             await _log_tool_usage(
                 db, user_id, "get_analysis", start_time, 200, workspace_id=workspace_id
             )
@@ -670,7 +686,35 @@ async def handle_get_cluster(
             except Exception as gate_exc:
                 return _gate_error_response(gate_exc)
 
+            # #1281 item 5: run_id-addressed handler — an agent-bound credential
+            # must be contained to its bound contexts even here. Resolve the
+            # run's context_id and gate (only when a scope is present, to avoid
+            # the extra lookup on the non-agent drill-down path). Deny → the same
+            # uniform cluster_not_found shape (no existence leak).
+            from auth.agent_scope import get_agent_scope
             from services.analysis import query_service
+
+            if get_agent_scope() is not None:
+                from services.agent_binding_service import agent_binding_permits
+
+                run_row = await query_service.get_analysis(
+                    db, workspace_id=workspace_id, run_id=run_id
+                )
+                if run_row is None or not await agent_binding_permits(
+                    db, run_row.context_id, "read"
+                ):
+                    await _log_tool_usage(
+                        db, user_id, "get_cluster", start_time, 404, workspace_id=workspace_id
+                    )
+                    return _error_response(
+                        "cluster_not_found",
+                        (
+                            f"Cluster #{cluster_index} not found in run {run_id} "
+                            "(or run not in your workspace)."
+                        ),
+                        run_id=str(run_id),
+                        cluster_index=cluster_index,
+                    )
 
             cluster = await query_service.get_cluster(
                 db,

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -364,6 +364,13 @@ class APIKey(Base):
             "agent_id IS NULL OR bound_context_id IS NULL",
             name="ck_api_keys_agent_public_exclusion",
         ),
+        # Issue #1281 item 4: an agent-bound member key is always
+        # workspace-scoped. Enforced at mint + re-asserted at verify; this
+        # single-table CHECK makes it a structural DB guarantee (migration e67).
+        CheckConstraint(
+            "agent_id IS NULL OR workspace_id IS NOT NULL",
+            name="ck_api_keys_agent_requires_workspace",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/memory_access_event.py
+++ b/backend/src/models/memory_access_event.py
@@ -108,6 +108,9 @@ class MemoryAccessEvent(Base):
     # unbound-traffic extension).
     agent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     session_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    # run_id is carried on the wire as the vendor attribute ``kagura.agent.run.id``
+    # (OTel GenAI semconv has no standard run/execution-id yet). The column is
+    # name-agnostic; upstream-tracking + additive migration obligation: #1285.
     run_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
     trace_id: Mapped[str | None] = mapped_column(String(32), nullable=True)
     span_id: Mapped[str | None] = mapped_column(String(16), nullable=True)

--- a/backend/src/services/agent_bootstrap_service.py
+++ b/backend/src/services/agent_bootstrap_service.py
@@ -271,7 +271,7 @@ class AgentBootstrapService:
 
         if "pinned" in include:
             components["pinned"] = await self._component(
-                "pinned", lambda: self._pinned(context, principal)
+                "pinned", lambda: self._pinned(context, principal, params.pinned_cap)
             )
         if "recall" in include:
             components["recall"] = await self._recall_component(
@@ -415,14 +415,19 @@ class AgentBootstrapService:
         instructions = f"{usage_guide}\n\n{KAGURA_MEMORY_INSTRUCTIONS}"
         return context_block, instructions
 
-    async def _pinned(self, context: Any, principal: BootstrapPrincipal) -> dict[str, Any]:
+    async def _pinned(
+        self, context: Any, principal: BootstrapPrincipal, pinned_cap: int | None = None
+    ) -> dict[str, Any]:
         from services.memory_service import MemoryService
 
         result = await MemoryService(self.db).load_pinned(
             user_id=principal.user_id,
             current_context_id=context.id,
             current_workspace_id=principal.workspace_id,
-            cap=None,  # inherit the load_pinned default clamp
+            # #1281 item 6: honor the caller's pinned_cap override (was a silent
+            # no-op). None → load_pinned applies its default clamp; a set value
+            # is clamped to [1, _PINNED_LOAD_CAP_MAX] by _clamp_pinned_cap.
+            cap=pinned_cap,
         )
         return {
             "memories": [

--- a/backend/src/services/memory_access_event_writer.py
+++ b/backend/src/services/memory_access_event_writer.py
@@ -143,6 +143,7 @@ async def emit_memory_access_event(
     memory_id: UUID | None = None,
     result_count: int | None = None,
     latency_ms: int | None = None,
+    query: str | None = None,
     query_hash: str | None = None,
     policy_decision: str | None = None,
     extra_metadata: dict[str, Any] | None = None,
@@ -154,6 +155,10 @@ async def emit_memory_access_event(
     Early-returns (no write, one contextvar read) when the request carries no
     verified agent identity — the backward-compat no-hot-path-write guarantee
     for legacy traffic. Fail-open end to end.
+
+    ``query``: raw query text — hashed here (HMAC-SHA256, dedicated audit key)
+    into ``query_hash``; the raw text is NEVER stored. Passing a pre-hashed
+    ``query_hash`` instead is also honored (``query`` wins if both are given).
     """
     from auth.agent_scope import get_agent_scope
 
@@ -170,6 +175,13 @@ async def emit_memory_access_event(
 
     corr = get_correlation()
     surface = corr.surface if corr else "rest"
+
+    # Hash the raw query with the dedicated audit key; never store it verbatim.
+    if query:
+        from config.settings import get_settings
+        from utils.hashing import hmac_sha256_hex
+
+        query_hash = hmac_sha256_hex(query, get_settings().audit_hmac_key)
 
     metadata = dict(extra_metadata) if extra_metadata else None
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -469,6 +469,18 @@ class MemoryService:
                 functools.partial(_log_embedding_task_result, memory_id=str(memory_id))
             )
 
+            # #1278/#1281 item 7: audit the write (no-op unless verified agent).
+            from services.memory_access_event_writer import emit_memory_access_event
+
+            await emit_memory_access_event(
+                operation="remember",
+                outcome="success",
+                workspace_id=UUID(workspace_id_str),
+                user_id=user_id,
+                context_id=UUID(context_id_str),
+                memory_id=memory_id,
+            )
+
             return RememberResponse(memory_id=memory_id, scope=memory.scope)
 
         except Exception as e:
@@ -1068,6 +1080,19 @@ class MemoryService:
         await self.db.commit()
 
         logger.info("memory_referenced", memory_id=str(memory_id), user_id=user_id)
+
+        # #1278/#1281 item 7: audit the Layer-3 adoption read (no-op unless
+        # verified agent identity).
+        from services.memory_access_event_writer import emit_memory_access_event
+
+        await emit_memory_access_event(
+            operation="reference",
+            outcome="success",
+            workspace_id=memory.workspace_id,
+            user_id=user_id,
+            context_id=memory.context_id,
+            memory_id=memory_id,
+        )
 
         # Issue #440: Fetch declared_link references for the dialog References
         # section. The edge invariant (`_validate_edge_context_invariant` in
@@ -2733,6 +2758,21 @@ class MemoryService:
             for r in search_results
             if r.get("semantic_score_raw") is not None
         ]
+        # #1278/#1281 item 7: audit the recall (no-op unless verified agent
+        # identity). result_count + a keyed hash of the query; raw query never
+        # stored. effective_workspace_id is the #708-aware search workspace.
+        from services.memory_access_event_writer import emit_memory_access_event
+
+        await emit_memory_access_event(
+            operation="recall",
+            outcome="success",
+            workspace_id=effective_workspace_id,
+            user_id=user_id,
+            context_id=current_context_id,
+            result_count=len(responses),
+            query=request.query,
+        )
+
         return RecallResponse(
             results=responses,
             related_tags=related_tags,

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -159,15 +159,20 @@ class MemoryService:
         self.context_service = ContextService(db)
 
     async def _get_context_isolation_params(
-        self, user_id: str, context_id: UUID | None, *, access: str = "read"
+        self,
+        user_id: str,
+        context_id: UUID | None,
+        *,
+        access: str = "read",
+        key_workspace_id: UUID | None = None,
     ) -> tuple[Context | None, str | None, str | None]:
         """Extract workspace_id and context_id for 3-level isolation (performance optimization).
 
         Single Collection Migration: Helper to avoid duplicate context fetches.
 
         Issue #1275 (RFC-0002 P0-2): this resolves the *declared* context for
-        the remember (write) / recall (read) / forget-by-context (write)
-        paths — a route that does not pass through
+        the remember (write) / load_pinned (read) / forget-by-context (write)
+        paths — routes that do not pass through
         ``PermissionService.resolve_context_for_workspace_read``. Apply the
         same subtractive agent-binding gate here so agent-bound REST/MCP
         requests cannot write into (or read from) a binding-denied context via
@@ -175,21 +180,39 @@ class MemoryService:
         No-op for non-agent credentials; deny raises the uniform
         ``NotFoundException("Context")`` matching ``get_context``.
 
+        Issue #963 / #1281 item 2: also confine a workspace-scoped API key to
+        its own workspace here. ``context_service.get_context`` authorizes on
+        membership in the context's owning workspace — necessary but not
+        sufficient for a workspace-scoped key whose holder is *also* a member of
+        another workspace (they could otherwise pass a foreign ``context_id`` and,
+        for remember, have the row stamped into that foreign workspace). REST
+        passes ``key_workspace_id=user["api_key_workspace_id"]`` (the PURE key
+        scope — None unless a workspace-scoped key was used); mismatch raises the
+        same uniform ``NotFoundException``. Mirrors the MCP-path
+        ``_resolve_context`` confinement. No-op for OAuth/session/global-key
+        callers (scope None), so it never over-confines them.
+
         Args:
             user_id: User ID
             context_id: Context ID
             access: ``"read"`` (default) or ``"write"`` — the binding gate.
+            key_workspace_id: Pure API-key workspace scope for #963 confinement,
+                or ``None`` to skip it.
 
         Returns:
             Tuple of (context_object, workspace_id_str, context_id_str)
 
         Raises:
-            NotFoundException: If context not found or the binding denies it.
+            NotFoundException: If context not found, key-workspace-confined, or
+                the binding denies it.
         """
         if not context_id:
             return None, None, None
 
         context = await self.context_service.get_context(user_id, context_id)
+
+        if key_workspace_id is not None and context.workspace_id != key_workspace_id:
+            raise NotFoundException("Context", str(context_id))
 
         from services.agent_binding_service import agent_binding_permits
 
@@ -272,6 +295,7 @@ class MemoryService:
         client: str = "unknown",
         current_context_id: UUID | None = None,
         current_workspace_id: UUID | None = None,  # NEW: Workspace ID (Issue #146)
+        key_workspace_id: UUID | None = None,  # Issue #963/#1281: pure key scope
     ) -> RememberResponse:
         """Store new memory.
 
@@ -316,7 +340,7 @@ class MemoryService:
         # Issue #1275: remember is a WRITE — gate the declared context against
         # the agent binding (no-op for non-agent credentials).
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id, access="write"
+            user_id, current_context_id, access="write", key_workspace_id=key_workspace_id
         )
 
         # Validate required parameters
@@ -2724,6 +2748,7 @@ class MemoryService:
         current_context_id: UUID | None = None,
         current_workspace_id: UUID | None = None,
         cap: int | str | None = None,
+        key_workspace_id: UUID | None = None,  # Issue #963/#1281: pure key scope
     ) -> LoadPinnedResponse:
         """Deterministically load a context's always-delivery memories (#886).
 
@@ -2747,7 +2772,7 @@ class MemoryService:
         from config.settings import get_settings
 
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id
+            user_id, current_context_id, key_workspace_id=key_workspace_id
         )
         if not workspace_id_str or not context_id_str:
             raise ValueError("load_pinned() requires current_context_id")
@@ -2802,6 +2827,7 @@ class MemoryService:
         request: ForgetRequest,
         user_id: str,
         current_context_id: UUID | None = None,
+        key_workspace_id: UUID | None = None,  # Issue #963/#1281: pure key scope
     ) -> ForgetResponse:
         """Delete memory (single or multiple via query).
 
@@ -2819,7 +2845,7 @@ class MemoryService:
         # Issue #1275: forget is a WRITE — gate the declared context against
         # the agent binding (no-op for non-agent credentials).
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id, access="write"
+            user_id, current_context_id, access="write", key_workspace_id=key_workspace_id
         )
 
         deleted_ids = []

--- a/backend/tests/api/test_agent_bootstrap_route.py
+++ b/backend/tests/api/test_agent_bootstrap_route.py
@@ -91,3 +91,17 @@ async def test_context_id_required_is_400(db, monkeypatch):
     _svc(monkeypatch, context_error=("context_id_required", "context_id is required."))
     with pytest.raises(BadRequestError):
         await agent_bootstrap(agent_id=AGENT_ID, body=BootstrapRequest(), user=USER, db=db)
+
+
+@pytest.mark.asyncio
+async def test_bad_session_id_charset_is_400(db, monkeypatch):
+    # #1281 item 6: REST reuses validate_session_id, so a value that passes the
+    # Pydantic max_length but violates [A-Za-z0-9._-] is a 400, not silently kept.
+    _svc(monkeypatch)
+    with pytest.raises(BadRequestError):
+        await agent_bootstrap(
+            agent_id=AGENT_ID,
+            body=BootstrapRequest(session_id="has space"),
+            user=USER,
+            db=db,
+        )

--- a/backend/tests/api/test_analysis_binding_gate.py
+++ b/backend/tests/api/test_analysis_binding_gate.py
@@ -9,7 +9,9 @@ non-agent credentials (agent_binding_permits returns True).
 
 from __future__ import annotations
 
+import json
 import uuid
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,6 +22,13 @@ CTX = uuid.uuid4()
 
 _WS_OK = "services.analysis.query_service.verify_context_in_workspace"
 _BINDING = "services.agent_binding_service.agent_binding_permits"
+
+
+def _db_gen():
+    async def _gen():
+        yield MagicMock()
+
+    return _gen
 
 
 @pytest.mark.asyncio
@@ -74,3 +83,47 @@ async def test_rest_gate_passes_when_binding_permits():
     ):
         # No raise = pass.
         await _verify_context_in_workspace(MagicMock(), workspace_id=WS, context_id=CTX)
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_analysis_run_id_addressed_gate_denies():
+    # #1281 item 5: the run_id-addressed get_analysis handler gates on the run's
+    # own context_id (no context_id in args), denying with uniform run_not_found.
+    from mcp_server.tools import analysis as mod
+
+    row = SimpleNamespace(context_id=CTX)
+    with (
+        patch("db.base.get_db", new=_db_gen()),
+        patch("auth.analysis_gates.check_memory_analysis_access_mcp", new=AsyncMock()),
+        patch("services.analysis.query_service.get_analysis", new=AsyncMock(return_value=row)),
+        patch(_BINDING, new=AsyncMock(return_value=False)),
+        patch("mcp_server.tools.analysis._log_tool_usage", new=AsyncMock()),
+    ):
+        result = await mod.handle_get_analysis(
+            args={"run_id": str(uuid.uuid4())}, user_id="u", workspace_id=WS
+        )
+    assert json.loads(result[0].text)["error"] == "run_not_found"
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_cluster_run_id_addressed_gate_denies():
+    # #1281 item 5: get_cluster resolves the run's context (scope present) and
+    # denies with uniform cluster_not_found when the binding rejects.
+    from mcp_server.tools import analysis as mod
+
+    row = SimpleNamespace(context_id=CTX)
+    with (
+        patch("db.base.get_db", new=_db_gen()),
+        patch("auth.analysis_gates.check_memory_analysis_access_mcp", new=AsyncMock()),
+        patch(
+            "auth.agent_scope.get_agent_scope",
+            return_value=SimpleNamespace(agent_id=uuid.uuid4(), enforcement_mode="enforce"),
+        ),
+        patch("services.analysis.query_service.get_analysis", new=AsyncMock(return_value=row)),
+        patch(_BINDING, new=AsyncMock(return_value=False)),
+        patch("mcp_server.tools.analysis._log_tool_usage", new=AsyncMock()),
+    ):
+        result = await mod.handle_get_cluster(
+            args={"run_id": str(uuid.uuid4()), "cluster_index": 0}, user_id="u", workspace_id=WS
+        )
+    assert json.loads(result[0].text)["error"] == "cluster_not_found"

--- a/backend/tests/api/test_analysis_binding_gate.py
+++ b/backend/tests/api/test_analysis_binding_gate.py
@@ -1,0 +1,76 @@
+"""Issue #1281 item 5: subtractive agent-binding gate on the analysis surfaces.
+
+Both the MCP helper (`_verify_context_in_workspace_mcp`) and the REST helper
+(`_verify_context_in_workspace`) apply `agent_binding_permits` after the
+workspace-boundary check, denying with the same uniform not-found shape when an
+agent-bound credential's binding does not permit the target context. No-op for
+non-agent credentials (agent_binding_permits returns True).
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+WS = uuid.uuid4()
+CTX = uuid.uuid4()
+
+_WS_OK = "services.analysis.query_service.verify_context_in_workspace"
+_BINDING = "services.agent_binding_service.agent_binding_permits"
+
+
+@pytest.mark.asyncio
+async def test_mcp_gate_denies_when_binding_rejects():
+    from mcp_server.tools.analysis import _verify_context_in_workspace_mcp
+
+    with (
+        patch(_WS_OK, new=AsyncMock(return_value=True)),
+        patch(_BINDING, new=AsyncMock(return_value=False)),
+    ):
+        result = await _verify_context_in_workspace_mcp(
+            MagicMock(), workspace_id=WS, context_id=CTX
+        )
+    # Non-None = an error envelope (context_not_found), not a pass-through.
+    assert result is not None
+
+
+@pytest.mark.asyncio
+async def test_mcp_gate_passes_when_binding_permits():
+    from mcp_server.tools.analysis import _verify_context_in_workspace_mcp
+
+    with (
+        patch(_WS_OK, new=AsyncMock(return_value=True)),
+        patch(_BINDING, new=AsyncMock(return_value=True)),
+    ):
+        result = await _verify_context_in_workspace_mcp(
+            MagicMock(), workspace_id=WS, context_id=CTX
+        )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_rest_gate_denies_when_binding_rejects():
+    from api.routes.analyses import _verify_context_in_workspace
+
+    with (
+        patch(_WS_OK, new=AsyncMock(return_value=True)),
+        patch(_BINDING, new=AsyncMock(return_value=False)),
+        pytest.raises(HTTPException) as exc,
+    ):
+        await _verify_context_in_workspace(MagicMock(), workspace_id=WS, context_id=CTX)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_rest_gate_passes_when_binding_permits():
+    from api.routes.analyses import _verify_context_in_workspace
+
+    with (
+        patch(_WS_OK, new=AsyncMock(return_value=True)),
+        patch(_BINDING, new=AsyncMock(return_value=True)),
+    ):
+        # No raise = pass.
+        await _verify_context_in_workspace(MagicMock(), workspace_id=WS, context_id=CTX)

--- a/backend/tests/api/test_analysis_binding_gate.py
+++ b/backend/tests/api/test_analysis_binding_gate.py
@@ -15,7 +15,6 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from fastapi import HTTPException
 
 WS = uuid.uuid4()
 CTX = uuid.uuid4()
@@ -63,11 +62,12 @@ async def test_mcp_gate_passes_when_binding_permits():
 @pytest.mark.asyncio
 async def test_rest_gate_denies_when_binding_rejects():
     from api.routes.analyses import _verify_context_in_workspace
+    from utils.exceptions import NotFoundException
 
     with (
         patch(_WS_OK, new=AsyncMock(return_value=True)),
         patch(_BINDING, new=AsyncMock(return_value=False)),
-        pytest.raises(HTTPException) as exc,
+        pytest.raises(NotFoundException) as exc,
     ):
         await _verify_context_in_workspace(MagicMock(), workspace_id=WS, context_id=CTX)
     assert exc.value.status_code == 404

--- a/backend/tests/api/test_correlation.py
+++ b/backend/tests/api/test_correlation.py
@@ -10,7 +10,7 @@ claims reach only a keyed-hash metadata field, never the agent_id column.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -77,6 +77,24 @@ class TestTokenValidation:
     @pytest.mark.parametrize("bad", [None, "", "x" * 129, "has space", "sess/1", "sess:1", 42])
     def test_invalid_dropped(self, bad):
         assert validate_correlation_token(bad) is None
+
+    def test_absent_value_is_silent(self):
+        # None = absent baggage key (bag.get -> None), the common case: no warn
+        # (Copilot review, #1277 — was spamming correlation_token_dropped).
+        import api.correlation as mod
+
+        with patch.object(mod.logger, "warning") as warn:
+            assert validate_correlation_token(None) is None
+        warn.assert_not_called()
+
+    @pytest.mark.parametrize("bad", ["", "x" * 129, "has space", 42])
+    def test_present_malformed_still_warns(self, bad):
+        # A *present* malformed value must still emit the structured drop warning.
+        import api.correlation as mod
+
+        with patch.object(mod.logger, "warning") as warn:
+            assert validate_correlation_token(bad) is None
+        warn.assert_called_once()
 
 
 class TestBuild:

--- a/backend/tests/api/test_memory_pinned_route.py
+++ b/backend/tests/api/test_memory_pinned_route.py
@@ -56,6 +56,24 @@ async def test_load_pinned_route_passes_context_and_cap_through():
 
 
 @pytest.mark.asyncio
+async def test_load_pinned_route_forwards_pure_api_key_workspace_scope():
+    """Issue #963/#1281 item 2: the route forwards the PURE key scope
+    (api_key_workspace_id), NOT current_workspace_id, as key_workspace_id — the
+    distinction that avoids over-confining OAuth/session/global-key callers."""
+    svc = AsyncMock()
+    svc.load_pinned = AsyncMock(return_value=_response())
+    key_ws = uuid4()
+    user = {"user_id": "u1", "current_workspace_id": uuid4(), "api_key_workspace_id": key_ws}
+    req = LoadPinnedRequest(context_id=str(uuid4()), cap=10)
+
+    await load_pinned(request=req, user=user, memory_service=svc)
+
+    kwargs = svc.load_pinned.await_args.kwargs
+    assert kwargs["key_workspace_id"] == key_ws
+    assert kwargs["key_workspace_id"] != user["current_workspace_id"]
+
+
+@pytest.mark.asyncio
 async def test_load_pinned_route_rejects_malformed_context_id_with_422():
     """A non-UUID context_id is a 422, not a DB DataError → 503 (finding #3)."""
     svc = AsyncMock()

--- a/backend/tests/auth/test_agent_bound_keys.py
+++ b/backend/tests/auth/test_agent_bound_keys.py
@@ -206,6 +206,23 @@ class TestAgentScopePropagation:
         set_agent_scope_from_verified(None)
         assert get_agent_scope() is None
 
+    @pytest.mark.asyncio
+    async def test_session_entry_resets_stale_scope(self):
+        # Issue #1281 item 3: a session request must never observe a stale agent
+        # scope left in the contextvar; the REST entry resets it up-front,
+        # symmetric with the MCP transport.
+        from types import SimpleNamespace
+
+        from auth.dependencies import get_current_user
+
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        request = SimpleNamespace(
+            state=SimpleNamespace(user={"user_id": "u"}),
+            url=SimpleNamespace(path="/x"),
+        )
+        await get_current_user(request)
+        assert get_agent_scope() is None
+
     def test_agent_id_without_mode_fails_closed_to_enforce(self):
         """code-review hardening: an agent-bound key (agent_id set) with a
         missing enforcement_mode is an anomaly — it must default to enforce

--- a/backend/tests/mcp_server/test_agent_bootstrap_tool.py
+++ b/backend/tests/mcp_server/test_agent_bootstrap_tool.py
@@ -103,6 +103,23 @@ class TestDispatch:
             )
         assert _payload(result)["error"] == "agent_not_found"
 
+    @pytest.mark.parametrize(
+        "code,expected_status", [("invalid_arguments", 400), ("agent_not_found", 404)]
+    )
+    @pytest.mark.asyncio
+    async def test_bootstrap_error_status_code_mapping(self, code, expected_status):
+        # #1281 item 6: usage_stats records 400 for client-argument errors and
+        # 404 for not-found / authorization denials (was 404 for all).
+        with ExitStack() as stack:
+            _enter(stack, principal_error=(code, "x"))
+            log = AsyncMock()
+            stack.enter_context(patch("mcp_server.tools.agent_bootstrap._log_tool_usage", new=log))
+            await handle_get_agent_bootstrap(
+                args={"agent_id": str(AGENT_ID)}, user_id="u", workspace_id=WORKSPACE_ID
+            )
+        # _log_tool_usage(db, user_id, tool, start_time, status_code, None, workspace_id)
+        assert log.await_args.args[4] == expected_status
+
     @pytest.mark.asyncio
     async def test_success_returns_envelope(self):
         with ExitStack() as stack:

--- a/backend/tests/services/test_agent_bootstrap_service.py
+++ b/backend/tests/services/test_agent_bootstrap_service.py
@@ -354,6 +354,19 @@ class TestEnvelope:
             )
 
     @pytest.mark.asyncio
+    async def test_pinned_forwards_cap_override(self):
+        # #1281 item 6: pinned_cap must reach load_pinned (was a silent no-op
+        # that always passed cap=None regardless of the caller's override).
+        svc = AgentBootstrapService(MagicMock())
+        load_pinned = AsyncMock(
+            return_value=SimpleNamespace(memories=[], total_available=0, truncated=False, cap=7)
+        )
+        with patch("services.memory_service.MemoryService") as ms_cls:
+            ms_cls.return_value.load_pinned = load_pinned
+            await svc._pinned(_context(), self._principal(), 7)
+        assert load_pinned.await_args.kwargs["cap"] == 7
+
+    @pytest.mark.asyncio
     async def test_query_absent_recall_skipped(self):
         import contextlib
 

--- a/backend/tests/services/test_memory_access_event_writer.py
+++ b/backend/tests/services/test_memory_access_event_writer.py
@@ -167,6 +167,29 @@ class TestEmitGate:
         assert kwargs["result_count"] == 3
 
     @pytest.mark.asyncio
+    async def test_query_is_hashed_never_stored_raw(self):
+        # #1281 item 7: emit hashes the raw query with the audit key; the row
+        # writer only ever receives query_hash, never the raw text.
+        recorder = AsyncMock()
+        scope = SimpleNamespace(agent_id=AGENT_ID, enforcement_mode="enforce")
+        with (
+            patch("auth.agent_scope.get_agent_scope", return_value=scope),
+            patch("api.correlation.get_correlation", return_value=None),
+            patch("services.memory_access_event_writer.record_memory_access_event", new=recorder),
+        ):
+            await emit_memory_access_event(
+                operation="recall",
+                outcome="success",
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                query="secret query text",
+            )
+        kwargs = recorder.await_args.kwargs
+        assert "query" not in kwargs  # raw query never forwarded to the row writer
+        assert kwargs["query_hash"] and kwargs["query_hash"] != "secret query text"
+        assert len(kwargs["query_hash"]) == 64  # HMAC-SHA256 hex
+
+    @pytest.mark.asyncio
     async def test_missing_workspace_is_noop(self):
         recorder = AsyncMock()
         scope = SimpleNamespace(agent_id=AGENT_ID, enforcement_mode="enforce")

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1013,6 +1013,68 @@ class TestForget:
         assert response.memory_ids == []
 
 
+class TestGetContextIsolationParamsKeyWorkspaceConfinement:
+    """Issue #963/#1281 item 2: pure API-key workspace-scope confinement on the
+    declared-context path (remember / load_pinned / forget), mirroring the MCP
+    _resolve_context check."""
+
+    @pytest.fixture
+    def service(self):
+        return MemoryService(MagicMock())
+
+    @staticmethod
+    def _ctx(ws_id):
+        c = MagicMock()
+        c.workspace_id = ws_id
+        return c
+
+    @pytest.mark.asyncio
+    async def test_foreign_key_scope_denies_as_not_found(self, service):
+        # Workspace-scoped key (key_ws) declaring a context owned by another
+        # workspace (ctx_ws) the member also belongs to → uniform NotFound.
+        from utils.exceptions import NotFoundException
+
+        key_ws, ctx_ws, ctx_id = uuid4(), uuid4(), uuid4()
+        service.context_service.get_context = AsyncMock(return_value=self._ctx(ctx_ws))
+        with patch(
+            "services.agent_binding_service.agent_binding_permits",
+            new=AsyncMock(return_value=True),
+        ):
+            with pytest.raises(NotFoundException):
+                await service._get_context_isolation_params(
+                    "u", ctx_id, access="write", key_workspace_id=key_ws
+                )
+
+    @pytest.mark.asyncio
+    async def test_matching_key_scope_allows(self, service):
+        ws, ctx_id = uuid4(), uuid4()
+        service.context_service.get_context = AsyncMock(return_value=self._ctx(ws))
+        with patch(
+            "services.agent_binding_service.agent_binding_permits",
+            new=AsyncMock(return_value=True),
+        ):
+            _ctx, ws_str, cid_str = await service._get_context_isolation_params(
+                "u", ctx_id, access="write", key_workspace_id=ws
+            )
+        assert ws_str == str(ws)
+        assert cid_str == str(ctx_id)
+
+    @pytest.mark.asyncio
+    async def test_no_key_scope_skips_confinement(self, service):
+        # OAuth/session/global-key: scope None → a foreign workspace is NOT
+        # confined here (over-confinement guard).
+        ctx_ws, ctx_id = uuid4(), uuid4()
+        service.context_service.get_context = AsyncMock(return_value=self._ctx(ctx_ws))
+        with patch(
+            "services.agent_binding_service.agent_binding_permits",
+            new=AsyncMock(return_value=True),
+        ):
+            _ctx, ws_str, _cid = await service._get_context_isolation_params(
+                "u", ctx_id, key_workspace_id=None
+            )
+        assert ws_str == str(ctx_ws)
+
+
 class TestExploreHints:
     """Test explore_hints generation in recall (Issue #216)."""
 

--- a/backend/tests/test_agent_constants.py
+++ b/backend/tests/test_agent_constants.py
@@ -122,3 +122,16 @@ def test_api_keys_agent_exclusion_check_matches_migration_literal() -> None:
         if getattr(c, "name", None) == "ck_api_keys_agent_public_exclusion"
     )
     assert check.sqltext.text == expected
+
+
+def test_api_keys_agent_requires_workspace_check_matches_migration_literal() -> None:
+    """``ck_api_keys_agent_requires_workspace`` matches the e67 literal (#1281)."""
+    from models.auth import APIKey
+
+    expected = "agent_id IS NULL OR workspace_id IS NOT NULL"
+    check = next(
+        c
+        for c in APIKey.__table_args__
+        if getattr(c, "name", None) == "ck_api_keys_agent_requires_workspace"
+    )
+    assert check.sqltext.text == expected


### PR DESCRIPTION
The tractable, behavior-preserving slice of #1281 (RFC-0002 P0-2/P0-4/P0-5 fast-follow). The design-gated items are split to #1286 per the agreed scope.

## What ships here (8 atomic commits)

- **#963 REST cross-workspace confinement** *(the security core)* — `MemoryService._get_context_isolation_params` authorized the declared context on workspace membership only, not the pure API-key workspace scope the MCP path enforces. A workspace-A-scoped key held by a member of workspace B could pass a foreign `context_id` — and for `remember`, have the row stamped into B. Now threads `key_workspace_id=user["api_key_workspace_id"]` and rejects on mismatch (no-op for OAuth/session/global-key). #1281 item 2.
- **#1277 correlation review fixes** — silence the `correlation_token_dropped` warning on absent baggage (was firing every request); fix the stale middleware-order comment. (PR #1283 Copilot review.)
- **agent_id ⇒ workspace_id CHECK** — migration e67 makes the P0-2 invariant a single-table DB CHECK. #1281 item 4.
- **REST agent-scope reset symmetry** — up-front `set_agent_scope(None)` at the REST auth entries, mirroring the MCP transport. #1281 item 3.
- **get_agent_bootstrap review fixes** — `pinned_cap` now reaches `load_pinned` (was a silent no-op); REST reuses the shared session_id/query validators; MCP maps client-arg errors to 400 vs 404. #1281 item 6 (PR #1282 review).
- **memory_access_events emission** — audit `recall`/`reference`/`remember` chokepoints; `emit` now hashes the raw query (HMAC, audit key) so it's never stored. Filed #1285 for the `kagura.agent.run.id` OTel vendor-attribute gap. #1281 item 7 (partial).
- **analysis binding gate** — the subtractive agent-binding gate on the MCP + REST analysis surfaces, including the run_id-addressed `get_cluster`/`get_analysis` tools (inner-review finding). #1281 item 5.

## Deferred to #1286 (design-gated / deeper)

- Per-memory type/source binding filtering (needs the F1 sign-off re-opened).
- `resolve_agent_correlation` explicit-arg identity-precedence conformance (#1277 Copilot #2 — dormant, fail-secure; a contract-ambiguity, not a live bug).
- Remaining audit emission (`update`/`forget`) + binding **deny-capture** persistence.

## Verification

- ruff clean (full backend); pyright 0 new errors; 215 + focused suites green.
- Adversarial inner review run on the diff — its one real finding (run_id-addressed analysis handlers ungated) is fixed in the final commit.

Closes #1281. Refs #1285, #1286, #1275, #1277, #1278.