### PR TITLE
chore(analysis): hardening batch — error envelopes, pagination, cost (#1247)

### DIFF
--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -50,6 +50,12 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Generic caller-facing message for unexpected errors (#1247). The real
+# detail is logged server-side as ``error_type`` + traceback; the raw
+# exception string — which can carry SQL / driver / BYOK-key internals —
+# is NEVER placed in the MCP error envelope returned to the client.
+_GENERIC_ANALYSIS_ERROR = "An internal error occurred while processing the analysis request."
+
 # Strong-ref set for ``asyncio.create_task`` — without this the task
 # can be GC'd before the loop schedules it. Mirrors the REST-side
 # pattern in ``api/routes/analyses.py`` so MCP and REST kick-offs
@@ -194,9 +200,10 @@ def _gate_error_response(exc: Exception) -> list[TextContent]:
             exc.message,
             **{k: v for k, v in exc.details.items() if v is not None},
         )
-    # Unexpected — log + generic error.
-    logger.error("analysis_mcp_unexpected_error", error=str(exc), exc_info=True)
-    return _error_response("internal_error", str(exc))
+    # Unexpected — log the real detail server-side, return a generic
+    # message so no SQL/driver internals leak into the MCP envelope (#1247).
+    logger.error("analysis_mcp_unexpected_error", error_type=type(exc).__name__, exc_info=True)
+    return _error_response("internal_error", _GENERIC_ANALYSIS_ERROR)
 
 
 def _serialize_run_row(row: Any) -> dict[str, Any]:
@@ -393,11 +400,11 @@ async def handle_analyze_context(
 
         except Exception as e:
             await db.rollback()
-            logger.error("analyze_context_failed", error=str(e), exc_info=True)
+            logger.error("analyze_context_failed", error_type=type(e).__name__, exc_info=True)
             await _log_tool_usage(
                 db, user_id, "analyze_context", start_time, 500, workspace_id=workspace_id
             )
-            return _error_response("analyze_context_error", str(e))
+            return _error_response("analyze_context_error", _GENERIC_ANALYSIS_ERROR)
 
     return _error_response("internal_error", "Database session unavailable")
 
@@ -470,11 +477,11 @@ async def handle_get_analysis(
             return _success_response(**_serialize_run_row(row))
 
         except Exception as e:
-            logger.error("get_analysis_failed", error=str(e), exc_info=True)
+            logger.error("get_analysis_failed", error_type=type(e).__name__, exc_info=True)
             await _log_tool_usage(
                 db, user_id, "get_analysis", start_time, 500, workspace_id=workspace_id
             )
-            return _error_response("get_analysis_error", str(e))
+            return _error_response("get_analysis_error", _GENERIC_ANALYSIS_ERROR)
 
     return _error_response("internal_error", "Database session unavailable")
 
@@ -540,11 +547,11 @@ async def handle_list_analyses(
             )
 
         except Exception as e:
-            logger.error("list_analyses_failed", error=str(e), exc_info=True)
+            logger.error("list_analyses_failed", error_type=type(e).__name__, exc_info=True)
             await _log_tool_usage(
                 db, user_id, "list_analyses", start_time, 500, workspace_id=workspace_id
             )
-            return _error_response("list_analyses_error", str(e))
+            return _error_response("list_analyses_error", _GENERIC_ANALYSIS_ERROR)
 
     return _error_response("internal_error", "Database session unavailable")
 
@@ -619,7 +626,7 @@ async def handle_get_active_analysis(
             return _success_response(**_serialize_run_row(row))
 
         except Exception as e:
-            logger.error("get_active_analysis_failed", error=str(e), exc_info=True)
+            logger.error("get_active_analysis_failed", error_type=type(e).__name__, exc_info=True)
             await _log_tool_usage(
                 db,
                 user_id,
@@ -628,7 +635,7 @@ async def handle_get_active_analysis(
                 500,
                 workspace_id=workspace_id,
             )
-            return _error_response("get_active_analysis_error", str(e))
+            return _error_response("get_active_analysis_error", _GENERIC_ANALYSIS_ERROR)
 
     return _error_response("internal_error", "Database session unavailable")
 
@@ -743,10 +750,10 @@ async def handle_get_cluster(
             return _success_response(**cluster)
 
         except Exception as e:
-            logger.error("get_cluster_failed", error=str(e), exc_info=True)
+            logger.error("get_cluster_failed", error_type=type(e).__name__, exc_info=True)
             await _log_tool_usage(
                 db, user_id, "get_cluster", start_time, 500, workspace_id=workspace_id
             )
-            return _error_response("get_cluster_error", str(e))
+            return _error_response("get_cluster_error", _GENERIC_ANALYSIS_ERROR)
 
     return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -269,6 +269,18 @@ async def _label_one_cluster(
         label_confidence = 0.0
 
     breakdown = accumulate_llm_response(None, result.response)
+    # #1247: fold in paid tokens burned by any earlier fallback-chain
+    # attempts that failed (e.g. a model whose output failed to parse) so
+    # cost_actual_cents reflects EVERY billed call, not just the winner.
+    # Keyed by the winning (provider, model); the reporter aggregates all
+    # cluster breakdowns under the run's frozen rate, so summing tokens
+    # here is what the cost ledger needs.
+    for prior in result.prior_usages:
+        breakdown.add_call(
+            input_tokens=prior.input_tokens,
+            output_tokens=prior.output_tokens,
+            cached_input_tokens=prior.cached_input_tokens,
+        )
 
     return ClusterLabel(
         cluster_index=cluster_index,

--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -36,6 +36,28 @@ its own session via ``_get_session_factory()``. SQLAlchemy 2.x
 session, and ``LLMService.complete_json`` performs a DB lookup
 (``_get_user_api_key`` resolving the BYOK key) inside its coroutine
 frame.
+
+**#1247 pooled-connection hold — WAIVED (documented rationale).** The
+per-task session's pooled connection stays borrowed across the LLM HTTP
+round-trip, so at ``Semaphore(8)`` up to 8 of the pool's 15 connections
+(``pool_size=5 + max_overflow=10``) are held for the duration of the
+labeling call. Releasing the connection before the HTTP call is NOT
+safely achievable within the analysis subsystem: the ONLY DB access in
+this coroutine is the BYOK key SELECT, and it happens *inside* the shared
+``LLMService.complete_json`` (via ``_get_provider`` → ``_get_user_api_key``),
+which couples that read to the HTTP call with no public seam to split
+them; and ``_label_one_cluster`` itself performs NO post-call DB write
+(persistence happens later in ``reporter`` on the orchestrator's shared
+session), so the "read → release → HTTP → re-acquire to persist" shape
+does not apply here. A correct fix requires either refactoring the
+cross-cutting ``LLMService`` (out of scope — it also serves the sleep
+subsystem) to expose pre-resolved-key / connection-releasing call paths,
+or reimplementing its provider-call + retry/JSON-parse/usage logic inside
+this module (risky duplication for a low-severity finding). The hold is
+bounded: at most 8 concurrent borrows (< 15-connection capacity), each
+lasting one labeling call (seconds, ``max_tokens=1024``), not the whole
+run. Tracked with the v1.5 ``LLMService`` ``fallback_chain`` work already
+noted in ``llm_caller.py``.
 """
 
 from __future__ import annotations
@@ -223,6 +245,12 @@ async def _label_one_cluster(
         # so concurrent BYOK lookups don't race the orchestrator's
         # shared session. The connection pool (size=5 + max_overflow=10)
         # comfortably absorbs 8 concurrent borrowed connections.
+        #
+        # #1247 (WAIVED): this connection stays borrowed across the LLM
+        # HTTP call. Releasing it first is not safely in-scope here — the
+        # BYOK read lives inside the shared LLMService.complete_json and
+        # there is no post-call DB write to re-acquire for. Full rationale
+        # in the module docstring ("#1247 pooled-connection hold").
         session_factory = _get_session_factory()
         async with session_factory() as task_session:
             task_llm_service = LLMService(task_session)

--- a/backend/src/services/analysis/llm_caller.py
+++ b/backend/src/services/analysis/llm_caller.py
@@ -94,10 +94,37 @@ class CallResult:
     actually produced the response — the labeler uses this to write
     one ``LLMCallBreakdown`` per (provider, model) pair into
     ``sleep_report_llm_usage``.
+
+    ``prior_usages`` (#1247) carries the token usage of any EARLIER
+    fallback-chain attempts that failed but still burned paid tokens
+    (e.g. a model that returned unparseable JSON on both its internal
+    tries). The labeler folds these into the cost breakdown so
+    ``cost_actual_cents`` reflects every billed call, not just the
+    winning response — otherwise a run that fell through to the fallback
+    model under-reports by up to one full model's spend per cluster.
     """
 
     parsed: dict[str, Any]
     response: LLMResponse
+    prior_usages: tuple[LLMResponse, ...] = ()
+
+
+def _billed_usage_from_error(exc: LLMServiceError) -> LLMResponse | None:
+    """Return the billed token usage of a failed LLM attempt, if any.
+
+    A fallback-chain attempt can fail *after* the provider round-trip
+    completed and consumed paid tokens (e.g. the model returned
+    unparseable JSON on both internal tries). When the raised
+    ``LLMServiceError`` carries the usage of that completed call via a
+    ``response`` attribute (an ``LLMResponse``), we surface it so the
+    caller can bill it. Returns ``None`` when the attempt spent no
+    billable tokens (a transport error before any completion) or when the
+    error does not expose usage — accumulation then simply skips it.
+    """
+    candidate = getattr(exc, "response", None)
+    if isinstance(candidate, LLMResponse):
+        return candidate
+    return None
 
 
 async def call_with_fallback(
@@ -145,6 +172,9 @@ async def call_with_fallback(
             'attempted_models': [...]}``.
     """
     last_error: LLMServiceError | None = None
+    # #1247: token usage of failed-but-billed earlier attempts, folded into
+    # the cost breakdown by the labeler so paid tokens are never dropped.
+    prior_usages: list[LLMResponse] = []
     for model in fallback_chain:
         try:
             response = await llm_service.complete_json(
@@ -164,7 +194,11 @@ async def call_with_fallback(
                 # OPENAI_API_KEY env credential.
                 disallow_env_fallback=True,
             )
-            return CallResult(parsed=response.parsed, response=response)
+            return CallResult(
+                parsed=response.parsed,
+                response=response,
+                prior_usages=tuple(prior_usages),
+            )
         except LLMServiceError as e:
             logger.warning(
                 "analysis_llm_call_failed",
@@ -172,6 +206,13 @@ async def call_with_fallback(
                 error=str(e),
             )
             last_error = e
+            # #1247: a failed attempt may still have consumed paid tokens
+            # (the provider call completed but its output failed to parse).
+            # Capture that usage when the error exposes it so cost
+            # accounting sums ALL billed calls, not just the winner.
+            billed = _billed_usage_from_error(e)
+            if billed is not None:
+                prior_usages.append(billed)
 
     raise AnalysisLLMUpstreamError(
         message=(

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -235,10 +235,12 @@ def _decode_list_cursor(cursor: str) -> tuple[datetime | None, UUID | None]:
     identical ``started_at``, so no row straddling a page boundary is
     skipped. ``started_at`` is normalized to naive UTC (repo convention).
 
-    Back-compat: a legacy cursor (bare ISO ``started_at``, pre-#1247)
-    decodes with ``id=None`` so tokens issued before this change still
-    page (the caller falls back to the strict ``started_at`` predicate).
-    Returns ``(None, None)`` when the token is unparseable.
+    Back-compat: a legacy cursor (bare ISO ``started_at``, pre-#1247, no
+    ``|`` separator) decodes with ``id=None`` so tokens issued before this
+    change still page (the caller falls back to the strict ``started_at``
+    predicate). Returns ``(None, None)`` when the token is unparseable —
+    including a compound cursor whose ``|`` separator is present but whose
+    UUID tail is malformed (a corrupt/tampered token, NOT a legacy one).
     """
     # ``to_utc_iso`` never emits ``|`` and a UUID never contains one, so
     # splitting on the LAST ``|`` cleanly separates the two components.
@@ -254,11 +256,16 @@ def _decode_list_cursor(cursor: str) -> tuple[datetime | None, UUID | None]:
         cursor_dt = cursor_dt.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
 
     cursor_id: UUID | None = None
-    if id_str:
+    if sep:
+        # A compound cursor MUST carry a valid UUID tail. A malformed
+        # suffix means a corrupt/tampered token — flag the whole cursor
+        # invalid (same as an unparseable datetime) rather than silently
+        # downgrading to the started_at-only predicate, which would
+        # reintroduce boundary-skipped rows for tied ``started_at`` values.
         try:
             cursor_id = UUID(id_str)
         except ValueError:
-            cursor_id = None
+            return None, None
     return cursor_dt, cursor_id
 
 

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -33,7 +33,7 @@ from typing import Any
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.analysis import (
@@ -227,6 +227,41 @@ async def get_analysis(
     return (await db.execute(stmt)).scalar_one_or_none()
 
 
+def _decode_list_cursor(cursor: str) -> tuple[datetime | None, UUID | None]:
+    """Decode a ``list_analyses`` keyset cursor into ``(started_at, id)``.
+
+    The compound cursor (#1247) is ``"<started_at_iso>|<run_id>"`` — the
+    ``id`` tiebreaker makes the keyset stable when several runs share an
+    identical ``started_at``, so no row straddling a page boundary is
+    skipped. ``started_at`` is normalized to naive UTC (repo convention).
+
+    Back-compat: a legacy cursor (bare ISO ``started_at``, pre-#1247)
+    decodes with ``id=None`` so tokens issued before this change still
+    page (the caller falls back to the strict ``started_at`` predicate).
+    Returns ``(None, None)`` when the token is unparseable.
+    """
+    # ``to_utc_iso`` never emits ``|`` and a UUID never contains one, so
+    # splitting on the LAST ``|`` cleanly separates the two components.
+    head, sep, tail = cursor.rpartition("|")
+    dt_str = head if sep else cursor
+    id_str = tail if sep else ""
+
+    try:
+        cursor_dt = datetime.fromisoformat(dt_str)
+    except ValueError:
+        return None, None
+    if cursor_dt.tzinfo is not None:
+        cursor_dt = cursor_dt.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+
+    cursor_id: UUID | None = None
+    if id_str:
+        try:
+            cursor_id = UUID(id_str)
+        except ValueError:
+            cursor_id = None
+    return cursor_dt, cursor_id
+
+
 async def list_analyses(
     db: AsyncSession,
     *,
@@ -237,11 +272,17 @@ async def list_analyses(
 ) -> tuple[list[MemoryAnalysis], str | None]:
     """List runs for a context, newest first, with cursor pagination.
 
-    Cursor is the ``started_at`` ISO-8601 of the last item on the
-    previous page. Newer runs that arrive between requests appear at
-    the top of page 1; the cursor walks backward in time so missing
-    them on a subsequent page is intentional (poll page 1 for the
-    freshest list).
+    Cursor is the compound ``"<started_at_iso>|<run_id>"`` of the last
+    item on the previous page (#1247). ``started_at`` alone is NOT unique
+    — several runs (e.g. a burst of scheduled analyses) can share the
+    same second — so a strict ``started_at`` cursor would silently skip
+    runs that straddle a page boundary. Ordering and the cursor predicate
+    are therefore a compound key ``(started_at, id)`` DESC.
+
+    Newer runs that arrive between requests appear at the top of page 1;
+    the cursor walks backward through ``(started_at, id)`` so missing them
+    on a subsequent page is intentional (poll page 1 for the freshest
+    list).
     """
     page_size = _clamp_limit(limit, DEFAULT_LIST_PAGE_SIZE, MAX_LIST_PAGE_SIZE)
 
@@ -250,22 +291,31 @@ async def list_analyses(
         MemoryAnalysis.context_id == context_id,
     ]
     if cursor:
-        try:
-            cursor_dt = datetime.fromisoformat(cursor)
-        except ValueError:
+        cursor_dt, cursor_id = _decode_list_cursor(cursor)
+        if cursor_dt is None:
             logger.warning("list_analyses_invalid_cursor", cursor=cursor)
-        else:
-            # Keyset pagination on started_at DESC — strict less-than
-            # so the cursor row itself is not duplicated on the next
-            # page. ``started_at`` is naive UTC by repo convention.
-            if cursor_dt.tzinfo is not None:
-                cursor_dt = cursor_dt.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+        elif cursor_id is None:
+            # Legacy started_at-only cursor (pre-#1247): strict less-than
+            # so the cursor row itself is not duplicated on the next page.
             conditions.append(MemoryAnalysis.started_at < cursor_dt)
+        else:
+            # Compound keyset on (started_at, id) DESC: everything strictly
+            # "older" than the cursor tuple. The id tiebreaker keeps runs
+            # sharing ``cursor_dt`` from being skipped across the boundary.
+            conditions.append(
+                or_(
+                    MemoryAnalysis.started_at < cursor_dt,
+                    and_(
+                        MemoryAnalysis.started_at == cursor_dt,
+                        MemoryAnalysis.id < cursor_id,
+                    ),
+                )
+            )
 
     stmt = (
         select(MemoryAnalysis)
         .where(and_(*conditions))
-        .order_by(MemoryAnalysis.started_at.desc())
+        .order_by(MemoryAnalysis.started_at.desc(), MemoryAnalysis.id.desc())
         .limit(page_size + 1)  # peek-one to detect last page
     )
     rows = list((await db.execute(stmt)).scalars().all())
@@ -273,13 +323,14 @@ async def list_analyses(
     next_cursor: str | None = None
     if len(rows) > page_size:
         rows = rows[:page_size]
-        # Cursor for next page is the started_at of the LAST row we
-        # returned, formatted with the project's standard ``Z`` suffix
-        # so JS clients that round-trip the cursor through their own
+        # Cursor for next page is the compound (started_at, id) of the LAST
+        # row we returned. ``started_at`` uses the project's standard ``Z``
+        # suffix so JS clients that round-trip the cursor through their own
         # parser don't drop the timezone info (#489 wire-format rule).
         from utils.datetime import to_utc_iso
 
-        next_cursor = to_utc_iso(rows[-1].started_at)
+        last = rows[-1]
+        next_cursor = f"{to_utc_iso(last.started_at)}|{last.id}"
 
     return rows, next_cursor
 

--- a/backend/tests/mcp_server/test_analysis_error_envelope.py
+++ b/backend/tests/mcp_server/test_analysis_error_envelope.py
@@ -1,0 +1,108 @@
+"""#1247: MCP analysis error envelopes must not leak raw exception text.
+
+Unexpected exceptions inside the analysis MCP handlers used to place
+``str(e)`` — which can carry SQL / driver / BYOK-key internals — directly
+into the error envelope returned to the caller. These tests pin the
+hardened behavior: the envelope message is a fixed generic string and the
+sensitive marker planted in the raised exception never reaches the caller.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.analysis import (
+    _GENERIC_ANALYSIS_ERROR,
+    handle_get_analysis,
+)
+
+# A marker string standing in for the kind of raw driver/SQL/credential
+# detail an unexpected exception can carry. It must never surface in the
+# caller-facing envelope.
+_SECRET_MARKER = 'relation "memory_analyses" does not exist; password=SUPERSECRET host=10.0.0.5'
+
+
+def _fake_get_db(db_mock):
+    """Async-generator factory standing in for ``db.base.get_db``."""
+
+    async def _gen():
+        yield db_mock
+
+    return _gen
+
+
+def _envelope(result) -> dict:
+    assert result, "handler returned an empty response list"
+    return json.loads(result[0].text)
+
+
+@pytest.fixture
+def db_mock():
+    m = MagicMock()
+    m.execute = AsyncMock()
+    m.commit = AsyncMock()
+    m.rollback = AsyncMock()
+    return m
+
+
+@pytest.mark.asyncio
+async def test_unexpected_service_error_envelope_is_generic(db_mock):
+    """A service raising an exception must yield a generic envelope, never
+    the raw exception text."""
+    with (
+        patch("db.base.get_db", _fake_get_db(db_mock)),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_access_mcp",
+            AsyncMock(return_value="UTC"),
+        ),
+        patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(side_effect=RuntimeError(_SECRET_MARKER)),
+        ),
+        patch("mcp_server.tools.analysis._log_tool_usage", AsyncMock()),
+    ):
+        result = await handle_get_analysis(
+            {"run_id": str(uuid4())},
+            "u1",
+            uuid4(),
+        )
+
+    body = _envelope(result)
+    assert body["status"] == "error"
+    assert body["error"] == "get_analysis_error"
+    assert body["message"] == _GENERIC_ANALYSIS_ERROR
+    # The raw exception detail (and its sensitive fragments) must be absent.
+    serialized = json.dumps(body)
+    assert "SUPERSECRET" not in serialized
+    assert "password=" not in serialized
+    assert "10.0.0.5" not in serialized
+    assert "memory_analyses" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_gate_unexpected_error_envelope_is_generic(db_mock):
+    """An unmapped exception from the gate chain routes through
+    ``_gate_error_response`` and must also produce the generic envelope."""
+    with (
+        patch("db.base.get_db", _fake_get_db(db_mock)),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_access_mcp",
+            AsyncMock(side_effect=RuntimeError(_SECRET_MARKER)),
+        ),
+        patch("mcp_server.tools.analysis._log_tool_usage", AsyncMock()),
+    ):
+        result = await handle_get_analysis(
+            {"run_id": str(uuid4())},
+            "u1",
+            uuid4(),
+        )
+
+    body = _envelope(result)
+    assert body["status"] == "error"
+    assert body["error"] == "internal_error"
+    assert body["message"] == _GENERIC_ANALYSIS_ERROR
+    assert "SUPERSECRET" not in json.dumps(body)

--- a/backend/tests/services/analysis/test_labeler_coverage.py
+++ b/backend/tests/services/analysis/test_labeler_coverage.py
@@ -336,6 +336,46 @@ class TestLabelOneCluster:
         assert captured["user_id"] == "u1"
         assert captured["context_id"] == "c1"
 
+    async def test_breakdown_includes_failed_attempt_tokens(self, monkeypatch) -> None:
+        """#1247: paid tokens from a failed fallback attempt are folded into
+        the cluster's cost breakdown (recorded cost reflects BOTH calls)."""
+        import asyncio
+
+        winner = _llm_response(parsed={"label": "L", "label_confidence": 0.5})
+        failed_usage = LLMResponse(
+            parsed={},
+            total_tokens=90,
+            input_tokens=60,
+            output_tokens=30,
+            cached_input_tokens=0,
+            provider="openai",
+            model="gpt-5-nano",
+        )
+
+        async def _fake(**_kwargs):  # noqa: ANN003
+            return CallResult(
+                parsed=winner.parsed,
+                response=winner,
+                prior_usages=(failed_usage,),
+            )
+
+        monkeypatch.setattr(labeler, "call_with_fallback", _fake)
+
+        cl = await _label_one_cluster(
+            cluster_index=0,
+            reps=[_mem()],
+            user_id="u",
+            workspace_id="w",
+            context_id=None,
+            sem=asyncio.Semaphore(1),
+        )
+
+        assert cl.breakdown is not None
+        # winner (_llm_response) is 20 in / 10 out; failed attempt adds 60 / 30.
+        assert cl.breakdown.calls == 2
+        assert cl.breakdown.input_tokens == 20 + 60
+        assert cl.breakdown.output_tokens == 10 + 30
+
     async def test_confidence_clamped_above_one(self, monkeypatch) -> None:
         """A confidence > 1 is clamped to 1.0."""
         import asyncio

--- a/backend/tests/services/analysis/test_llm_caller.py
+++ b/backend/tests/services/analysis/test_llm_caller.py
@@ -142,6 +142,88 @@ async def test_502_wrapping_after_chain_exhausted() -> None:
     assert "All fallback models exhausted" in str(err)
 
 
+@pytest.mark.asyncio
+async def test_failed_attempt_billed_tokens_are_accumulated() -> None:
+    """#1247: a failed fallback attempt that still burned paid tokens must
+    have its usage carried forward so cost reflects BOTH calls.
+
+    The primary model fails *after* the provider round-trip completed
+    (unparseable JSON on both internal tries) — the ``LLMServiceError``
+    carries that call's usage via ``response``. The fallback model then
+    succeeds. The returned ``CallResult`` exposes the failed usage in
+    ``prior_usages``, and the labeler's breakdown accumulation sums both.
+    """
+    failed_usage = LLMResponse(
+        parsed={},
+        total_tokens=90,
+        input_tokens=60,
+        output_tokens=30,
+        cached_input_tokens=0,
+        provider="openai",
+        model="gpt-5-nano",
+    )
+    primary_error = LLMServiceError("nano returned unparseable json twice")
+    # Real ``LLMServiceError`` is a plain Exception; the caller reads an
+    # optional ``response`` carrying the billed usage of the failed call.
+    primary_error.response = failed_usage  # type: ignore[attr-defined]
+
+    llm_service = AsyncMock()
+    llm_service.complete_json = AsyncMock(side_effect=[primary_error, _ok_response("gpt-5.5")])
+
+    result = await call_with_fallback(
+        llm_service,
+        user_id="u1",
+        workspace_id="w1",
+        context_id=None,
+        system_prompt="sys",
+        prompt="p",
+    )
+
+    # Winner is the fallback model; the failed attempt's usage is preserved.
+    assert result.response.model == "gpt-5.5"
+    assert len(result.prior_usages) == 1
+    assert result.prior_usages[0].input_tokens == 60
+    assert result.prior_usages[0].output_tokens == 30
+
+    # The recorded cost breakdown (the same accumulation the labeler does)
+    # must reflect BOTH calls, not just the winning response.
+    from services.sleep.reporter import accumulate_llm_response
+
+    breakdown = accumulate_llm_response(None, result.response)
+    for prior in result.prior_usages:
+        breakdown.add_call(
+            input_tokens=prior.input_tokens,
+            output_tokens=prior.output_tokens,
+            cached_input_tokens=prior.cached_input_tokens,
+        )
+    assert breakdown.calls == 2
+    # winner (_ok_response) is 80 in / 40 out; failed attempt adds 60 / 30.
+    assert breakdown.input_tokens == 80 + 60
+    assert breakdown.output_tokens == 40 + 30
+
+
+@pytest.mark.asyncio
+async def test_failed_attempt_without_usage_is_skipped() -> None:
+    """A failed attempt that exposes no usage (transport error before any
+    completion) contributes nothing — prior_usages stays empty."""
+    llm_service = AsyncMock()
+    llm_service.complete_json = AsyncMock(
+        side_effect=[LLMServiceError("connection refused"), _ok_response("gpt-5.5")]
+    )
+
+    result = await call_with_fallback(
+        llm_service,
+        user_id="u1",
+        workspace_id="w1",
+        context_id=None,
+        system_prompt="sys",
+        prompt="p",
+    )
+
+    assert result.response.model == "gpt-5.5"
+    assert result.prior_usages == ()
+
+
 def test_filter_hallucinated_ids_drops_non_members() -> None:
     """The frozenset guard returns only members, preserving input order."""
     requested = frozenset({"id-1", "id-2", "id-3"})

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -350,6 +350,29 @@ async def test_list_analyses_legacy_started_at_only_cursor_still_pages(
     assert page2[0].started_at < page1[-1].started_at
 
 
+def test_decode_list_cursor_malformed_uuid_tail_is_invalid():
+    """#1247 (Copilot): a compound cursor whose ``|`` separator is present
+    but whose UUID tail is malformed is a corrupt/tampered token — it must
+    decode to ``(None, None)`` (invalid), NOT silently downgrade to the
+    started_at-only predicate, which would reintroduce boundary-skipped
+    rows for tied ``started_at`` values."""
+    from services.analysis.query_service import _decode_list_cursor
+
+    # Valid datetime + garbage UUID suffix → whole cursor invalid.
+    assert _decode_list_cursor("2026-07-15T01:00:00|not-a-uuid") == (None, None)
+    # Trailing separator with empty UUID tail is likewise malformed.
+    assert _decode_list_cursor("2026-07-15T01:00:00|") == (None, None)
+
+    # Contrast: a legacy bare-ISO cursor (no separator) stays a valid
+    # started_at-only cursor (id=None) — back-compat preserved.
+    dt, cid = _decode_list_cursor("2026-07-15T01:00:00")
+    assert dt is not None and cid is None
+    # And a well-formed compound cursor decodes both components.
+    good_id = uuid4()
+    dt, cid = _decode_list_cursor(f"2026-07-15T01:00:00|{good_id}")
+    assert dt is not None and cid == good_id
+
+
 @pytest.mark.asyncio
 async def test_get_active_analysis_returns_most_recent_succeeded(
     db_session, fixture_workspace_id, fixture_context_id, fixture_pricing

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -99,9 +99,15 @@ async def _make_run(
     pricing,
     status: str = "succeeded",
     started_offset_minutes: int = 0,
+    started_at: datetime | None = None,
 ) -> MemoryAnalysis:
-    """Insert a MemoryAnalysis row with reasonable defaults."""
-    started_at = utcnow() - timedelta(minutes=started_offset_minutes)
+    """Insert a MemoryAnalysis row with reasonable defaults.
+
+    ``started_at`` overrides the offset-derived timestamp so tests can
+    pin several rows to an identical instant (keyset-tiebreaker cases).
+    """
+    if started_at is None:
+        started_at = utcnow() - timedelta(minutes=started_offset_minutes)
     finished_at = (started_at + timedelta(seconds=10)) if status != "running" else None
     run = MemoryAnalysis(
         id=uuid4(),
@@ -246,6 +252,102 @@ async def test_list_analyses_newest_first_with_cursor_pagination(
     page1_ids = {r.id for r in page1}
     page2_ids = {r.id for r in page2}
     assert page1_ids.isdisjoint(page2_ids)
+
+
+@pytest.mark.asyncio
+async def test_list_analyses_identical_started_at_no_skip(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1247: runs sharing an identical ``started_at`` must not be skipped
+    across a page boundary.
+
+    With a strict ``started_at``-only cursor, page 2's ``started_at <
+    cursor`` predicate excludes every row that shares the boundary
+    timestamp, silently dropping runs. The compound ``(started_at, id)``
+    keyset keeps them all reachable.
+    """
+    shared_ts = utcnow().replace(microsecond=0) - timedelta(minutes=5)
+    runs = []
+    for _ in range(4):
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+            started_at=shared_ts,
+        )
+        runs.append(run)
+    all_ids = {r.id for r in runs}
+
+    # Page 1 (limit=2): 2 of the 4 identical-timestamp runs.
+    page1, cursor = await query_service.list_analyses(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        limit=2,
+    )
+    assert len(page1) == 2
+    assert cursor is not None
+    # Compound cursor carries both the timestamp and the id tiebreaker.
+    assert "|" in cursor
+
+    # Page 2: the REMAINING 2 runs — none skipped despite equal started_at.
+    page2, cursor2 = await query_service.list_analyses(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        limit=2,
+        cursor=cursor,
+    )
+    assert len(page2) == 2
+    assert cursor2 is None  # last page
+
+    page1_ids = {r.id for r in page1}
+    page2_ids = {r.id for r in page2}
+    assert page1_ids.isdisjoint(page2_ids)
+    # All four runs appear exactly once across the two pages (no skip).
+    assert page1_ids | page2_ids == all_ids
+
+
+@pytest.mark.asyncio
+async def test_list_analyses_legacy_started_at_only_cursor_still_pages(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """Back-compat: a pre-#1247 cursor (bare ISO ``started_at``, no id)
+    still advances the page instead of erroring."""
+    from utils.datetime import to_utc_iso
+
+    for offset in (60, 30, 10):
+        await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+            started_offset_minutes=offset,
+        )
+
+    page1, _ = await query_service.list_analyses(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        limit=2,
+    )
+    # Simulate an in-flight legacy cursor: the started_at of the last row,
+    # WITHOUT the ``|<id>`` tiebreaker suffix.
+    legacy_cursor = to_utc_iso(page1[-1].started_at)
+    assert "|" not in legacy_cursor
+
+    page2, _ = await query_service.list_analyses(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        limit=2,
+        cursor=legacy_cursor,
+    )
+    # The oldest run (60 min ago) is strictly older than page1's boundary
+    # timestamp, so the legacy cursor still returns it.
+    assert len(page2) == 1
+    assert page2[0].started_at < page1[-1].started_at
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The four low-severity Memory Analysis hardening items from #1247, batched as one PR (each an atomic commit). Three implemented, one waived with a documented rationale (the issue explicitly allowed waivers).

## Implemented

- **MCP error envelopes no longer leak `str(e)`** — all 6 caller-facing sites in `mcp_server/tools/analysis.py` (5 handlers + the `_gate_error_response` unexpected branch) now return a shared generic message; logs switched to `error_type=type(e).__name__` (+ `exc_info` server-side). Closes the SQL/driver/BYOK-internal disclosure to same-tenant callers. Test plants a sensitive marker in a raised exception and asserts it never reaches the envelope.
- **`list_analyses` keyset pagination id tiebreaker** — sort/page on the compound key `(started_at, id) DESC` so rows with identical `started_at` no longer straddle a page boundary and get skipped. Cursor token is now `"<started_at_iso>|<run_id>"`, with a back-compat path decoding legacy bare-ISO cursors (id=None → strict `started_at` fallback) so in-flight tokens keep paging.
- **Failed LLM attempts' billed tokens accumulated** — `call_with_fallback` carries each failed-but-billed attempt's usage via `CallResult.prior_usages`; the labeler folds them into the cost breakdown so `cost_actual_cents` / the #472 ledger bill every paid call, not just the winner.

## Waived (documented in code)

- **Labeler pooled-connection hold across the LLM HTTP call** — releasing the session first is not safely achievable within the analysis subsystem: the only DB access in `_label_one_cluster` (the BYOK key SELECT) happens *inside* `LLMService.complete_json` with no public pre-resolved-key seam, and there is no post-call DB write to re-acquire for. A real fix needs an `LLMService` refactor (out of scope — it also serves the sleep subsystem). The hold is bounded (≤8 of 15 pool connections, seconds per call). Rationale written into `labeler.py`.

## Note

- The cost-accumulation plumbing is correct and forward-compatible, but current-prod `LLMServiceError` does not yet attach usage to the raised error, so the failed-model tokens are captured only once `LLMService.complete_json` populates that (a one-line change in `llm_service.py`, outside this subsystem — left as a noted follow-up).

313 analysis/labeler/llm/query tests green; ruff clean. Closes #1247.