### PR TITLE
fix(api): emit one audit row per governed agent transition (#1294)

### DIFF
--- a/backend/src/api/routes/agents.py
+++ b/backend/src/api/routes/agents.py
@@ -28,12 +28,10 @@ from models.agent import Agent
 from models.api_base import TZAwareBaseModel
 from services.agent_registry_service import (
     AUDIT_AGENT_DELETED,
-    AUDIT_AGENT_ENFORCEMENT_WIDENED,
     AUDIT_AGENT_REGISTERED,
-    AUDIT_AGENT_UPDATED,
     AgentRegistryService,
     add_agent_audit_row,
-    enforcement_widened,
+    add_agent_update_audit_rows,
 )
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
@@ -231,18 +229,17 @@ async def update_agent(
 
     changes = await service.update_agent(agent, updates)
     if changes:
-        widened = enforcement_widened(changes)
-        transition = changes.get("enforcement_mode") or changes.get("status")
-        add_agent_audit_row(
+        # #1294: one audit row per governed transition — a combined
+        # status+enforcement PATCH must not collapse into a single old/new pair.
+        add_agent_update_audit_rows(
             db,
             actor_user_id=user_id,
             actor_email=email,
-            action=AUDIT_AGENT_ENFORCEMENT_WIDENED if widened else AUDIT_AGENT_UPDATED,
             agent_id=agent.id,
+            agent_name=agent.name,
             workspace_id=workspace_id,
-            metadata={**metadata, "agent_name": agent.name, "changes": changes},
-            old_value=transition.get("old") if transition else None,
-            new_value=transition.get("new") if transition else None,
+            changes=changes,
+            extra_metadata=metadata,
         )
         await db.commit()
         await db.refresh(agent)

--- a/backend/src/mcp_server/tools/agent_registry.py
+++ b/backend/src/mcp_server/tools/agent_registry.py
@@ -194,11 +194,8 @@ async def handle_update_agent(
     from db.base import get_db
     from mcp_server.tools.resource import _check_owner_admin_role
     from services.agent_registry_service import (
-        AUDIT_AGENT_ENFORCEMENT_WIDENED,
-        AUDIT_AGENT_UPDATED,
         AgentRegistryService,
-        add_agent_audit_row,
-        enforcement_widened,
+        add_agent_update_audit_rows,
     )
     from utils.exceptions import ConflictError, ValidationError
 
@@ -220,18 +217,17 @@ async def handle_update_agent(
             return _error_response("agent_name_conflict", e.message)
 
         if changes:
-            widened = enforcement_widened(changes)
-            transition = changes.get("enforcement_mode") or changes.get("status")
-            add_agent_audit_row(
+            # #1294: one audit row per governed transition (parity with the REST
+            # surface) — a combined status+enforcement PATCH must not collapse.
+            add_agent_update_audit_rows(
                 db,
                 actor_user_id=user_id,
                 actor_email=None,
-                action=AUDIT_AGENT_ENFORCEMENT_WIDENED if widened else AUDIT_AGENT_UPDATED,
                 agent_id=agent.id,
+                agent_name=agent.name,
                 workspace_id=workspace_id,
-                metadata={"via": "mcp", "agent_name": agent.name, "changes": changes},
-                old_value=transition.get("old") if transition else None,
-                new_value=transition.get("new") if transition else None,
+                changes=changes,
+                extra_metadata={"via": "mcp"},
             )
             await db.commit()
             await db.refresh(agent)

--- a/backend/src/services/agent_registry_service.py
+++ b/backend/src/services/agent_registry_service.py
@@ -149,6 +149,75 @@ def add_agent_audit_row(
     )
 
 
+# Governed transitions that each earn their own first-class audit row (#1294):
+# the ``status`` kill-switch and the ``enforcement_mode`` change. Ordered so a
+# combined PATCH emits rows deterministically (status before enforcement).
+_GOVERNED_TRANSITION_FIELDS: tuple[str, ...] = ("status", "enforcement_mode")
+
+
+def add_agent_update_audit_rows(
+    db: AsyncSession,
+    *,
+    actor_user_id: str,
+    actor_email: str | None,
+    agent_id: uuid.UUID,
+    agent_name: str,
+    workspace_id: uuid.UUID,
+    changes: dict[str, dict[str, Any]],
+    extra_metadata: dict[str, Any] | None = None,
+) -> None:
+    """Emit the security-mutation audit row(s) for an ``update_agent`` change set.
+
+    #1294: a combined PATCH (e.g. ``{"status":"retired","enforcement_mode":"shadow"}``)
+    must NOT collapse two governed transitions into a single old/new pair. This
+    emits **one row per governed transition** (``status`` kill-switch,
+    ``enforcement_mode``) so each is first-class in the structured
+    ``old_value``/``new_value`` columns, and ``enforce``→``shadow`` keeps its
+    distinct ``agent_enforcement_widened`` action. A change set with no governed
+    transition (``name`` / free-form text only) emits a single ``agent_updated``
+    row with no old/new pair — preserving the prior behaviour for those fields.
+
+    Every emitted row carries the full ``changes`` set in ``metadata`` so the
+    combined PATCH remains reconstructable; only the structured old/new columns
+    are per-transition. Rows are added to the session but NOT committed — the
+    caller commits atomically with the mutation.
+    """
+    if not changes:
+        return
+    base_metadata = {**(extra_metadata or {}), "agent_name": agent_name, "changes": changes}
+    governed = [field for field in _GOVERNED_TRANSITION_FIELDS if field in changes]
+    if not governed:
+        # name / free-form text only — one generic row, no transition pair.
+        add_agent_audit_row(
+            db,
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            action=AUDIT_AGENT_UPDATED,
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            metadata=base_metadata,
+        )
+        return
+    for field in governed:
+        pair = changes[field]
+        action = (
+            AUDIT_AGENT_ENFORCEMENT_WIDENED
+            if field == "enforcement_mode" and enforcement_widened(changes)
+            else AUDIT_AGENT_UPDATED
+        )
+        add_agent_audit_row(
+            db,
+            actor_user_id=actor_user_id,
+            actor_email=actor_email,
+            action=action,
+            agent_id=agent_id,
+            workspace_id=workspace_id,
+            metadata=base_metadata,
+            old_value=pair.get("old"),
+            new_value=pair.get("new"),
+        )
+
+
 class AgentRegistryService:
     """CRUD + throttled liveness writes for the Agent Registry."""
 

--- a/backend/tests/api/test_agents_routes.py
+++ b/backend/tests/api/test_agents_routes.py
@@ -87,6 +87,17 @@ def audit(monkeypatch):
     return recorder
 
 
+@pytest.fixture
+def audit_update(monkeypatch):
+    # update_agent funnels its audit through add_agent_update_audit_rows (#1294);
+    # the route's contract is "call it with the change set + commit atomically".
+    # Row-emission correctness (one row per governed transition) is pinned at the
+    # service level in test_agent_registry_service.py::TestUpdateAuditRows.
+    recorder = MagicMock()
+    monkeypatch.setattr(agents_routes, "add_agent_update_audit_rows", recorder)
+    return recorder
+
+
 class TestRegisterAgent:
     @pytest.mark.asyncio
     async def test_creates_audits_and_commits(self, db, service, audit):
@@ -165,10 +176,11 @@ class TestGetAndList:
 
 class TestUpdateAgent:
     @pytest.mark.asyncio
-    async def test_transition_audited_with_old_new(self, db, service, audit):
+    async def test_transition_forwards_change_set_and_commits(self, db, service, audit_update):
         agent = _fake_agent()
         service.get_agent.return_value = agent
-        service.update_agent.return_value = {"status": {"old": "active", "new": "suspended"}}
+        changes = {"status": {"old": "active", "new": "suspended"}}
+        service.update_agent.return_value = changes
 
         await update_agent(
             agent_id=agent.id,
@@ -177,31 +189,37 @@ class TestUpdateAgent:
             db=db,
         )
 
-        kwargs = audit.call_args.kwargs
-        assert kwargs["action"] == "agent_updated"
-        assert kwargs["old_value"] == "active"
-        assert kwargs["new_value"] == "suspended"
+        kwargs = audit_update.call_args.kwargs
+        assert kwargs["changes"] == changes
+        assert kwargs["agent_id"] == agent.id
+        assert kwargs["agent_name"] == agent.name
         db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_enforce_to_shadow_uses_widening_action(self, db, service, audit):
+    async def test_combined_status_enforcement_patch_forwards_both(self, db, service, audit_update):
+        # #1294: the route must hand the FULL change set to the audit helper so
+        # the status kill-switch and the enforcement change are both recorded —
+        # the helper (not the route) fans them into one row per transition.
         agent = _fake_agent()
         service.get_agent.return_value = agent
-        service.update_agent.return_value = {
-            "enforcement_mode": {"old": "enforce", "new": "shadow"}
+        changes = {
+            "status": {"old": "active", "new": "retired"},
+            "enforcement_mode": {"old": "enforce", "new": "shadow"},
         }
+        service.update_agent.return_value = changes
 
         await update_agent(
             agent_id=agent.id,
-            data=AgentUpdate(enforcement_mode="shadow"),
+            data=AgentUpdate(status="retired", enforcement_mode="shadow"),
             user=MOCK_USER,
             db=db,
         )
 
-        assert audit.call_args.kwargs["action"] == "agent_enforcement_widened"
+        assert audit_update.call_args.kwargs["changes"] == changes
+        db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_noop_update_skips_audit_and_commit(self, db, service, audit):
+    async def test_noop_update_skips_audit_and_commit(self, db, service, audit_update):
         agent = _fake_agent()
         service.get_agent.return_value = agent
         service.update_agent.return_value = {}
@@ -214,7 +232,7 @@ class TestUpdateAgent:
         )
 
         assert result is agent
-        audit.assert_not_called()
+        audit_update.assert_not_called()
         db.commit.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/backend/tests/mcp_server/test_agent_registry_tools.py
+++ b/backend/tests/mcp_server/test_agent_registry_tools.py
@@ -212,6 +212,36 @@ class TestUpdateAgent:
         assert audit.call_args.kwargs["new_value"] == "shadow"
 
     @pytest.mark.asyncio
+    async def test_combined_status_enforcement_patch_emits_two_rows(self):
+        # #1294: a combined status+enforcement PATCH on the MCP surface must not
+        # collapse into one audit row — parity with the REST surface.
+        agent = _fake_agent()
+        svc = MagicMock(
+            get_agent=AsyncMock(return_value=agent),
+            update_agent=AsyncMock(
+                return_value={
+                    "status": {"old": "active", "new": "retired"},
+                    "enforcement_mode": {"old": "enforce", "new": "shadow"},
+                }
+            ),
+        )
+        with ExitStack() as stack:
+            _, audit = _enter(stack, service=svc)
+            result = await handle_update_agent(
+                args={"agent_id": str(agent.id), "status": "retired", "enforcement_mode": "shadow"},
+                user_id="u",
+                workspace_id=WORKSPACE_ID,
+            )
+        assert _payload(result)["status"] == "success"
+        assert audit.call_count == 2
+        emitted = {
+            c.kwargs["action"]: (c.kwargs.get("old_value"), c.kwargs.get("new_value"))
+            for c in audit.call_args_list
+        }
+        assert emitted["agent_updated"] == ("active", "retired")
+        assert emitted["agent_enforcement_widened"] == ("enforce", "shadow")
+
+    @pytest.mark.asyncio
     async def test_noop_update_writes_no_audit(self):
         agent = _fake_agent()
         svc = MagicMock(

--- a/backend/tests/services/test_agent_registry_service.py
+++ b/backend/tests/services/test_agent_registry_service.py
@@ -20,8 +20,10 @@ from models.agent import Agent
 from services.agent_registry_service import (
     AUDIT_AGENT_ENFORCEMENT_WIDENED,
     AUDIT_AGENT_REGISTERED,
+    AUDIT_AGENT_UPDATED,
     AgentRegistryService,
     add_agent_audit_row,
+    add_agent_update_audit_rows,
     enforcement_widened,
     validate_agent_enforcement_mode,
     validate_agent_name,
@@ -315,3 +317,105 @@ class TestAuditRow:
         # Raw enum values per the roles.py transition precedent.
         assert row.old_value_hash == "enforce"
         assert row.new_value_hash == "shadow"
+
+
+# ---------------------------------------------------------------------------
+# add_agent_update_audit_rows — one row per governed transition (#1294)
+# ---------------------------------------------------------------------------
+
+
+def _emit_rows(changes, *, extra_metadata=None):
+    """Run add_agent_update_audit_rows against a mock db; return the AuditLog rows."""
+    db = MagicMock()
+    add_agent_update_audit_rows(
+        db,
+        actor_user_id="user-1",
+        actor_email="u@example.com",
+        agent_id=uuid.uuid4(),
+        agent_name="ci-bot",
+        workspace_id=WORKSPACE_ID,
+        changes=changes,
+        extra_metadata=extra_metadata,
+    )
+    return [call.args[0] for call in db.add.call_args_list]
+
+
+class TestUpdateAuditRows:
+    def test_combined_patch_emits_one_row_per_governed_transition(self):
+        # #1294: a combined status+enforcement PATCH must NOT collapse — the
+        # status kill-switch and the enforcement change each get their own row
+        # with their own old/new pair, and enforce→shadow keeps the widening
+        # action. Before the fix this produced a single widened row that dropped
+        # the status old/new entirely.
+        rows = _emit_rows(
+            {
+                "status": {"old": "active", "new": "retired"},
+                "enforcement_mode": {"old": "enforce", "new": "shadow"},
+            }
+        )
+        assert len(rows) == 2
+        by_action = {r.action: r for r in rows}
+        assert set(by_action) == {AUDIT_AGENT_UPDATED, AUDIT_AGENT_ENFORCEMENT_WIDENED}
+        # status kill-switch is first-class, not buried under the widened row.
+        status_row = by_action[AUDIT_AGENT_UPDATED]
+        assert (status_row.old_value_hash, status_row.new_value_hash) == ("active", "retired")
+        enf_row = by_action[AUDIT_AGENT_ENFORCEMENT_WIDENED]
+        assert (enf_row.old_value_hash, enf_row.new_value_hash) == ("enforce", "shadow")
+
+    def test_status_ordered_before_enforcement(self):
+        rows = _emit_rows(
+            {
+                "enforcement_mode": {"old": "enforce", "new": "shadow"},
+                "status": {"old": "active", "new": "suspended"},
+            }
+        )
+        # Deterministic order regardless of dict insertion order: status first.
+        assert [r.old_value_hash for r in rows] == ["active", "enforce"]
+
+    def test_status_only_single_row(self):
+        rows = _emit_rows({"status": {"old": "active", "new": "suspended"}})
+        assert len(rows) == 1
+        assert rows[0].action == AUDIT_AGENT_UPDATED
+        assert (rows[0].old_value_hash, rows[0].new_value_hash) == ("active", "suspended")
+
+    def test_enforcement_widened_single_row(self):
+        rows = _emit_rows({"enforcement_mode": {"old": "enforce", "new": "shadow"}})
+        assert len(rows) == 1
+        assert rows[0].action == AUDIT_AGENT_ENFORCEMENT_WIDENED
+
+    def test_enforcement_narrowing_uses_updated_action(self):
+        rows = _emit_rows({"enforcement_mode": {"old": "shadow", "new": "enforce"}})
+        assert len(rows) == 1
+        assert rows[0].action == AUDIT_AGENT_UPDATED
+        assert (rows[0].old_value_hash, rows[0].new_value_hash) == ("shadow", "enforce")
+
+    def test_combined_non_widening_emits_two_updated_rows(self):
+        rows = _emit_rows(
+            {
+                "status": {"old": "active", "new": "suspended"},
+                "enforcement_mode": {"old": "shadow", "new": "enforce"},
+            }
+        )
+        assert len(rows) == 2
+        assert [r.action for r in rows] == [AUDIT_AGENT_UPDATED, AUDIT_AGENT_UPDATED]
+
+    def test_name_only_single_generic_row_without_pair(self):
+        rows = _emit_rows({"name": {"old": "ci-bot", "new": "ci-bot-2"}})
+        assert len(rows) == 1
+        assert rows[0].action == AUDIT_AGENT_UPDATED
+        assert rows[0].old_value_hash is None
+        assert rows[0].new_value_hash is None
+
+    def test_empty_changes_emits_nothing(self):
+        assert _emit_rows({}) == []
+
+    def test_every_row_carries_full_change_set_and_extra_metadata(self):
+        changes = {
+            "status": {"old": "active", "new": "retired"},
+            "enforcement_mode": {"old": "enforce", "new": "shadow"},
+        }
+        rows = _emit_rows(changes, extra_metadata={"via": "mcp"})
+        for r in rows:
+            assert r.user_metadata["changes"] == changes
+            assert r.user_metadata["agent_name"] == "ci-bot"
+            assert r.user_metadata["via"] == "mcp"


### PR DESCRIPTION
## Summary

A single `PATCH /api/v1/agents/{id}` carrying **both** a `status` kill-switch and an
`enforcement_mode` change (e.g. `{"status":"retired","enforcement_mode":"shadow"}`)
wrote exactly **one** audit row: `widened=True` → `action=agent_enforcement_widened`,
and `transition = changes.get("enforcement_mode") or changes.get("status")` resolved
to the enforcement pair only. So the **status (kill-switch) old/new was dropped** from
the structured audit columns and the status transition was buried under the
enforcement-widened action. Both the REST route and the MCP handler had the identical
bug (copy-paste drift).

## Fix

A shared `add_agent_update_audit_rows(...)` helper (in `agent_registry_service.py`)
emits **one row per governed transition** — `status` and `enforcement_mode` — each with
its own `old_value`/`new_value` pair in the structured columns, so each is first-class.
`enforce`→`shadow` keeps its distinct `agent_enforcement_widened` action; every other
governed change uses `agent_updated`. A change set with no governed transition (name /
free-form text only) emits a single `agent_updated` row with no old/new pair —
preserving prior behaviour. Every emitted row carries the full change set in `metadata`
so the combined PATCH stays reconstructable.

Both the REST route and the MCP handler now call the **one** helper — closing the drift
that let the two surfaces share the same bug.

## Tests

- **Service-level** `TestUpdateAuditRows` pins the row-emission matrix: combined
  status+enforcement → **two** rows with the right action + old/new each; deterministic
  ordering (status before enforcement); widening vs narrowing action; name-only → single
  row with no pair; empty change set → zero rows; full change set carried in metadata.
- **REST + MCP** tests pin the combined-PATCH case on both surfaces (route forwards the
  full change set + commits once; MCP emits two rows).
- No migration; **no new audit-action constant** (reuses the existing vocabulary).

## Verification

74 tests green across `test_agent_registry_service` / `test_agents_routes` /
`test_agent_registry_tools`. `ruff` + `ruff format` clean; `pyright` 0 errors on the
three changed source files.

Closes #1294

🤖 Generated with [Claude Code](https://claude.com/claude-code)