### PR TITLE
feat(feedback): add operator-only host-arbitrated transport

### DIFF
--- a/backend/src/api/routes/feedback.py
+++ b/backend/src/api/routes/feedback.py
@@ -12,19 +12,30 @@ write. The caller's ``user_id`` is stored for attribution.
 
 from __future__ import annotations
 
+from typing import Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import APIKeyOrSessionUser
+from auth.agent_scope import get_agent_scope
+from auth.dependencies import APIKeyOrSessionUser, require_workspace_admin
 from auth.workspace_roles import ContextRole
 from db.base import get_db
 from models.retrieval_feedback import NOTE_MAX_LEN, QUERY_MAX_LEN
-from services.feedback_service import FeedbackService
+from services.feedback_service import (
+    HOST_EXPERIMENT_ID_MAX_LEN,
+    HOST_VERDICT_REFERENCE_MAX_LEN,
+    FeedbackService,
+)
 from services.permission_service import PermissionService
-from utils.exceptions import MemoryCloudException
+from utils.exceptions import (
+    AuthorizationError,
+    InternalError,
+    MemoryCloudException,
+    NotFoundException,
+)
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -55,12 +66,57 @@ class FeedbackResponse(BaseModel):
     helpful: bool
 
 
+class HostFeedbackRequest(BaseModel):
+    """Trusted operator verdict; provenance is intentionally not caller-settable."""
+
+    memory_id: UUID = Field(..., description="The recalled memory being rated")
+    helpful: bool = Field(..., description="Independent host verdict")
+    query: str | None = Field(None, max_length=QUERY_MAX_LEN)
+    verdict_source: Literal["objective_check", "trusted_host_check", "hitl_approval"]
+    verdict_reference: str = Field(..., max_length=HOST_VERDICT_REFERENCE_MAX_LEN)
+    experiment_id: str | None = Field(None, max_length=HOST_EXPERIMENT_ID_MAX_LEN)
+    note: str | None = Field(None, max_length=NOTE_MAX_LEN)
+
+    @field_validator("verdict_reference")
+    @classmethod
+    def validate_verdict_reference(cls, value: str) -> str:
+        value = value.strip()
+        if not value:
+            raise ValueError("verdict_reference must not be blank")
+        return value
+
+    @field_validator("experiment_id")
+    @classmethod
+    def validate_experiment_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        value = value.strip()
+        if not value:
+            raise ValueError("experiment_id must not be blank")
+        return value
+
+
 async def get_feedback_service(db: AsyncSession = Depends(get_db)) -> FeedbackService:
     return FeedbackService(db)
 
 
 async def get_permission_service(db: AsyncSession = Depends(get_db)) -> PermissionService:
     return PermissionService(db)
