### PR TITLE
feat(auth): F4 conformance + memory-access deny capture (#1286)

### DIFF
--- a/backend/src/api/correlation.py
+++ b/backend/src/api/correlation.py
@@ -13,8 +13,11 @@ advisory: nothing here grants or denies access. Invalid values are dropped
 generation so every audit row is correlatable.
 
 Identity precedence (normative): credential-bound ``agent_id`` (verified key)
-> explicit bootstrap arg > baggage claim. A claim never outranks a credential
-— see :func:`resolve_agent_correlation`.
+> explicit bootstrap arg > baggage claim. A claim never outranks a credential,
+and winning precedence is never a verification exemption — on an agent-unbound
+credential the winning candidate (explicit arg included) still passes the
+Rule-2 same-member predicate before reaching ``agent_id``. See
+:func:`resolve_agent_correlation`.
 """
 
 from __future__ import annotations
@@ -35,8 +38,9 @@ BAGGAGE_SESSION_ID = "gen_ai.conversation.id"
 BAGGAGE_SESSION_ID_ALIAS = "session.id"
 BAGGAGE_RUN_ID = "kagura.agent.run.id"
 
-# policy_decision stamped on rows whose agent_id came from a *verified baggage
-# claim* on an agent-UNBOUND credential (attribution without containment).
+# policy_decision stamped on rows whose agent_id came from a *verified claim*
+# (explicit arg or baggage) on an agent-UNBOUND credential (attribution
+# without containment).
 POLICY_DECISION_UNBOUND = "unbound"
 
 _CORRELATION_TOKEN_MAX_LEN = 128
@@ -283,10 +287,13 @@ async def resolve_agent_correlation(
       ``unverified_agent_claim`` — never precedence-resolved in favor of the
       claim.
     - **Agent-unbound credential** (Rules 2/5): an explicit arg wins over
-      baggage (``correlation_conflict`` when they disagree); a baggage claim is
-      trusted into ``agent_id`` IFF :func:`verify_baggage_agent_claim` passes,
-      and such rows are stamped ``policy_decision='unbound'``. An unverified
-      claim is keyed-hashed only.
+      baggage as the *candidate* (``correlation_conflict`` when they
+      disagree) — precedence, not a verification exemption: the winning
+      candidate (explicit arg or baggage claim) is trusted into ``agent_id``
+      IFF :func:`verify_baggage_agent_claim` passes, and such rows are
+      stamped ``policy_decision='unbound'``. The keyed-hash slot records the
+      highest-precedence *unverified* claim: the candidate itself on
+      verifier-False, or the losing baggage claim on a verified conflict.
     """
     baggage_claim_raw = correlation.agent_claim if correlation else None
 
@@ -305,25 +312,26 @@ async def resolve_agent_correlation(
         )
 
     # --- Agent-unbound credential. ---------------------------------------
-    if member_user_id is None or workspace_id is None:
-        # Cannot verify anything — keep any raw claim as a hash only.
-        return ResolvedAgentCorrelation(
-            agent_id=None,
-            policy_decision=None,
-            unverified_agent_claim_hash=_hash_claim(baggage_claim_raw)
-            if baggage_claim_raw
-            else None,
-            correlation_conflict=False,
-        )
-
-    # Rule 5: explicit arg wins over baggage; conflict flagged when they differ.
+    # Conflict is a pure fact of the two inputs — computed before any guard
+    # so every unbound-path row carries it.
     conflict = bool(
         explicit_agent_id is not None
         and baggage_claim_raw
         and baggage_claim_raw != str(explicit_agent_id)
     )
+    # Rule 5: the explicit arg wins the *candidate* slot over baggage.
     candidate = explicit_agent_id
     candidate_raw = str(explicit_agent_id) if explicit_agent_id is not None else baggage_claim_raw
+
+    if member_user_id is None or workspace_id is None:
+        # Cannot verify anything — keep the highest-precedence raw claim as
+        # a hash only (explicit arg shadows baggage, as on the bound path).
+        return ResolvedAgentCorrelation(
+            agent_id=None,
+            policy_decision=None,
+            unverified_agent_claim_hash=_hash_claim(candidate_raw) if candidate_raw else None,
+            correlation_conflict=conflict,
+        )
 
     if candidate is None:
         # Only a baggage claim — parse it to a UUID.
@@ -340,11 +348,15 @@ async def resolve_agent_correlation(
         db, claimed_agent_id=candidate, member_user_id=member_user_id, workspace_id=workspace_id
     )
     if verified:
-        # Attribution without containment — stamp 'unbound'.
+        # Attribution without containment — stamp 'unbound'. On a conflict
+        # the losing baggage claim is the unverified one: hash it rather
+        # than dropping it to a bare boolean (#1286 item 1).
         return ResolvedAgentCorrelation(
             agent_id=candidate,
             policy_decision=POLICY_DECISION_UNBOUND,
-            unverified_agent_claim_hash=None,
+            unverified_agent_claim_hash=_hash_claim(baggage_claim_raw)
+            if conflict and baggage_claim_raw
+            else None,
             correlation_conflict=conflict,
         )
     # Rule 3: unverified claim never reaches agent_id — keyed hash only.

--- a/backend/src/api/routes/feedback.py
+++ b/backend/src/api/routes/feedback.py
@@ -87,7 +87,9 @@ async def record_feedback(
     try:
         # Read-adjacent: VIEWER may rate recall. Uniform 404 on unreachable
         # context (IDOR guard), same posture as the other context-scoped routes.
-        await perm.check_context_access(user_id, context_id, required_role=ContextRole.VIEWER)
+        await perm.check_context_access(
+            user_id, context_id, required_role=ContextRole.VIEWER, operation="feedback"
+        )
         row = await service.record_feedback(
             context_id=context_id,
             memory_id=body.memory_id,

--- a/backend/src/auth/agent_scope.py
+++ b/backend/src/auth/agent_scope.py
@@ -35,6 +35,13 @@ class AgentScope:
 
     agent_id: UUID
     enforcement_mode: str
+    # #1286 (P0-5): the credential's workspace scope — deny-capture stamps it
+    # as the audit row's workspace_id (the CALLER scope; the requested,
+    # unverified identifiers ride event_metadata only). Agent-bound keys are
+    # workspace-scoped by the F1 mint invariant, so the auth adapters always
+    # populate it; ``None`` (legacy constructions / test doubles) makes the
+    # writer drop the row rather than guess a workspace — fail-safe.
+    workspace_id: UUID | None = None
 
 
 _agent_scope: ContextVar[AgentScope | None] = ContextVar("agent_scope", default=None)
@@ -74,4 +81,10 @@ def set_agent_scope_from_verified(verified: Any) -> None:
         from models.agent import AGENT_ENFORCEMENT_ENFORCE
 
         mode = AGENT_ENFORCEMENT_ENFORCE
-    set_agent_scope(AgentScope(agent_id=agent_id, enforcement_mode=mode))
+    set_agent_scope(
+        AgentScope(
+            agent_id=agent_id,
+            enforcement_mode=mode,
+            workspace_id=getattr(verified, "workspace_id", None),
+        )
+    )

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -177,6 +177,8 @@ async def _resolve_context(
     db: "AsyncSession",
     user_id: str,
     context_id: UUID,
+    *,
+    operation: str | None = None,
 ) -> Any:
     """Resolve and validate context access.
 
@@ -184,6 +186,10 @@ async def _resolve_context(
         db: Database session
         user_id: User ID
         context_id: Context UUID
+        operation: MAE operation vocabulary value for #1286 deny capture
+            (threaded by the memory write tools: remember / update / forget).
+            ``None`` for callers outside that vocabulary — their binding
+            denies stay log-only here.
 
     Returns:
         Context object
@@ -237,8 +243,18 @@ async def _resolve_context(
     if scope is not None:
         from services.agent_binding_service import ACCESS_WRITE, AgentBindingService
 
+        # #1286 (P0-5): emit_would_deny=False — this is a PRE-gate; in shadow
+        # mode the request proceeds into the service-layer gate (isolation
+        # params / can_access_memory), which re-evaluates and emits the
+        # single would_deny row. A hard deny stops the request HERE, so the
+        # evaluation emits it (the service gate is never reached).
         allowed, decision = await AgentBindingService(db).evaluate_context_access(
-            scope, context_id, ACCESS_WRITE
+            scope,
+            context_id,
+            ACCESS_WRITE,
+            operation=operation,
+            user_id=user_id,
+            emit_would_deny=False,
         )
         if not allowed:
             logger.warning(

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -243,18 +243,18 @@ async def _resolve_context(
     if scope is not None:
         from services.agent_binding_service import ACCESS_WRITE, AgentBindingService
 
-        # #1286 (P0-5): emit_would_deny=False — this is a PRE-gate; in shadow
-        # mode the request proceeds into the service-layer gate (isolation
-        # params / can_access_memory), which re-evaluates and emits the
-        # single would_deny row. A hard deny stops the request HERE, so the
-        # evaluation emits it (the service gate is never reached).
+        # #1286 (P0-5): deny capture. In shadow mode the request proceeds
+        # into the service-layer gates, which may re-evaluate the same
+        # context — the writer's request-scoped dedup collapses those shadow
+        # rows to one, so this pre-gate emits unconditionally. A hard deny
+        # stops the request HERE (the service gate is never reached), so its
+        # emission is load-bearing.
         allowed, decision = await AgentBindingService(db).evaluate_context_access(
             scope,
             context_id,
             ACCESS_WRITE,
             operation=operation,
             user_id=user_id,
-            emit_would_deny=False,
         )
         if not allowed:
             logger.warning(
@@ -278,6 +278,7 @@ async def _resolve_context_for_read(
     context_id: UUID,
     *,
     required_role: str = "viewer",
+    operation: str | None = None,
 ) -> Any:
     """Resolve a context_id to a Context the caller can read, MCP-flavored.
 
@@ -304,11 +305,16 @@ async def _resolve_context_for_read(
     from utils.exceptions import NotFoundException
 
     try:
+        # #1286 (P0-5): ``operation`` threads MAE audit identity into the
+        # binding filter so an enforce-mode hard deny at THIS pre-gate — which
+        # stops the request before any service-layer gate — still persists
+        # its denied row (the MCP read face of the #1291/#1292 parity lesson).
         return await PermissionService(db).resolve_context_for_workspace_read(
             user_id=user_id,
             context_id=context_id,
             required_role=required_role,
             key_workspace_id=_mcp_key_workspace_scope.get(),
+            operation=operation,
         )
     except NotFoundException as exc:
         raise _ContextNotFoundError(

--- a/backend/src/mcp_server/tools/feedback.py
+++ b/backend/src/mcp_server/tools/feedback.py
@@ -73,7 +73,7 @@ async def handle_feedback(
             return _error_response("invalid_context_id_format", str(exc))
         try:
             # Read-adjacent: verify the caller can reach the context (IDOR guard).
-            await _resolve_context_for_read(db, user_id, context_id)
+            await _resolve_context_for_read(db, user_id, context_id, operation="feedback")
         except _ContextNotFoundError as exc:
             return exc.to_response()
 

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -348,7 +348,9 @@ async def handle_load_pinned(
             current_context_id = _resolve_context_id(args["context_id"])
             # Read path: uniform context_not_found on any deny (CWE-639 / OWASP
             # A01), mirroring handle_recall / handle_recall_upcoming.
-            current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+            current_context = await _resolve_context_for_read(
+                db, user_id, current_context_id, operation="load_pinned"
+            )
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -467,7 +469,9 @@ async def handle_recall(
                     dict.fromkeys(_resolve_context_id(cid) for cid in context_ids_arg)
                 )
                 current_context_id = cross_context_ids[0]
-                current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+                current_context = await _resolve_context_for_read(
+                    db, user_id, current_context_id, operation="recall"
+                )
                 # #708 H3: all contexts must belong to the same workspace —
                 # Option A paid_by routing has a single source-of-truth
                 # workspace. Check inline so a mismatch short-circuits
@@ -484,7 +488,9 @@ async def handle_recall(
                 # private secondary. Rejecting at API boundary mirrors
                 # the same-embedding-model invariant pattern below.
                 for cid in cross_context_ids[1:]:
-                    cross_ctx = await _resolve_context_for_read(db, user_id, cid)
+                    cross_ctx = await _resolve_context_for_read(
+                        db, user_id, cid, operation="recall"
+                    )
                     if cross_ctx.workspace_id != current_context.workspace_id:
                         return _error_response(
                             "workspace_mismatch",
@@ -521,7 +527,9 @@ async def handle_recall(
                         "Missing required field: context_id (or provide context_ids with 2+ UUIDs).",
                     )
                 current_context_id = _resolve_context_id(args["context_id"])
-                current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+                current_context = await _resolve_context_for_read(
+                    db, user_id, current_context_id, operation="recall"
+                )
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -749,7 +757,9 @@ async def handle_reference(
             # Issue #708 bundle: migrate read paths to the CWE-639-uniform
             # resolver so deny reasons (private non-creator, not a workspace
             # member, etc.) cannot be distinguished by callers.
-            current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+            current_context = await _resolve_context_for_read(
+                db, user_id, current_context_id, operation="reference"
+            )
 
             service = MemoryService(db)
             try:

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -76,7 +76,9 @@ async def handle_remember(
             if perm_error:
                 return perm_error
 
-            current_context = await _resolve_context(db, user_id, current_context_id)
+            current_context = await _resolve_context(
+                db, user_id, current_context_id, operation="remember"
+            )
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -181,7 +183,9 @@ async def handle_update_memory(
             if perm_error:
                 return perm_error
 
-            current_context = await _resolve_context(db, user_id, current_context_id)
+            current_context = await _resolve_context(
+                db, user_id, current_context_id, operation="update"
+            )
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -674,7 +678,9 @@ async def handle_forget(
             if perm_error:
                 return perm_error
 
-            current_context = await _resolve_context(db, user_id, current_context_id)
+            current_context = await _resolve_context(
+                db, user_id, current_context_id, operation="forget"
+            )
 
             service = MemoryService(db)
             result = await execute_with_timeout(

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -65,18 +65,19 @@ def _validate_type_array(value: Any, field: str) -> list[str] | None:
     forward-provisioned in the F1 DDL, but per-memory type/source enforcement
     is materially larger than the context-level binding gate (it must filter
     each recall/reference/write by the memory's own type) and lands in a
-    follow-up (#1281). To avoid a **fail-open** — an admin setting a restriction
-    that is silently ignored, a false sense of containment — CRUD rejects any
-    non-NULL value for now. ``NULL`` (= all types, the P0-2-enforced value) is
-    the only accepted value. Code-review of #1275. (Same "provisioned-but-
-    reserved" posture as ``write_policy='staged'``.)
+    follow-up (#1299, split out of #1286 and deferred to P1). To avoid a
+    **fail-open** — an admin setting a restriction that is silently ignored, a
+    false sense of containment — CRUD rejects any non-NULL value for now.
+    ``NULL`` (= all types, the P0-2-enforced value) is the only accepted
+    value. Code-review of #1275. (Same "provisioned-but-reserved" posture as
+    ``write_policy='staged'``.)
     """
     if value is None:
         return None
     raise ValidationError(
         f"'{field}' is reserved: per-type binding filters are provisioned but "
         "not yet enforced — set it to null (all types) for now. Type/source "
-        "filtering ships in a follow-up (#1281).",
+        "filtering ships in a follow-up (#1299).",
         field=field,
     )
 

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -346,7 +346,6 @@ class AgentBindingService:
         operation: str | None = None,
         user_id: str | None = None,
         requested_memory_id: uuid.UUID | None = None,
-        emit_would_deny: bool = True,
     ) -> tuple[bool, str]:
         """Evaluate the binding intersection for one context.
 
@@ -365,10 +364,11 @@ class AgentBindingService:
         proceeds; the row is the shadow→enforce ramp signal). The requested
         identifiers ride ``event_metadata`` as claims (the authoritative
         ``context_id`` / ``memory_id`` columns stay NULL) and ``workspace_id``
-        is the CREDENTIAL scope. ``emit_would_deny=False`` is for pre-gates
-        whose request re-hits a service-layer gate (the MCP write path):
-        the downstream gate emits the single shadow row; a hard deny stops
-        the request at the pre-gate, so that is always emitted here.
+        is the CREDENTIAL scope. When several gates evaluate the SAME denied
+        context in one request (pre-gate + service gate), the writer's
+        request-scoped dedup collapses the shadow rows to one — every gate
+        may emit unconditionally. Hard denies stop the request, so only one
+        gate can ever reach its emission.
         """
         result = await self.db.execute(
             select(AgentContextBinding).where(
@@ -400,16 +400,15 @@ class AgentBindingService:
                 access=access,
                 bound=binding is not None,
             )
-            if emit_would_deny:
-                await self._emit_decision(
-                    scope,
-                    context_id,
-                    access,
-                    DECISION_WOULD_DENY,
-                    operation=operation,
-                    user_id=user_id,
-                    requested_memory_id=requested_memory_id,
-                )
+            await self._emit_decision(
+                scope,
+                context_id,
+                access,
+                DECISION_WOULD_DENY,
+                operation=operation,
+                user_id=user_id,
+                requested_memory_id=requested_memory_id,
+            )
             return True, DECISION_WOULD_DENY
 
         logger.warning(

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -41,6 +41,10 @@ logger = get_logger(__name__)
 DECISION_ALLOWED = "allowed"
 DECISION_BINDING_DENIED = "binding_denied"
 DECISION_WOULD_DENY = "would_deny"
+# #1286 (P0-5): an RBAC-shaped deny observed on the binding-evaluation path
+# (can_access_memory collapses RBAC and binding into one bool — the rbac
+# branches stamp this so the two deny causes stay distinguishable in audit).
+DECISION_RBAC_DENIED = "rbac_denied"
 
 # Access kinds the chokepoints evaluate.
 ACCESS_READ = "read"
@@ -86,7 +90,15 @@ def _validate_write_policy(value: Any) -> str:
     return value
 
 
-async def agent_binding_permits(db: AsyncSession, context_id: uuid.UUID, access: str) -> bool:
+async def agent_binding_permits(
+    db: AsyncSession,
+    context_id: uuid.UUID,
+    access: str,
+    *,
+    operation: str | None = None,
+    user_id: str | None = None,
+    requested_memory_id: uuid.UUID | None = None,
+) -> bool:
     """Reusable subtractive gate for the per-request agent scope.
 
     Returns True when the request is not an agent credential (scope None) or
@@ -99,6 +111,11 @@ async def agent_binding_permits(db: AsyncSession, context_id: uuid.UUID, access:
     closing the "MemoryService authorizes via its own RBAC path, not the
     named chokepoint" gap (Copilot/inner review of #1275). No-op cost for
     every non-agent credential (one contextvar read).
+
+    #1286 (P0-5): ``operation`` / ``user_id`` / ``requested_memory_id`` are
+    the audit-identity passthrough — when a memory-op caller threads them,
+    the evaluation persists its deny decisions to ``memory_access_events``
+    (see :meth:`AgentBindingService.evaluate_context_access`).
     """
     from auth.agent_scope import get_agent_scope
 
@@ -106,7 +123,12 @@ async def agent_binding_permits(db: AsyncSession, context_id: uuid.UUID, access:
     if scope is None:
         return True
     allowed, _decision = await AgentBindingService(db).evaluate_context_access(
-        scope, context_id, access
+        scope,
+        context_id,
+        access,
+        operation=operation,
+        user_id=user_id,
+        requested_memory_id=requested_memory_id,
     )
     return allowed
 
@@ -315,7 +337,15 @@ class AgentBindingService:
     # ------------------------------------------------------------------
 
     async def evaluate_context_access(
-        self, scope: AgentScope, context_id: uuid.UUID, access: str
+        self,
+        scope: AgentScope,
+        context_id: uuid.UUID,
+        access: str,
+        *,
+        operation: str | None = None,
+        user_id: str | None = None,
+        requested_memory_id: uuid.UUID | None = None,
+        emit_would_deny: bool = True,
     ) -> tuple[bool, str]:
         """Evaluate the binding intersection for one context.
 
@@ -325,6 +355,19 @@ class AgentBindingService:
         legacy semantics (the migration ramp) — callers MUST treat it as
         allowed. This function can only subtract: it is called strictly AFTER
         the existing RBAC decision allowed the request.
+
+        #1286 (P0-5) deny capture: when the caller threads audit identity
+        (``operation`` + ``user_id``), the decision is persisted to
+        ``memory_access_events`` — a hard deny as ``outcome='denied'`` /
+        ``policy_decision='binding_denied'``; a shadow would-deny as
+        ``outcome='success'`` / ``policy_decision='would_deny'`` (the request
+        proceeds; the row is the shadow→enforce ramp signal). The requested
+        identifiers ride ``event_metadata`` as claims (the authoritative
+        ``context_id`` / ``memory_id`` columns stay NULL) and ``workspace_id``
+        is the CREDENTIAL scope. ``emit_would_deny=False`` is for pre-gates
+        whose request re-hits a service-layer gate (the MCP write path):
+        the downstream gate emits the single shadow row; a hard deny stops
+        the request at the pre-gate, so that is always emitted here.
         """
         result = await self.db.execute(
             select(AgentContextBinding).where(
@@ -347,8 +390,8 @@ class AgentBindingService:
             return True, DECISION_ALLOWED
 
         if scope.enforcement_mode == AGENT_ENFORCEMENT_SHADOW:
-            # Shadow ramp: proceed, but record the violation. The durable
-            # would_deny row lands in memory_access_events with P0-5 (#1278).
+            # Shadow ramp: proceed, but record the violation (#1286 item 2 —
+            # the durable would_deny row this log line used to promise).
             logger.warning(
                 "agent_binding_would_deny",
                 agent_id=str(scope.agent_id),
@@ -356,6 +399,16 @@ class AgentBindingService:
                 access=access,
                 bound=binding is not None,
             )
+            if emit_would_deny:
+                await self._emit_decision(
+                    scope,
+                    context_id,
+                    access,
+                    DECISION_WOULD_DENY,
+                    operation=operation,
+                    user_id=user_id,
+                    requested_memory_id=requested_memory_id,
+                )
             return True, DECISION_WOULD_DENY
 
         logger.warning(
@@ -365,7 +418,55 @@ class AgentBindingService:
             access=access,
             bound=binding is not None,
         )
+        await self._emit_decision(
+            scope,
+            context_id,
+            access,
+            DECISION_BINDING_DENIED,
+            operation=operation,
+            user_id=user_id,
+            requested_memory_id=requested_memory_id,
+        )
         return False, DECISION_BINDING_DENIED
+
+    async def _emit_decision(
+        self,
+        scope: AgentScope,
+        context_id: uuid.UUID,
+        access: str,
+        decision: str,
+        *,
+        operation: str | None,
+        user_id: str | None,
+        requested_memory_id: uuid.UUID | None,
+    ) -> None:
+        """Persist a deny/would-deny decision (#1286 item 2, P0-5).
+
+        No-op unless the caller threaded audit identity — un-threaded
+        chokepoints (enumeration surfaces, non-memory ops outside the MAE
+        vocabulary) keep the log-only behavior. The writer is fail-open on
+        its own independent session, so this can never break the request.
+        """
+        if operation is None or user_id is None:
+            return
+        from services.memory_access_event_writer import emit_memory_access_event
+
+        metadata: dict[str, str] = {
+            "requested_context_id": str(context_id),
+            "access": access,
+        }
+        if requested_memory_id is not None:
+            metadata["requested_memory_id"] = str(requested_memory_id)
+        await emit_memory_access_event(
+            operation=operation,
+            # Shadow proceeds — the request outcome IS success; the ramp
+            # signal rides policy_decision.
+            outcome="denied" if decision == DECISION_BINDING_DENIED else "success",
+            workspace_id=scope.workspace_id,
+            user_id=user_id,
+            policy_decision=decision,
+            extra_metadata=metadata,
+        )
 
     async def readable_context_ids(self, agent_id: uuid.UUID) -> set[uuid.UUID]:
         """The agent's read set — for enumeration-surface intersection."""

--- a/backend/src/services/memory_access_event_writer.py
+++ b/backend/src/services/memory_access_event_writer.py
@@ -18,6 +18,7 @@ setting-gated and separately reviewed.
 from __future__ import annotations
 
 from contextlib import aclosing
+from contextvars import ContextVar
 from typing import Any
 from uuid import UUID
 
@@ -28,6 +29,20 @@ logger = get_logger(__name__)
 # Max recall result memory_ids stored in event_metadata (identifiers only,
 # content never; under the 4 KB cap).
 MAX_METADATA_MEMORY_IDS = 32
+
+# #1286 (P0-5): request-scoped dedup for shadow ``would_deny`` rows. One
+# request can legitimately traverse several binding gates that evaluate the
+# SAME denied context (MCP pre-gate → declared-context isolation gate →
+# memory-id gate); without dedup the shadow→enforce ramp metric double-counts.
+# Keyed on (operation, requested_context_id, access) so DISTINCT contexts
+# evaluated in one request (e.g. update's declared context vs the memory's
+# own) still land their own rows. Task-context isolation gives each ASGI
+# request a fresh empty set — the same per-request guarantee AgentScope
+# relies on. Hard denies are never deduped: they stop the request, so only
+# one gate can ever emit.
+_would_deny_emitted: ContextVar[frozenset[tuple[str, str | None, str | None]]] = ContextVar(
+    "mae_would_deny_emitted", default=frozenset()
+)
 
 
 def _validate_enums(
@@ -184,6 +199,20 @@ async def emit_memory_access_event(
         query_hash = hmac_sha256_hex(query, get_settings().audit_hmac_key)
 
     metadata = dict(extra_metadata) if extra_metadata else None
+
+    # #1286 (P0-5): collapse per-request duplicate shadow rows (see the
+    # ``_would_deny_emitted`` contract above). Vocabulary literal matches
+    # MAE_POLICY_DECISIONS / AgentBindingService.DECISION_WOULD_DENY.
+    if policy_decision == "would_deny":
+        key = (
+            operation,
+            (metadata or {}).get("requested_context_id"),
+            (metadata or {}).get("access"),
+        )
+        seen = _would_deny_emitted.get()
+        if key in seen:
+            return
+        _would_deny_emitted.set(seen | {key})
 
     await record_memory_access_event(
         workspace_id=workspace_id,

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -668,6 +668,18 @@ class MemoryService:
             re_embedded=needs_reembed,
         )
 
+        # #1286 item 2 (P0-5): audit the write (no-op unless verified agent).
+        from services.memory_access_event_writer import emit_memory_access_event
+
+        await emit_memory_access_event(
+            operation="update",
+            outcome="success",
+            workspace_id=memory.workspace_id,
+            user_id=user_id,
+            context_id=memory.context_id,
+            memory_id=memory.id,
+        )
+
         return UpdateMemoryResponse(
             memory_id=memory.id,
             operation="updated",
@@ -928,6 +940,21 @@ class MemoryService:
             re_embedded=needs_reembed,
         )
 
+        # #1286 item 2 (P0-5): audit the write (no-op unless verified agent).
+        # PATCH is the REST-side update surface (#439); MCP's is
+        # `_update_in_place` — both emit operation="update" so the audit
+        # vocabulary stays unified across surfaces (#1291/#1292 parity).
+        from services.memory_access_event_writer import emit_memory_access_event
+
+        await emit_memory_access_event(
+            operation="update",
+            outcome="success",
+            workspace_id=memory.workspace_id,
+            user_id=user_id,
+            context_id=memory.context_id,
+            memory_id=memory.id,
+        )
+
         # Build the response inline from the in-scope ORM row. Delegating to
         # ``self.reference(...)`` here would re-fetch the row, re-run the
         # permission check, bump access-stats (a write — wrong for PATCH),
@@ -1005,6 +1032,10 @@ class MemoryService:
             context=request.context,
         )
 
+        # #1286 (P0-5) audit note: the upsert path intentionally emits NO
+        # operation="update" event — the inner remember()/forget() calls each
+        # emit their own row, which describes exactly what happened
+        # physically (a new row created, the old row soft-deleted).
         result = await self.remember(
             remember_request,
             user_id=user_id,
@@ -2912,6 +2943,10 @@ class MemoryService:
         )
 
         deleted_ids = []
+        # #1286 item 2 (P0-5): the deleted rows' own (hard-validated)
+        # workspace/context — the audit fallback when no context is declared.
+        deleted_workspace_ids: set[UUID] = set()
+        deleted_context_ids: set[UUID] = set()
 
         # Case 1: Delete by memory_id
         if request.memory_id:
@@ -2948,6 +2983,8 @@ class MemoryService:
 
                 memory_workspace_id = str(memory.workspace_id)
                 memory_context_id = str(memory.context_id)
+                deleted_workspace_ids.add(memory.workspace_id)
+                deleted_context_ids.add(memory.context_id)
 
                 # Soft delete in PostgreSQL (set deleted_at, deleted_by)
 
@@ -3036,6 +3073,10 @@ class MemoryService:
                         )
 
                     deleted_ids.append(memory_response.memory_id)
+                    if memory.workspace_id:
+                        deleted_workspace_ids.add(memory.workspace_id)
+                    if memory.context_id:
+                        deleted_context_ids.add(memory.context_id)
 
             logger.info(
                 "memories_soft_deleted_by_query",
@@ -3045,6 +3086,39 @@ class MemoryService:
             )
 
         await self.db.commit()
+
+        # #1286 item 2 (P0-5): audit the destructive write (no-op unless a
+        # verified agent). The REST route declares no context (#246), so the
+        # isolation helper resolves no workspace on that surface — fall back
+        # to the deleted rows' own workspace/context (unambiguous only when
+        # every deleted row shares one) so the audit row is never silently
+        # dropped on the REST face (#1291/#1292 parity lesson).
+        emit_workspace = UUID(workspace_id_str) if workspace_id_str else None
+        emit_context = UUID(context_id_str) if context_id_str else None
+        if emit_workspace is None and len(deleted_workspace_ids) == 1:
+            emit_workspace = next(iter(deleted_workspace_ids))
+        if emit_context is None and len(deleted_context_ids) == 1:
+            emit_context = next(iter(deleted_context_ids))
+
+        from services.memory_access_event_writer import (
+            MAX_METADATA_MEMORY_IDS,
+            emit_memory_access_event,
+        )
+
+        await emit_memory_access_event(
+            operation="forget",
+            outcome="success",
+            workspace_id=emit_workspace,
+            user_id=user_id,
+            context_id=emit_context,
+            memory_id=deleted_ids[0] if len(deleted_ids) == 1 else None,
+            result_count=len(deleted_ids),
+            extra_metadata=(
+                {"memory_ids": [str(mid) for mid in deleted_ids[:MAX_METADATA_MEMORY_IDS]]}
+                if len(deleted_ids) > 1
+                else None
+            ),
+        )
 
         return ForgetResponse(deleted_count=len(deleted_ids), memory_ids=deleted_ids)
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -165,6 +165,7 @@ class MemoryService:
         *,
         access: str = "read",
         key_workspace_id: UUID | None = None,
+        operation: str | None = None,
     ) -> tuple[Context | None, str | None, str | None]:
         """Extract workspace_id and context_id for 3-level isolation (performance optimization).
 
@@ -198,6 +199,8 @@ class MemoryService:
             access: ``"read"`` (default) or ``"write"`` — the binding gate.
             key_workspace_id: Pure API-key workspace scope for #963 confinement,
                 or ``None`` to skip it.
+            operation: MAE operation vocabulary value threaded into the
+                binding gate for #1286 deny capture, or ``None`` (log-only).
 
         Returns:
             Tuple of (context_object, workspace_id_str, context_id_str)
@@ -216,7 +219,9 @@ class MemoryService:
 
         from services.agent_binding_service import agent_binding_permits
 
-        if not await agent_binding_permits(self.db, context_id, access):
+        if not await agent_binding_permits(
+            self.db, context_id, access, operation=operation, user_id=user_id
+        ):
             raise NotFoundException("Context", str(context_id))
 
         return context, str(context.workspace_id), str(context_id)
@@ -340,7 +345,11 @@ class MemoryService:
         # Issue #1275: remember is a WRITE — gate the declared context against
         # the agent binding (no-op for non-agent credentials).
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id, access="write", key_workspace_id=key_workspace_id
+            user_id,
+            current_context_id,
+            access="write",
+            key_workspace_id=key_workspace_id,
+            operation="remember",  # #1286 (P0-5): deny-capture audit identity
         )
 
         # Validate required parameters
@@ -555,6 +564,8 @@ class MemoryService:
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
             access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
+            operation="update",  # #1286 (P0-5): deny-capture audit identity
+            memory_id=request.memory_id,
         )
         if not can_access:
             raise NotFoundException("Memory", str(request.memory_id))
@@ -755,6 +766,8 @@ class MemoryService:
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
             access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
+            operation="update",  # #1286 (P0-5): deny-capture audit identity
+            memory_id=memory_id,
         )
         if not can_access:
             raise NotFoundException("Memory", str(memory_id))
@@ -1088,6 +1101,8 @@ class MemoryService:
             memory_user_id=MemoryAuthorId(memory.user_id),
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
+            operation="reference",  # #1286 (P0-5): deny-capture audit identity
+            memory_id=memory_id,
         )
 
         if not can_access:
@@ -2219,7 +2234,13 @@ class MemoryService:
         from services.agent_binding_service import agent_binding_permits
 
         for _gated_cid in context_ids if context_ids else [current_context_id]:
-            if not await agent_binding_permits(self.db, _gated_cid, "read"):
+            if not await agent_binding_permits(
+                self.db,
+                _gated_cid,
+                "read",
+                operation="recall",  # #1286 (P0-5): deny-capture audit identity
+                user_id=user_id,
+            ):
                 raise NotFoundException("Context", str(_gated_cid))
 
         # #708 Option A: route embedding cost (key + spend cap + paid_by
@@ -2866,7 +2887,10 @@ class MemoryService:
         from config.settings import get_settings
 
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id, key_workspace_id=key_workspace_id
+            user_id,
+            current_context_id,
+            key_workspace_id=key_workspace_id,
+            operation="load_pinned",  # #1286 (P0-5): deny-capture audit identity
         )
         if not workspace_id_str or not context_id_str:
             raise ValueError("load_pinned() requires current_context_id")
@@ -2939,7 +2963,11 @@ class MemoryService:
         # Issue #1275: forget is a WRITE — gate the declared context against
         # the agent binding (no-op for non-agent credentials).
         context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
-            user_id, current_context_id, access="write", key_workspace_id=key_workspace_id
+            user_id,
+            current_context_id,
+            access="write",
+            key_workspace_id=key_workspace_id,
+            operation="forget",  # #1286 (P0-5): deny-capture audit identity
         )
 
         deleted_ids = []
@@ -2963,6 +2991,8 @@ class MemoryService:
                     workspace_id=memory.workspace_id,
                     context_id=memory.context_id,
                     access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
+                    operation="forget",  # #1286 (P0-5): the denied row is the ONLY
+                    memory_id=request.memory_id,  # record — this deny is a silent empty success
                 )
 
                 if not can_access:
@@ -3243,6 +3273,9 @@ class MemoryService:
         from services.permission_service import CallerId, MemoryAuthorId, PermissionService
 
         perm_service = PermissionService(self.db)
+        # #1286 (P0-5): no operation threaded — "explore" is outside the
+        # MAE_OPERATIONS vocabulary; its denies stay log-only until the
+        # vocabulary grows (CHECK widening = a migration, out of scope here).
         can_access = await perm_service.can_access_memory(
             user_id=CallerId(user_id),
             memory_user_id=MemoryAuthorId(seed_memory.user_id),

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -245,6 +245,7 @@ class PermissionService:
         *,
         required_role: WorkspaceRole | str = WorkspaceRole.VIEWER,
         key_workspace_id: UUID | None = None,
+        operation: str | None = None,
     ) -> Context:
         """Resolve a ``context_id`` to a Context the caller can read, with uniform 404.
 
@@ -408,12 +409,14 @@ class PermissionService:
         # writers pass admin/owner. WorkspaceRole is a StrEnum, so the
         # comparison holds for both str and enum callers.
         access = "read" if required_role == WorkspaceRole.VIEWER else "write"
-        await self._apply_agent_binding_filter(context_id, access=access, user_id=user_id)
+        await self._apply_agent_binding_filter(
+            context_id, access=access, user_id=user_id, operation=operation
+        )
 
         return context
 
     async def _apply_agent_binding_filter(
-        self, context_id: UUID, *, access: str, user_id: str
+        self, context_id: UUID, *, access: str, user_id: str, operation: str | None = None
     ) -> None:
         """Deny with the uniform 404 when the agent binding subtracts access.
 
@@ -423,6 +426,14 @@ class PermissionService:
         the context exists but is write-forbidden would leak the CWE-639
         signal the uniform-404 posture removes. Shadow-mode violations are
         logged and allowed (``would_deny``, the enforcement ramp).
+
+        #1286 (P0-5): ``operation`` threads MAE audit identity into the
+        evaluation so denies at THIS chokepoint persist — for the MCP read
+        tools this is the pre-gate that raises before any service-layer gate
+        runs, so without it enforce-mode read denies leave no audit row on
+        the MCP face (the #1291/#1292 parity class). ``None`` (callers
+        outside the MAE vocabulary — context CRUD/metadata reads) keeps the
+        log-only behavior.
         """
         from auth.agent_scope import get_agent_scope
 
@@ -433,7 +444,7 @@ class PermissionService:
         from services.agent_binding_service import AgentBindingService
 
         allowed, decision = await AgentBindingService(self.db).evaluate_context_access(
-            scope, context_id, access
+            scope, context_id, access, operation=operation, user_id=user_id
         )
         if not allowed:
             logger.warning(
@@ -507,6 +518,8 @@ class PermissionService:
         user_id: str,
         context_id: UUID,
         required_role: ContextRole | str = ContextRole.VIEWER,
+        *,
+        operation: str | None = None,
     ) -> tuple[Context, ContextRole]:
         """Check if user has required context access.
 
@@ -551,7 +564,9 @@ class PermissionService:
             required_role if isinstance(required_role, ContextRole) else ContextRole(required_role)
         )
         access = "read" if required == ContextRole.VIEWER else "write"
-        await self._apply_agent_binding_filter(context_id, access=access, user_id=user_id)
+        await self._apply_agent_binding_filter(
+            context_id, access=access, user_id=user_id, operation=operation
+        )
 
         return context, effective_role
 

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -905,6 +905,8 @@ class PermissionService:
         workspace_id: UUID,
         context_id: UUID,
         access: str = "read",
+        operation: str | None = None,
+        memory_id: UUID | None = None,
     ) -> bool:
         """Check if user can access a memory based on workspace membership and context privacy.
 
@@ -921,12 +923,24 @@ class PermissionService:
         forget) MUST pass ``access="write"`` so a ``can_read``-only binding
         cannot be used to mutate. No-op for non-agent credentials.
 
+        #1286 item 2 (P0-5): ``operation`` / ``memory_id`` are the
+        audit-identity passthrough. The binding-shaped deny is persisted
+        inside the binding evaluation; the rbac-shaped branches below stamp
+        ``policy_decision='rbac_denied'`` themselves — this is the one
+        chokepoint where the two deny causes collapse into a single bool, so
+        the emission is what keeps them distinguishable in audit. No-op for
+        non-agent traffic and for un-threaded callers.
+
         Args:
             user_id: Requesting user ID
             memory_user_id: Memory creator's user ID
             workspace_id: Workspace ID
             context_id: Context ID
             access: ``"read"`` (default) or ``"write"`` — the binding gate.
+            operation: MAE operation vocabulary value for deny capture, or
+                ``None`` (no emission) for callers outside that vocabulary.
+            memory_id: The requested memory id — rides ``event_metadata`` as
+                an unverified claim on deny rows.
 
         Returns:
             True if user can access, False otherwise
@@ -938,7 +952,45 @@ class PermissionService:
             # must not reach its own memories there via memory_id).
             from services.agent_binding_service import agent_binding_permits
 
-            return await agent_binding_permits(self.db, context_id, access)
+            return await agent_binding_permits(
+                self.db,
+                context_id,
+                access,
+                operation=operation,
+                user_id=str(user_id),
+                requested_memory_id=memory_id,
+            )
+
+        async def _emit_rbac_denied() -> None:
+            # #1286 item 2 (P0-5): persist the rbac-shaped deny for agent
+            # traffic. workspace_id = the CREDENTIAL scope (never the
+            # memory's workspace param — that is derived from the requested,
+            # unverified identifier); requested ids ride event_metadata.
+            if operation is None:
+                return
+            from auth.agent_scope import get_agent_scope
+
+            scope = get_agent_scope()
+            if scope is None:
+                # D34: only verified-agent traffic is audited.
+                return
+            from services.agent_binding_service import DECISION_RBAC_DENIED
+            from services.memory_access_event_writer import emit_memory_access_event
+
+            metadata: dict[str, str] = {
+                "requested_context_id": str(context_id),
+                "access": access,
+            }
+            if memory_id is not None:
+                metadata["requested_memory_id"] = str(memory_id)
+            await emit_memory_access_event(
+                operation=operation,
+                outcome="denied",
+                workspace_id=scope.workspace_id,
+                user_id=str(user_id),
+                policy_decision=DECISION_RBAC_DENIED,
+                extra_metadata=metadata,
+            )
 
         # Owner can always access their own memories (RBAC), but the binding
         # still subtracts.
@@ -953,9 +1005,11 @@ class PermissionService:
 
         if not is_shared:
             # Private context: only creator can access
+            await _emit_rbac_denied()
             return False
 
         # Shared context: check workspace membership, then the binding.
         if not await self.is_workspace_member(user_id, workspace_id):
+            await _emit_rbac_denied()
             return False
         return await _binding_ok()

--- a/backend/tests/api/test_correlation.py
+++ b/backend/tests/api/test_correlation.py
@@ -206,6 +206,132 @@ class TestPrecedence:
         assert res.correlation_conflict is True
 
 
+class TestUnboundExplicitArgConformance:
+    """#1286 item 1 — F4 Rule 5 conformance for an explicit arg on an
+    agent-unbound credential.
+
+    "Explicit wins" is candidate precedence over baggage, NOT a verification
+    exemption: the explicit arg still passes the Rule-2 same-member predicate
+    before reaching ``agent_id``. The keyed-hash slot always records the
+    highest-precedence *unverified* claim — so on a verified conflict it is
+    the disagreeing baggage claim that gets hashed, and on verifier-False it
+    is the (unverified) explicit arg itself.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unbound_explicit_arg_unverified_hashed_only(self, monkeypatch):
+        # The case PR #1283's review flagged as unpinned: the verifier says NO
+        # to the explicit arg — it must never reach agent_id (fail-secure).
+        from api.correlation import _hash_claim
+
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=False),
+        )
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=OTHER_AGENT,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+        )
+        assert res.agent_id is None  # never reaches the column
+        assert res.policy_decision is None
+        assert res.unverified_agent_claim_hash == _hash_claim(str(OTHER_AGENT))
+        assert res.correlation_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_unbound_explicit_only_verified_stamps_unbound(self, monkeypatch):
+        # Verified explicit arg on an unbound credential carries the same
+        # 'unbound' stamp as a verified baggage claim (Rule 2's stamp).
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=True),
+        )
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=OTHER_AGENT,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+        )
+        assert res.agent_id == OTHER_AGENT
+        assert res.policy_decision == POLICY_DECISION_UNBOUND
+        assert res.unverified_agent_claim_hash is None
+        assert res.correlation_conflict is False
+
+    @pytest.mark.asyncio
+    async def test_unbound_verified_conflict_hashes_disagreeing_baggage(self, monkeypatch):
+        # On a verified conflict the losing baggage claim must not vanish
+        # into a bare boolean — it is the unverified claim, so it is hashed.
+        from api.correlation import _hash_claim
+
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=True),
+        )
+        baggage_claim = str(uuid.uuid4())
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=baggage_claim)
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=OTHER_AGENT,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+            correlation=corr,
+        )
+        assert res.agent_id == OTHER_AGENT
+        assert res.policy_decision == POLICY_DECISION_UNBOUND
+        assert res.unverified_agent_claim_hash == _hash_claim(baggage_claim)
+        assert res.correlation_conflict is True
+
+    @pytest.mark.asyncio
+    async def test_unbound_unverified_conflict_hashes_explicit_arg(self, monkeypatch):
+        # Verifier-False on conflict: nothing verified, so the hash slot keeps
+        # the highest-precedence unverified claim (the explicit arg — same
+        # shadowing the credential-bound path applies); baggage disagreement
+        # is evidenced by correlation_conflict.
+        from api.correlation import _hash_claim
+
+        monkeypatch.setattr(
+            "api.correlation.verify_baggage_agent_claim",
+            AsyncMock(return_value=False),
+        )
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=str(uuid.uuid4()))
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=OTHER_AGENT,
+            member_user_id="m",
+            workspace_id=WORKSPACE_ID,
+            correlation=corr,
+        )
+        assert res.agent_id is None
+        assert res.policy_decision is None
+        assert res.unverified_agent_claim_hash == _hash_claim(str(OTHER_AGENT))
+        assert res.correlation_conflict is True
+
+    @pytest.mark.asyncio
+    async def test_guard_path_hashes_explicit_over_baggage(self):
+        # Unverifiable request shape (no member/workspace): every claim is
+        # unverified — the explicit arg must not be dropped without a trace.
+        from api.correlation import _hash_claim
+
+        corr = CorrelationContext(trace_id="t", span_id="s", agent_claim=str(uuid.uuid4()))
+        res = await resolve_agent_correlation(
+            MagicMock(),
+            credential_agent_id=None,
+            explicit_agent_id=OTHER_AGENT,
+            member_user_id=None,
+            workspace_id=None,
+            correlation=corr,
+        )
+        assert res.agent_id is None
+        assert res.policy_decision is None
+        assert res.unverified_agent_claim_hash == _hash_claim(str(OTHER_AGENT))
+        assert res.correlation_conflict is True
+
+
 class TestVerifyPredicate:
     @pytest.mark.asyncio
     async def test_verifies_only_same_member_bound_agent(self):

--- a/backend/tests/api/test_feedback_routes.py
+++ b/backend/tests/api/test_feedback_routes.py
@@ -54,7 +54,12 @@ async def test_record_feedback_success_uses_read_gate(service, perm, context_id,
     assert resp.memory_id == memory_id
     assert resp.helpful is True
     perm.check_context_access.assert_awaited_once_with(
-        "test_user", context_id, required_role=ContextRole.VIEWER
+        "test_user",
+        context_id,
+        required_role=ContextRole.VIEWER,
+        # #1286 (P0-5): deny-capture audit identity — a binding/rbac deny at
+        # this gate persists an operation="feedback" row.
+        operation="feedback",
     )
     # user_id is taken from the authenticated principal, not the body.
     service.record_feedback.assert_awaited_once()

--- a/backend/tests/auth/test_agent_bound_keys.py
+++ b/backend/tests/auth/test_agent_bound_keys.py
@@ -187,7 +187,12 @@ class TestAgentScopePropagation:
         )
         set_agent_scope_from_verified(verified)
         scope = get_agent_scope()
-        assert scope == AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce")
+        # #1286 (P0-5): the scope carries the credential's workspace so
+        # deny-capture can stamp the audit row's workspace_id from the CALLER
+        # scope (never from the requested, unverified identifier).
+        assert scope == AgentScope(
+            agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=WORKSPACE_ID
+        )
 
     def test_unbound_key_clears_scope(self):
         set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce"))
@@ -239,4 +244,6 @@ class TestAgentScopePropagation:
         )
         set_agent_scope_from_verified(verified)
         scope = get_agent_scope()
-        assert scope == AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce")
+        assert scope == AgentScope(
+            agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=WORKSPACE_ID
+        )

--- a/backend/tests/integration/test_agent_features_e2e.py
+++ b/backend/tests/integration/test_agent_features_e2e.py
@@ -235,3 +235,110 @@ async def test_recall_under_agent_identity_writes_memory_access_event(env, db_se
     assert recall_rows, "recall under agent identity must emit a memory_access_events row"
     assert recall_rows[0].agent_id == env["agent"].id
     assert recall_rows[0].outcome == "success"
+
+
+# ---------------------------------------------------------------------------
+# #1286 item 2 (P0-5): deny capture — the decisions the log line used to
+# promise are now durable rows, end to end against the real DB.
+# ---------------------------------------------------------------------------
+
+
+async def _mae_rows(db_session, ws_id):
+    return (
+        (
+            await db_session.execute(
+                select(MemoryAccessEvent).where(MemoryAccessEvent.workspace_id == ws_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_enforce_deny_persists_binding_denied_row(env, db_session):
+    # The uniform 404 stays the response; the durable record is the new part.
+    set_agent_scope(
+        AgentScope(
+            agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"]
+        )
+    )
+    svc = _svc(db_session, found_memory_ids=[env["mem_unbound"]])
+    with pytest.raises(NotFoundException):
+        await svc.recall(
+            RecallRequest(query="secret", k=10, search_mode="keyword"),
+            user_id=env["uid"],
+            current_context_id=env["ctx_unbound"],
+            current_workspace_id=env["ws_id"],
+        )
+
+    denied = [r for r in await _mae_rows(db_session, env["ws_id"]) if r.outcome == "denied"]
+    assert len(denied) == 1, "the hard deny must persist exactly one denied row"
+    row = denied[0]
+    assert row.operation == "recall"
+    assert row.policy_decision == "binding_denied"
+    assert row.agent_id == env["agent"].id
+    # workspace_id = the CREDENTIAL scope; the requested (denied) context
+    # never reaches the authoritative column — it rides event_metadata.
+    assert row.workspace_id == env["ws_id"]
+    assert row.context_id is None
+    assert row.event_metadata["requested_context_id"] == str(env["ctx_unbound"])
+    assert row.event_metadata["access"] == "read"
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_shadow_would_deny_persists_ramp_row_and_proceeds(env, db_session):
+    # Shadow mode: the request proceeds AND leaves the would_deny ramp signal
+    # — exactly one (no double-count), alongside the normal success row.
+    set_agent_scope(
+        AgentScope(
+            agent_id=env["agent"].id, enforcement_mode="shadow", workspace_id=env["ws_id"]
+        )
+    )
+    svc = _svc(db_session, found_memory_ids=[env["mem_unbound"]])
+    resp = await svc.recall(
+        RecallRequest(query="secret", k=10, search_mode="keyword"),
+        user_id=env["uid"],
+        current_context_id=env["ctx_unbound"],
+        current_workspace_id=env["ws_id"],
+    )
+    assert str(env["mem_unbound"]) in {str(r.memory_id) for r in resp.results}
+
+    rows = await _mae_rows(db_session, env["ws_id"])
+    ramp = [r for r in rows if r.policy_decision == "would_deny"]
+    assert len(ramp) == 1, "shadow must persist exactly one would_deny row"
+    assert ramp[0].operation == "recall"
+    assert ramp[0].outcome == "success"  # the request DID proceed
+    assert ramp[0].event_metadata["requested_context_id"] == str(env["ctx_unbound"])
+    # The op's own success row still lands, unstamped.
+    plain = [r for r in rows if r.operation == "recall" and r.policy_decision is None]
+    assert plain, "the normal recall success row must still be emitted"
+    assert all(r.outcome != "denied" for r in rows)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_forget_by_id_silent_deny_leaves_its_only_record(env, db_session):
+    # forget-by-id deny returns a success-shaped empty response (CWE-639
+    # posture) — before #1286 the deny left NO trace. The denied row is its
+    # only record.
+    from models.schemas import ForgetRequest
+
+    set_agent_scope(
+        AgentScope(
+            agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"]
+        )
+    )
+    svc = MemoryService(db_session)
+    resp = await svc.forget(ForgetRequest(memory_id=env["mem_unbound"]), env["uid"])
+    assert resp.deleted_count == 0 and resp.memory_ids == []
+
+    rows = await _mae_rows(db_session, env["ws_id"])
+    denied = [r for r in rows if r.outcome == "denied"]
+    assert len(denied) == 1
+    row = denied[0]
+    assert row.operation == "forget"
+    assert row.policy_decision == "binding_denied"
+    assert row.memory_id is None  # requested id is a claim, not a column
+    assert row.event_metadata["requested_memory_id"] == str(env["mem_unbound"])
+    # No success row — the delete never happened.
+    assert not [r for r in rows if r.operation == "forget" and r.outcome == "success"]

--- a/backend/tests/integration/test_agent_features_e2e.py
+++ b/backend/tests/integration/test_agent_features_e2e.py
@@ -17,7 +17,7 @@ independent session, which the teardown cleans up by workspace_id.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
@@ -134,10 +134,20 @@ async def env(db_session):
         "mem_unbound": mem_unbound.id,
     }
 
-    # The audit writer commits on an independent session — clean those rows up.
+    # The audit writer commits on an independent session — clean those rows
+    # up. memory_access_events is append-only by trigger (e66), so test
+    # cleanup must disable the user triggers for the DELETE (table owner
+    # privilege; the trigger exists to stop application-path mutation, not
+    # test-harness residue removal). Rollback first: a test that ended in a
+    # raised NotFoundException may have left the session tx aborted.
+    from sqlalchemy import text
+
+    await db_session.rollback()
+    await db_session.execute(text("ALTER TABLE memory_access_events DISABLE TRIGGER USER"))
     await db_session.execute(
         delete(MemoryAccessEvent).where(MemoryAccessEvent.workspace_id == ws_id)
     )
+    await db_session.execute(text("ALTER TABLE memory_access_events ENABLE TRIGGER USER"))
     await db_session.commit()
 
 
@@ -259,9 +269,7 @@ async def _mae_rows(db_session, ws_id):
 async def test_enforce_deny_persists_binding_denied_row(env, db_session):
     # The uniform 404 stays the response; the durable record is the new part.
     set_agent_scope(
-        AgentScope(
-            agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"]
-        )
+        AgentScope(agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"])
     )
     svc = _svc(db_session, found_memory_ids=[env["mem_unbound"]])
     with pytest.raises(NotFoundException):
@@ -291,9 +299,7 @@ async def test_shadow_would_deny_persists_ramp_row_and_proceeds(env, db_session)
     # Shadow mode: the request proceeds AND leaves the would_deny ramp signal
     # — exactly one (no double-count), alongside the normal success row.
     set_agent_scope(
-        AgentScope(
-            agent_id=env["agent"].id, enforcement_mode="shadow", workspace_id=env["ws_id"]
-        )
+        AgentScope(agent_id=env["agent"].id, enforcement_mode="shadow", workspace_id=env["ws_id"])
     )
     svc = _svc(db_session, found_memory_ids=[env["mem_unbound"]])
     resp = await svc.recall(
@@ -324,9 +330,7 @@ async def test_forget_by_id_silent_deny_leaves_its_only_record(env, db_session):
     from models.schemas import ForgetRequest
 
     set_agent_scope(
-        AgentScope(
-            agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"]
-        )
+        AgentScope(agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"])
     )
     svc = MemoryService(db_session)
     resp = await svc.forget(ForgetRequest(memory_id=env["mem_unbound"]), env["uid"])
@@ -342,3 +346,57 @@ async def test_forget_by_id_silent_deny_leaves_its_only_record(env, db_session):
     assert row.event_metadata["requested_memory_id"] == str(env["mem_unbound"])
     # No success row — the delete never happened.
     assert not [r for r in rows if r.operation == "forget" and r.outcome == "success"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_shadow_forget_by_id_declared_context_single_would_deny(env, db_session):
+    # Review finding (#1286): forget-by-id WITH a declared context traverses
+    # TWO service-layer binding gates (declared-context isolation params +
+    # can_access_memory) — the writer's request-scoped dedup must collapse
+    # the shadow signal to exactly one would_deny row, or the shadow→enforce
+    # ramp metric double-counts every such request.
+    from models.schemas import ForgetRequest
+
+    set_agent_scope(
+        AgentScope(agent_id=env["agent"].id, enforcement_mode="shadow", workspace_id=env["ws_id"])
+    )
+    svc = MemoryService(db_session)
+    with patch("services.memory_service.delete_memory_from_qdrant", AsyncMock()):
+        resp = await svc.forget(
+            ForgetRequest(memory_id=env["mem_unbound"]),
+            env["uid"],
+            current_context_id=env["ctx_unbound"],
+        )
+    assert resp.deleted_count == 1  # shadow proceeds
+
+    rows = await _mae_rows(db_session, env["ws_id"])
+    ramp = [r for r in rows if r.policy_decision == "would_deny" and r.operation == "forget"]
+    assert len(ramp) == 1, f"expected the single deduped shadow row, got {len(ramp)}"
+    # The destructive write itself is also audited (success row).
+    assert [r for r in rows if r.operation == "forget" and r.outcome == "success"]
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_read_pre_gate_enforce_deny_persists_row(env, db_session):
+    # Review finding (#1286, the #1291/#1292 parity class): the MCP read face
+    # resolves via resolve_context_for_workspace_read, whose binding filter
+    # raises the uniform 404 BEFORE any service-layer gate — with operation
+    # threaded it must persist the denied row itself.
+    from services.permission_service import PermissionService
+
+    set_agent_scope(
+        AgentScope(agent_id=env["agent"].id, enforcement_mode="enforce", workspace_id=env["ws_id"])
+    )
+    with pytest.raises(NotFoundException):
+        await PermissionService(db_session).resolve_context_for_workspace_read(
+            user_id=env["uid"], context_id=env["ctx_unbound"], operation="recall"
+        )
+
+    rows = await _mae_rows(db_session, env["ws_id"])
+    denied = [r for r in rows if r.outcome == "denied"]
+    assert len(denied) == 1
+    assert denied[0].operation == "recall"
+    assert denied[0].policy_decision == "binding_denied"
+    assert denied[0].workspace_id == env["ws_id"]
+    assert denied[0].context_id is None
+    assert denied[0].event_metadata["requested_context_id"] == str(env["ctx_unbound"])

--- a/backend/tests/integration/test_agent_features_e2e.py
+++ b/backend/tests/integration/test_agent_features_e2e.py
@@ -143,12 +143,22 @@ async def env(db_session):
     from sqlalchemy import text
 
     await db_session.rollback()
-    await db_session.execute(text("ALTER TABLE memory_access_events DISABLE TRIGGER USER"))
-    await db_session.execute(
-        delete(MemoryAccessEvent).where(MemoryAccessEvent.workspace_id == ws_id)
-    )
-    await db_session.execute(text("ALTER TABLE memory_access_events ENABLE TRIGGER USER"))
-    await db_session.commit()
+    try:
+        # DISABLE + DELETE + ENABLE + COMMIT are one transaction: either all
+        # persist (triggers re-enabled at commit) or none do. ALTER TABLE ...
+        # DISABLE TRIGGER is transactional DDL in PostgreSQL, so the explicit
+        # rollback below also rolls the DISABLE back — the append-only
+        # invariant can never be left disabled for later tests (Copilot
+        # review of #1300).
+        await db_session.execute(text("ALTER TABLE memory_access_events DISABLE TRIGGER USER"))
+        await db_session.execute(
+            delete(MemoryAccessEvent).where(MemoryAccessEvent.workspace_id == ws_id)
+        )
+        await db_session.execute(text("ALTER TABLE memory_access_events ENABLE TRIGGER USER"))
+        await db_session.commit()
+    except Exception:
+        await db_session.rollback()
+        raise
 
 
 def _svc(db_session, *, found_memory_ids):

--- a/backend/tests/mcp_server/test_deny_capture_threading.py
+++ b/backend/tests/mcp_server/test_deny_capture_threading.py
@@ -1,0 +1,122 @@
+"""#1286 (P0-5): pin the MCP handlers' MAE audit-identity threading.
+
+Each memory-op handler must pass its ``operation`` into the context pre-gate
+(``_resolve_context`` for writes, ``_resolve_context_for_read`` for reads).
+A dropped ``operation=`` silently reverts enforce-mode denies on that handler
+to log-only — the pre-gate raises before any service-layer gate runs, so its
+emission is the ONLY record (the review finding on the #1291/#1292 parity
+class). The pre-gate emission semantics themselves are pinned in
+``test_agent_binding_service`` / ``test_permission_agent_binding``; here we
+pin only that every handler threads the right vocabulary value.
+"""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools import feedback as feedback_tools
+from mcp_server.tools import memory as memory_tools
+from mcp_server.tools._helpers import _ContextNotFoundError
+
+
+async def _invoke_with_denying_pre_gate(module, handler_name, args, helper_name):
+    """Run a handler with the named pre-gate helper raising the uniform deny;
+    return the helper mock so the caller can assert the threaded kwargs."""
+    resolver = AsyncMock(side_effect=_ContextNotFoundError(uuid4(), "denied"))
+
+    async def gen():
+        yield AsyncMock()
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("db.base.get_db", new=gen))
+        for maybe in ("_log_tool_usage", "_check_viewer_permission"):
+            if hasattr(module, maybe):
+                stack.enter_context(
+                    patch(f"{module.__name__}.{maybe}", new=AsyncMock(return_value=None))
+                )
+        stack.enter_context(patch(f"{module.__name__}.{helper_name}", new=resolver))
+        handler = getattr(module, handler_name)
+        try:
+            await handler(args=args, user_id="u", workspace_id=uuid4())
+        except Exception:  # noqa: BLE001 — envelope vs raise is not under test
+            pass
+    return resolver
+
+
+_CTX = str(uuid4())
+_MID = str(uuid4())
+
+CASES = [
+    (
+        memory_tools,
+        "handle_recall",
+        {"query": "q", "context_id": _CTX},
+        "_resolve_context_for_read",
+        "recall",
+    ),
+    (
+        memory_tools,
+        "handle_load_pinned",
+        {"context_id": _CTX},
+        "_resolve_context_for_read",
+        "load_pinned",
+    ),
+    (
+        memory_tools,
+        "handle_reference",
+        {"memory_id": _MID, "context_id": _CTX},
+        "_resolve_context_for_read",
+        "reference",
+    ),
+    (
+        feedback_tools,
+        "handle_feedback",
+        {"context_id": _CTX, "memory_id": _MID, "helpful": True},
+        "_resolve_context_for_read",
+        "feedback",
+    ),
+    (
+        memory_tools,
+        "handle_remember",
+        {
+            "summary": "a searchable summary for the pin",
+            "content": "c",
+            "type": "note",
+            "context_id": _CTX,
+        },
+        "_resolve_context",
+        "remember",
+    ),
+    (
+        memory_tools,
+        "handle_update_memory",
+        {"memory_id": _MID, "context_id": _CTX, "tags": ["x"]},
+        "_resolve_context",
+        "update",
+    ),
+    (
+        memory_tools,
+        "handle_forget",
+        {"memory_id": _MID, "context_id": _CTX},
+        "_resolve_context",
+        "forget",
+    ),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "module, handler_name, args, helper_name, expected_op",
+    CASES,
+    ids=[c[4] if c[1] != "handle_update_memory" else "update" for c in CASES],
+)
+async def test_handler_threads_operation_into_pre_gate(
+    module, handler_name, args, helper_name, expected_op
+):
+    resolver = await _invoke_with_denying_pre_gate(module, handler_name, dict(args), helper_name)
+    assert resolver.await_count >= 1, f"{handler_name} never reached {helper_name}"
+    assert resolver.await_args.kwargs.get("operation") == expected_op

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -347,36 +347,20 @@ class TestDenyCaptureEmission:
         assert kw["workspace_id"] == ws
 
     @pytest.mark.asyncio
-    async def test_shadow_emission_suppressed_for_pre_gate(self):
-        # The MCP pre-gate (_resolve_context) passes emit_would_deny=False:
-        # the service-layer gate re-evaluates the same request and emits the
-        # single shadow row — no double-counting on the MCP face.
+    async def test_shadow_emits_unconditionally_dedup_is_writer_side(self):
+        # Every gate (pre-gates included) emits its would_deny; when several
+        # gates evaluate the SAME denied context in one request, the writer's
+        # request-scoped dedup collapses the rows to one — no per-call-site
+        # suppression flags (pinned in test_memory_access_event_writer).
         (allowed, decision), emit, _ = await self._evaluate(
             None,
             _scope(mode="shadow", workspace_id=uuid.uuid4()),
             ACCESS_WRITE,
             operation="remember",
             user_id="caller",
-            emit_would_deny=False,
         )
         assert (allowed, decision) == (True, DECISION_WOULD_DENY)
-        emit.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_hard_deny_emits_even_when_would_deny_suppressed(self):
-        # A hard deny STOPS the request at the pre-gate — the service-layer
-        # gate is never reached, so the pre-gate must emit it.
-        (allowed, decision), emit, _ = await self._evaluate(
-            None,
-            _scope(mode="enforce", workspace_id=uuid.uuid4()),
-            ACCESS_WRITE,
-            operation="remember",
-            user_id="caller",
-            emit_would_deny=False,
-        )
-        assert (allowed, decision) == (False, DECISION_BINDING_DENIED)
         emit.assert_awaited_once()
-        assert emit.await_args.kwargs["outcome"] == "denied"
 
     @pytest.mark.asyncio
     async def test_no_emission_without_operation(self):

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -10,7 +10,7 @@ migration/drift/cascade coverage lives in the integration gates.
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -59,8 +59,10 @@ def _binding(**overrides) -> AgentContextBinding:
     return AgentContextBinding(**defaults)
 
 
-def _scope(agent_id=None, mode="enforce") -> AgentScope:
-    return AgentScope(agent_id=agent_id or uuid.uuid4(), enforcement_mode=mode)
+def _scope(agent_id=None, mode="enforce", workspace_id=None) -> AgentScope:
+    return AgentScope(
+        agent_id=agent_id or uuid.uuid4(), enforcement_mode=mode, workspace_id=workspace_id
+    )
 
 
 def _service(execute_results: list | None = None) -> AgentBindingService:
@@ -275,3 +277,168 @@ class TestReadableContextIds:
         db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=scalars)))
         service = AgentBindingService(db)
         assert await service.readable_context_ids(uuid.uuid4()) == set(ids)
+
+
+# ---------------------------------------------------------------------------
+# Deny capture (#1286 item 2, P0-5)
+# ---------------------------------------------------------------------------
+
+
+class TestDenyCaptureEmission:
+    """The binding-evaluation path persists its deny decisions to
+    memory_access_events when the caller threads audit identity (operation +
+    user_id). Hard deny → outcome='denied' / policy='binding_denied'; shadow
+    → outcome='success' / policy='would_deny'. The requested identifiers ride
+    event_metadata as claims — the authoritative context_id / memory_id
+    columns stay NULL — and workspace_id is the CREDENTIAL scope
+    (AgentScope.workspace_id), never the requested one."""
+
+    async def _evaluate(self, binding, scope, access, ctx=None, **kw):
+        service = _service(execute_results=[binding])
+        ctx = ctx or uuid.uuid4()
+        with patch(
+            "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+        ) as emit:
+            result = await service.evaluate_context_access(scope, ctx, access, **kw)
+        return result, emit, ctx
+
+    @pytest.mark.asyncio
+    async def test_enforce_deny_emits_denied_row(self):
+        ws = uuid.uuid4()
+        (allowed, decision), emit, ctx = await self._evaluate(
+            None,
+            _scope(mode="enforce", workspace_id=ws),
+            ACCESS_READ,
+            operation="recall",
+            user_id="caller",
+        )
+        assert (allowed, decision) == (False, DECISION_BINDING_DENIED)
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        assert kw["operation"] == "recall"
+        assert kw["outcome"] == "denied"
+        assert kw["policy_decision"] == DECISION_BINDING_DENIED
+        assert kw["workspace_id"] == ws
+        assert kw["user_id"] == "caller"
+        assert kw["extra_metadata"]["requested_context_id"] == str(ctx)
+        assert kw["extra_metadata"]["access"] == ACCESS_READ
+        # The requested identifier never lands in the authoritative column.
+        assert kw.get("context_id") is None
+        assert kw.get("memory_id") is None
+
+    @pytest.mark.asyncio
+    async def test_shadow_would_deny_emits_success_row(self):
+        ws = uuid.uuid4()
+        (allowed, decision), emit, _ = await self._evaluate(
+            None,
+            _scope(mode="shadow", workspace_id=ws),
+            ACCESS_READ,
+            operation="recall",
+            user_id="caller",
+        )
+        assert (allowed, decision) == (True, DECISION_WOULD_DENY)
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        # The request PROCEEDS in shadow — the outcome is success; the
+        # would-deny signal rides policy_decision (the shadow→enforce ramp
+        # analysis key).
+        assert kw["outcome"] == "success"
+        assert kw["policy_decision"] == DECISION_WOULD_DENY
+        assert kw["workspace_id"] == ws
+
+    @pytest.mark.asyncio
+    async def test_shadow_emission_suppressed_for_pre_gate(self):
+        # The MCP pre-gate (_resolve_context) passes emit_would_deny=False:
+        # the service-layer gate re-evaluates the same request and emits the
+        # single shadow row — no double-counting on the MCP face.
+        (allowed, decision), emit, _ = await self._evaluate(
+            None,
+            _scope(mode="shadow", workspace_id=uuid.uuid4()),
+            ACCESS_WRITE,
+            operation="remember",
+            user_id="caller",
+            emit_would_deny=False,
+        )
+        assert (allowed, decision) == (True, DECISION_WOULD_DENY)
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_hard_deny_emits_even_when_would_deny_suppressed(self):
+        # A hard deny STOPS the request at the pre-gate — the service-layer
+        # gate is never reached, so the pre-gate must emit it.
+        (allowed, decision), emit, _ = await self._evaluate(
+            None,
+            _scope(mode="enforce", workspace_id=uuid.uuid4()),
+            ACCESS_WRITE,
+            operation="remember",
+            user_id="caller",
+            emit_would_deny=False,
+        )
+        assert (allowed, decision) == (False, DECISION_BINDING_DENIED)
+        emit.assert_awaited_once()
+        assert emit.await_args.kwargs["outcome"] == "denied"
+
+    @pytest.mark.asyncio
+    async def test_no_emission_without_operation(self):
+        # Callers that have not threaded audit identity (non-memory ops,
+        # enumeration surfaces) keep the pre-#1286 behavior: log only.
+        (allowed, _), emit, _ = await self._evaluate(
+            None, _scope(mode="enforce", workspace_id=uuid.uuid4()), ACCESS_READ
+        )
+        assert allowed is False
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_allowed_no_emission(self):
+        (allowed, _), emit, _ = await self._evaluate(
+            _binding(can_read=True),
+            _scope(mode="enforce", workspace_id=uuid.uuid4()),
+            ACCESS_READ,
+            operation="recall",
+            user_id="caller",
+        )
+        assert allowed is True
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_requested_memory_id_rides_metadata(self):
+        mid = uuid.uuid4()
+        (_, _), emit, _ = await self._evaluate(
+            None,
+            _scope(mode="enforce", workspace_id=uuid.uuid4()),
+            ACCESS_WRITE,
+            operation="forget",
+            user_id="caller",
+            requested_memory_id=mid,
+        )
+        kw = emit.await_args.kwargs
+        assert kw["extra_metadata"]["requested_memory_id"] == str(mid)
+        assert kw.get("memory_id") is None
+
+    @pytest.mark.asyncio
+    async def test_agent_binding_permits_threads_audit_kwargs(self):
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import agent_binding_permits
+
+        set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
+        try:
+            with patch(
+                "services.agent_binding_service.AgentBindingService.evaluate_context_access",
+                AsyncMock(return_value=(False, DECISION_BINDING_DENIED)),
+            ) as ev:
+                mid = uuid.uuid4()
+                ok = await agent_binding_permits(
+                    MagicMock(),
+                    uuid.uuid4(),
+                    ACCESS_READ,
+                    operation="reference",
+                    user_id="caller",
+                    requested_memory_id=mid,
+                )
+            assert ok is False
+            kw = ev.await_args.kwargs
+            assert kw["operation"] == "reference"
+            assert kw["user_id"] == "caller"
+            assert kw["requested_memory_id"] == mid
+        finally:
+            set_agent_scope(None)

--- a/backend/tests/services/test_memory_access_event_writer.py
+++ b/backend/tests/services/test_memory_access_event_writer.py
@@ -201,3 +201,83 @@ class TestEmitGate:
                 operation="recall", outcome="success", workspace_id=None, user_id="u"
             )
         recorder.assert_not_awaited()
+
+
+class TestWouldDenyDedup:
+    """#1286 (P0-5): request-scoped dedup for shadow would_deny rows.
+
+    Several binding gates can evaluate the SAME denied context in one request
+    (MCP pre-gate → declared-context isolation gate → memory-id gate); the
+    writer collapses those to one row, keyed on
+    (operation, requested_context_id, access). Distinct keys still land their
+    own rows, and hard denies are never deduped. Task-context isolation gives
+    every request (and every test) a fresh set.
+    """
+
+    @staticmethod
+    def _scope():
+        return SimpleNamespace(agent_id=AGENT_ID, workspace_id=WORKSPACE_ID)
+
+    async def _emit(self, recorder, *, policy, ctx, access="write", operation="forget"):
+        with (
+            patch("auth.agent_scope.get_agent_scope", return_value=self._scope()),
+            patch("api.correlation.get_correlation", return_value=None),
+            patch("services.memory_access_event_writer.record_memory_access_event", new=recorder),
+        ):
+            await emit_memory_access_event(
+                operation=operation,
+                outcome="success" if policy == "would_deny" else "denied",
+                workspace_id=WORKSPACE_ID,
+                user_id="u",
+                policy_decision=policy,
+                extra_metadata={"requested_context_id": ctx, "access": access},
+            )
+
+    @pytest.mark.asyncio
+    async def test_same_key_second_would_deny_skipped(self):
+        recorder = AsyncMock()
+        ctx = str(uuid.uuid4())
+        await self._emit(recorder, policy="would_deny", ctx=ctx)
+        await self._emit(recorder, policy="would_deny", ctx=ctx)
+        assert recorder.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_distinct_context_lands_own_row(self):
+        # update's declared context vs the memory's own context are DISTINCT
+        # shadow signals — both must persist.
+        recorder = AsyncMock()
+        await self._emit(recorder, policy="would_deny", ctx=str(uuid.uuid4()))
+        await self._emit(recorder, policy="would_deny", ctx=str(uuid.uuid4()))
+        assert recorder.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_distinct_operation_lands_own_row(self):
+        recorder = AsyncMock()
+        ctx = str(uuid.uuid4())
+        await self._emit(recorder, policy="would_deny", ctx=ctx, operation="remember")
+        await self._emit(recorder, policy="would_deny", ctx=ctx, operation="forget")
+        assert recorder.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_hard_denies_never_deduped(self):
+        recorder = AsyncMock()
+        ctx = str(uuid.uuid4())
+        await self._emit(recorder, policy="binding_denied", ctx=ctx)
+        await self._emit(recorder, policy="binding_denied", ctx=ctx)
+        assert recorder.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_fresh_task_context_resets(self):
+        # Each request runs in its own task context — the dedup set never
+        # leaks across requests (same isolation guarantee AgentScope uses).
+        import asyncio
+
+        recorder = AsyncMock()
+        ctx = str(uuid.uuid4())
+
+        async def _one_request():
+            await self._emit(recorder, policy="would_deny", ctx=ctx)
+
+        await asyncio.create_task(_one_request())
+        await asyncio.create_task(_one_request())
+        assert recorder.await_count == 2

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -8,8 +8,10 @@ import pytest
 
 from models.schemas import (
     ForgetRequest,
+    PatchMemoryRequest,
     RecallRequest,
     RememberRequest,
+    UpdateMemoryRequest,
 )
 from services.memory_service import MemoryService
 
@@ -1772,3 +1774,194 @@ class TestExploreAccessStats:
         # Only one update_access_stats call: for the seed, with client="api".
         service.memory_repo.update_access_stats.assert_awaited_once_with(seed_id, client="api")
         service.db.commit.assert_awaited()
+
+
+class TestAccessEventEmission:
+    """#1286 item 2 (P0-5): update/patch/forget success-event emission.
+
+    The emission lives in the service layer so REST and MCP get it for free
+    (the writer stamps surface from the correlation contextvar and no-ops
+    unless a verified AgentScope is set — these tests patch the writer, so
+    they pin the CALL contract, not the writer's own gating).
+    """
+
+    @staticmethod
+    def _memory_row(ws, ctx, mid):
+        from datetime import datetime
+
+        memory = MagicMock()
+        memory.id = mid
+        memory.user_id = "author"
+        memory.workspace_id = ws
+        memory.context_id = ctx
+        memory.deleted_at = None
+        memory.summary = "s"
+        memory.context_summary = None
+        memory.content = "c"
+        memory.details = None
+        memory.type = "note"
+        memory.scope = "working"
+        memory.importance = 0.5
+        memory.tags = []
+        memory.context = None
+        memory.created_at = datetime(2026, 1, 1)
+        memory.client = "test"
+        memory.source_uri = None
+        memory.source_type = None
+        return memory
+
+    @pytest.mark.asyncio
+    async def test_update_in_place_emits_update_event(self):
+        service = MemoryService(MagicMock())
+        ws, ctx, mid = uuid4(), uuid4(), uuid4()
+        service.memory_repo.get = AsyncMock(return_value=self._memory_row(ws, ctx, mid))
+        service.db.commit = AsyncMock()
+        service.db.flush = AsyncMock()
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.can_access_memory",
+                AsyncMock(return_value=True),
+            ),
+            patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
+            patch("services.memory_service.update_memory_payload_in_qdrant", AsyncMock()),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            res = await service.update_memory(
+                UpdateMemoryRequest(memory_id=mid, tags=["x"]), "caller"
+            )
+
+        assert res.operation == "updated"
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        assert kw["operation"] == "update"
+        assert kw["outcome"] == "success"
+        assert kw["workspace_id"] == ws
+        assert kw["context_id"] == ctx
+        assert kw["memory_id"] == mid
+        assert kw["user_id"] == "caller"
+
+    @pytest.mark.asyncio
+    async def test_patch_memory_emits_update_event(self):
+        # PATCH is the REST-side update surface (#439) — it must emit the
+        # same operation="update" as MCP's _update_in_place (REST/MCP parity).
+        service = MemoryService(MagicMock())
+        ws, ctx, mid = uuid4(), uuid4(), uuid4()
+        service.memory_repo.get = AsyncMock(return_value=self._memory_row(ws, ctx, mid))
+        service.db.commit = AsyncMock()
+        service.db.flush = AsyncMock()
+        service._fetch_declared_link_refs = AsyncMock(return_value=([], False, [], False))
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.can_access_memory",
+                AsyncMock(return_value=True),
+            ),
+            patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
+            patch("services.memory_service.update_memory_payload_in_qdrant", AsyncMock()),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            await service.patch_memory(mid, PatchMemoryRequest(tags=["x"]), "caller")
+
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        assert kw["operation"] == "update"
+        assert kw["outcome"] == "success"
+        assert kw["workspace_id"] == ws
+        assert kw["memory_id"] == mid
+
+    @pytest.mark.asyncio
+    async def test_forget_by_id_falls_back_to_memory_row_workspace(self):
+        # REST forget declares no context (#246): the isolation helper
+        # resolves no workspace there. The emission must fall back to the
+        # deleted row's own (hard-validated) workspace, not silently no-op.
+        service = MemoryService(MagicMock())
+        ws, ctx, mid = uuid4(), uuid4(), uuid4()
+        service.memory_repo.get = AsyncMock(return_value=self._memory_row(ws, ctx, mid))
+        service.memory_repo.update = AsyncMock()
+        service.db.commit = AsyncMock()
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.can_access_memory",
+                AsyncMock(return_value=True),
+            ),
+            patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
+            patch("services.memory_service.delete_memory_from_qdrant", AsyncMock()),
+            patch("repositories.neural_edge.NeuralEdgeRepository") as edge_cls,
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            edge_cls.return_value.delete_node_edges = AsyncMock(return_value=0)
+            res = await service.forget(ForgetRequest(memory_id=mid), "caller")
+
+        assert res.deleted_count == 1
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        assert kw["operation"] == "forget"
+        assert kw["outcome"] == "success"
+        assert kw["workspace_id"] == ws
+        assert kw["context_id"] == ctx
+        assert kw["memory_id"] == mid
+        assert kw["result_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_forget_with_declared_context_uses_helper_workspace(self):
+        # When a context IS declared (MCP always), the isolation helper's
+        # workspace wins over the row's.
+        service = MemoryService(MagicMock())
+        ws_helper, ws_row, ctx, mid = uuid4(), uuid4(), uuid4(), uuid4()
+        mock_context = MagicMock(id=ctx, workspace_id=ws_helper)
+        service.context_service.get_context = AsyncMock(return_value=mock_context)
+        service.memory_repo.get = AsyncMock(return_value=self._memory_row(ws_row, ctx, mid))
+        service.memory_repo.update = AsyncMock()
+        service.db.commit = AsyncMock()
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.can_access_memory",
+                AsyncMock(return_value=True),
+            ),
+            patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
+            patch("services.memory_service.delete_memory_from_qdrant", AsyncMock()),
+            patch("repositories.neural_edge.NeuralEdgeRepository") as edge_cls,
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            edge_cls.return_value.delete_node_edges = AsyncMock(return_value=0)
+            res = await service.forget(
+                ForgetRequest(memory_id=mid), "caller", current_context_id=ctx
+            )
+
+        assert res.deleted_count == 1
+        kw = emit.await_args.kwargs
+        assert kw["workspace_id"] == ws_helper
+
+    @pytest.mark.asyncio
+    async def test_forget_denied_by_id_emits_no_success_event(self):
+        # The silent-filter deny (empty success-shaped response) must not
+        # produce a success audit row. (The denied row itself lands via the
+        # can_access_memory deny-capture — pinned in the permission tests.)
+        service = MemoryService(MagicMock())
+        ws, ctx, mid = uuid4(), uuid4(), uuid4()
+        service.memory_repo.get = AsyncMock(return_value=self._memory_row(ws, ctx, mid))
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.can_access_memory",
+                AsyncMock(return_value=False),
+            ),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            res = await service.forget(ForgetRequest(memory_id=mid), "caller")
+
+        assert res.deleted_count == 0
+        emit.assert_not_awaited()

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1822,7 +1822,7 @@ class TestAccessEventEmission:
             patch(
                 "services.permission_service.PermissionService.can_access_memory",
                 AsyncMock(return_value=True),
-            ),
+            ) as can_access,
             patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
             patch("services.memory_service.update_memory_payload_in_qdrant", AsyncMock()),
             patch(
@@ -1842,6 +1842,11 @@ class TestAccessEventEmission:
         assert kw["context_id"] == ctx
         assert kw["memory_id"] == mid
         assert kw["user_id"] == "caller"
+        # #1286 deny-capture audit identity must reach the permission gate —
+        # dropping it silently reverts deny rows for this op to log-only.
+        perm_kw = can_access.await_args.kwargs
+        assert perm_kw["operation"] == "update"
+        assert perm_kw["memory_id"] == mid
 
     @pytest.mark.asyncio
     async def test_patch_memory_emits_update_event(self):
@@ -1889,7 +1894,7 @@ class TestAccessEventEmission:
             patch(
                 "services.permission_service.PermissionService.can_access_memory",
                 AsyncMock(return_value=True),
-            ),
+            ) as can_access,
             patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
             patch("services.memory_service.delete_memory_from_qdrant", AsyncMock()),
             patch("repositories.neural_edge.NeuralEdgeRepository") as edge_cls,
@@ -1909,6 +1914,10 @@ class TestAccessEventEmission:
         assert kw["context_id"] == ctx
         assert kw["memory_id"] == mid
         assert kw["result_count"] == 1
+        # #1286 deny-capture audit identity must reach the permission gate.
+        perm_kw = can_access.await_args.kwargs
+        assert perm_kw["operation"] == "forget"
+        assert perm_kw["memory_id"] == mid
 
     @pytest.mark.asyncio
     async def test_forget_with_declared_context_uses_helper_workspace(self):
@@ -1965,3 +1974,44 @@ class TestAccessEventEmission:
 
         assert res.deleted_count == 0
         emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_forget_by_query_multi_row_metadata_contract(self):
+        # #1286 review finding: plural deletes must NOT stamp a single
+        # authoritative memory_id — the ids ride event_metadata (capped at
+        # MAX_METADATA_MEMORY_IDS) with result_count carrying the total.
+        from types import SimpleNamespace
+
+        service = MemoryService(MagicMock())
+        ws, ctx = uuid4(), uuid4()
+        ids = [uuid4(), uuid4()]
+        rows = {mid: self._memory_row(ws, ctx, mid) for mid in ids}
+        service.context_service.get_context = AsyncMock(
+            return_value=MagicMock(id=ctx, workspace_id=ws)
+        )
+        service.recall = AsyncMock(
+            return_value=SimpleNamespace(results=[SimpleNamespace(memory_id=m) for m in ids])
+        )
+        service.memory_repo.get = AsyncMock(side_effect=lambda m: rows.get(m))
+        service.memory_repo.update = AsyncMock()
+        service.db.commit = AsyncMock()
+
+        with (
+            patch("services.memory_service.resolve_collection_name", AsyncMock(return_value="c")),
+            patch("services.memory_service.delete_memory_from_qdrant", AsyncMock()),
+            patch("repositories.neural_edge.NeuralEdgeRepository") as edge_cls,
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            edge_cls.return_value.delete_node_edges = AsyncMock(return_value=0)
+            res = await service.forget(
+                ForgetRequest(query="q", k=10), "caller", current_context_id=ctx
+            )
+
+        assert res.deleted_count == 2
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        assert kw["memory_id"] is None  # plural: no single authoritative id
+        assert kw["result_count"] == 2
+        assert kw["extra_metadata"]["memory_ids"] == [str(m) for m in ids]

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -521,13 +521,14 @@ class TestCanAccessMemoryDenyCapture:
 
 
 class TestMcpPreGateDenyCapture:
-    """#1286 item 2 (P0-5): the MCP write pre-gate threads audit identity
-    into the binding evaluation with emit_would_deny=False — the service
-    layer re-evaluates and emits the single shadow row; the pre-gate is
-    responsible only for the hard deny that stops the request here."""
+    """#1286 item 2 (P0-5): the MCP pre-gates thread audit identity into the
+    binding evaluation. Every gate emits unconditionally; the writer's
+    request-scoped dedup collapses duplicate shadow rows (pinned in
+    test_memory_access_event_writer) — a hard deny stops the request at the
+    pre-gate, so its emission is the only record."""
 
     @pytest.mark.asyncio
-    async def test_resolve_context_threads_operation_with_would_deny_suppressed(self):
+    async def test_write_pre_gate_threads_operation(self):
         from mcp_server.tools._helpers import _ContextNotFoundError, _resolve_context
 
         set_agent_scope(
@@ -545,4 +546,40 @@ class TestMcpPreGateDenyCapture:
         kw = instance.evaluate_context_access.await_args.kwargs
         assert kw["operation"] == "remember"
         assert kw["user_id"] == "u"
-        assert kw["emit_would_deny"] is False
+
+    @pytest.mark.asyncio
+    async def test_read_pre_gate_threads_operation(self):
+        # The MCP READ face: recall/load_pinned/reference/feedback resolve via
+        # _resolve_context_for_read -> resolve_context_for_workspace_read.
+        # Without this threading, an enforce-mode read deny raises the uniform
+        # 404 BEFORE any service-layer gate and leaves no audit row (the
+        # #1291/#1292 parity class, caught by the pre-ship review).
+        from mcp_server.tools._helpers import _ContextNotFoundError, _resolve_context_for_read
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                AsyncMock(side_effect=NotFoundException("Context", "x")),
+            ) as resolve,
+            pytest.raises(_ContextNotFoundError),
+        ):
+            await _resolve_context_for_read(MagicMock(), "u", uuid.uuid4(), operation="recall")
+        assert resolve.await_args.kwargs["operation"] == "recall"
+
+    @pytest.mark.asyncio
+    async def test_binding_filter_threads_operation_into_evaluation(self):
+        # resolve_context_for_workspace_read / check_context_access forward
+        # operation into _apply_agent_binding_filter -> evaluate_context_access
+        # so the deny at this chokepoint persists its row.
+        set_agent_scope(
+            AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=uuid.uuid4())
+        )
+        perm = _perm()
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with patcher, pytest.raises(NotFoundException):
+            await perm._apply_agent_binding_filter(
+                uuid.uuid4(), access="read", user_id="u", operation="recall"
+            )
+        kw = instance.evaluate_context_access.await_args.kwargs
+        assert kw["operation"] == "recall"
+        assert kw["user_id"] == "u"

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -325,7 +325,7 @@ class TestMemoryServiceRecallGate:
 
         allowed_id, denied_id = uuid.uuid4(), uuid.uuid4()
 
-        async def _permits(_db, cid, _access):
+        async def _permits(_db, cid, _access, **_audit_kw):  # #1286 passthrough
             return cid != denied_id
 
         svc = self._svc()
@@ -371,3 +371,178 @@ class TestMemoryServiceRecallGate:
                 current_context_id=uuid.uuid4(),
                 current_workspace_id=uuid.uuid4(),
             )
+
+
+class TestCanAccessMemoryDenyCapture:
+    """#1286 item 2 (P0-5): rbac-shaped denials at the memory-id chokepoint
+    persist policy_decision='rbac_denied' rows for agent traffic. The
+    binding-shaped denial is emitted inside the binding evaluation itself
+    (pinned in test_agent_binding_service) — here we pin that the audit
+    identity (operation / requested memory_id) is THREADED through to it."""
+
+    @pytest.mark.asyncio
+    async def test_private_context_rbac_deny_emits_rbac_denied(self):
+        ws = uuid.uuid4()
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=ws))
+        perm = _perm()
+        ctx, mid = uuid.uuid4(), uuid.uuid4()
+        with (
+            patch(
+                "services.context_service.ContextService.is_context_shared",
+                AsyncMock(return_value=False),
+            ),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            ok = await perm.can_access_memory(
+                user_id="caller",
+                memory_user_id="author",
+                workspace_id=WORKSPACE_ID,
+                context_id=ctx,
+                operation="reference",
+                memory_id=mid,
+            )
+        assert ok is False
+        emit.assert_awaited_once()
+        kw = emit.await_args.kwargs
+        assert kw["operation"] == "reference"
+        assert kw["outcome"] == "denied"
+        assert kw["policy_decision"] == "rbac_denied"
+        # Credential scope — never the memory's workspace param.
+        assert kw["workspace_id"] == ws
+        assert kw["user_id"] == "caller"
+        assert kw["extra_metadata"]["requested_context_id"] == str(ctx)
+        assert kw["extra_metadata"]["requested_memory_id"] == str(mid)
+        assert kw.get("context_id") is None
+        assert kw.get("memory_id") is None
+
+    @pytest.mark.asyncio
+    async def test_non_member_rbac_deny_emits_rbac_denied(self):
+        ws = uuid.uuid4()
+        set_agent_scope(AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=ws))
+        perm = _perm()
+        perm.is_workspace_member = AsyncMock(return_value=False)
+        with (
+            patch(
+                "services.context_service.ContextService.is_context_shared",
+                AsyncMock(return_value=True),
+            ),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            ok = await perm.can_access_memory(
+                user_id="caller",
+                memory_user_id="author",
+                workspace_id=WORKSPACE_ID,
+                context_id=uuid.uuid4(),
+                operation="update",
+                memory_id=uuid.uuid4(),
+            )
+        assert ok is False
+        emit.assert_awaited_once()
+        assert emit.await_args.kwargs["policy_decision"] == "rbac_denied"
+
+    @pytest.mark.asyncio
+    async def test_non_agent_rbac_deny_emits_nothing(self):
+        # No agent scope (session / plain member key) → D34: only verified
+        # agent traffic is audited.
+        perm = _perm()
+        with (
+            patch(
+                "services.context_service.ContextService.is_context_shared",
+                AsyncMock(return_value=False),
+            ),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            ok = await perm.can_access_memory(
+                user_id="caller",
+                memory_user_id="author",
+                workspace_id=WORKSPACE_ID,
+                context_id=uuid.uuid4(),
+                operation="reference",
+                memory_id=uuid.uuid4(),
+            )
+        assert ok is False
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_operation_rbac_deny_emits_nothing(self):
+        # Un-threaded callers (explore — not in the MAE vocabulary yet) keep
+        # the pre-#1286 shape: deny without a row.
+        set_agent_scope(
+            AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=uuid.uuid4())
+        )
+        perm = _perm()
+        with (
+            patch(
+                "services.context_service.ContextService.is_context_shared",
+                AsyncMock(return_value=False),
+            ),
+            patch(
+                "services.memory_access_event_writer.emit_memory_access_event", AsyncMock()
+            ) as emit,
+        ):
+            ok = await perm.can_access_memory(
+                user_id="caller",
+                memory_user_id="author",
+                workspace_id=WORKSPACE_ID,
+                context_id=uuid.uuid4(),
+            )
+        assert ok is False
+        emit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_audit_identity_threaded_to_binding_gate(self):
+        set_agent_scope(
+            AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=uuid.uuid4())
+        )
+        perm = _perm()
+        mid = uuid.uuid4()
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with patcher:
+            ok = await perm.can_access_memory(
+                user_id="caller",
+                memory_user_id="caller",
+                workspace_id=WORKSPACE_ID,
+                context_id=uuid.uuid4(),
+                access="write",
+                operation="forget",
+                memory_id=mid,
+            )
+        assert ok is False
+        kw = instance.evaluate_context_access.await_args.kwargs
+        assert kw["operation"] == "forget"
+        assert kw["user_id"] == "caller"
+        assert kw["requested_memory_id"] == mid
+
+
+class TestMcpPreGateDenyCapture:
+    """#1286 item 2 (P0-5): the MCP write pre-gate threads audit identity
+    into the binding evaluation with emit_would_deny=False — the service
+    layer re-evaluates and emits the single shadow row; the pre-gate is
+    responsible only for the hard deny that stops the request here."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_threads_operation_with_would_deny_suppressed(self):
+        from mcp_server.tools._helpers import _ContextNotFoundError, _resolve_context
+
+        set_agent_scope(
+            AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=uuid.uuid4())
+        )
+        context = SimpleNamespace(id=uuid.uuid4(), workspace_id=WORKSPACE_ID)
+        service = MagicMock(get_context=AsyncMock(return_value=context))
+        patcher, instance = _patch_binding_service(False, "binding_denied")
+        with (
+            patch("services.context_service.ContextService", return_value=service),
+            patcher,
+            pytest.raises(_ContextNotFoundError),
+        ):
+            await _resolve_context(MagicMock(), "u", context.id, operation="remember")
+        kw = instance.evaluate_context_access.await_args.kwargs
+        assert kw["operation"] == "remember"
+        assert kw["user_id"] == "u"
+        assert kw["emit_would_deny"] is False

--- a/docs/design/agent-otel-correlation.md
+++ b/docs/design/agent-otel-correlation.md
@@ -128,15 +128,16 @@ with the following hard rules:
    (`event_metadata.unverified_agent_claim`, as a keyed hash — see below) with the audit
    row's `agent_id` taken from the credential. A claim is **never precedence-resolved in
    favor of the claim** against the credential.
-2. **Baggage claims are verified before being trusted in audit rows.** This verified-claim
+2. **Claims are verified before being trusted in audit rows.** This verified-claim
    path applies **only when the authenticated credential carries no `api_keys.agent_id`
    binding**; when the credential is agent-bound, Rule 1 controls unconditionally and a
    disagreeing claim is never written to `agent_id`, regardless of any same-member binding of
-   the claimed agent. For an agent-unbound credential, the verification predicate is precise:
-   a baggage `gen_ai.agent.id` claim verifies **iff** the claimed agent is bound, via
-   `api_keys.agent_id`, to the same member row as the authenticated credential. A verified
-   claim may populate the audit row's `agent_id` column; because the credential itself is
-   bound to no agent, such rows are stamped `policy_decision='unbound'` so the
+   the claimed agent. For an agent-unbound credential, the verification predicate is precise
+   and gates **every** unbound-path candidate — the explicit bootstrap arg exactly like a
+   baggage `gen_ai.agent.id` claim: the candidate verifies **iff** the claimed agent is
+   bound, via `api_keys.agent_id`, to the same member row as the authenticated credential. A
+   verified candidate may populate the audit row's `agent_id` column; because the credential
+   itself is bound to no agent, such rows are stamped `policy_decision='unbound'` so the
    attribution-without-containment state is explicit in every row, never implied.
 3. **An unverified claim never reaches the `agent_id` column.** The request proceeds
    unchanged (correlation is advisory; rejecting requests on bad headers would let a
@@ -152,8 +153,16 @@ with the following hard rules:
    keeps such rows distinguishable from credential-verified attribution.
 4. **Only `get_agent_bootstrap`'s explicit `agent_id` hard-fails** on mismatch (uniform
    `agent_not_found`), because there it is a functional input, not telemetry.
-5. **Credentials not bound to any agent**: if an explicit `agent_id` disagrees with baggage,
-   the explicit value wins and the event records `correlation_conflict: true` in metadata.
+5. **Credentials not bound to any agent**: if an explicit `agent_id` disagrees with a
+   baggage claim, the explicit value wins the **candidate slot** (precedence per the order
+   above) and the event records `correlation_conflict: true` in metadata. Winning precedence
+   is **not** a verification exemption (clarified by #1286; the pre-clarification wording
+   was ambiguously readable as "trusted directly"): the explicit candidate is still verified
+   per Rule 2 before reaching `agent_id`, and is stamped `policy_decision='unbound'` when it
+   does. The keyed-hash slot (Rule 3) records the highest-precedence *unverified* claim: on
+   a verified conflict that is the losing baggage claim; on verification failure it is the
+   explicit candidate itself, which never reaches `agent_id` — with `correlation_conflict`
+   preserved in both shapes.
 
 ## Vendor-attribute gap: `kagura.agent.run.id`
 

--- a/docs/design/agent-registry-and-bindings.md
+++ b/docs/design/agent-registry-and-bindings.md
@@ -185,7 +185,7 @@ Additional requirements:
 | Caller / credential | Before | After (Phase A: schema only) | After (Phase B: enforcement live) |
 |---|---|---|---|
 | REST/MCP request, key without `agent_id` (every credential existing today) | current behavior | **byte-for-byte unchanged** | **byte-for-byte unchanged** |
-| Key with `agent_id`, agent `enforce`, context **has** binding row | n/a | n/a | existing RBAC decision ∩ context-level binding (`can_read`, `write_policy`). Type/source filters are schema-reserved but non-`NULL` values are rejected until #1286 lands |
+| Key with `agent_id`, agent `enforce`, context **has** binding row | n/a | n/a | existing RBAC decision ∩ context-level binding (`can_read`, `write_policy`). Type/source filters are schema-reserved but non-`NULL` values are rejected until #1299 lands (per-memory type/source enforcement, split out of #1286 and deferred to P1 — P0-2 stays context-level only) |
 | Key with `agent_id`, agent `enforce`, context has **no** binding row | n/a | n/a | denied — uniform `context_not_found` (default-deny applies **only to newly bound agents**) |
 | Key with `agent_id`, agent `shadow` | n/a | n/a | legacy semantics; violations recorded as `would_deny` audit rows |
 | Key with `agent_id`, agent `suspended`/`retired` | n/a | n/a | rejected at verify time (fail-closed kill switch) |


### PR DESCRIPTION
Closes #1286

## Summary
- **Item 1 (P0-4)** — F4 identity precedence conformed to the fail-secure reading: "explicit wins" is candidate precedence over baggage, **not** a verification exemption. The doc (Rules 2/5) now says what the code does; the code closes the two real gaps — a verified conflict hashes the *disagreeing baggage claim* (previously dropped to a bare boolean) and the unverifiable guard path hashes the highest-precedence claim instead of silently dropping the explicit arg. Adds the verifier-False regression PR #1283's review flagged.
- **Item 2 (P0-5, success)** — `memory_access_events` emission for `update` (both `_update_in_place` and REST `patch_memory`, one vocabulary across faces) and `forget` (once per call; multi-row ids ride `event_metadata` capped at 32; the REST no-declared-context surface falls back to the deleted rows' own hard-validated workspace instead of silently dropping the row).
- **Item 2 (P0-5, deny capture)** — the binding-evaluation path persists its decisions: hard deny → `outcome='denied'` / `policy_decision='binding_denied'`; shadow → `outcome='success'` / `policy_decision='would_deny'` (the shadow→enforce ramp key); `can_access_memory`'s rbac branches stamp `rbac_denied`. `AgentScope` gains `workspace_id` so deny rows stamp the **credential** scope; requested identifiers ride `event_metadata` only (authoritative columns stay NULL).
- **No migration** — the e66 DDL already provisioned the whole vocabulary; this PR only adds the emission calls.

## Implementation notes
- Audit identity (`operation` / `user_id` / requested ids) threads as keyword-only optional kwargs through the binding gates (`agent_binding_permits`, `evaluate_context_access`, `can_access_memory`, `_get_context_isolation_params`, `_apply_agent_binding_filter`, `resolve_context_for_workspace_read`, `check_context_access`, MCP `_resolve_context[_for_read]`). Un-threaded callers (ops outside `MAE_OPERATIONS`: explore, set_state, context CRUD) keep log-only behavior explicitly — widening the CHECK is a migration, deferred to the #1299 cycle.
- A pre-ship adversarial review found and this PR fixes: (a) the MCP **read** face raised the uniform 404 at a binding filter with no audit identity — enforce-mode read denies left zero rows on the agent transport while the identical REST deny persisted (the #1291/#1292 parity class); (b) one shadow request could land duplicate `would_deny` rows across stacked gates — fixed at the common chokepoint with a request-scoped ContextVar dedup in the writer keyed `(operation, requested_context_id, access)`; distinct contexts still land their own rows, hard denies are never deduped.
- Uniform-404 / CWE-639 posture unchanged: emission is fail-open on an independent session and never alters responses. Accepted residuals (documented in commit 5eea537): ~ms deny-emission latency, the writer's independent-session pool cost (unchanged #1278 design), and the upsert-replace remember+forget row shape.
- F1 doc + `_validate_type_array` anchors re-pointed from "#1286" to **#1299** (per-memory type/source filtering was split out to P1 at the design gate).

## Test evidence
- Full local suite **5,511 passed**; integration E2E **10/10** on the real DB (denied-row shape incl. credential-scope workspace + NULL authoritative columns, exactly-one deduped shadow row, read pre-gate persisting its denied row, forget silent-deny leaving its only record); alembic round-trip + drift gates green; lint/format clean; pyright 0 new errors.
- New pins: 7-handler MCP operation-threading parametrized test (the one-line-revert class), writer dedup semantics (5 cases incl. fresh-task isolation), forget multi-row metadata contract, F4 conformance matrix.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1286-feat-chore-auth-p0-4-p0-5-deferred-identity-p.gate1.md
- ~/.claude/cache/gh-issue-driven/1286-feat-chore-auth-p0-4-p0-5-deferred-identity-p.gate2.md

🤖 Generated via /gh-issue-driven:ship
