### PR TITLE
docs: sync documentation with v0.49.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://github.com/kagura-ai/memory-cloud/blob/dev/README.md
+    url: https://github.com/kagura-ai/memory-cloud/blob/main/README.md
     about: Check the documentation before opening an issue
   - name: Discussions
     url: https://github.com/kagura-ai/memory-cloud/discussions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,40 @@
 # Changelog
 
-Release notes are published on [GitHub Releases](https://github.com/kagura-ai/memory-cloud/releases).
+Release notes are published on [GitHub Releases](https://github.com/kagura-ai/memory-cloud/releases),
+which is the canonical source for the complete release history. This file highlights the current
+release train and preserves selected historical development notes.
 
 ## [Unreleased]
+
+## [v0.49.0](https://github.com/kagura-ai/memory-cloud/releases/tag/v0.49.0) — 2026-07-15
+
+### Added
+- **Agent Registry** ([#1274](https://github.com/kagura-ai/memory-cloud/issues/1274)): workspace-scoped agent identities and lifecycle APIs/MCP tools.
+- **Agent↔context bindings and agent-bound API keys** ([#1275](https://github.com/kagura-ai/memory-cloud/issues/1275)): subtractive context access policy for agent credentials.
+- **Agent bootstrap** ([#1276](https://github.com/kagura-ai/memory-cloud/issues/1276)): `get_agent_bootstrap` returns the effective context envelope for an agent.
+- **Agent correlation** ([#1277](https://github.com/kagura-ai/memory-cloud/issues/1277)): W3C `traceparent`/baggage parsing on REST and MCP, verified identity precedence, and correlated bootstrap envelopes. Correlation is observability only; server-side OTel span export remains a P1 non-goal.
+- **Agent memory audit** ([#1278](https://github.com/kagura-ai/memory-cloud/issues/1278)): append-only, trigger-enforced `memory_access_events` storage with a fail-open independent writer, HMAC-keyed query hashes, erasure handling, and emission for bootstrap, load-pinned, feedback, recall, reference, and remember operations.
+
+### Changed
+- **Agent control-plane hardening** ([#1281](https://github.com/kagura-ai/memory-cloud/issues/1281)): confined REST memory calls to the API key's workspace, added the agent-key workspace database invariant, reset REST agent scope defensively, fixed bootstrap cap/validation/error mapping, and applied subtractive agent bindings to analysis surfaces.
+- **Memory Analysis hardening** ([#1247](https://github.com/kagura-ai/memory-cloud/issues/1247)): generic MCP error envelopes, stable `(started_at, id)` keyset pagination, and accounting for failed-but-billed LLM attempts. The connection-pool item was explicitly waived pending a broader `LLMService` refactor.
+
+### Notes
+- This is an additive release with no breaking REST or MCP changes. Agent enforcement remains opt-in and defaults to `shadow`.
+- Per-memory type/source binding filters remain fail-closed and accept only `null`. Audit emission for `update`/`forget`, binding deny/`would_deny` persistence, and identity-precedence contract follow-ups continue in [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286).
+
+## [v0.48.0](https://github.com/kagura-ai/memory-cloud/releases/tag/v0.48.0) — 2026-07-14
+
+### Changed
+- REST and MCP batch resource ingestion now share `ResourceIngestService`, including identical UTF-8 byte-size accounting and validation behavior ([#1255](https://github.com/kagura-ai/memory-cloud/issues/1255)).
+- Added implementation-ready Agent Memory & Context Control Plane design, operations, and evaluation documents ([#1258](https://github.com/kagura-ai/memory-cloud/issues/1258)–[#1264](https://github.com/kagura-ai/memory-cloud/issues/1264)). These documents define the v0.49.0 delivery plan; they did not by themselves ship the control plane.
+
+## [v0.47.0](https://github.com/kagura-ai/memory-cloud/releases/tag/v0.47.0) — 2026-07-14
+
+### Fixed
+- Hardened memory analysis runs with a configurable memory-count cap (`ANALYSIS_MAX_MEMORY_COUNT`, default 10,000), failure when more than half of cluster-label calls fail, all-or-nothing cancellation, strict BYOK enforcement, soft-deleted-context invisibility, and race-safe run creation/assignment handling ([milestone](https://github.com/kagura-ai/memory-cloud/milestone/78)).
+
+## Historical development notes (pre-v0.16.0)
 
 ### Added
 - **Embedded LanceDB vector backend — "Kagura Lite" (preview)**: a feature-flagged, in-process vector store for single-process self-hosted / CLI / desktop / edge deployments that want to avoid running a separate Qdrant server. Set `KAGURA_VECTOR_BACKEND=lance` (default `qdrant` is unchanged — the new path is a single `is None` branch in `db/qdrant.py`, zero behavior change for the server). New `db/vector_store.py` introduces a `VectorStore` Protocol + cached backend selector; `db/lance_store.py` implements `LanceVectorStore`. Japanese stays owned by the existing Sudachi pipeline (lemmas + readings + synonym/hiragana augmentation) feeding a weighted `search_text` FTS column, so recall behavior matches the Qdrant path without relying on LanceDB's native CJK tokenizer; hybrid 60/40 fusion stays in `services/search_service.py`. Isolation is a single-quote-escaped, UUID-validated SQL pre-filter (`build_lance_filter`). LanceDB is an **optional** dependency (`pip install '.[lite]'`) — the default install is unchanged. **Preview limitations**: `copy_context_points`, cross-collection GDPR `delete_user_points`, and the admin BM25-drift scroll raise `NotImplementedError` under this backend; the server (multi-process + nightly Sleep writer) deployment should stay on Qdrant since LanceDB writes are single-process. Unit-tested: backend selector + the security-critical filter/escaping builder (LanceDB-independent). **Post-merge hardening (max code-review follow-up):** semantic search now sets `.metric("cosine")` explicitly (LanceDB defaulted to L2 → wrong/negative similarity scores that broke confidence/absence detection); all writes serialized under the store lock (LanceDB is single-writer even in-process); embedding dimension tracked per-collection (multi-model variants no longer collide); date-range filters normalized to canonical UTC (offset-aware, validated); FTS + scalar indexes rebuilt lazily after the first write; importance-range consistency validated (4xx parity with Qdrant); reads/deletes on a not-yet-created collection return empty instead of erroring.

--- a/README.ja.md
+++ b/README.ja.md
@@ -61,7 +61,8 @@
 | **AI Reranking** | セルフホスト (Ollama/vLLM — ローカル・無料)、Voyage AI、Cohere — cross-encoder reranker で精度向上 |
 | **Neural Memory Graph** | Hebbian 学習がバックグラウンドで知識グラフを構築。`explore()` がそれを辿り偶発的発見を提供 |
 | **Agent Memory Substrate** | 単なる知識ストアを超えて — delivery mode (pin / 時刻トリガ)、サーバー署名の trust boundary、agent state レーン、retrieval feedback シグナル。自律エージェントのループに必要なプリミティブ群 |
-| **50 の MCP ツール** | Memory、Agent Substrate、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
+| **Agent Control Plane (preview)** | Workspace スコープの Agent Registry、減算的な context binding、agent-bound member key、ライフサイクル kill switch、1 呼出の session bootstrap。v0.49.0 で導入 |
+| **60 の MCP ツール** | Memory、Agent Substrate、Agent Control Plane、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
 | **マルチプロバイダ** | 埋め込みに OpenAI かセルフホスト (Ollama、vLLM — ローカル・非公開・コストゼロ) |
 | **チーム対応** | Workspace、RBAC、context 分離、共有メモリ |
 | **Web UI** | Next.js ダッシュボード — context、検索設定、メンバー管理 |
@@ -293,7 +294,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP ツール
 
-12 カテゴリ・全 50 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
+13 カテゴリ・全 60 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
 
 ### Memory (6)
 
@@ -318,6 +319,25 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `get_state` | state を 1 件取得、または context の全 live state を列挙 | Viewer+ |
 | `feedback` | recall したメモリが有用だったかを記録 (append-only シグナル) | Viewer+ |
 
+### Agent Control Plane (10、preview)
+
+v0.49.0 の control plane は既存の workspace RBAC を土台にする。Agent は principal ではなく registry resource であり、context binding は agent-bound member key の権限を減らすことしかできない。Registry、binding、composed bootstrap、W3C Trace Context / baggage correlation、append-only audit 基盤は実装済み。
+
+| ツール | 説明 | 必要ロール |
+|--------|------|------------|
+| `register_agent` | workspace スコープの agent を登録 | Owner/Admin |
+| `list_agents` | 登録 agent と lifecycle/enforcement status を列挙 | Owner/Admin |
+| `get_agent` | agent を 1 件取得 | Owner/Admin |
+| `update_agent` | metadata、`status`、`enforcement_mode` を更新 | Owner/Admin |
+| `delete_agent` | agent と bound key を恒久削除。運用上は `status="retired"` を推奨 | Owner/Admin |
+| `bind_agent_context` | 減算的な context binding を追加 | Owner/Admin |
+| `list_agent_bindings` | agent の context binding 一覧 | Owner/Admin |
+| `update_agent_binding` | read/write/default binding policy を更新 | Owner/Admin |
+| `unbind_agent_context` | binding を削除 (enforce mode では default-deny) | Owner/Admin |
+| `get_agent_bootstrap` | session start 用に context guide + pinned + 任意の trusted recall + upcoming + state を合成 | Agent-bound key または Owner/Admin |
+
+> **Preview 境界:** memory type/source 単位の filter は schema 予約済みで、fail-closed として `null` のみ受け付ける。`traceparent` と W3C baggage による `agent_id` / `session_id` / `run_id` correlation は実装済みだが、server-side span export は P0 の対象外。`memory_access_events` は bootstrap、load-pinned、feedback、recall、reference、remember で稼働し、`update`/`forget` emission と deny/`would_deny` 永続化は [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286) で継続する。
+
 ### Neural Edges (4)
 
 | ツール | 説明 | 必要ロール |
@@ -337,7 +357,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `update_context` | context 設定更新 (summary、usage guide、resource_id、is_public) | Editor+ |
 | `delete_context` | context とその全メモリを削除 | Owner/Admin |
 | `merge_contexts` | source context から target context へメモリを統合 | Owner/Admin |
-| `update_search_config` | context 単位で hybrid search 重みと reranker 設定を調整 | Editor+ |
+| `update_search_config` | context 単位で hybrid search 重み、reranker、query-intent routing (`routing_mode`) を調整 | Editor+ |
 
 ### Tags (1)
 
@@ -366,6 +386,8 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `get_analysis` | 完了済み分析 (クラスタ、ラベル、統計) 取得 | Owner |
 | `get_active_analysis` | 実行中分析の取得 (あれば) | Owner |
 | `get_cluster` | 単一クラスタの所属メモリを drilldown | Owner |
+
+分析 run は `ANALYSIS_MAX_MEMORY_COUNT` (既定 10,000、preview/start の両方で超過を拒否) で上限を持つ。v0.47.0 以降、cancel は all-or-nothing、削除済み context の run は REST/MCP の双方で不可視、strict BYOK labeling は platform key へ fallback せず、labeling 対象 cluster の過半数が失敗した run は `failed` になる。
 
 ### Resources — 外部データ取り込み (6)
 
@@ -419,7 +441,10 @@ MCP ツールに加えてフル REST API を提供:
 
 - **Memory**: remember、recall、reference、forget、explore (`/api/v1/memory/*`)
 - **Contexts**: CRUD、検索設定 (`/api/v1/contexts/*`)
-- **Attachments**: メモリ添付ファイル (`/api/v1/attachments/*`、5MB 上限)
+- **Agents (preview)**: Registry、context binding、composed bootstrap (`/api/v1/agents/*`)
+- **Files**: R2 の presigned upload/download (`/api/v1/files/*`、最大 100 MiB)。旧 `/api/v1/attachments/*` は `410 Gone`
+- **Analyses**: メモリー分析の preview/start/read/cancel (`/api/v1/analyses/*`)
+- **Resources**: 外部 event 取込と resource 参照 (`/api/v1/resources/*`)
 - **Workspaces**: 管理、メンバー、招待 (`/api/v1/workspaces/*`)
 - **Admin**: ユーザ、プラン管理、neural config (`/api/v1/admin/*`)
 - **Secrets**: ゼロ知識シークレットストア — ciphertext のみ、サーバーは復号しない (`/api/v1/config/secrets/*`)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **AI Reranking** | Self-hosted (Ollama/vLLM — local, free), Voyage AI, or Cohere — cross-encoder reranking for precision |
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
 | **Agent Memory Substrate** | Beyond a knowledge store: delivery modes (pinned / time-triggered), a server-stamped trust boundary, an agent state lane, and a retrieval-feedback signal — the primitives an autonomous agent loop needs. |
-| **50 MCP Tools** | Memory, Agent Substrate, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
+| **Agent Control Plane (preview)** | Workspace-scoped Agent Registry, subtractive context bindings, agent-bound member keys, lifecycle kill switches, and one-call session bootstrap. Introduced in v0.49.0. |
+| **60 MCP Tools** | Memory, Agent Substrate, Agent Control Plane, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
 | **Multi-Provider** | OpenAI or self-hosted (Ollama, vLLM — local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |
@@ -418,7 +419,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP Tools
 
-50 tools across 12 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+60 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
 
 ### Memory (6)
 
@@ -442,6 +443,25 @@ The primitives an autonomous agent loop needs beyond a knowledge store — see [
 | `set_state` | Upsert agent scratch state (key→value, optional TTL; excluded from recall) | Editor+ |
 | `get_state` | Read one state key, or list all live state for a context | Viewer+ |
 | `feedback` | Record whether a recalled memory was helpful (append-only signal) | Viewer+ |
+
+### Agent Control Plane (10, preview)
+
+The v0.49.0 control plane builds on existing workspace RBAC: agents are registry resources, not principals, and context bindings can only remove access from an agent-bound member key. Registry, bindings, composed bootstrap, W3C Trace Context/baggage correlation, and the append-only audit foundation are implemented.
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `register_agent` | Register a workspace-scoped agent | Owner/Admin |
+| `list_agents` | List registered agents and lifecycle/enforcement status | Owner/Admin |
+| `get_agent` | Get one registered agent | Owner/Admin |
+| `update_agent` | Update metadata, `status`, or `enforcement_mode` | Owner/Admin |
+| `delete_agent` | Permanently delete an agent and its bound keys; prefer `status="retired"` operationally | Owner/Admin |
+| `bind_agent_context` | Add a purely subtractive context binding | Owner/Admin |
+| `list_agent_bindings` | List an agent's context bindings | Owner/Admin |
+| `update_agent_binding` | Update read/write/default binding policy | Owner/Admin |
+| `unbind_agent_context` | Remove a binding (default-deny in enforce mode) | Owner/Admin |
+| `get_agent_bootstrap` | Compose context guide + pinned + optional trusted recall + upcoming + state for session start | Agent-bound key or Owner/Admin |
+
+> **Preview boundary:** per-memory type/source filters are schema-reserved and fail closed by accepting only `null`. `traceparent` plus W3C baggage correlation for `agent_id` / `session_id` / `run_id` is implemented, but server-side span export remains out of scope for P0. `memory_access_events` is live for bootstrap, load-pinned, feedback, recall, reference, and remember; `update`/`forget` emission and deny/`would_deny` persistence remain tracked in [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286).
 
 ### Neural Edges (4)
 
@@ -491,6 +511,8 @@ Cluster memories into themes (kouchou-ai-style UMAP + KMeans + LLM labeling) for
 | `get_analysis` | Get a completed analysis (clusters, labels, stats) | Owner |
 | `get_active_analysis` | Get the in-flight analysis for a context (if any) | Owner |
 | `get_cluster` | Drill into a single cluster's member memories | Owner |
+
+Analysis runs are capped by `ANALYSIS_MAX_MEMORY_COUNT` (default 10,000; preview and start reject larger contexts). Since v0.47.0, cancellation is all-or-nothing, deleted-context runs are invisible on both REST and MCP, strict BYOK labeling never falls back to the platform key, and runs fail when more than half of labelable clusters fail labeling.
 
 ### Resources — External Data Ingestion (6)
 
@@ -544,7 +566,10 @@ In addition to MCP tools, a full REST API is available:
 
 - **Memory**: remember, recall, reference, forget, explore (`/api/v1/memory/*`)
 - **Contexts**: CRUD, search settings (`/api/v1/contexts/*`)
-- **Attachments**: File upload/download for memories (`/api/v1/attachments/*`, 5MB limit)
+- **Agents (preview)**: Registry, context bindings, and composed bootstrap (`/api/v1/agents/*`)
+- **Files**: Presigned upload/download backed by R2 (`/api/v1/files/*`, up to 100 MiB); legacy `/api/v1/attachments/*` routes return `410 Gone`
+- **Analyses**: Memory Analysis preview/start/read/cancel (`/api/v1/analyses/*`)
+- **Resources**: External event ingestion and resource inspection (`/api/v1/resources/*`)
 - **Workspaces**: Management, members, invitations (`/api/v1/workspaces/*`)
 - **Admin**: Users, plan management, neural config (`/api/v1/admin/*`)
 - **Secrets**: Zero-knowledge secret store — ciphertext-only, server never decrypts (`/api/v1/config/secrets/*`)

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -134,6 +134,8 @@ async def lifespan(app: FastAPI):
 openapi_tags = [
     # Authentication & Users
     {"name": "authentication", "description": "OAuth2 login and session management"},
+    {"name": "google-oauth2", "description": "Google OAuth2 login and callback flow"},
+    {"name": "github-oauth2", "description": "GitHub OAuth2 login and callback flow"},
     {"name": "users", "description": "User profile and settings"},
     {
         "name": "account-erasure",
@@ -142,12 +144,31 @@ openapi_tags = [
             "(Issue #360). Session-only auth (no API keys)."
         ),
     },
+    {
+        "name": "account-linking",
+        "description": "Link, unlink, and list external login providers for the current account",
+    },
+    {
+        "name": "me-oauth",
+        "description": "Refresh the current user's OAuth-backed session credentials",
+    },
     # Workspace
     {"name": "workspace", "description": "Workspace dashboard and stats"},
     {"name": "workspaces", "description": "Workspace CRUD operations"},
     {"name": "workspace-plan", "description": "Workspace plan management (self-service)"},
     {"name": "invitations", "description": "Team member invitations"},
     {"name": "member-credentials", "description": "API key and OAuth credential management"},
+    {
+        "name": "agents",
+        "description": (
+            "Agent Control Plane preview: workspace Agent Registry, subtractive context "
+            "bindings, and composed session bootstrap"
+        ),
+    },
+    {
+        "name": "billing-handoff",
+        "description": "Create a signed handoff from Memory Cloud to the external billing service",
+    },
     # Memory & Search
     {"name": "contexts", "description": "Context management"},
     {"name": "context-search-config", "description": "Per-context search settings"},
@@ -189,12 +210,17 @@ openapi_tags = [
     },
     # Integrations
     {"name": "api-keys", "description": "MCP API key management"},
+    {
+        "name": "share-keys",
+        "description": "Share-key lifecycle, public recall, and share-session inspection",
+    },
     {"name": "oauth2-server", "description": "OAuth2 client management"},
     {"name": "external-keys", "description": "External API keys (OpenAI, Cohere, etc.)"},
     {
         "name": "secrets",
         "description": "Zero-knowledge secret store (age ciphertext; server never decrypts)",
     },
+    {"name": "resources", "description": "Resource listing and event-history inspection"},
     {"name": "resource-tokens", "description": "Resource token management"},
     {"name": "resource-ingest", "description": "External data ingestion API"},
     {"name": "resource-schema", "description": "Resource schema registry"},
@@ -202,6 +228,14 @@ openapi_tags = [
     {
         "name": "workspace-connectors",
         "description": "ai-worker chat-ingest connector provisioning",
+    },
+    {
+        "name": "connectors",
+        "description": "External connector installation and callback flows (currently Slack)",
+    },
+    {
+        "name": "workers",
+        "description": "Authenticated connector-worker runtime configuration",
     },
     {
         "name": "analyses",
@@ -218,13 +252,26 @@ openapi_tags = [
     # Admin
     {"name": "admin", "description": "Admin: user management and system stats"},
     {"name": "admin-plans", "description": "Admin: plan tier and quota management"},
+    {
+        "name": "admin-memory-health",
+        "description": "Admin: per-context memory health diagnosis and signal breakdown",
+    },
+    {"name": "admin-neural", "description": "Admin: trigger Neural Memory recalibration"},
+    {
+        "name": "admin-signup-gate",
+        "description": "Admin: signup-gate configuration and allowlist management",
+    },
+    {
+        "name": "admin-sleep",
+        "description": "Admin: manually run Sleep Maintenance and undo individual merges",
+    },
     {"name": "neural-config", "description": "Admin: neural memory configuration"},
     {
         "name": "sleep-reports",
         "description": "Admin: Sleep Maintenance execution reports and audit log",
     },
     {
-        "name": "bm25-drift (preview)",
+        "name": "bm25-drift",
         "description": (
             "Admin: BM25 IDF drift observability (Issue #343). "
             "Cron is disabled by default and scheduled for production "
@@ -233,6 +280,10 @@ openapi_tags = [
         ),
     },
     {"name": "system-admins", "description": "Admin: system administrator management"},
+    {
+        "name": "internal-billing",
+        "description": "Internal service-authenticated plan and downgrade-eligibility endpoints",
+    },
     # System
     {"name": "config", "description": "Environment configuration management (admin)"},
     {"name": "system", "description": "System health and info"},
@@ -790,24 +841,24 @@ async def serve_openapi_spec():
     return JSONResponse(app.openapi())
 
 
-@app.get("/")
+@app.get("/", tags=["system"])
 async def root():
     """Root endpoint."""
     return {
         "name": "Kagura Memory Cloud",
-        "version": "0.1.0",
+        "version": APP_VERSION,
         "description": "Remote MCP Server + Web Management",
         "status": "ok",
     }
 
 
-@app.get("/health")
+@app.get("/health", tags=["system"])
 async def health():
     """Health check endpoint (liveness probe — always fast)."""
     return {"status": "ok"}
 
 
-@app.get("/readiness")
+@app.get("/readiness", tags=["system"])
 async def readiness():
     """Readiness probe for blue-green deploy.
 

--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -289,9 +289,13 @@ class BindingCreate(BaseModel):
     can_read: bool = True
     write_policy: Literal["deny", "direct"] = "deny"
     is_default: bool = Field(False, description="Bootstrap default binding (max one per agent)")
-    allowed_memory_types: list[str] | None = Field(None, description="NULL = all types; [] = none")
+    allowed_memory_types: list[str] | None = Field(
+        None,
+        description="Reserved for #1286; only null is accepted until per-memory enforcement ships",
+    )
     allowed_source_types: list[str] | None = Field(
-        None, description="Values from the memories.source_type set; NULL = all; [] = none"
+        None,
+        description="Reserved for #1286; only null is accepted until per-memory enforcement ships",
     )
 
 
@@ -301,8 +305,12 @@ class BindingUpdate(BaseModel):
     can_read: bool | None = None
     write_policy: Literal["deny", "direct"] | None = None
     is_default: bool | None = None
-    allowed_memory_types: list[str] | None = None
-    allowed_source_types: list[str] | None = None
+    allowed_memory_types: list[str] | None = Field(
+        None, description="Reserved for #1286; only null is currently accepted"
+    )
+    allowed_source_types: list[str] | None = Field(
+        None, description="Reserved for #1286; only null is currently accepted"
+    )
 
 
 class BindingResponse(TZAwareBaseModel):

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2283,7 +2283,7 @@ The effective permission for an agent-bound request is the existing RBAC
 decision ∩ binding: can_read gates reads, write_policy ('deny'|'direct')
 gates writes. Under enforcement_mode='enforce', contexts WITHOUT a binding
 row are denied for the agent (default-deny); under 'shadow', violations are
-only logged. NULL type filters = unrestricted; [] = deny-all.
+only logged. Type filters are reserved for Issue #1286; omit them for now.
 
 Returns: {status, binding: {id, context_id, can_read, write_policy, is_default, ...}}.""",
             "inputSchema": {
@@ -2315,12 +2315,12 @@ Returns: {status, binding: {id, context_id, can_read, write_policy, is_default, 
                     "allowed_memory_types": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Optional memory-type filter. Omit/null = all types; [] = none.",
+                        "description": "Reserved for #1286. Omit/null is the only accepted value until per-memory enforcement ships.",
                     },
                     "allowed_source_types": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Optional source-type filter (memories.source_type values). Omit/null = all; [] = none.",
+                        "description": "Reserved for #1286. Omit/null is the only accepted value until per-memory enforcement ships.",
                     },
                 },
                 "required": ["agent_id", "context_id"],
@@ -2371,12 +2371,12 @@ Returns: {status, binding, changed: [field, ...]}.""",
                     "allowed_memory_types": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "null = all types; [] = none.",
+                        "description": "Reserved for #1286; only null is currently accepted.",
                     },
                     "allowed_source_types": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "null = all; [] = none.",
+                        "description": "Reserved for #1286; only null is currently accepted.",
                     },
                 },
                 "required": ["agent_id", "binding_id"],
@@ -2591,7 +2591,7 @@ Returns: {status, name, rotation_needed: true}.""",
         },
     ]
     # Pre-1.0 schema policy (#990): every tool inputSchema is strict — no
-    # undeclared top-level parameters. Applied centrally here so all 50 tools
+    # undeclared top-level parameters. Applied centrally here so all tools
     # stay uniform and any new tool inherits the policy automatically. This is
     # advisory (handlers read args defensively via ``.get`` and never
     # Pydantic-validate), so it tightens the client-facing contract without

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -141,7 +141,8 @@ class RememberRequest(BaseModel):
             logger.warning(
                 f"Summary length ({length} chars) exceeds recommended 250 chars. "
                 f"Consider splitting into multiple semantic memories for better search quality. "
-                f"See docs: /docs/chunking-guide.md"
+                "See docs: https://github.com/kagura-ai/memory-cloud/blob/main/"
+                "docs/chunking-guide.md"
             )
         elif length < 50:
             logger.info(

--- a/backend/tests/api/test_api_routes_coverage.py
+++ b/backend/tests/api/test_api_routes_coverage.py
@@ -4,6 +4,7 @@ Tests API endpoints with mocked auth to exercise route handler code paths.
 Issue #14: Increase unit test coverage.
 """
 
+import re
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -56,6 +57,7 @@ class TestHealthEndpoints:
         """Root endpoint returns project info."""
         response = client.get("/")
         assert response.status_code == 200
+        assert response.json()["version"] == app.version
 
     def test_health(self, client):
         """Health endpoint returns ok."""
@@ -138,11 +140,32 @@ class TestSystemEndpoints:
         with TestClient(app, raise_server_exceptions=False) as c:
             yield c
 
-    def test_system_openapi_tags(self, client):
-        """OpenAPI schema has proper tags."""
-        response = client.get("/openapi.json")
-        data = response.json()
+    def test_system_openapi_tags(self):
+        """Every operation uses a declared, kebab-case OpenAPI tag."""
+        data = app.openapi()
         assert len(data["paths"]) > 0
+
+        declared_tags = [tag["name"] for tag in data.get("tags", [])]
+        assert len(declared_tags) == len(set(declared_tags)), "Duplicate OpenAPI tags"
+
+        http_methods = {"get", "post", "put", "patch", "delete", "options", "head", "trace"}
+        used_tags: set[str] = set()
+        untagged_operations: list[str] = []
+        for path, path_item in data["paths"].items():
+            for method, operation in path_item.items():
+                if method.lower() not in http_methods:
+                    continue
+                tags = operation.get("tags", [])
+                if not tags:
+                    untagged_operations.append(f"{method.upper()} {path}")
+                used_tags.update(tags)
+
+        assert not untagged_operations, f"Untagged OpenAPI operations: {untagged_operations}"
+        undeclared_tags = sorted(used_tags - set(declared_tags))
+        assert not undeclared_tags, f"Undeclared OpenAPI tags: {undeclared_tags}"
+        assert all(re.fullmatch(r"[a-z0-9]+(?:-[a-z0-9]+)*", tag) for tag in declared_tags), (
+            "OpenAPI tags must use kebab-case"
+        )
 
     def test_system_routes_no_500(self, client):
         """System endpoints should not return 500."""

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -6,9 +6,11 @@ Verify MCP tools work correctly by executing them in sequence against temporary 
 Exercises the core memory/edge/context/tag/analysis/sleep tools, the **agent-memory-substrate**
 lane (`delivery_mode` pinning + `load_pinned`, the agent session-state lane, retrieval `feedback`,
 and the `trust_tier` recall filter), and owner-scoped binding introspection.
+When the caller is a workspace owner/admin, it also exercises the v0.49 Agent Control Plane
+(registry, context bindings, and bootstrap composition).
 Optionally exercises PRO-only resource rows (setup_resource, ingest_events, get_resource_impact, get_resource_schema, list_resource_tokens, plus delete_context cleanup) if the workspace has a PRO plan.
 
-The canonical tool registry is `backend/src/mcp_server/tools/__init__.py` (**50 tools**). The
+The canonical definitions are `backend/src/mcp_server/tools/_definitions.py` (**60 tools**). The
 **Coverage cross-check** section near the end mirrors that registry so the "all MCP tools" claim
 stays honest — every registered tool is either exercised here or listed there with a reason. This
 is a live runbook, not a pytest suite, so the cross-check is a manual reconciliation step: when a
@@ -348,7 +350,52 @@ delete_context(context_id=<resource_context_id>)
 -> Verify: success response (resource context soft-deleted)
 ```
 
-### 7.9. Connector tools (gated-skip)
+### 7.9. Agent Control Plane tools (owner/admin only)
+
+**Pre-check:** These tools require the workspace owner/admin role. If the caller lacks that role,
+skip this section and record "Agent Control Plane skipped — owner/admin required" in the report.
+Type filters are intentionally omitted because they remain reserved until
+[#1281](https://github.com/kagura-ai/memory-cloud/issues/1281).
+
+```
+register_agent(name="smoke-test-agent-{unix_timestamp}", description="Temporary MCP smoke-test agent", framework="codex", environment="test", version="smoke-1")
+-> Verify: returns an active agent with enforcement_mode="enforce"
+-> Save returned agent.id as agent_id
+
+list_agents()
+-> Verify: agents contains agent_id
+
+get_agent(agent_id=<agent_id>)
+-> Verify: returns the registered agent
+
+bind_agent_context(agent_id=<agent_id>, context_id=..., can_read=true, write_policy="deny", is_default=true)
+-> Verify: returns a default binding for the test context
+-> Save returned binding.id as agent_binding_id
+
+list_agent_bindings(agent_id=<agent_id>)
+-> Verify: bindings contains agent_binding_id
+
+update_agent_binding(agent_id=<agent_id>, binding_id=<agent_binding_id>, write_policy="direct")
+-> Verify: changed includes write_policy and binding.write_policy="direct"
+
+get_agent_bootstrap(agent_id=<agent_id>, query="MCP smoke test")
+-> Verify: returns the default context and component results; degraded may be true only with an explained component error
+
+update_agent(agent_id=<agent_id>, version="smoke-2")
+-> Verify: changed includes version and agent.version="smoke-2"
+
+unbind_agent_context(agent_id=<agent_id>, binding_id=<agent_binding_id>)
+-> Verify: deleted=true
+
+delete_agent(agent_id=<agent_id>)
+-> Verify: deleted=true
+```
+
+If this section fails partway through, cleanup retries `unbind_agent_context` when a binding was
+created and `delete_agent` when an agent was created. Treat an already-deleted/not-found result as
+successful cleanup.
+
+### 7.10. Connector tools (gated-skip)
 
 `setup_connector` provisions an external connector (Slack/Discord/Teams) and requires platform
 credentials plus a real connector target, so it is **not** exercised inline (it would create
@@ -362,11 +409,18 @@ setup_connector — SKIP (documented)
 
 ### Cleanup
 
-Unpin and delete the pinned memory first (so delivery_mode="always" state does not survive the run),
-then tear down the remaining artifacts. The agent-state entry (set_state) needs no explicit delete —
-it is removed with its context below and also expires via its TTL.
+Remove any remaining Agent Control Plane artifacts, then unpin and delete the pinned memory (so
+delivery_mode="always" state does not survive the run) and tear down the remaining artifacts. The
+agent-state entry (set_state) needs no explicit delete — it is removed with its context below and
+also expires via its TTL.
 
 ```
+unbind_agent_context(agent_id=<agent_id>, binding_id=<agent_binding_id>)
+-> Run only if Agent Control Plane cleanup did not already remove the binding
+
+delete_agent(agent_id=<agent_id>)
+-> Run only if Agent Control Plane cleanup did not already remove the agent
+
 update_memory(memory_id=<pinned_memory_id>, context_id=..., delivery_mode="on_recall")
 -> Verify: success response (pinned memory unpinned — no longer deterministically loaded)
 
@@ -386,16 +440,16 @@ delete_context(context_id=...)
 ### 8. Coverage cross-check (anti-drift)
 
 Reconcile this skill against the canonical registry so the "all MCP tools" claim cannot silently
-rot. The source of truth is `backend/src/mcp_server/tools/__init__.py` (**50 tools**). Every
-registered tool must be in exactly one column below. **If `tools/__init__.py` and this table
+rot. The source of truth is `backend/src/mcp_server/tools/_definitions.py` (**60 tools**). Every
+registered tool must be in exactly one column below. **If `_definitions.py` and this table
 disagree, the skill is out of date — add a row (or a documented exclusion) before merging.**
 
-Optional live assertion: count the keys in the registry and confirm it equals 50 (the number this
+Optional live assertion: count the named definitions and confirm it equals 60 (the number this
 table is built for); if it differs, a tool was added/removed and this skill needs updating:
 
 ```
-grep -cE '^\s*"[a-z_]+"\s*:\s*handle_' backend/src/mcp_server/tools/__init__.py
--> Verify: equals 50 (else: reconcile this section with the registry)
+grep -cE '^\s*"name"\s*:\s*"[a-z_]+"' backend/src/mcp_server/tools/_definitions.py
+-> Verify: equals 60 (else: reconcile this section with the definitions)
 ```
 
 **Exercised inline (33 core tools):** list_contexts, create_context, get_context_info,
@@ -405,6 +459,10 @@ feedback, set_state, get_state, reference, explore, update_memory, forget, list_
 update_edge, delete_edge, list_tags, list_my_bindings, describe_binding, merge_contexts, get_usage,
 list_analyses, get_active_analysis, get_analysis, get_cluster, get_sleep_history, get_sleep_report,
 rollback_sleep_run, delete_context.
+
+**Exercised with owner/admin role, else SKIP (10 tools):** register_agent, list_agents,
+get_agent, update_agent, delete_agent, bind_agent_context, list_agent_bindings,
+update_agent_binding, unbind_agent_context, get_agent_bootstrap.
 
 **Exercised only on PRO plan, else SKIP (5 tools):** setup_resource, ingest_events,
 get_resource_impact, get_resource_schema, list_resource_tokens.
@@ -426,8 +484,8 @@ get_resource_impact, get_resource_schema, list_resource_tokens.
 | `secret_list` | Owner/admin metadata listing; grouped with the secret-store flow. |
 | `secret_revoke_grant` | Operates on an existing grant produced by `secret_put`. |
 
-33 + 5 + 12 = **50** — the full registry. The gap between "exercised inline" and the registry is
-**only** the 5 PRO-gated rows (run when PRO) and the 12 documented exclusions above.
+33 + 10 + 5 + 12 = **60** — the full registry. The conditional rows are the 10 owner/admin Agent
+Control Plane tools and 5 PRO-gated resource tools; the remaining 12 are documented exclusions.
 
 ### 9. Report
 
@@ -485,6 +543,16 @@ Print a summary table (numbers are illustrative; the executed order follows the 
 | 45 | delete_context | Soft-delete merge target and its memories | PASS/FAIL |
 | 46 | forget | Delete memory 2 | PASS/FAIL |
 | 47 | delete_context | Delete source context (+ its agent-state) | PASS/FAIL |
+| A1 | register_agent | Register temporary agent (owner/admin only) | PASS/FAIL/SKIP |
+| A2 | list_agents | List registry and find temporary agent (owner/admin only) | PASS/FAIL/SKIP |
+| A3 | get_agent | Get temporary agent (owner/admin only) | PASS/FAIL/SKIP |
+| A4 | bind_agent_context | Bind test context as default (owner/admin only) | PASS/FAIL/SKIP |
+| A5 | list_agent_bindings | List bindings (owner/admin only) | PASS/FAIL/SKIP |
+| A6 | update_agent_binding | Set write_policy=direct (owner/admin only) | PASS/FAIL/SKIP |
+| A7 | get_agent_bootstrap | Compose default-context bootstrap (owner/admin only) | PASS/FAIL/SKIP |
+| A8 | update_agent | Update agent version (owner/admin only) | PASS/FAIL/SKIP |
+| A9 | unbind_agent_context | Remove temporary binding (owner/admin only) | PASS/FAIL/SKIP |
+| A10 | delete_agent | Delete temporary agent (owner/admin only) | PASS/FAIL/SKIP |
 | P1 | setup_resource | Create resource context + token (PRO only) | PASS/FAIL/SKIP |
 | P2 | ingest_events | Batch ingest 2 test events (PRO only) | PASS/FAIL/SKIP |
 | P3 | get_resource_impact | Get resource stats (PRO only) | PASS/FAIL/SKIP |
@@ -492,21 +560,24 @@ Print a summary table (numbers are illustrative; the executed order follows the 
 | P5 | list_resource_tokens | List tokens for resource (PRO only) | PASS/FAIL/SKIP |
 | P6 | delete_context | Delete resource context (PRO only) | PASS/FAIL/SKIP |
 
-**Result: N/47 core rows passed** (+ N/6 PRO resource rows passed, or SKIP if not PRO)
+**Result: N/47 core rows passed** (+ N/10 Agent Control Plane rows and N/6 PRO resource rows
+passed, or SKIP when the corresponding gate is unavailable)
 
 Note: the 47 rows are test *steps*, not distinct tools — several tools (remember, recall,
 update_memory, forget, delete_context, list_edges, list_tags) are exercised in multiple rows.
-Distinct-tool coverage is reconciled in the Coverage cross-check (33 core + 5 PRO + 12 documented-skip = 50).
+Distinct-tool coverage is reconciled in the Coverage cross-check
+(33 core + 10 owner/admin + 5 PRO + 12 documented-skip = 60).
 
 Test context: smoke-test-{timestamp} (cleaned up)
 
 Documented exclusions / gated-skip (see Coverage cross-check) — not counted as FAIL:
 - analyze_context (billing + BYOK + owner + Pro-tier)
+- Agent Control Plane tools may be role-gated (owner/admin); if skipped, list A1–A10 as SKIP
 - setup_connector (external connector credentials + live target)
 - File tools: init_file_upload, complete_file_upload, get_file_download_url, delete_file, list_files (multipart S3/R2)
 - Secret tools: secret_register_pubkey, secret_put, secret_get, secret_list, secret_revoke_grant (zero-knowledge: age keypairs + owner approval + ciphertext)
 
-Registry reconciliation: 33 core + 5 PRO + 12 documented-skip = 50 tools in tools/__init__.py.
+Registry reconciliation: 33 core + 10 owner/admin + 5 PRO + 12 documented-skip = 60 tools in _definitions.py.
 ```
 
 If any step fails:

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,10 @@
 - [Architecture](architecture.md) — System design, data flow, and tech stack (incl. **LLM Knowledge Base 5-layer mapping**)
 - [API Reference](api-reference.md) — REST API endpoints, authentication, request/response examples
 - [Derived-Layer Boundary](derived-layer-boundary.md) — Design rule: raw memories are exportable, the derived/learned layer is the moat (table classification + feature-review checklist)
+- [Agent Registry & Context Bindings](design/agent-registry-and-bindings.md) — Implemented v0.49.0-preview registry, agent-bound key, and subtractive binding contract
+- [`get_agent_bootstrap` Contract](design/agent-bootstrap-contract.md) — Implemented composed session-start bundle and fail-soft component contract
+- [Agent Correlation Design](design/agent-otel-correlation.md) — Implemented W3C session/run/trace mapping and verified identity precedence (v0.49.0 preview)
+- [`memory_access_events` Design](design/memory-access-events.md) — Implemented append-only agent audit schema/writer and current emission coverage
 
 ## Guides
 
@@ -21,3 +25,5 @@
 - [Sleep Maintenance](sleep-maintenance.md) — Background 6-phase cleanup cycle, sleep_mode, observability, and rollback (the **Compile / Enhance** consolidation layer)
 - [Deployment](deployment.md) — Production deployment with Caddy reverse proxy (incl. the embedded LanceDB **"Kagura Lite"** backend, preview)
 - [Troubleshooting](troubleshooting.md) — Environment-specific setup fixes (e.g. WSL2 + Claude Code MCP OAuth callback)
+- [Agent Credential Runbook](ops/agent-credential-runbook.md) — Mint, rotate, revoke, expire, and kill-switch agent-bound workload keys
+- [`memory_access_events` Retention Plan](ops/memory-access-events-retention.md) — Capacity triggers and partitioning/retention plan for the live audit table

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6,7 +6,7 @@ Kagura Memory Cloud provides both REST APIs and MCP (Model Context Protocol) too
 
 - **REST API Base URL**: `http://localhost:8080/api/v1`
 - **MCP Server Endpoint**: `http://localhost:8080/mcp/w/{WORKSPACE_ID}` (Streamable HTTP transport)
-- **OpenAPI Specification**: [openapi.json](../api/openapi.json)
+- **OpenAPI Specification**: `http://localhost:8080/openapi.json`
 
 ## Authentication
 
@@ -240,7 +240,7 @@ curl -X POST http://localhost:8080/api/v1/memory/remember \
 2. **Context object**: `{"paper_id": "rag-2024", "section": "intro"}`
 3. **Context overlap**: Mention related sections in `context_summary`
 
-See [Chunking Guide](/docs/chunking-guide.md) for comprehensive examples and anti-patterns.
+See [Chunking Guide](chunking-guide.md) for comprehensive examples and anti-patterns.
 
 ---
 
@@ -564,6 +564,29 @@ Soft-delete a context. The context row is marked deleted (sets `deleted_at`) so 
 
 ---
 
+## Agent Control Plane APIs (v0.49.0 preview)
+
+Agents are workspace-scoped registry resources, not principals. Registry and binding mutations require workspace `Owner` or `Admin`. Agent-bound member keys keep their existing RBAC ceiling; bindings are purely subtractive.
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/agents` | Register an agent (`active`, `enforce` by default) |
+| `GET /api/v1/agents` | List registered agents |
+| `GET /api/v1/agents/{agent_id}` | Get one agent |
+| `PATCH /api/v1/agents/{agent_id}` | Update metadata, lifecycle status, or enforcement mode |
+| `DELETE /api/v1/agents/{agent_id}` | Permanently delete the agent and cascade agent-bound keys; prefer `status="retired"` operationally |
+| `POST /api/v1/agents/{agent_id}/bindings` | Add a context binding |
+| `GET /api/v1/agents/{agent_id}/bindings` | List bindings |
+| `PATCH /api/v1/agents/{agent_id}/bindings/{binding_id}` | Update read/write/default policy |
+| `DELETE /api/v1/agents/{agent_id}/bindings/{binding_id}` | Remove a binding |
+| `POST /api/v1/agents/{agent_id}/bootstrap` | Compose context guide, pinned, optional trusted recall, upcoming, and state for session start |
+
+Owner-provisioned member keys are minted through `POST /api/v1/workspaces/{workspace_id}/members/{user_id}/credentials/api-keys`; supplying `agent_id` attaches the registered agent. Agent-bound keys for `suspended` or `retired` agents fail verification. In `enforce` mode, requests to unbound contexts use the same not-found shape as inaccessible contexts.
+
+> **Preview boundary:** `allowed_memory_types` and `allowed_source_types` are forward-provisioned fields, but non-`null` values are rejected fail-closed until the per-memory enforcement work in [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286) lands. REST and MCP accept W3C `traceparent` and baggage keys `gen_ai.agent.id`, `gen_ai.conversation.id` (or `session.id`), and `kagura.agent.run.id`; invalid advisory values are dropped and credential-bound agent identity always wins. Server-side span export is not part of P0. The append-only `memory_access_events` table and writer ship in v0.49.0 with bootstrap, load-pinned, feedback, recall, reference, and remember emission; `update`/`forget` and deny capture remain in #1286.
+
+---
+
 ## Agent State APIs
 
 A per-context key→value scratch lane for autonomous agent loops (current task, plan step, cursor). Stored in a dedicated `agent_states` table — **structurally excluded from `recall()`** so it never pollutes semantic search. Part of the [Agent Memory Substrate](concepts.md#agent-memory-substrate). Reads require `Viewer`; writes require `Editor`.
@@ -633,6 +656,38 @@ Record an explicit, attributable signal on whether a recalled memory was helpful
 | `note` | string | No | Free-text rationale (max 2000 chars) |
 
 **Response:** `201 Created` — `{ "feedback_id": "<uuid>", "memory_id": "<uuid>", "helpful": true }`
+
+---
+
+## Memory Analysis APIs
+
+Memory Analysis clusters a context with UMAP + KMeans and labels clusters with the workspace owner's BYOK provider. It requires workspace `Owner`, Pro plan access, the configured allowlist/quota gates, and an active BYOK key.
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/v1/contexts/{context_id}/analyses/preview` | Estimate count/cost and validate the run without creating it |
+| `POST /api/v1/contexts/{context_id}/analyses` | Start a run (`202 Accepted`) |
+| `GET /api/v1/contexts/{context_id}/analyses` | List runs with cursor pagination |
+| `GET /api/v1/contexts/{context_id}/analyses/active` | Return the most recent succeeded run |
+| `GET /api/v1/contexts/{context_id}/analyses/{run_id}` | Get one run |
+| `GET /api/v1/contexts/{context_id}/analyses/{run_id}/clusters` | List cluster summaries |
+| `GET /api/v1/contexts/{context_id}/analyses/{run_id}/positions` | List per-memory 2D positions |
+| `DELETE /api/v1/contexts/{context_id}/analyses/{run_id}` | Cancel a running analysis |
+
+`ANALYSIS_MAX_MEMORY_COUNT` defaults to 10,000 and is enforced by preview, start, and the pre-materialization count probe. Since v0.47.0, cancellation is all-or-nothing and stops in-flight labeling, deleted-context runs are invisible across REST and MCP, the labeling path disallows platform-key fallback, and a run fails when more than `MAX_CLUSTER_FAILURE_RATIO` (0.5) of labelable clusters fail.
+
+---
+
+## Resource Ingest APIs
+
+| Endpoint | Purpose / authentication |
+|---|---|
+| `POST /api/v1/resources/{resource_id}/events` | Ingest one event with a resource token |
+| `POST /api/v1/resources/{resource_id}/events/batch` | Ingest up to 100 events with partial-success semantics and a resource token |
+| `GET /api/v1/resources` | List resources visible to the authenticated workspace principal |
+| `GET /api/v1/resources/{resource_id}/events` | Inspect a resource's event history |
+
+Since v0.48.0, the REST batch endpoint and MCP `ingest_events` delegate to the same `ResourceIngestService`. Authentication and wire envelopes remain surface-specific, while quota, authoritative Resource resolution, UTF-8 byte-size validation, per-event SAVEPOINT handling, constraint mapping, commit behavior, and post-commit indexer scheduling share one implementation.
 
 ---
 
@@ -951,7 +1006,7 @@ Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, 
 
 ## MCP Tools
 
-Kagura Memory Cloud provides 50 MCP tools for AI assistants across 12 categories (Memory, Agent Substrate, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
+Kagura Memory Cloud provides 60 MCP tools for AI assistants across 13 categories (Memory, Agent Substrate, Agent Control Plane, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
 
 ### 1. remember
 
@@ -1126,6 +1181,16 @@ Record whether a recalled memory was helpful (read-adjacent; any `Viewer` may ca
 }
 ```
 
+### Agent Control Plane tools (preview)
+
+| Tool | Purpose |
+|---|---|
+| `register_agent` / `list_agents` / `get_agent` / `update_agent` / `delete_agent` | Workspace Agent Registry CRUD (Owner/Admin) |
+| `bind_agent_context` / `list_agent_bindings` / `update_agent_binding` / `unbind_agent_context` | Purely subtractive context policy (Owner/Admin) |
+| `get_agent_bootstrap` | Fail-soft composition of context guide + pinned + optional trusted recall + upcoming + state; identity and authorization fail closed |
+
+The control-plane tools use the same JSON-RPC shape as the examples above. Their REST companions and the current preview limitations are documented in [Agent Control Plane APIs](#agent-control-plane-apis-v0490-preview).
+
 ---
 
 ## Rate Limits
@@ -1162,7 +1227,7 @@ All errors follow this format:
 
 - **Python SDK**: [`kagura-memory-python-sdk`](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` (sync HTTP client) and `KaguraAgent` (LLM agent integration). Supports OAuth2 device flow via `kagura auth login` against the pre-seeded `kagura-cli` public client.
 - **JavaScript SDK**: Planned
-- **Example Code**: [GitHub Repository](https://github.com/kagura-ai/memory-cloud/tree/main/examples)
+- **Example Code**: [README Quick Start](../README.md#quick-start) and the [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk)
 
 ---
 
@@ -1170,4 +1235,4 @@ All errors follow this format:
 
 - **GitHub Issues**: [Report bugs](https://github.com/kagura-ai/memory-cloud/issues)
 - **Documentation**: [http://localhost:8080/docs](http://localhost:8080/docs)
-- **OpenAPI Spec**: [openapi.json](../api/openapi.json)
+- **OpenAPI Spec**: `http://localhost:8080/openapi.json`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,11 +31,11 @@ Karpathy's pattern describes any "living knowledge base" as 5 layers. Kagura's i
                               ↓
 ┌──────────────────────┬──────────────────────────────────────┐
 │   MCP Server (HTTP)  │          REST API (FastAPI)          │
-│  - 50 MCP Tools      │  - Memory CRUD                       │
+│  - 60 MCP Tools      │  - Memory CRUD                       │
 │    (memory / agent   │  - OAuth2 endpoints                  │
-│     substrate / edges│  - API Key management                │
-│     / contexts / tags│  - Agent state + feedback lanes      │
-│     / files /analyses│  - Resource Ingest API               │
+│     substrate/control│  - API Key + Agent management        │
+│     / edges / context│  - Agent state + feedback lanes      │
+│     / files / analysis│ - Resource Ingest API               │
 │     / resources /    │  - Admin: sleep-reports, neural cfg  │
 │     sleep / usage)   │                                      │
 │  - Session Mgmt      │                                      │
@@ -48,6 +48,7 @@ Karpathy's pattern describes any "living knowledge base" as 5 layers. Kagura's i
 │  GraphService │ NeuralMemoryEngine │ WorkspaceService       │
 │  PermissionService │ SleepService │ LLMService              │
 │  ResourceIndexer │ ContextService │ QuotaService            │
+│  AgentRegistry │ AgentBinding │ AgentBootstrap              │
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
@@ -273,6 +274,17 @@ The feedback signal is the prerequisite for a future Eval→Skill self-update lo
 
 Connectors provisioned via `setup_connector` (#910 / #911) seed a canonical chat **resource schema** at registration: a single `text` field (fulltext+vector indexed) holding the ai-worker's per-message LLM summary. Lineage (`source_uri` / memory details) stays in `event_metadata`, not the payload. Defined in `ConnectorProvisioningService` (`backend/src/services/connector_provisioning.py`).
 
+## Agent Memory & Context Control Plane (v0.49.0 preview)
+
+The control plane extends workspace RBAC rather than creating a second principal system:
+
+1. `agents` registers a workload inside one workspace. The row is a resource, not a credential.
+2. An owner-provisioned member key may point to the agent through nullable `api_keys.agent_id`. Verification rejects keys for `suspended` or `retired` agents.
+3. `agent_context_bindings` narrows the underlying member/RBAC decision. In `enforce` mode, only bound contexts survive the intersection; in `shadow` mode the legacy permission result remains active while violations are observed.
+4. `get_agent_bootstrap` resolves the agent and binding, then composes existing context/pinned/recall/upcoming/state services. It does not introduce a parallel retrieval or ranking path.
+
+Registry, context-level bindings, bootstrap, transport correlation, and the append-only `memory_access_events` audit foundation are implemented. REST middleware and the MCP authentication seam parse W3C `traceparent`/baggage into a request-local correlation context; credential-bound identity has precedence, and missing trace/span IDs are generated server-side. This is observability plumbing, not an authorization input or server-side span exporter. Type/source filters are forward-provisioned but reject non-`null` values until per-memory enforcement lands. The audit writer currently covers bootstrap, load-pinned, feedback, recall, reference, and remember; filters, `update`/`forget` emission, and deny persistence continue in [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286).
+
 ## Database Design
 
 ### PostgreSQL Tables
@@ -281,10 +293,12 @@ Tables are grouped by domain. The authoritative list lives in `backend/src/model
 
 **Identity & access**
 - **users** — User accounts
-- **api_keys** — API key management (SHA256 hashed)
+- **api_keys** — API key management (SHA256 hashed); optional `agent_id` binds an owner-provisioned member key to a registered agent
 - **external_api_keys** — OpenAI/Cohere keys (Fernet encrypted)
 - **oauth_clients** / **oauth_authorization_codes** / **oauth_tokens** — OAuth2 server
 - **audit_logs** — Security-relevant audit trail
+- **agents** — Workspace-scoped agent registry with lifecycle (`active | suspended | retired`) and binding enforcement mode (`shadow | enforce`)
+- **agent_context_bindings** — Purely subtractive per-agent context read/write/default policy; type/source columns are reserved and reject non-`null` values pending #1286
 
 **Workspaces & contexts** (top-level tenancy)
 - **workspaces** — Top-level organizational unit (team / project owner)
@@ -297,7 +311,7 @@ Tables are grouped by domain. The authoritative list lives in `backend/src/model
 
 **Memories & graph**
 - **memories** — 3-layer memory storage. Carries server-stamped `source_type` (provenance) and `delivery_mode` (`on_recall` / `always` / `on_trigger`)
-- **attachments** — Small files (≤5 MB) stored **inline as PostgreSQL `BYTEA`**, linked to a memory (Issue #330). Distinct from R2 object storage — see *File storage* below and the [Object Storage (R2)](#object-storage-r2) section
+- **attachments** — Legacy small-file rows (≤5 MB) stored inline as PostgreSQL `BYTEA`. The public `/api/v1/attachments/*` routes are deprecated and return `410 Gone`; new uploads use `file_objects` in R2
 - **neural_memory_edges** — Primary Hebbian edge storage (workspace + context scoped)
 - **graph_memory** — Legacy NetworkX JSON (read paths still reference it; new writes go to `neural_memory_edges`)
 
@@ -312,6 +326,8 @@ Tables are grouped by domain. The authoritative list lives in `backend/src/model
 - **resource_schemas** — Versioned schemas declared per Resource
 - **indexer_state** — Per-(resource, context) indexer cursor + error metrics
 - **resource_tokens** — Per-Resource ingest tokens (workspace-scoped)
+
+Since v0.48.0, REST and MCP batch ingest are thin adapters over `ResourceIngestService`. Quota, identity resolution, UTF-8 byte-size validation, per-event SAVEPOINT handling, partial-success semantics, commit behavior, and post-commit scheduling therefore have one implementation on both surfaces.
 
 **File storage (R2 object storage)** (Issue #485 — see [Object Storage (R2)](#object-storage-r2))
 - **file_objects** — One row per uploaded file held in Cloudflare R2. `status` ∈ `reserved | uploaded | failed` (`CHECK`); `storage_backend` is `r2`-only (`CHECK valid_file_storage_backend`); `storage_key` = `{workspace_id}/{sha256[:2]}/{sha256}`. A partial-unique index dedups *active* files per `(workspace_id, lower(sha256))` (excludes soft-deleted and `failed` rows). **This — not `attachments` — is the R2-backed path**; `attachments` is inline Postgres BYTEA.
@@ -422,6 +438,8 @@ Authorization is **workspace-scoped RBAC**. Every authenticated request is resol
 **Context-level privacy**:
 - **Private** (`is_private=true`): Only the creator can access
 - **Shared** (`is_private=false`): All workspace members with the appropriate role
+
+**Agent-bound credentials** add a subtractive layer after the existing RBAC decision. `enforce` mode intersects access with `agent_context_bindings`; `shadow` mode records the would-deny result without narrowing access. Requests made with keys that have no `agent_id` are unchanged.
 
 All checks funnel through `PermissionService` in `backend/src/services/permission_service.py`; clients never supply a raw `workspace_id` without server-side verification.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -309,14 +309,26 @@ An agent loop needs durable, *exact-match* scratch state (current task, plan ste
 
 See [Architecture › Agent Memory Substrate](architecture.md#agent-memory-substrate-lanes) for the table-level design and how these lanes sit beside `memories`.
 
+## Agent Memory & Context Control Plane (preview)
+
+The control plane is a separate layer over the Agent Memory Substrate. The substrate defines *what an agent can load and retain*; the control plane identifies an agent workload, narrows its existing workspace permissions, and assembles a safe session-start bundle.
+
+- **Agent Registry** — `agents` rows are workspace-scoped resources, not authentication principals. `active | suspended | retired` is a fail-closed lifecycle switch; `shadow | enforce` controls whether binding violations are observed or denied.
+- **Agent-bound member keys** — an owner-provisioned member key may carry `api_keys.agent_id`. It still authenticates as the member and keeps the same RBAC ceiling.
+- **Subtractive context bindings** — `agent_context_bindings` computes effective access as existing RBAC ∩ binding. A binding can never grant access. In `enforce` mode, an unbound context is denied with the same not-found shape used for inaccessible contexts.
+- **Composed bootstrap** — `get_agent_bootstrap` combines the context guide, pinned memories, an optional trusted-only recall, upcoming time memories, and agent state. Components fail softly; identity and authorization fail closed.
+
+The v0.49.0 milestone shipped the registry, context-level bindings, agent-bound keys, bootstrap, W3C Trace Context/baggage correlation, and the append-only `memory_access_events` foundation. Correlation is observability, never authorization; credential-bound identity outranks explicit/bootstrap and baggage claims. Per-memory type/source filters remain reserved and reject non-`null` values; audit emission currently covers bootstrap, load-pinned, feedback, recall, reference, and remember. Filter enforcement, `update`/`forget` emission, and deny persistence continue in [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286). See the [F1 binding design](design/agent-registry-and-bindings.md), [F2 bootstrap contract](design/agent-bootstrap-contract.md), and [F4 correlation design](design/agent-otel-correlation.md).
+
 ## MCP Tools
 
-Kagura Memory Cloud exposes 50 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), grouped into 12 categories:
+Kagura Memory Cloud exposes 60 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), grouped into 13 categories:
 
 | Category | Tools | Purpose |
 |----------|-------|---------|
 | Memory | 6 | `remember`, `recall`, `reference`, `update_memory`, `forget`, `explore` — store / search / discover memories |
 | Agent Substrate | 5 | `load_pinned`, `recall_upcoming`, `set_state`, `get_state`, `feedback` — delivery-mode-aware retrieval, agent state lane, feedback signal (see [Agent Memory Substrate](#agent-memory-substrate)) |
+| Agent Control Plane (preview) | 10 | `register_agent`, `list_agents`, `get_agent`, `update_agent`, `delete_agent`, `bind_agent_context`, `list_agent_bindings`, `update_agent_binding`, `unbind_agent_context`, `get_agent_bootstrap` — registry, subtractive scoping, and session bootstrap |
 | Neural Edges | 4 | `list_edges`, `create_edge`, `update_edge`, `delete_edge` — manage the Hebbian graph manually |
 | Contexts | 7 | `get_context_info`, `list_contexts`, `create_context`, `update_context`, `delete_context`, `merge_contexts`, `update_search_config` |
 | Tags | 1 | `list_tags` — tag vocabulary discovery for alignment before `remember`/`recall` |

--- a/docs/design/agent-bootstrap-contract.md
+++ b/docs/design/agent-bootstrap-contract.md
@@ -1,14 +1,15 @@
 # Design sign-off: `get_agent_bootstrap` composed contract (RFC-0002 F2)
 
-- **Status**: Signed off (gating design for P0-3 implementation)
+- **Status**: Implemented by [#1276](https://github.com/kagura-ai/memory-cloud/issues/1276) / PR #1282; pinned-cap, REST validation, and MCP error-mapping hardening shipped in [#1281](https://github.com/kagura-ai/memory-cloud/issues/1281)
 - **Issue**: [#1259](https://github.com/kagura-ai/memory-cloud/issues/1259) — gating item F2 of RFC-0002
   (Agent Memory & Context Control Plane; RFC text maintained locally, lands in
   `docs/rfc/0002-agent-memory-context-control-plane.md` when published)
-- **Consumers**: implementers of P0-3 (`get_agent_bootstrap` MCP tool + REST companion),
+- **Consumers**: maintainers and integrators of P0-3 (`get_agent_bootstrap` MCP tool + REST companion),
   SDK maintainers (parity follow-up)
 - **Depends on**: [Agent Registry & Context Bindings](agent-registry-and-bindings.md)
-  (F1, [#1258](https://github.com/kagura-ai/memory-cloud/issues/1258) — that design doc
-  lands with the #1258 PR; the link resolves once it merges) for agent/binding resolution
+  (F1, [#1258](https://github.com/kagura-ai/memory-cloud/issues/1258), implemented by
+  [#1274](https://github.com/kagura-ai/memory-cloud/issues/1274) and
+  [#1275](https://github.com/kagura-ai/memory-cloud/issues/1275)) for agent/binding resolution
 
 `get_agent_bootstrap` is the single session-start call that rehydrates an agent's cognitive
 state: context metadata and usage guide, always-load pinned memories, a trusted-only semantic
@@ -186,8 +187,8 @@ are different layers, not an inconsistency. A flattened bespoke bundle schema wa
 ## Cross-repo follow-up (implementation checklist)
 
 - `kagura-memory-python-sdk`: the `kagura-mcp` proxy forwards `/mcp` transparently (new tool
-  auto-exposed, no change needed), but `client.py`/`cli.py` are per-tool explicit — file an
-  SDK parity follow-up for `get_agent_bootstrap` when P0-3 lands.
+  auto-exposed, no change needed), but `client.py`/`cli.py` are per-tool explicit. The SDK
+  parity follow-up for `get_agent_bootstrap` is still pending and must be filed separately.
 
 ## Sign-off checklist (maps to #1259)
 

--- a/docs/design/agent-otel-correlation.md
+++ b/docs/design/agent-otel-correlation.md
@@ -1,10 +1,10 @@
 # Design sign-off: OTel GenAI attribute mapping for agent correlation (RFC-0002 F4)
 
-- **Status**: Signed off (gating design for P0-4 implementation)
+- **Status**: Implemented by [#1277](https://github.com/kagura-ai/memory-cloud/issues/1277) / PR #1283; audit persistence shipped in [#1278](https://github.com/kagura-ai/memory-cloud/issues/1278), with identity-contract follow-up in [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286) and the vendor attribute gap in [#1285](https://github.com/kagura-ai/memory-cloud/issues/1285)
 - **Issue**: [#1261](https://github.com/kagura-ai/memory-cloud/issues/1261) — gating item F4 of RFC-0002
   (Agent Memory & Context Control Plane; RFC text maintained locally, lands in
   `docs/rfc/0002-agent-memory-context-control-plane.md` when published)
-- **Consumers**: implementers of P0-4 (correlation parsing + identity precedence) and P0-5
+- **Consumers**: maintainers of P0-4 (correlation parsing + identity precedence) and P0-5
   (`memory_access_events` correlation columns), operators joining Kagura audit rows against
   their own tracing backend, SDK maintainers
 - **Depends on**: Agent Registry & Context Bindings (F1, #1258) for agent identity and
@@ -110,11 +110,10 @@ just telemetry.
 
 The credential-derived identity is the only *authenticated* agent identity. Per the Agent
 Registry design (F1, #1258), an agent's credential is an ordinary workspace-scoped member API
-key that gains a nullable `agent_id` binding; verification surfaces it on the authenticated
-principal. (Current tree: `VerifiedKey` in `backend/src/auth/api_keys.py` carries no
-`agent_id` field yet — the NamedTuple was explicitly designed for additive attribution
-shapes, and F1/P0-2 adds the field alongside the `api_keys.agent_id` column. The
-owner-provisioned mint flow it extends is `backend/src/api/routes/member_credentials.py`.)
+key with a nullable `agent_id` binding. P0-2 is implemented: `VerifiedKey` in
+`backend/src/auth/api_keys.py` carries `agent_id`, and verification surfaces it through the
+per-request `AgentScope`. The owner-provisioned mint flow is
+`backend/src/api/routes/member_credentials.py`.
 
 **Precedence order**:
 
@@ -213,13 +212,13 @@ guidance), with an explicit migration obligation:
 ## Repo reality notes (descriptive)
 
 - The RFC's DDL sketches reference migration ids `e61_*` chaining from head
-  `e60_1228_read_attributions`; both are stale against the current tree. The repo's alembic
-  head is `e62_1245_assign_mem_idx`
-  (`backend/alembic/versions/e62_1245_assign_mem_idx.py`), and `e61_`/`e62_` prefixes are
-  already taken. New migrations chain from the current head at implementation time; nothing
-  in this design depends on a specific revision id.
-- There is no OTel/`traceparent`/baggage handling anywhere in `backend/src` today; P0-4
-  introduces it at the two seams named above (MCP transport auth point, REST middleware).
+  `e60_1228_read_attributions`; both are stale. F1/P0-2 landed as `e63`/`e64`/`e65`.
+  P0-4 required no migration: `api/correlation.py` plus REST correlation middleware and the
+  MCP transport auth seam populate a request-local context. P0-5 persists the correlation
+  columns on `memory_access_events` via migration `e66_1278_memory_access_events`.
+- P0-4 accepts W3C `traceparent` and baggage on both transports, validates/drops advisory
+  correlation tokens, generates missing trace/span IDs, and applies credential-first identity
+  precedence. It intentionally emits no OTel spans and materializes no session/run table.
 
 ## Sign-off checklist (maps to #1261)
 

--- a/docs/design/agent-registry-and-bindings.md
+++ b/docs/design/agent-registry-and-bindings.md
@@ -1,10 +1,10 @@
 # Design sign-off: Agent Registry & Context Bindings (RFC-0002 F1)
 
-- **Status**: Signed off (gating design for P0-1 / P0-2 implementation)
+- **Status**: Implemented by [#1274](https://github.com/kagura-ai/memory-cloud/issues/1274) / [#1275](https://github.com/kagura-ai/memory-cloud/issues/1275); type/source filter enforcement remains tracked by [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286)
 - **Issue**: [#1258](https://github.com/kagura-ai/memory-cloud/issues/1258) — gating item F1 of RFC-0002
   (Agent Memory & Context Control Plane; RFC text maintained locally, lands in
   `docs/rfc/0002-agent-memory-context-control-plane.md` when published)
-- **Consumers**: implementers of P0-1 (Agent Registry) and P0-2 (bindings + agent-scoped
+- **Consumers**: maintainers and integrators of P0-1 (Agent Registry) and P0-2 (bindings + agent-scoped
   credentials), reviewers of the corresponding migrations
 
 This document freezes the DDL, the migration plan, the backward-compatibility matrix, and
@@ -154,11 +154,10 @@ CREATE INDEX CONCURRENTLY idx_api_keys_agent ON api_keys (agent_id) WHERE agent_
 
 ## Migration plan (normative)
 
-**Revision naming.** The RFC sketch cited `e61_*` chaining from `e60_1228_read_attributions`;
-the e-series has since advanced (current head: `e62_1245_assign_mem_idx`). The F1 migrations
-chain from **the current head at implementation time** using the next free `eNN_<issue>_<slug>`
-identifiers (revision ids ≤ 32 chars, linear chain, symmetric downgrades — follow
-`backend/alembic/versions/e35_889_agent_state.py` as the additive-table precedent).
+**Revision naming.** The RFC sketch cited `e61_*` chaining from `e60_1228_read_attributions`.
+The implementation landed as `e63_1274_agents`, `e64_1275_agent_bindings`, and
+`e65_1275_api_keys_agent`. Follow-ups chain from the actual current head using the next free
+`eNN_<issue>_<slug>` identifier (revision ids ≤ 32 chars, linear chain, symmetric downgrades).
 
 **Two distinct migration classes**, shipped as separate revisions:
 
@@ -186,7 +185,7 @@ Additional requirements:
 | Caller / credential | Before | After (Phase A: schema only) | After (Phase B: enforcement live) |
 |---|---|---|---|
 | REST/MCP request, key without `agent_id` (every credential existing today) | current behavior | **byte-for-byte unchanged** | **byte-for-byte unchanged** |
-| Key with `agent_id`, agent `enforce`, context **has** binding row | n/a | n/a | existing RBAC decision ∩ binding (`can_read`, `write_policy`, type/source filters) |
+| Key with `agent_id`, agent `enforce`, context **has** binding row | n/a | n/a | existing RBAC decision ∩ context-level binding (`can_read`, `write_policy`). Type/source filters are schema-reserved but non-`NULL` values are rejected until #1286 lands |
 | Key with `agent_id`, agent `enforce`, context has **no** binding row | n/a | n/a | denied — uniform `context_not_found` (default-deny applies **only to newly bound agents**) |
 | Key with `agent_id`, agent `shadow` | n/a | n/a | legacy semantics; violations recorded as `would_deny` audit rows |
 | Key with `agent_id`, agent `suspended`/`retired` | n/a | n/a | rejected at verify time (fail-closed kill switch) |

--- a/docs/design/memory-access-events.md
+++ b/docs/design/memory-access-events.md
@@ -1,18 +1,19 @@
 # Design sign-off: `memory_access_events` schema + deny-logging review (RFC-0002 F3)
 
-- **Status**: Signed off (gating design for P0-5 implementation)
+- **Status**: Implemented by [#1278](https://github.com/kagura-ai/memory-cloud/issues/1278) / PR #1284; remaining operation emission and deny capture are tracked by [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286)
 - **Issue**: [#1260](https://github.com/kagura-ai/memory-cloud/issues/1260) — gating item F3 of RFC-0002
   (Agent Memory & Context Control Plane; RFC text maintained locally and currently
   unpublished — it would land at `docs/rfc/0002-agent-memory-context-control-plane.md`;
   this document is self-contained and does not require it)
-- **Consumers**: implementers of P0-5 (`memory_access_events` migration + audit writer),
+- **Consumers**: maintainers of P0-5 (`memory_access_events` migration + audit writer),
   the CSO review record for the deny-logging layer, ops (retention escalation, F7)
 - **Depends on**: the Agent Registry & Context Bindings sign-off
   (`docs/design/agent-registry-and-bindings.md`, F1,
-  [#1258](https://github.com/kagura-ai/memory-cloud/issues/1258) — lands with the #1258 PR)
+  [#1258](https://github.com/kagura-ai/memory-cloud/issues/1258), implemented by #1274/#1275)
   for the agent/binding vocabulary; the session/run/trace correlation design
-  (F4, [#1261](https://github.com/kagura-ai/memory-cloud/issues/1261)) for the semantics of
-  the correlation columns this table stores
+  (F4, [#1261](https://github.com/kagura-ai/memory-cloud/issues/1261), implemented by
+  [#1277](https://github.com/kagura-ai/memory-cloud/issues/1277)) for the semantics of the
+  correlation columns this table stores
 
 `MemoryAccessEvent` (`memory_access_events`) is the append-only audit row for the eight
 memory operations performed under verified agent identity: **recall / reference / remember /
@@ -21,6 +22,10 @@ latency, policy decision, and keyed (HMAC) hashes — **never** raw prompts, ret
 content, secrets, or PII. This document restates every RFC-0002 decision the schema depends
 on (D20–D25, D29, D34) so it is self-contained, records the CSO review of the deny-logging
 layer, and settles the one question RFC-0002 deferred to F3 (the deny-capture layer).
+
+The v0.49.0 implementation emits bootstrap, load-pinned, feedback, recall, reference, and
+remember events. The schema already reserves all eight operations; `update`/`forget`
+emission plus denied/`would_deny` persistence remain in #1286.
 
 ## Scope and non-goals
 
@@ -66,7 +71,7 @@ append-only (extension = additive migration), following the append-only-tuple co
 | `update` | `MemoryService.update_memory` / `_update_in_place` |
 | `forget` | `MemoryService.forget` (soft-delete path) |
 | `load_pinned` | `MemoryService.load_pinned` |
-| `bootstrap` | the bootstrap composition service (P0-3; see the bootstrap contract sign-off, `docs/design/agent-bootstrap-contract.md` — F2, [#1259](https://github.com/kagura-ai/memory-cloud/issues/1259); lands with the #1259 PR) |
+| `bootstrap` | `AgentBootstrapService` (P0-3, implemented by #1276; see `docs/design/agent-bootstrap-contract.md` — F2, [#1259](https://github.com/kagura-ai/memory-cloud/issues/1259)) |
 | `feedback` | `FeedbackService.record_feedback` (`backend/src/services/feedback_service.py`) — the same service whose non-agent-callable `record_host_feedback` seam the gateway integration uses |
 
 Composition semantics: because instrumentation lives in the chokepoints,
@@ -171,10 +176,10 @@ Schema notes:
   of the P1 unbound-traffic extension).
 - For recall, up to 32 result `memory_ids` go in `event_metadata` under the 4 KB cap;
   identifiers are permitted payload, content is not.
-- **Migration reality**: RFC-0002's sketch names an older head; the repo's current alembic
-  head is `e62_1245_assign_mem_idx` (`backend/alembic/versions/e62_1245_assign_mem_idx.py`).
-  The P0-5 migration chains from whatever the head is at implementation time (revision id
-  ≤ 32 chars, linear chain, symmetric downgrade), is additive-only (blue-green safe), and
+- **Migration reality**: RFC-0002's sketch names an older head. F1/P0-2 landed as
+  `e63_1274_agents` → `e64_1275_agent_bindings` → `e65_1275_api_keys_agent`; P0-5 landed as
+  `e66_1278_memory_access_events`, followed by the `e67_1281_agent_key_workspace` invariant.
+  The P0-5 migration is additive-only (blue-green safe), has a symmetric downgrade, and
   the ORM model is imported in both `models/__init__.py` and `alembic/env.py` so it passes
   both integration gates (`backend/tests/integration/test_alembic_migrations.py` round-trip
   and `backend/tests/integration/test_create_all_vs_alembic_drift.py`).

--- a/docs/eval/agent-provenance-feedback-gate.md
+++ b/docs/eval/agent-provenance-feedback-gate.md
@@ -78,8 +78,8 @@ They are settable per context via the `update_search_config` MCP tool
 `PUT /api/v1/contexts/{context_id}/search-config`
 (`backend/src/api/routes/context_search_config.py`). Consequently, a "reinforcement-default
 flip" under this gate means a **column-default change plus migration**, not an env-var change;
-new migrations chain from the repository's current alembic head (`e62_1245_assign_mem_idx`) at
-implementation time — not from any revision id sketched in RFC drafts.
+new migrations chain from the repository's actual head at implementation time — not from any
+revision id sketched in RFC drafts. F1/P0-2 already occupies `e63`/`e64`/`e65`.
 
 ## Restated RFC-0002 decisions this gate depends on
 
@@ -96,8 +96,8 @@ Restated here so the document is self-contained (the RFC is maintained locally a
   rejected for P0 because bootstrap reads genuinely influence behavior and a lane-specific
   carve-out would fork recall semantics.
 - **Bootstrap purity (Decision D11)** — the designed `get_agent_bootstrap` recall component
-  (`docs/design/agent-bootstrap-contract.md`, F2 sign-off, #1259 — pending merge at time of
-  writing) is a pure composition over the normal recall chokepoint: it deliberately keeps
+  (`docs/design/agent-bootstrap-contract.md`, F2 sign-off, #1259; implemented by #1276) is a
+  pure composition over the normal recall chokepoint: it deliberately keeps
   recall's counter and reinforcement side effects, because bootstrap reads influence behavior
   and should reinforce.
 - **Threat model T5 residual (forged feedback)** — with arbitration OFF (the default),
@@ -143,9 +143,9 @@ semantics).
 
 - Exposing a public transport for `record_host_feedback` (own design; the seam exists at the
   service layer and the harness can call it in-process).
-- The P1 fleet dashboard and per-agent feedback-anomaly views (they consume the planned
-  `memory_access_events` audit table, which is **not yet in the tree**; this gate is designed
-  to run without it, using harness-local attribution).
+- The P1 fleet dashboard and per-agent feedback-anomaly views. The `memory_access_events`
+  table is in the tree as of v0.49.0, but those visualization surfaces remain out of scope;
+  this gate continues to run with harness-local attribution.
 - Tuning the bounded-boost design or the recall/explore signal boundary (#120).
 - Content-level screening of in-tier poisoning (server-side DLP; P1, separate). Arbitration
   protects **ranking**, not content — poisoning containment remains `trust_tier` plus

--- a/docs/ops/agent-credential-runbook.md
+++ b/docs/ops/agent-credential-runbook.md
@@ -1,11 +1,11 @@
 # Ops runbook: agent workload credentials — mint / rotate / revoke (RFC-0002 F5)
 
-- **Status**: Signed off (gating ops runbook for P0-2 general availability)
+- **Status**: Operational for P0-2/P0-3 (implemented by #1275/#1276); P1 DLP remains deferred
 - **Issue**: [#1262](https://github.com/kagura-ai/memory-cloud/issues/1262) — gating item F5 of RFC-0002
   (Agent Memory & Context Control Plane; RFC text maintained locally, lands in
   `docs/rfc/0002-agent-memory-context-control-plane.md` when published)
 - **Consumers**: operators of production/self-hosted deployments; workspace owners
-  provisioning credentials for agent workloads; implementers of P0-2 (agent-bound keys)
+  provisioning credentials for agent workloads; maintainers of P0-2 (agent-bound keys)
 - **Depends on**: the owner-provisioned member-key flow (#1165, **shipped** —
   `backend/src/api/routes/member_credentials.py`); the Agent Registry & Context Bindings
   design (F1, #1258, `docs/design/agent-registry-and-bindings.md`) for the [P0-2] deltas only
@@ -16,8 +16,8 @@ numbered procedures is shipped, verified behavior. Blocks marked **[P0-2]** desc
 agent-bound keys (`api_keys.agent_id`) — **shipped with #1275**: mint accepts `agent_id`
 (owner-provisioned path only), verify rejects keys whose agent is `suspended`/`retired`, and
 the fleet kill switch in section 6 is live. Blocks marked **[P0-3]** describe the bootstrap
-contract (F2, #1259); blocks marked **[P1]** describe the deferred DLP item — those two are
-not implemented yet.
+contract (F2, #1259), shipped with #1276. Blocks marked **[P1]** describe the deferred DLP
+item, which is not implemented yet.
 
 ## Scope and non-goals
 
@@ -43,7 +43,8 @@ not implemented yet.
 
 ## Workload identity model (current reality, restated from RFC-0002)
 
-A workload identity today is the composition of two existing rows — no new tables:
+A workload identity is built on the existing member/key principal model, with an optional
+Agent Registry attachment:
 
 1. A `workspace_members` row with role `member` or `viewer`, optionally narrowed by
    `allowed_context_ids` (enforced for member/viewer reads in
@@ -53,6 +54,9 @@ A workload identity today is the composition of two existing rows — no new tab
    form `kagura_<random>` (`API_KEY_PREFIX`, `backend/src/auth/api_keys.py`); only the SHA-256
    hash is stored for verification, and the non-secret 16-character `key_prefix` is the
    identifier used in audit rows and logs.
+3. For an agent workload, an `agents` registry row plus optional `agent_context_bindings`.
+   The member key carries `api_keys.agent_id`; the binding can only subtract from the member's
+   existing RBAC/context access.
 
 The three guarantees this runbook leans on, all implemented in
 `backend/src/api/routes/member_credentials.py`:
@@ -69,14 +73,13 @@ The three guarantees this runbook leans on, all implemented in
   (`plaintext_encrypted`) nulled. The plaintext exists **only** in the single 201 response.
   There is no re-reveal path; a fumbled response means revoke + re-mint.
 
-> **[P0-2]** RFC-0002 adds exactly one column and one verify-time consequence:
+> **[P0-2]** RFC-0002 added exactly one key column and its verify-time consequence:
 > `api_keys.agent_id` (nullable FK → `agents.id`, `ON DELETE CASCADE`, mutually exclusive
 > with `bound_context_id` via CHECK), and verification that rejects keys whose agent is
 > `suspended`/`retired`. The mint service additionally validates
 > `agents.workspace_id == api_keys.workspace_id`. The credential *lifecycle* in this runbook
-> is unchanged by RFC-0002. Migration note: the RFC's sketch revision ids are stale — the
-> repo's alembic head is `e62_1245_assign_mem_idx`; new migrations chain from the current
-> head at implementation time.
+> is unchanged by RFC-0002. The implementation migrations are `e63_1274_agents`,
+> `e64_1275_agent_bindings`, and `e65_1275_api_keys_agent`.
 
 ## Conventions used in examples
 
@@ -397,7 +400,7 @@ uploaded as memory sources.
 
 **Why this is a hard rule and not hygiene advice:** memories are a *retrieval surface*.
 Anything stored as memory content is embedded, indexed, and replayed into model context by
-`recall` and (P0-3) the bootstrap bundle — across sessions, and to every principal with read
+`recall` and the P0-3 bootstrap bundle — across sessions, and to every principal with read
 access to the context. A secret written as a memory is a secret published to the context's
 entire read set, with derived copies (vector points, caches) that outlive a single delete.
 
@@ -405,8 +408,9 @@ entire read set, with derived copies (vector points, caches) that outlive a sing
 
 - **P0 (now): write-path guidance.** The `remember`/`update_memory` tool descriptions state
   the rule. Compliance is on the writer.
-- **[P0-3]: bootstrap restatement.** The bootstrap `instructions` block will restate the
-  rule to every agent at session start (F2 design, #1259 — not yet implemented).
+- **[P0-3]: bootstrap restatement.** The implemented bootstrap `instructions` block includes
+  `KAGURA_MEMORY_INSTRUCTIONS`, which restates the no-secrets rule at every session start
+  (F2 design #1259; implementation #1276).
 - **[P1]: server-side DLP.** Secret-pattern screening at the write path (`kagura_` key
   prefixes, PEM headers, JWT shapes) is the designated P1 item. Until it lands, nothing
   server-side stops a determined or confused writer — which is why the response procedure

--- a/docs/ops/memory-access-events-retention.md
+++ b/docs/ops/memory-access-events-retention.md
@@ -1,12 +1,12 @@
 # Ops plan: `memory_access_events` retention and partitioning (RFC-0002 F7)
 
-- **Status**: Signed off (gating ops plan for the first `memory_access_events` retention
-  escalation)
+- **Status**: Operational baseline since v0.49.0; governs the first `memory_access_events`
+  retention escalation
 - **Issue**: [#1264](https://github.com/kagura-ai/memory-cloud/issues/1264) — gating item F7 of
   RFC-0002 (Agent Memory & Context Control Plane; RFC text maintained locally, lands in
   `docs/rfc/0002-agent-memory-context-control-plane.md` when published)
 - **Consumers**: operators of production deployments (measurement cadence + escalation
-  execution), implementers of the escalation migration, P0-5 implementers (F3, #1260 — the
+  execution), implementers of the escalation migration, P0-5 maintainers (F3, #1260 — the
   model-docstring trigger note, the no-TRUNCATE trigger, and the erasure carve-out shape are
   inputs to the schema sign-off)
 - **Depends on**: MemoryAccessEvent schema sign-off (F3, #1260) for the canonical table and
@@ -22,6 +22,10 @@ things now, so that nothing is improvised at escalation time: it **fixes the esc
 trigger** (with a soft threshold that makes it actionable), **fixes the measurement plan**
 operators run until the trigger, and **fixes the decision structure** — criteria, a
 provisional default (monthly range partitioning), and the evidence that would flip it.
+
+The v0.49.0 writer currently emits bootstrap, load-pinned, feedback, recall, reference, and
+remember. The table already accepts all eight operation values; `update`/`forget` emission
+and deny persistence remain tracked by #1286 and do not change this retention policy.
 
 ## Scope and non-goals
 
@@ -304,11 +308,10 @@ is re-opened. Concretely, before flipping the setting:
 ## Migration reality notes
 
 - The RFC sketch's revision-id guidance ("chain from head `e60_1228_read_attributions` as
-  `e61_*`/`e62_*`") is stale against the current tree: the repo's alembic head is already
-  `e62_1245_assign_mem_idx` (`backend/alembic/versions/e62_1245_assign_mem_idx.py`). Both the
-  P0-5 table-creation migration and, later, the escalation migration chain from whatever head
-  exists at their implementation time — revision ids ≤ 32 chars, linear chain, symmetric
-  downgrade.
+  `e61_*`/`e62_*`") is stale. F1/P0-2 landed as `e63`/`e64`/`e65`, P0-5 landed as
+  `e66_1278_memory_access_events`, and the agent-key invariant followed as `e67`. A later
+  escalation migration chains from the then-current head — revision ids ≤ 32 chars, linear
+  chain, symmetric downgrade.
 - Both integration gates must pass for every migration in this lane:
   `backend/tests/integration/test_alembic_migrations.py` (round-trip incl. `downgrade -1`) and
   `backend/tests/integration/test_create_all_vs_alembic_drift.py`. The partitioned shape will
@@ -317,10 +320,10 @@ is re-opened. Concretely, before flipping the setting:
   historical partition and the month children exist only on the alembic side — call this out
   in the escalation issue rather than discovering it in CI.
 - The table keeps its public name `memory_access_events` through the swap, so the
-  data-boundary classification and erasure wiring — which the P0-5 creating PR adds
+  data-boundary classification and erasure wiring added by #1278
   (`OPERATIONAL_TABLES` in `backend/src/models/data_boundary.py`, enforced by
-  `backend/tests/test_derived_layer_boundary.py`; the table is not yet in the registry
-  today) — stay valid through the escalation without changes.
+  `backend/tests/test_derived_layer_boundary.py`) stay valid through the escalation without
+  changes.
 
 ## Sign-off checklist (maps to #1264)
 


### PR DESCRIPTION
## Summary

- synchronize `CHANGELOG.md`, English/Japanese READMEs, and design/operations docs with the completed v0.47.0–v0.49.0 milestones
- record v0.49.0 as released while distinguishing shipped Agent Control Plane behavior from the follow-up work tracked in #1286
- refresh REST/OpenAPI documentation, MCP inventory (60 tools across 13 categories), file-upload guidance, and Memory Analysis behavior
- add OpenAPI drift guards for tag declarations, operation tagging, naming, and the root version

## Why

The documentation audit began while v0.49.0 was in progress. After the release, several pages still described #1278, #1281, and #1247 as pending. The current wording now matches the tagged implementation: the append-only audit foundation and six operation emissions ship in v0.49.0, while type/source filtering, `update`/`forget` emission, and deny persistence continue in #1286.

## Impact

Documentation and generated API metadata only; no runtime behavior change. The added tests prevent future OpenAPI tag/version drift.

## Validation

- `ruff format` and `ruff check` on all modified Python files
- 6 focused pytest tests passed (`test_root`, OpenAPI tag audit, MCP schema policy)
- OpenAPI audit: 216 paths, 264 operations, 52 declared/used tags, no undeclared, unused, untagged, or summary-less operations
- MCP audit: 60 definitions and 60 handlers, no parity diff
- 15 modified Markdown files checked with no broken relative links
- `git diff --check`