+
+
+async def require_host_feedback_operator(
+    user: dict = Depends(require_workspace_admin),
+) -> dict:
+    """Allow trusted owner/admin principals, but never an agent-bound key."""
+    scope = get_agent_scope()
+    if scope is not None:
+        logger.warning(
+            "host_feedback_agent_credential_rejected",
+            user_id=user.get("user_id"),
+            agent_id=str(scope.agent_id),
+        )
+        raise AuthorizationError(reason="agent_bound_credential")
+    return user
 
 
 @router.post(
@@ -112,3 +168,63 @@ async def record_feedback(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to record retrieval feedback",
         ) from e
+
+
+@router.post(
+    "/{context_id}/host-feedback",
+    response_model=FeedbackResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def record_host_feedback(
+    context_id: UUID,
+    body: HostFeedbackRequest,
+    user: dict = Depends(require_host_feedback_operator),
+    service: FeedbackService = Depends(get_feedback_service),
+    perm: PermissionService = Depends(get_permission_service),
+):
+    """Record a server-stamped host verdict from a trusted operator."""
+    user_id = user["user_id"]
+    active_workspace_id = UUID(str(user["current_workspace_id"]))
+    try:
+        context = await perm.resolve_context_for_workspace_read(
+            user_id,
+            context_id,
+            required_role="admin",
+            key_workspace_id=user.get("api_key_workspace_id"),
+        )
+        # Session/global-key operators are membership-authorized across their
+        # workspaces; this mutation is deliberately confined to the selected one.
+        if context.workspace_id != active_workspace_id:
+            raise NotFoundException("Context")
+
+        actor_metadata = {
+            "via": "api_key" if "api_key_workspace_id" in user else "session",
+        }
+        if user.get("api_key_prefix"):
+            actor_metadata["key_prefix"] = user["api_key_prefix"]
+
+        row = await service.record_host_feedback(
+            context_id=context_id,
+            memory_id=body.memory_id,
+            helpful=body.helpful,
+            user_id=user_id,
+            actor_email=user.get("email"),
+            actor_metadata=actor_metadata,
+            query=body.query,
+            verdict_source=body.verdict_source,
+            verdict_reference=body.verdict_reference,
+            experiment_id=body.experiment_id,
+            note=body.note,
+        )
+        return FeedbackResponse(feedback_id=row.id, memory_id=row.memory_id, helpful=row.helpful)
+    except (HTTPException, MemoryCloudException):
+        raise
+    except Exception as e:
+        logger.error(
+            "host_feedback_failed",
+            user_id=user_id,
+            context_id=str(context_id),
+            memory_id=str(body.memory_id),
+            error=str(e),
+        )
+        raise InternalError("Failed to record host feedback") from e

--- a/backend/src/api/routes/feedback.py
+++ b/backend/src/api/routes/feedback.py
@@ -197,9 +197,18 @@ async def record_host_feedback(
         if context.workspace_id != active_workspace_id:
             raise NotFoundException("Context")
 
-        actor_metadata = {
-            "via": "api_key" if "api_key_workspace_id" in user else "session",
-        }
+        # Three credential shapes reach this operator endpoint (all built in
+        # auth.dependencies): API keys carry api_key_workspace_id, OAuth
+        # Bearer principals carry oauth_scope (and are NOT workspace-bound),
+        # session cookies carry neither. Discriminate on those markers so the
+        # audit attribution names the real credential type.
+        if "api_key_workspace_id" in user:
+            via = "api_key"
+        elif "oauth_scope" in user:
+            via = "oauth_bearer"
+        else:
+            via = "session"
+        actor_metadata = {"via": via}
         if user.get("api_key_prefix"):
             actor_metadata["key_prefix"] = user["api_key_prefix"]
 

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -16,7 +16,7 @@ from uuid import UUID
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.auth import AuditLog
+from models.auth import AuditLog, Context
 from models.memory import Memory
 from models.retrieval_feedback import (
     _ALL_FEEDBACK_PROVENANCES,
@@ -66,8 +66,14 @@ class FeedbackService:
         query: str | None,
         note: str | None,
         provenance: str,
-    ) -> tuple[RetrievalFeedback, UUID | None]:
-        """Validate and stage one append-only event without committing it."""
+    ) -> tuple[RetrievalFeedback, UUID]:
+        """Validate and stage one append-only event without committing it.
+
+        The returned workspace id is always resolved: ``Memory.workspace_id``
+        is nullable (legacy rows), so when it is NULL the owning Context's
+        ``workspace_id`` (NOT NULL by schema) is used instead — audit
+        attribution must never record a null workspace.
+        """
         if provenance not in _ALL_FEEDBACK_PROVENANCES:
             raise ValueError(
                 f"invalid feedback provenance {provenance!r}; "
@@ -85,6 +91,18 @@ class FeedbackService:
         if existing is None:
             raise NotFoundException("Memory")
 
+        workspace_id = existing.workspace_id
+        if workspace_id is None:
+            workspace_id = (
+                await self.db.execute(
+                    select(Context.workspace_id).where(Context.id == context_id)
+                )
+            ).scalar_one_or_none()
+            if workspace_id is None:
+                # Fail fast: attribution is part of the audit contract, and a
+                # memory whose context cannot be resolved is unexpected state.
+                raise NotFoundException("Context")
+
         row = RetrievalFeedback(
             context_id=context_id,
             memory_id=memory_id,
@@ -95,7 +113,7 @@ class FeedbackService:
             provenance=provenance,
         )
         self.db.add(row)
-        return row, existing.workspace_id
+        return row, workspace_id
 
     async def record_feedback(
         self,
@@ -225,7 +243,7 @@ class FeedbackService:
                 resource=f"memory:{memory_id}",
                 user_metadata={
                     **(actor_metadata or {}),
-                    "workspace_id": str(workspace_id) if workspace_id is not None else None,
+                    "workspace_id": str(workspace_id),
                     "context_id": str(context_id),
                     "memory_id": str(memory_id),
                     "helpful": helpful,

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -94,9 +94,7 @@ class FeedbackService:
         workspace_id = existing.workspace_id
         if workspace_id is None:
             workspace_id = (
-                await self.db.execute(
-                    select(Context.workspace_id).where(Context.id == context_id)
-                )
+                await self.db.execute(select(Context.workspace_id).where(Context.id == context_id))
             ).scalar_one_or_none()
             if workspace_id is None:
                 # Fail fast: attribution is part of the audit contract, and a

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -10,11 +10,13 @@ never writes to it or the search index.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.auth import AuditLog
 from models.memory import Memory
 from models.retrieval_feedback import (
     _ALL_FEEDBACK_PROVENANCES,
@@ -25,6 +27,15 @@ from models.retrieval_feedback import (
     RetrievalFeedback,
 )
 from utils.exceptions import NotFoundException
+
+HOST_VERDICT_SOURCES: tuple[str, ...] = (
+    "objective_check",
+    "trusted_host_check",
+    "hitl_approval",
+)
+HOST_VERDICT_REFERENCE_MAX_LEN = 1024
+HOST_EXPERIMENT_ID_MAX_LEN = 255
+AUDIT_HOST_FEEDBACK_RECORDED = "host_feedback_recorded"
 
 
 @dataclass(frozen=True)
@@ -45,6 +56,46 @@ class FeedbackService:
 
     def __init__(self, db: AsyncSession):
         self.db = db
+
+    async def _stage_feedback(
+        self,
+        context_id: UUID,
+        memory_id: UUID,
+        helpful: bool,
+        user_id: str,
+        query: str | None,
+        note: str | None,
+        provenance: str,
+    ) -> tuple[RetrievalFeedback, UUID | None]:
+        """Validate and stage one append-only event without committing it."""
+        if provenance not in _ALL_FEEDBACK_PROVENANCES:
+            raise ValueError(
+                f"invalid feedback provenance {provenance!r}; "
+                f"expected one of {_ALL_FEEDBACK_PROVENANCES}"
+            )
+        existing = (
+            await self.db.execute(
+                select(Memory.id, Memory.workspace_id).where(
+                    Memory.id == memory_id,
+                    Memory.context_id == context_id,
+                    Memory.deleted_at.is_(None),
+                )
+            )
+        ).one_or_none()
+        if existing is None:
+            raise NotFoundException("Memory")
+
+        row = RetrievalFeedback(
+            context_id=context_id,
+            memory_id=memory_id,
+            helpful=helpful,
+            user_id=user_id,
+            query=query[:QUERY_MAX_LEN] if query is not None else None,
+            note=note[:NOTE_MAX_LEN] if note is not None else None,
+            provenance=provenance,
+        )
+        self.db.add(row)
+        return row, existing.workspace_id
 
     async def record_feedback(
         self,
@@ -72,37 +123,15 @@ class FeedbackService:
         (REST/MCP) never passes it, so an agent's signal is always ``agent`` (it
         cannot forge ``host``); only :meth:`record_host_feedback` stamps ``host``.
         """
-        if provenance not in _ALL_FEEDBACK_PROVENANCES:
-            raise ValueError(
-                f"invalid feedback provenance {provenance!r}; "
-                f"expected one of {_ALL_FEEDBACK_PROVENANCES}"
-            )
-        # Fetch workspace_id alongside the existence check so the audit emission
-        # below reuses it instead of a second round-trip (Copilot review, #1278).
-        # `.one_or_none()` on a Row disambiguates "no row" from "row with NULL
-        # workspace_id" (a bare scalar_one_or_none would conflate them).
-        existing = (
-            await self.db.execute(
-                select(Memory.id, Memory.workspace_id).where(
-                    Memory.id == memory_id,
-                    Memory.context_id == context_id,
-                    Memory.deleted_at.is_(None),
-                )
-            )
-        ).one_or_none()
-        if existing is None:
-            raise NotFoundException("Memory")
-
-        row = RetrievalFeedback(
-            context_id=context_id,
-            memory_id=memory_id,
-            helpful=helpful,
-            user_id=user_id,
-            query=query[:QUERY_MAX_LEN] if query is not None else None,
-            note=note[:NOTE_MAX_LEN] if note is not None else None,
-            provenance=provenance,
+        row, workspace_id = await self._stage_feedback(
+            context_id,
+            memory_id,
+            helpful,
+            user_id,
+            query,
+            note,
+            provenance,
         )
-        self.db.add(row)
         await self.db.commit()
         await self.db.refresh(row)
 
@@ -115,7 +144,7 @@ class FeedbackService:
             await emit_memory_access_event(
                 operation="feedback",
                 outcome="success",
-                workspace_id=existing.workspace_id,
+                workspace_id=workspace_id,
                 user_id=user_id,
                 context_id=context_id,
                 memory_id=memory_id,
@@ -128,8 +157,15 @@ class FeedbackService:
         memory_id: UUID,
         helpful: bool,
         user_id: str,
-        verdict: str,
         query: str | None = None,
+        *,
+        verdict_source: str = "trusted_host_check",
+        verdict_reference: str | None = None,
+        experiment_id: str | None = None,
+        note: str | None = None,
+        actor_email: str | None = None,
+        actor_metadata: dict[str, Any] | None = None,
+        verdict: str | None = None,
     ) -> RetrievalFeedback:
         """Record a HOST-ARBITRATED, forge-resistant feedback signal (Issue #1065).
 
@@ -139,27 +175,69 @@ class FeedbackService:
         ``provenance='host'`` so the re-rank can weight it distinctly from an
         agent's self-emitted ``feedback`` for untrusted callers.
 
-        This is deliberately NOT exposed on the agent-callable feedback() path —
-        the *computation* of the verdict is the host's job (e.g.
-        ``kagura-ai/kagura-agent#165``); this records its outcome with
-        server-authoritative provenance. The verdict reference is preserved in the
-        note for audit.
+        The caller must identify an allowed independent verdict source and a
+        concrete reference. ``verdict`` remains a compatibility alias for the
+        old service-only seam; new callers use ``verdict_reference``. The event
+        and its security audit row commit atomically.
         """
-        # Flatten whitespace (no newlines fracturing the audit note) and cap so
-        # the "host-verdict: " prefix is never lost to record_feedback's silent
-        # NOTE_MAX_LEN truncation — the prefix is what marks the entry as a verdict.
-        prefix = "host-verdict: "
-        flat_verdict = " ".join(str(verdict).split())
-        host_note = f"{prefix}{flat_verdict[: NOTE_MAX_LEN - len(prefix)]}"
-        return await self.record_feedback(
-            context_id=context_id,
-            memory_id=memory_id,
-            helpful=helpful,
-            user_id=user_id,
-            query=query,
-            note=host_note,
-            provenance=FEEDBACK_PROVENANCE_HOST,
+        if verdict_source not in HOST_VERDICT_SOURCES:
+            raise ValueError(
+                f"invalid verdict_source {verdict_source!r}; expected one of {HOST_VERDICT_SOURCES}"
+            )
+        reference = verdict_reference if verdict_reference is not None else verdict
+        flat_reference = " ".join(str(reference or "").split())
+        if not flat_reference:
+            raise ValueError("verdict_reference must identify an independent verdict")
+        if len(flat_reference) > HOST_VERDICT_REFERENCE_MAX_LEN:
+            raise ValueError(
+                f"verdict_reference must be at most {HOST_VERDICT_REFERENCE_MAX_LEN} characters"
+            )
+
+        clean_experiment_id = None
+        if experiment_id is not None:
+            clean_experiment_id = experiment_id.strip()
+            if not clean_experiment_id:
+                raise ValueError("experiment_id must not be blank")
+            if len(clean_experiment_id) > HOST_EXPERIMENT_ID_MAX_LEN:
+                raise ValueError(
+                    f"experiment_id must be at most {HOST_EXPERIMENT_ID_MAX_LEN} characters"
+                )
+
+        # Preserve a compact human-readable copy on the feedback event while
+        # keeping the structured, exact attribution in the audit lane.
+        prefix = f"host-verdict[{verdict_source}]: "
+        suffix = f" | note: {' '.join(note.split())}" if note else ""
+        host_note = f"{prefix}{flat_reference}{suffix}"[:NOTE_MAX_LEN]
+        row, workspace_id = await self._stage_feedback(
+            context_id,
+            memory_id,
+            helpful,
+            user_id,
+            query,
+            host_note,
+            FEEDBACK_PROVENANCE_HOST,
         )
+        self.db.add(
+            AuditLog(
+                user_email=actor_email or f"{user_id}@api",
+                user_id=user_id,
+                action=AUDIT_HOST_FEEDBACK_RECORDED,
+                resource=f"memory:{memory_id}",
+                user_metadata={
+                    **(actor_metadata or {}),
+                    "workspace_id": str(workspace_id) if workspace_id is not None else None,
+                    "context_id": str(context_id),
+                    "memory_id": str(memory_id),
+                    "helpful": helpful,
+                    "verdict_source": verdict_source,
+                    "verdict_reference": flat_reference,
+                    "experiment_id": clean_experiment_id,
+                },
+            )
+        )
+        await self.db.commit()
+        await self.db.refresh(row)
+        return row
 
     async def aggregate_for_memory(
         self, context_id: UUID, memory_id: UUID, *, host_only: bool = False

--- a/backend/tests/api/test_feedback_routes.py
+++ b/backend/tests/api/test_feedback_routes.py
@@ -215,6 +215,44 @@ class TestHostFeedbackRoute:
         )
 
     @pytest.mark.asyncio
+    async def test_oauth_bearer_operator_is_attributed_as_oauth_not_session(
+        self, service, perm, context_id, memory_id
+    ):
+        # OAuth Bearer principals (auth.dependencies._build_oauth_user_dict)
+        # carry oauth_scope and no api_key_workspace_id; the audit `via`
+        # marker must not mislabel them as "session" (PR #1307 review).
+        oauth_workspace_id = uuid4()
+        oauth_user = {
+            "user_id": "operator",
+            "email": "operator@oauth",
+            "role": "user",
+            "current_context_id": None,
+            "current_workspace_id": oauth_workspace_id,
+            "oauth_scope": "memory:admin",
+        }
+        context = MagicMock(workspace_id=oauth_workspace_id)
+        perm.resolve_context_for_workspace_read = AsyncMock(return_value=context)
+        service.record_host_feedback = AsyncMock(
+            return_value=MagicMock(id=uuid4(), memory_id=memory_id, helpful=True)
+        )
+
+        await record_host_feedback(
+            context_id=context_id,
+            body=HostFeedbackRequest(
+                memory_id=memory_id,
+                helpful=True,
+                verdict_source="objective_check",
+                verdict_reference="pytest://oauth/attribution",
+            ),
+            user=oauth_user,
+            service=service,
+            perm=perm,
+        )
+
+        actor_metadata = service.record_host_feedback.await_args.kwargs["actor_metadata"]
+        assert actor_metadata["via"] == "oauth_bearer"
+
+    @pytest.mark.asyncio
     async def test_context_idor_is_uniform_404(self, service, perm, context_id, memory_id):
         perm.resolve_context_for_workspace_read = AsyncMock(
             side_effect=NotFoundException("Context")

--- a/backend/tests/api/test_feedback_routes.py
+++ b/backend/tests/api/test_feedback_routes.py
@@ -17,11 +17,27 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 
-from api.routes.feedback import FeedbackRequest, record_feedback
+from api.routes.feedback import (
+    FeedbackRequest,
+    HostFeedbackRequest,
+    record_feedback,
+    record_host_feedback,
+    require_host_feedback_operator,
+)
+from auth.agent_scope import AgentScope, set_agent_scope
 from auth.workspace_roles import ContextRole
-from utils.exceptions import AuthorizationError, NotFoundException
+from models.agent import AGENT_ENFORCEMENT_ENFORCE
+from utils.exceptions import AuthorizationError, InternalError, NotFoundException
 
 MOCK_USER = {"user_id": "test_user"}
+OPERATOR_WORKSPACE_ID = uuid4()
+OPERATOR_USER = {
+    "user_id": "operator",
+    "email": "operator@example.com",
+    "current_workspace_id": OPERATOR_WORKSPACE_ID,
+    "api_key_workspace_id": OPERATOR_WORKSPACE_ID,
+    "api_key_prefix": "kagura_operator",
+}
 
 
 @pytest.fixture
@@ -37,7 +53,10 @@ def memory_id():
 @pytest.fixture
 def service(memory_id):
     row = MagicMock(id=uuid4(), memory_id=memory_id, helpful=True)
-    return MagicMock(record_feedback=AsyncMock(return_value=row))
+    return MagicMock(
+        record_feedback=AsyncMock(return_value=row),
+        record_host_feedback=AsyncMock(return_value=row),
+    )
 
 
 @pytest.fixture
@@ -139,3 +158,180 @@ async def test_mcp_handle_feedback_rejects_overlong_note():
     )
     # _error_response returns a single TextContent whose text carries the error.
     assert "validation_error" in result[0].text
+
+
+class TestHostFeedbackRoute:
+    def test_public_and_host_schemas_never_accept_provenance(self):
+        assert "provenance" not in FeedbackRequest.model_fields
+        assert "provenance" not in HostFeedbackRequest.model_fields
+
+    @pytest.mark.asyncio
+    async def test_success_uses_admin_workspace_gate_and_host_seam(
+        self, service, perm, context_id, memory_id
+    ):
+        target_workspace_id = OPERATOR_USER["current_workspace_id"]
+        context = MagicMock(workspace_id=target_workspace_id)
+        perm.resolve_context_for_workspace_read = AsyncMock(return_value=context)
+        service.record_host_feedback = AsyncMock(
+            return_value=MagicMock(id=uuid4(), memory_id=memory_id, helpful=True)
+        )
+        body = HostFeedbackRequest(
+            memory_id=memory_id,
+            helpful=True,
+            query="bootstrap task 07",
+            verdict_source="objective_check",
+            verdict_reference="pytest://bootstrap/task-07",
+            experiment_id="bootstrap-ab-2026-07-16",
+            note="assertions passed",
+        )
+
+        response = await record_host_feedback(
+            context_id=context_id,
+            body=body,
+            user=OPERATOR_USER,
+            service=service,
+            perm=perm,
+        )
+
+        assert response.memory_id == memory_id
+        perm.resolve_context_for_workspace_read.assert_awaited_once_with(
+            "operator",
+            context_id,
+            required_role="admin",
+            key_workspace_id=OPERATOR_USER["api_key_workspace_id"],
+        )
+        service.record_host_feedback.assert_awaited_once_with(
+            context_id=context_id,
+            memory_id=memory_id,
+            helpful=True,
+            user_id="operator",
+            actor_email="operator@example.com",
+            actor_metadata={"via": "api_key", "key_prefix": "kagura_operator"},
+            query="bootstrap task 07",
+            verdict_source="objective_check",
+            verdict_reference="pytest://bootstrap/task-07",
+            experiment_id="bootstrap-ab-2026-07-16",
+            note="assertions passed",
+        )
+
+    @pytest.mark.asyncio
+    async def test_context_idor_is_uniform_404(self, service, perm, context_id, memory_id):
+        perm.resolve_context_for_workspace_read = AsyncMock(
+            side_effect=NotFoundException("Context")
+        )
+
+        with pytest.raises(NotFoundException):
+            await record_host_feedback(
+                context_id=context_id,
+                body=HostFeedbackRequest(
+                    memory_id=memory_id,
+                    helpful=False,
+                    verdict_source="hitl_approval",
+                    verdict_reference="approval://ops/42",
+                ),
+                user=OPERATOR_USER,
+                service=service,
+                perm=perm,
+            )
+
+        service.record_host_feedback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_active_workspace_mismatch_is_uniform_404(
+        self, service, perm, context_id, memory_id
+    ):
+        perm.resolve_context_for_workspace_read = AsyncMock(
+            return_value=MagicMock(workspace_id=uuid4())
+        )
+
+        with pytest.raises(NotFoundException):
+            await record_host_feedback(
+                context_id=context_id,
+                body=HostFeedbackRequest(
+                    memory_id=memory_id,
+                    helpful=True,
+                    verdict_source="trusted_host_check",
+                    verdict_reference="host://runner/17",
+                ),
+                user=OPERATOR_USER,
+                service=service,
+                perm=perm,
+            )
+
+        service.record_host_feedback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_memory_idor_is_uniform_404(self, service, perm, context_id, memory_id):
+        perm.resolve_context_for_workspace_read = AsyncMock(
+            return_value=MagicMock(workspace_id=OPERATOR_USER["current_workspace_id"])
+        )
+        service.record_host_feedback = AsyncMock(side_effect=NotFoundException("Memory"))
+
+        with pytest.raises(NotFoundException):
+            await record_host_feedback(
+                context_id=context_id,
+                body=HostFeedbackRequest(
+                    memory_id=memory_id,
+                    helpful=False,
+                    verdict_source="objective_check",
+                    verdict_reference="pytest://bootstrap/task-09",
+                ),
+                user=OPERATOR_USER,
+                service=service,
+                perm=perm,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unexpected_host_failure_uses_canonical_internal_error(
+        self, service, perm, context_id, memory_id
+    ):
+        perm.resolve_context_for_workspace_read = AsyncMock(
+            return_value=MagicMock(workspace_id=OPERATOR_USER["current_workspace_id"])
+        )
+        service.record_host_feedback = AsyncMock(side_effect=RuntimeError("db down"))
+
+        with pytest.raises(InternalError, match="Failed to record host feedback"):
+            await record_host_feedback(
+                context_id=context_id,
+                body=HostFeedbackRequest(
+                    memory_id=memory_id,
+                    helpful=False,
+                    verdict_source="objective_check",
+                    verdict_reference="pytest://bootstrap/task-09",
+                ),
+                user=OPERATOR_USER,
+                service=service,
+                perm=perm,
+            )
+
+    @pytest.mark.asyncio
+    async def test_agent_bound_credential_is_rejected_even_for_admin(self):
+        set_agent_scope(
+            AgentScope(
+                agent_id=uuid4(),
+                enforcement_mode=AGENT_ENFORCEMENT_ENFORCE,
+                workspace_id=uuid4(),
+            )
+        )
+        try:
+            with pytest.raises(AuthorizationError) as exc:
+                await require_host_feedback_operator(OPERATOR_USER)
+            assert exc.value.status_code == 403
+        finally:
+            set_agent_scope(None)
+
+    @pytest.mark.asyncio
+    async def test_unbound_operator_credential_is_allowed(self):
+        set_agent_scope(None)
+        assert await require_host_feedback_operator(OPERATOR_USER) is OPERATOR_USER
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"verdict_source": "agent_self_report", "verdict_reference": "agent said yes"},
+            {"verdict_source": "objective_check", "verdict_reference": "   "},
+        ],
+    )
+    def test_schema_rejects_untrusted_or_blank_verdict(self, payload, memory_id):
+        with pytest.raises(ValueError):
+            HostFeedbackRequest(memory_id=memory_id, helpful=True, **payload)

--- a/backend/tests/integration/test_retrieval_feedback.py
+++ b/backend/tests/integration/test_retrieval_feedback.py
@@ -15,7 +15,7 @@ import pytest_asyncio
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.auth import Context, Workspace
+from models.auth import AuditLog, Context, Workspace
 from models.memory import Memory
 from models.retrieval_feedback import RetrievalFeedback
 from services.feedback_service import FeedbackService
@@ -293,7 +293,16 @@ async def test_host_only_aggregation_excludes_agent_feedback(
     # Agent forges 3 helpful; the host independently verdicts 1 helpful.
     for _ in range(3):
         await svc.record_feedback(s["ctx"].id, mem.id, True, s["owner"])  # provenance='agent'
-    await svc.record_host_feedback(s["ctx"].id, mem.id, True, s["owner"], verdict="check_exit=0")
+    await svc.record_host_feedback(
+        s["ctx"].id,
+        mem.id,
+        True,
+        s["owner"],
+        actor_email="operator@example.com",
+        verdict_source="objective_check",
+        verdict_reference="pytest://bootstrap/task-07",
+        experiment_id="bootstrap-ab-07",
+    )
 
     # Default (all provenances): the agent self-report inflates the tally.
     all_agg = await svc.aggregate_for_memories(s["ctx"].id, [mem.id])
@@ -315,3 +324,19 @@ async def test_host_only_aggregation_excludes_agent_feedback(
         .all()
     )
     assert sorted(provenances) == ["agent", "agent", "agent", "host"]
+
+    audit = (
+        await db_session.execute(
+            select(AuditLog).where(
+                AuditLog.action == "host_feedback_recorded",
+                AuditLog.user_id == s["owner"],
+            )
+        )
+    ).scalar_one()
+    assert audit.created_at is not None
+    assert audit.user_email == "operator@example.com"
+    assert audit.resource == f"memory:{mem.id}"
+    assert audit.user_metadata["context_id"] == str(s["ctx"].id)
+    assert audit.user_metadata["memory_id"] == str(mem.id)
+    assert audit.user_metadata["experiment_id"] == "bootstrap-ab-07"
+    assert audit.user_metadata["verdict_reference"] == "pytest://bootstrap/task-07"

--- a/backend/tests/services/test_feedback_provenance.py
+++ b/backend/tests/services/test_feedback_provenance.py
@@ -14,6 +14,7 @@ from uuid import uuid4
 
 import pytest
 
+from models.auth import AuditLog
 from models.retrieval_feedback import (
     FEEDBACK_PROVENANCE_AGENT,
     FEEDBACK_PROVENANCE_HOST,
@@ -46,25 +47,75 @@ class TestFeedbackProvenance:
     async def test_record_host_feedback_stamps_host_and_keeps_verdict(self):
         svc, db = _svc_with_existing_memory()
         await svc.record_host_feedback(
-            uuid4(), uuid4(), helpful=True, user_id="cockpit", verdict="check_exit=0"
+            uuid4(),
+            uuid4(),
+            helpful=True,
+            user_id="cockpit",
+            actor_email="cockpit@example.com",
+            verdict_source="objective_check",
+            verdict_reference="check://pytest/bootstrap-07?exit=0",
+            experiment_id="bootstrap-ab-07",
         )
-        row = db.add.call_args.args[0]
+        rows = [call.args[0] for call in db.add.call_args_list]
+        row = next(row for row in rows if not isinstance(row, AuditLog))
+        audit = next(row for row in rows if isinstance(row, AuditLog))
         assert row.provenance == FEEDBACK_PROVENANCE_HOST
-        assert row.note is not None and "check_exit=0" in row.note
+        assert row.note is not None and "check://pytest/bootstrap-07?exit=0" in row.note
+        assert audit.action == "host_feedback_recorded"
+        assert audit.user_email == "cockpit@example.com"
+        assert audit.user_metadata["experiment_id"] == "bootstrap-ab-07"
+        assert audit.user_metadata["verdict_source"] == "objective_check"
+        assert audit.user_metadata["verdict_reference"] == "check://pytest/bootstrap-07?exit=0"
+        assert "context_id" in audit.user_metadata
+        assert "memory_id" in audit.user_metadata
+        db.commit.assert_awaited_once()
 
     async def test_host_verdict_is_flattened_and_capped(self):
-        # The verdict is the audit trail of the host seam: newlines are flattened
-        # (no fractured audit log) and the "host-verdict: " prefix always survives
-        # record_feedback's NOTE_MAX_LEN truncation.
+        # The human-readable event copy is flattened and capped; the structured
+        # verdict reference remains separately preserved in the audit row.
         svc, db = _svc_with_existing_memory()
-        long_verdict = "line1\nline2\t" + "x" * 5000
+        long_note = "line1\nline2\t" + "x" * 5000
         await svc.record_host_feedback(
-            uuid4(), uuid4(), helpful=True, user_id="cockpit", verdict=long_verdict
+            uuid4(),
+            uuid4(),
+            helpful=True,
+            user_id="cockpit",
+            verdict_source="trusted_host_check",
+            verdict_reference="host://runner/17",
+            note=long_note,
         )
-        row = db.add.call_args.args[0]
-        assert row.note.startswith("host-verdict: ")
+        row = next(
+            call.args[0] for call in db.add.call_args_list if not isinstance(call.args[0], AuditLog)
+        )
+        assert row.note.startswith("host-verdict[trusted_host_check]: ")
         assert "\n" not in row.note and "\t" not in row.note
         assert len(row.note) <= NOTE_MAX_LEN
+
+    async def test_record_host_feedback_rejects_missing_independent_reference(self):
+        svc, db = _svc_with_existing_memory()
+        with pytest.raises(ValueError, match="verdict_reference"):
+            await svc.record_host_feedback(
+                uuid4(),
+                uuid4(),
+                helpful=True,
+                user_id="cockpit",
+                verdict_source="objective_check",
+                verdict_reference="  ",
+            )
+        db.add.assert_not_called()
+
+    async def test_record_host_feedback_rejects_agent_self_report_source(self):
+        svc, db = _svc_with_existing_memory()
+        with pytest.raises(ValueError, match="verdict_source"):
+            await svc.record_host_feedback(
+                uuid4(),
+                uuid4(),
+                helpful=True,
+                user_id="cockpit",
+                verdict_source="agent_self_report",
+                verdict_reference="agent said it worked",
+            )
+        db.add.assert_not_called()
 
     async def test_record_feedback_rejects_forged_provenance(self):
         # Defence in depth: even a service-layer caller cannot inject a bad value

--- a/backend/tests/services/test_feedback_provenance.py
+++ b/backend/tests/services/test_feedback_provenance.py
@@ -21,6 +21,7 @@ from models.retrieval_feedback import (
     NOTE_MAX_LEN,
 )
 from services.feedback_service import FeedbackService
+from utils.exceptions import NotFoundException
 
 
 def _svc_with_existing_memory():
@@ -126,3 +127,55 @@ class TestFeedbackProvenance:
                 uuid4(), uuid4(), helpful=True, user_id="u", provenance="forged"
             )
         db.add.assert_not_called()
+
+
+def _svc_with_legacy_memory(context_workspace_id):
+    """A FeedbackService whose memory row has workspace_id=None (legacy) and
+    whose Context lookup resolves to ``context_workspace_id``."""
+    db = MagicMock()
+    memory_row = MagicMock()
+    memory_row.workspace_id = None
+    mem_result = MagicMock()
+    mem_result.one_or_none = MagicMock(return_value=memory_row)
+    ctx_result = MagicMock()
+    ctx_result.scalar_one_or_none = MagicMock(return_value=context_workspace_id)
+    db.execute = AsyncMock(side_effect=[mem_result, ctx_result])
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return FeedbackService(db), db
+
+
+class TestHostFeedbackWorkspaceAttribution:
+    """Audit attribution must never record a null workspace_id (PR #1307
+    review): Memory.workspace_id is nullable for legacy rows, so the owning
+    Context's NOT NULL workspace_id is the fallback."""
+
+    async def test_audit_derives_workspace_from_context_for_legacy_memory(self):
+        ctx_ws = uuid4()
+        svc, db = _svc_with_legacy_memory(ctx_ws)
+        await svc.record_host_feedback(
+            uuid4(),
+            uuid4(),
+            helpful=True,
+            user_id="cockpit",
+            verdict_source="objective_check",
+            verdict_reference="check://pytest/legacy-ws?exit=0",
+        )
+        audit = next(
+            call.args[0] for call in db.add.call_args_list if isinstance(call.args[0], AuditLog)
+        )
+        assert audit.user_metadata["workspace_id"] == str(ctx_ws)
+
+    async def test_fails_fast_when_workspace_unresolvable(self):
+        svc, db = _svc_with_legacy_memory(None)
+        with pytest.raises(NotFoundException):
+            await svc.record_host_feedback(
+                uuid4(),
+                uuid4(),
+                helpful=True,
+                user_id="cockpit",
+                verdict_source="objective_check",
+                verdict_reference="check://pytest/no-ws?exit=0",
+            )
+        db.commit.assert_not_awaited()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -657,6 +657,34 @@ Record an explicit, attributable signal on whether a recalled memory was helpful
 
 **Response:** `201 Created` — `{ "feedback_id": "<uuid>", "memory_id": "<uuid>", "helpful": true }`
 
+### POST /api/v1/contexts/{context_id}/host-feedback
+
+Record an independently verified outcome with server-stamped `host` provenance.
+This endpoint is for trusted workspace owners/admins and operator automation only;
+agent-bound API keys are always rejected. The public feedback endpoint above is
+unchanged and can only produce `agent` provenance.
+
+```json
+{
+  "memory_id": "550e8400-e29b-41d4-a716-446655440000",
+  "helpful": true,
+  "query": "bootstrap task 07",
+  "verdict_source": "objective_check",
+  "verdict_reference": "pytest://bootstrap/task-07",
+  "experiment_id": "bootstrap-ab-2026-07-16",
+  "note": "all assertions passed"
+}
+```
+
+`verdict_source` must be `objective_check`, `trusted_host_check`, or
+`hitl_approval`; `verdict_reference` must identify the check/run/approval that
+produced the verdict. The feedback event and its actor/context/memory/experiment
+audit record are append-only and committed together.
+
+Keep this operator credential outside the evaluated agent's process and prompt.
+An evaluated model must never receive, read, log, or invoke the credential; the
+trusted harness submits the verdict only after its independent check completes.
+
 ---
 
 ## Memory Analysis APIs


### PR DESCRIPTION
## Summary

- add `POST /api/v1/contexts/{context_id}/host-feedback` for trusted owner/admin operators
- reject every agent-bound credential and keep provenance server-stamped as `host`
- require an independent verdict source/reference and atomically persist feedback plus structured audit attribution
- preserve the public REST/MCP feedback contract as agent-provenance only
- document that operator credentials must never enter an evaluated model process or prompt

## Security contract

- active-workspace and context access are confined with uniform 404 behavior
- memory/context mismatch uses the existing uniform memory-not-found guard
- audit captures actor, workspace, context, memory, verdict source/reference, experiment, and server timestamp
- agent callers cannot provide or forge a provenance field

## Validation

- 23 focused route/service tests passed
- 10 retrieval-feedback DB integration tests passed
- API/auth/MCP group: 1736 passed (canonical-error guard rechecked after the only fix)
- service/neural/db/repository group: 2389 passed, 1 skipped
- top-level group: 211 passed, 8 skipped
- `ruff check src tests` passed
- `pyright --pythonpath ...` passed for both changed source files
- one unrelated Windows chmod test is not portable because Windows ignores the POSIX write-bit change

Closes #1305
Related: kagura-ai/kagura-agent#188, #1065, #1263