### PR TITLE
fix(auth): apply agent-binding gate in MemoryService.recall (#1291)

### DIFF
--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -2173,6 +2173,24 @@ class MemoryService:
         if not current_workspace_id or not current_context_id:
             raise ValueError("recall() requires current_workspace_id and current_context_id")
 
+        # #1291: recall does NOT pass through
+        # ``PermissionService.resolve_context_for_workspace_read`` — the MCP
+        # handler gates that path via ``_resolve_context_for_read``, but the REST
+        # ``/memory/recall`` route calls this service method directly and so
+        # bypassed the subtractive agent-binding filter before this fix. Apply
+        # the gate HERE (service layer) so an agent-bound credential cannot read
+        # a binding-denied context via ANY caller. No-op for non-agent
+        # credentials (``get_agent_scope()`` is None → one contextvar read, no
+        # DB query); deny raises the uniform ``NotFoundException("Context")``
+        # matching the MCP path's 404. Covers the single declared context and
+        # each entry on the #81 cross-context list (exactly the set searched
+        # below).
+        from services.agent_binding_service import agent_binding_permits
+
+        for _gated_cid in context_ids if context_ids else [current_context_id]:
+            if not await agent_binding_permits(self.db, _gated_cid, "read"):
+                raise NotFoundException("Context", str(_gated_cid))
+
         # #708 Option A: route embedding cost (key + spend cap + paid_by
         # + search + graph) to the context's owner workspace. Rate-limit
         # gating stays on the caller upstream — do NOT change it here.

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -286,3 +286,88 @@ class TestMemoryServiceDeclaredContextGate:
         svc = self._service(None)
         result = await svc._get_context_isolation_params("u", None, access="write")
         assert result == (None, None, None)
+
+
+class TestMemoryServiceRecallGate:
+    """#1291: MemoryService.recall() applies the subtractive agent-binding gate
+    at the SERVICE layer. The MCP recall handler gates via
+    ``_resolve_context_for_read``, but the REST ``/memory/recall`` route calls
+    ``recall()`` directly — so before this fix an agent-bound key could read a
+    binding-denied context via REST. The gate must live in recall() itself."""
+
+    def _svc(self):
+        from services.memory_service import MemoryService
+
+        svc = MemoryService.__new__(MemoryService)
+        svc.db = MagicMock()
+        return svc
+
+    @pytest.mark.asyncio
+    async def test_enforce_binding_deny_raises_context_404(self):
+        from models.schemas import RecallRequest
+
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
+        svc = self._svc()
+        patcher, _ = _patch_binding_service(False, "binding_denied")
+        with patcher, pytest.raises(NotFoundException):
+            await svc.recall(
+                RecallRequest(query="q"),
+                user_id="u",
+                current_context_id=uuid.uuid4(),
+                current_workspace_id=uuid.uuid4(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_cross_context_gate_checks_every_entry_not_just_first(self):
+        # A denied context in the SECOND slot must still 404 — proves the gate
+        # loops over the whole #81 cross-context list, not only the head.
+        from models.schemas import RecallRequest
+
+        allowed_id, denied_id = uuid.uuid4(), uuid.uuid4()
+
+        async def _permits(_db, cid, _access):
+            return cid != denied_id
+
+        svc = self._svc()
+        with (
+            patch(
+                "services.agent_binding_service.agent_binding_permits",
+                new=AsyncMock(side_effect=_permits),
+            ),
+            pytest.raises(NotFoundException),
+        ):
+            await svc.recall(
+                RecallRequest(query="q"),
+                user_id="u",
+                current_context_id=allowed_id,
+                current_workspace_id=uuid.uuid4(),
+                context_ids=[allowed_id, denied_id],
+            )
+
+    @pytest.mark.asyncio
+    async def test_permitted_is_noop_and_execution_continues(self):
+        # When the binding permits (or there is no agent scope), the gate must
+        # NOT raise and recall proceeds — proven by reaching the next service
+        # call (_resolve_search_mode), which we stub to raise a sentinel.
+        from models.schemas import RecallRequest
+        from services.memory_service import MemoryService
+
+        svc = self._svc()
+        with (
+            patch(
+                "services.agent_binding_service.agent_binding_permits",
+                new=AsyncMock(return_value=True),
+            ),
+            patch.object(
+                MemoryService,
+                "_resolve_search_mode",
+                new=AsyncMock(side_effect=RuntimeError("past-the-gate")),
+            ),
+            pytest.raises(RuntimeError, match="past-the-gate"),
+        ):
+            await svc.recall(
+                RecallRequest(query="q"),
+                user_id="u",
+                current_context_id=uuid.uuid4(),
+                current_workspace_id=uuid.uuid4(),
+            )


### PR DESCRIPTION
Closes #1291. Found by the v0.49.0 post-release feature audit; bug verified by code trace, fix verified by regression tests.

## Problem

The RFC-0002 P0-2 subtractive agent-binding filter (#1275) was applied on the **MCP** recall path (the handler calls `_resolve_context_for_read` → `resolve_context_for_workspace_read` → `_apply_agent_binding_filter`) but **not** on the **REST** `/api/v1/memory/recall` path, which forwards the client `context_id` straight into `MemoryService.recall()` (routes/memory.py:226). `recall()` itself had no binding gate — its :2361 comment states it relies on the caller having resolved access. The REST route does not.

Result: an `enforce`-mode agent-bound member key could read memories from a workspace context its binding does **not** permit, via REST recall — bypassing the feature's core subtractive-isolation contract on the primary read surface. Reachable because REST recall accepts `APIKeyOrSessionUser` and `set_agent_scope_from_verified` runs for every verified API key (dependencies.py:592).

Exposure was **latent** (no agents/bindings provisioned in prod yet, feature shipped in v0.49.0), so no active exposure — but a real defect.

## Fix

Apply the subtractive gate at the **service layer** inside `recall()` (defense-in-depth: protects every caller and the whole "a handler forgot" bug class), using the existing `agent_binding_permits(db, context_id, "read")` primitive over the single declared context and each entry on the #81 cross-context list. Deny raises the uniform `NotFoundException("Context")` matching the MCP path's 404.

- **Zero cost on normal traffic**: for non-agent credentials `get_agent_scope()` is `None` → `agent_binding_permits` returns immediately with no DB query (one contextvar read).
- **Consistent with the codebase**: same primitive + same `context_id` handling as the sibling `_get_context_isolation_params` chokepoint used by remember / load_pinned / forget.

## Tests

`TestMemoryServiceRecallGate` (3):
- `test_enforce_binding_deny_raises_context_404` — real scope→binding path denies → uniform 404.
- `test_cross_context_gate_checks_every_entry_not_just_first` — a denial in the 2nd cross-context slot still 404s (loop gates every entry).
- `test_permitted_is_noop_and_execution_continues` — permitted → gate is a no-op, execution continues.

Verification: 429 passed across recall route + memory service + MCP + binding suites; ruff clean; raw-HTTPException guard green (canonical `NotFoundException`); Layer-A integration + full v0.49.0 unit surface (340) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)