### PR TITLE
fix(auth): apply trusted-tier gate to bootstrap pinned + time lanes (#1293)

### DIFF
--- a/backend/src/repositories/memory.py
+++ b/backend/src/repositories/memory.py
@@ -7,7 +7,8 @@ from uuid import UUID
 from sqlalchemy import and_, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.memory import DELIVERY_MODE_ALWAYS, Memory
+from models.auth import CONTEXT_TRUST_TIER_TRUSTED, Context
+from models.memory import DELIVERY_MODE_ALWAYS, SOURCE_TYPE_CONNECTOR, Memory
 from repositories.base import BaseRepository
 from utils.datetime import utcnow
 from utils.exceptions import NotFoundException
@@ -309,7 +310,7 @@ class MemoryRepository(BaseRepository[Memory]):
     )
 
     async def list_pinned(
-        self, workspace_id: UUID, context_id: UUID, limit: int
+        self, workspace_id: UUID, context_id: UUID, limit: int, *, trusted_only: bool = False
     ) -> tuple[list, int]:
         """Deterministic always-load set for a context (Issue #886).
 
@@ -335,12 +336,24 @@ class MemoryRepository(BaseRepository[Memory]):
         Returns:
             ``(rows, total)`` — the bounded ordered partial rows and full count.
         """
-        conditions = (
+        conditions = [
             Memory.workspace_id == workspace_id,
             Memory.context_id == context_id,
             Memory.delivery_mode == DELIVERY_MODE_ALWAYS,
             Memory.deleted_at.is_(None),
-        )
+        ]
+        if trusted_only:
+            # #1293: the bootstrap pinned lane is behaviour-establishing (OWASP
+            # LLM01/LLM03, F2 invariant 3), so it must not surface the
+            # external/connector-origin rows the recall lane already drops.
+            # Mirror recall()'s two-part gate exactly: context-level trust signal
+            # (connector contexts = 'external') + row-level defense-in-depth.
+            conditions.append(
+                Memory.context_id.in_(
+                    select(Context.id).where(Context.trust_tier == CONTEXT_TRUST_TIER_TRUSTED)
+                )
+            )
+            conditions.append(Memory.source_type != SOURCE_TYPE_CONNECTOR)
         # Fetch limit+1 so the common (untruncated) case needs a single query:
         # if we get <= limit rows, that count IS the exact total. Only when the
         # probe row appears (set exceeds the cap) do we pay for a COUNT to report

--- a/backend/src/services/agent_bootstrap_service.py
+++ b/backend/src/services/agent_bootstrap_service.py
@@ -428,6 +428,9 @@ class AgentBootstrapService:
             # no-op). None → load_pinned applies its default clamp; a set value
             # is clamped to [1, _PINNED_LOAD_CAP_MAX] by _clamp_pinned_cap.
             cap=pinned_cap,
