### PR TITLE
feat(plugin): /compact nudge at end of session-summary (#1028)

### DIFF
--- a/claude-skills/session-summary.md
+++ b/claude-skills/session-summary.md
@@ -90,4 +90,10 @@ Related issues: #12, #34
 ...
 
 Total: N items saved to context {context_name}
+
+💡 Learnings are saved to Kagura Memory. If you're **continuing** work, run `/compact` now to free up context. Skip it if you're ending the session — compaction isn't needed when you're done.
 ```
+
+The `/compact` line is a **continue-only nudge**, not an instruction to run: saving to Kagura Memory is a durable save point, so the transcript can be compacted afterward with little loss when work continues. Leave the continue/end decision with the user — omit or ignore the nudge on a true session end.
+
+Do **not** attempt to auto-invoke `/compact` — it is a Claude Code harness (CLI) built-in, not a shell command or a skill action, so it cannot be triggered from this skill or a hook. The nudge is the whole mechanism.


### PR DESCRIPTION
Closes #1028.

## What

Appends a **continue-only** `/compact` nudge to the Report step of `claude-skills/session-summary.md`:

> 💡 Learnings are saved to Kagura Memory. If you're **continuing** work, run `/compact` now to free up context. Skip it if you're ending the session — compaction isn't needed when you're done.

Saving to Kagura Memory is a durable save point, so the transcript can be compacted with little loss when work continues — coupling "summarize → free up context" lowers ongoing token cost. The nudge keeps the continue/end decision with the user.

## Acceptance criteria

- [x] `session-summary` final report ends with a continue-only `/compact` nudge.
- [x] No attempt to auto-invoke `/compact` — documented as impossible (it's a Claude Code CLI built-in, not a shell command or skill action, so it can't be triggered from a skill or hook). The nudge is the whole mechanism.
- [x] Nudge wording makes clear it's skipped when the session is ending.

## Scope

`claude-skills/` only — `plugin.json` sets `"commands": ["./claude-skills/"]`, so that directory **is** the Claude Code plugin's command source. The `plugins/kagura-memory/` `.codex-plugin` `SKILL.md` variant is a different harness where `/compact` (a Claude Code built-in) does not apply, and its SYNC contract covers only the type-vocabulary / pin-guidance sections, not the report step.

Docs-only, behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)