+            # #1293: pinned is behaviour-establishing — trusted-tier only, parity
+            # with the recall lane's filters={"trust_tier": "trusted"}.
+            trusted_only=True,
         )
         return {
             "memories": [
@@ -516,7 +519,14 @@ class AgentBootstrapService:
         q_from = parse_query_bound("now")
         q_until = parse_query_bound(params.upcoming_until) if params.upcoming_until else None
         results = await query_upcoming_time_memories(
-            self.db, context.id, q_from=q_from, q_until=q_until, k=20
+            # #1293: the time-memory lane is behaviour-establishing too — apply
+            # the same trusted-tier gate as pinned/recall.
+            self.db,
+            context.id,
+            q_from=q_from,
+            q_until=q_until,
+            k=20,
+            trusted_only=True,
         )
         return {"results": results, "from": q_from, "until": q_until}
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -2807,6 +2807,7 @@ class MemoryService:
         current_workspace_id: UUID | None = None,
         cap: int | str | None = None,
         key_workspace_id: UUID | None = None,  # Issue #963/#1281: pure key scope
+        trusted_only: bool = False,
     ) -> LoadPinnedResponse:
         """Deterministically load a context's always-delivery memories (#886).
 
@@ -2823,6 +2824,10 @@ class MemoryService:
             current_context_id: Bound context (the always-load set is per-context).
             current_workspace_id: Bound workspace (isolation scope).
             cap: Optional override for the hard cap (defaults to settings).
+            trusted_only: #1293 — when set (the agent-bootstrap pinned lane),
+                apply the recall trusted-tier gate so external/connector-origin
+                rows never establish behaviour at session start. Left False for
+                the user-initiated standalone ``load_pinned`` surface.
 
         Returns:
             LoadPinnedResponse with the bounded ordered set + truncation flags.
@@ -2838,7 +2843,7 @@ class MemoryService:
         effective_cap = self._clamp_pinned_cap(cap, get_settings().pinned_load_cap)
 
         rows, total = await self.memory_repo.list_pinned(
-            UUID(workspace_id_str), UUID(context_id_str), effective_cap
+            UUID(workspace_id_str), UUID(context_id_str), effective_cap, trusted_only=trusted_only
         )
         truncated = total > effective_cap
         if truncated:

--- a/backend/src/services/time_memory.py
+++ b/backend/src/services/time_memory.py
@@ -41,6 +41,7 @@ async def query_upcoming_time_memories(
     q_from: str | None,
     q_until: str | None,
     k: int,
+    trusted_only: bool = False,
 ) -> list[dict[str, Any]]:
     """Return the context's Time Memories whose window overlaps ``[q_from, q_until]``.
 
@@ -50,8 +51,15 @@ async def query_upcoming_time_memories(
     lexical comparison equals a chronological one. Soonest-first, capped at
     ``k``. Result rows are byte-compatible with the ``recall_upcoming`` handler
     (``memory_id`` / ``summary`` / ``type`` / ``details``).
+
+    When ``trusted_only`` is set (the bootstrap upcoming lane, #1293), apply the
+    same trusted-tier gate the recall lane uses so an external/connector-origin
+    time memory cannot establish behaviour at session start (OWASP LLM01/LLM03).
+    The standalone ``recall_upcoming`` tool leaves it ``False`` — a user-initiated
+    read is not the injection surface bootstrap is.
     """
-    from models.memory import Memory
+    from models.auth import CONTEXT_TRUST_TIER_TRUSTED, Context
+    from models.memory import SOURCE_TYPE_CONNECTOR, Memory
 
     query = (
         select(Memory)
@@ -59,6 +67,12 @@ async def query_upcoming_time_memories(
         .where(Memory.type == "time")
         .where(Memory.context_id == context_id)
     )
+    if trusted_only:
+        query = query.where(
+            Memory.context_id.in_(
+                select(Context.id).where(Context.trust_tier == CONTEXT_TRUST_TIER_TRUSTED)
+            )
+        ).where(Memory.source_type != SOURCE_TYPE_CONNECTOR)
     # Window overlap: stored [trigger_from, trigger_until] overlaps the query
     # window [q_from, q_until] iff trigger_until >= q_from AND trigger_from <= q_until.
     if q_from is not None:

--- a/backend/tests/integration/test_bootstrap_trusted_tier_e2e.py
+++ b/backend/tests/integration/test_bootstrap_trusted_tier_e2e.py
@@ -1,0 +1,255 @@
+"""End-to-end validation of the #1293 trusted-tier gate on the non-recall
+behaviour-establishing bootstrap lanes (pinned + upcoming time memories).
+
+The recall lane already drops external/connector-origin rows when bootstrap
+passes ``filters={"trust_tier": "trusted"}`` (agent_bootstrap_service `_recall`).
+Before #1293 the **pinned** lane (`load_pinned` → `MemoryRepository.list_pinned`)
+and the **time-memory** lane (`query_upcoming_time_memories`) applied no trust
+filter, so a connector-origin (e.g. Slack/Discord-ingested) pinned or upcoming
+memory surfaced verbatim at session start — an indirect prompt-injection vector
+on exactly the behaviour-establishing surface the recall lane guards
+(OWASP LLM01/LLM03, F2 invariant 3).
+
+These tests pin the fix at the query layer against the real DB: the same
+two-part gate recall uses (context ``trust_tier == trusted`` + row-level
+``source_type != connector``) now applies when ``trusted_only=True``, and stays
+a no-op (returns everything) when it is not — the standalone ``load_pinned`` /
+``recall_upcoming`` tools are user-initiated reads and keep their prior default.
+
+Setup rows are flushed (not committed) on ``db_session`` so they vanish on the
+session rollback. ``load_pinned``'s ``memory_access_events`` writer is a no-op
+here (no verified agent identity is set), so there is no committed side effect
+to clean up.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+
+from auth.workspace_roles import WorkspaceRole
+from models.auth import (
+    CONTEXT_TRUST_TIER_EXTERNAL,
+    Context,
+    User,
+    Workspace,
+    WorkspaceMember,
+)
+from models.memory import (
+    DELIVERY_MODE_ALWAYS,
+    SOURCE_TYPE_CONNECTOR,
+    SOURCE_TYPE_MANUAL,
+    Memory,
+)
+from services.memory_service import MemoryService
+from services.time_memory import query_upcoming_time_memories
+
+
+def _mem(uid, ws_id, ctx_id, *, summary, source_type, pinned=False, time=False):
+    # trigger_from/trigger_until are STORED generated columns
+    # (details->'trigger'->>'from'/'until') — never set them directly; seed the
+    # ``details.trigger`` JSON and Postgres computes them.
+    return Memory(
+        id=uuid.uuid4(),
+        user_id=uid,
+        workspace_id=ws_id,
+        context_id=ctx_id,
+        summary=summary,
+        content=f"body::{summary}",
+        type="time" if time else "note",
+        client="test",
+        tags=[],
+        source_type=source_type,
+        delivery_mode=DELIVERY_MODE_ALWAYS if pinned else "on_recall",
+        details=(
+            {"trigger": {"from": "2026-01-01T00:00:00", "until": "2099-12-31T23:59:59"}}
+            if time
+            else None
+        ),
+    )
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def env(db_session):
+    """Workspace + owner + a trusted context (default) and an external context,
+    each seeded with a manual and a connector-origin pinned + time memory."""
+    uid = f"e2e-trust-{uuid.uuid4().hex[:8]}"
+    ws_id = uuid.uuid4()
+
+    db_session.add(
+        User(
+            email=f"{uid}@example.test",
+            user_id=uid,
+            name="E2E Trust Owner",
+            role="user",
+            is_initial_admin=False,
+            auth_method="oauth",
+            auth_provider="google",
+        )
+    )
+    await db_session.flush()
+
+    db_session.add(
+        Workspace(
+            id=ws_id,
+            name=f"ws-{uuid.uuid4().hex[:8]}",
+            plan_name="free",
+            owner_user_id=uid,
+            daily_api_limit=500,
+            weekly_api_limit=2500,
+        )
+    )
+    db_session.add(WorkspaceMember(workspace_id=ws_id, user_id=uid, role=WorkspaceRole.OWNER))
+    await db_session.flush()
+
+    # Trusted context (server_default trust_tier='trusted') + an external one.
+    ctx_trusted = Context(id=uuid.uuid4(), workspace_id=ws_id, name="trusted", created_by=uid)
+    ctx_external = Context(
+        id=uuid.uuid4(),
+        workspace_id=ws_id,
+        name="external",
+        created_by=uid,
+        trust_tier=CONTEXT_TRUST_TIER_EXTERNAL,
+    )
+    db_session.add_all([ctx_trusted, ctx_external])
+    await db_session.flush()
+
+    p_manual = _mem(
+        uid,
+        ws_id,
+        ctx_trusted.id,
+        summary="pin-manual",
+        source_type=SOURCE_TYPE_MANUAL,
+        pinned=True,
+    )
+    p_conn = _mem(
+        uid,
+        ws_id,
+        ctx_trusted.id,
+        summary="pin-connector",
+        source_type=SOURCE_TYPE_CONNECTOR,
+        pinned=True,
+    )
+    p_ext = _mem(
+        uid,
+        ws_id,
+        ctx_external.id,
+        summary="pin-external",
+        source_type=SOURCE_TYPE_MANUAL,
+        pinned=True,
+    )
+    t_manual = _mem(
+        uid, ws_id, ctx_trusted.id, summary="time-manual", source_type=SOURCE_TYPE_MANUAL, time=True
+    )
+    t_conn = _mem(
+        uid,
+        ws_id,
+        ctx_trusted.id,
+        summary="time-connector",
+        source_type=SOURCE_TYPE_CONNECTOR,
+        time=True,
+    )
+    t_ext = _mem(
+        uid,
+        ws_id,
+        ctx_external.id,
+        summary="time-external",
+        source_type=SOURCE_TYPE_MANUAL,
+        time=True,
+    )
+    db_session.add_all([p_manual, p_conn, p_ext, t_manual, t_conn, t_ext])
+    await db_session.flush()
+
+    yield {
+        "uid": uid,
+        "ws_id": ws_id,
+        "ctx_trusted": ctx_trusted.id,
+        "ctx_external": ctx_external.id,
+        "p_manual": p_manual.id,
+        "p_conn": p_conn.id,
+        "t_manual": t_manual.id,
+        "t_conn": t_conn.id,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# pinned lane (load_pinned -> list_pinned)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_pinned_trusted_only_drops_connector_row(env, db_session):
+    # #1293: the bootstrap pinned lane must not surface a connector-origin
+    # pinned memory even inside an otherwise-trusted context (row-level
+    # defense-in-depth, mirrors recall).
+    resp = await MemoryService(db_session).load_pinned(
+        user_id=env["uid"],
+        current_context_id=env["ctx_trusted"],
+        current_workspace_id=env["ws_id"],
+        trusted_only=True,
+    )
+    returned = {str(m.memory_id) for m in resp.memories}
+    assert str(env["p_manual"]) in returned
+    assert str(env["p_conn"]) not in returned
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_pinned_default_is_unfiltered(env, db_session):
+    # Backward-compat: the standalone load_pinned surface (trusted_only=False)
+    # is a user-initiated read and must still return every pinned row.
+    resp = await MemoryService(db_session).load_pinned(
+        user_id=env["uid"],
+        current_context_id=env["ctx_trusted"],
+        current_workspace_id=env["ws_id"],
+    )
+    returned = {str(m.memory_id) for m in resp.memories}
+    assert str(env["p_manual"]) in returned
+    assert str(env["p_conn"]) in returned
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_pinned_trusted_only_external_context_returns_nothing(env, db_session):
+    # An external-tier context is untrusted wholesale — nothing from it may
+    # establish behaviour at session start.
+    resp = await MemoryService(db_session).load_pinned(
+        user_id=env["uid"],
+        current_context_id=env["ctx_external"],
+        current_workspace_id=env["ws_id"],
+        trusted_only=True,
+    )
+    assert resp.memories == []
+
+
+# --------------------------------------------------------------------------- #
+# upcoming lane (query_upcoming_time_memories)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_upcoming_trusted_only_drops_connector_row(env, db_session):
+    rows = await query_upcoming_time_memories(
+        db_session, env["ctx_trusted"], q_from=None, q_until=None, k=20, trusted_only=True
+    )
+    ids = {r["memory_id"] for r in rows}
+    assert str(env["t_manual"]) in ids
+    assert str(env["t_conn"]) not in ids
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_upcoming_trusted_only_external_context_returns_nothing(env, db_session):
+    rows = await query_upcoming_time_memories(
+        db_session, env["ctx_external"], q_from=None, q_until=None, k=20, trusted_only=True
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_upcoming_default_is_unfiltered(env, db_session):
+    rows = await query_upcoming_time_memories(
+        db_session, env["ctx_trusted"], q_from=None, q_until=None, k=20
+    )
+    ids = {r["memory_id"] for r in rows}
+    assert str(env["t_manual"]) in ids
+    assert str(env["t_conn"]) in ids

--- a/backend/tests/services/test_agent_bootstrap_service.py
+++ b/backend/tests/services/test_agent_bootstrap_service.py
@@ -367,6 +367,29 @@ class TestEnvelope:
         assert load_pinned.await_args.kwargs["cap"] == 7
 
     @pytest.mark.asyncio
+    async def test_pinned_requests_trusted_only(self):
+        # #1293: the behaviour-establishing pinned lane must ask load_pinned for
+        # the trusted-only set (parity with the recall lane's trust_tier filter).
+        svc = AgentBootstrapService(MagicMock())
+        load_pinned = AsyncMock(
+            return_value=SimpleNamespace(memories=[], total_available=0, truncated=False, cap=100)
+        )
+        with patch("services.memory_service.MemoryService") as ms_cls:
+            ms_cls.return_value.load_pinned = load_pinned
+            await svc._pinned(_context(), self._principal(), None)
+        assert load_pinned.await_args.kwargs["trusted_only"] is True
+
+    @pytest.mark.asyncio
+    async def test_upcoming_requests_trusted_only(self):
+        # #1293: the time-memory lane is behaviour-establishing too — it must
+        # pass trusted_only through to the shared upcoming query.
+        svc = AgentBootstrapService(MagicMock())
+        upcoming = AsyncMock(return_value=[])
+        with patch("services.time_memory.query_upcoming_time_memories", new=upcoming):
+            await svc._upcoming(_context(), BootstrapParams(agent_id=AGENT_ID))
+        assert upcoming.await_args.kwargs["trusted_only"] is True
+
+    @pytest.mark.asyncio
     async def test_query_absent_recall_skipped(self):
         import contextlib
 


### PR DESCRIPTION
## Summary

`AgentBootstrapService` output is behaviour-establishing at agent session start,
so F2 invariant 3 (OWASP LLM01/LLM03 indirect prompt injection) requires it to be
**trusted-only**. The **recall** lane enforced this (`filters={"trust_tier":"trusted"}`
→ `MemoryService.recall` drops non-trusted-tier / connector-source rows), but the
**pinned** lane (`load_pinned` → `list_pinned`) and the **time-memory** lane
(`query_upcoming_time_memories`) applied **no** trust filter. So an external /
connector-origin (e.g. Slack/Discord-ingested) pinned or upcoming-time memory in a
bootstrap context surfaced verbatim at session start — an injection vector on
exactly the surface the recall lane guards.

## Fix

Thread a `trusted_only` flag (default `False`) into `list_pinned` /
`MemoryService.load_pinned` and `query_upcoming_time_memories`, applying the same
two-part gate recall uses:
- context-level `Context.trust_tier == 'trusted'` (connector contexts are `'external'`)
- row-level `source_type != 'connector'` defense-in-depth

The bootstrap `_pinned` / `_upcoming` lanes opt in (`trusted_only=True`); the
user-initiated standalone `load_pinned` / `recall_upcoming` MCP+REST tools keep the
prior default (unfiltered) — mirroring the recall precedent where the trust filter
is bootstrap-supplied, not a default. No config knob (F2 "not configurable in v1").

## Tests

- **Integration** (`tests/integration/test_bootstrap_trusted_tier_e2e.py`, real DB):
  a connector-origin pinned/time row and an external-tier context are dropped under
  `trusted_only`, and both are returned without it (backward-compat), for both lanes.
- **Unit wiring**: bootstrap passes `trusted_only=True` on both lanes.
- No migration. `list_pinned`'s `trusted_only` filter applies to **both** the
  limit+1 SELECT and the fallback COUNT (no `total_available` inflation).

## Verification

Full local run of every touched suite green (bootstrap service/route/tool, memory
service, pinned/time routes, recall_upcoming, load_pinned repo+service). `ruff` +
`ruff format` clean; `pyright` 0 new errors. Adversarial self-review confirmed
byte-parity with the recall gate and that the other bootstrap lanes (`_state` reads
the separate `agent_states` KV table; `_policy` is a static stub) are correctly out
of scope.

Closes #1293

🤖 Generated with [Claude Code](https://claude.com/claude-code)