### PR TITLE
chore(infra): add Renovate for digest-pinned postgres image bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,10 @@ jobs:
       github.event_name == 'push'
     services:
       postgres:
-        image: &postgres-image postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
+        # Literal pin (not a YAML anchor) in all three service blocks: Renovate's
+        # github-actions manager detects plain `image:` values, and the postgres
+        # packageRule group (renovate.json, #1310) bumps every site in one PR.
+        image: postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
         env:
           POSTGRES_USER: kagura
           POSTGRES_PASSWORD: kagura_dev_password
@@ -318,7 +321,7 @@ jobs:
       NEXT_PUBLIC_API_URL: http://localhost:8080
     services:
       postgres:
-        image: *postgres-image
+        image: postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
         env:
           POSTGRES_USER: kagura
           POSTGRES_PASSWORD: kagura_dev_password
@@ -456,7 +459,7 @@ jobs:
       GOOGLE_CLIENT_SECRET: e2e-mock-google-client-secret
     services:
       postgres:
-        image: *postgres-image
+        image: postgres:18.4-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
         env:
           POSTGRES_USER: kagura
           POSTGRES_PASSWORD: kagura_dev_password

--- a/backend/README.md
+++ b/backend/README.md
@@ -123,7 +123,7 @@ backend/
 
 - **Web Framework**: FastAPI 0.115+
 - **ASGI Server**: Uvicorn
-- **Database**: PostgreSQL 15+ (SQLAlchemy + asyncpg; CI/local are pinned to 18.4 — production migrates via `docs/ops/postgres-18-migration-runbook.md`)
+- **Database**: PostgreSQL 18+ (SQLAlchemy + asyncpg; CI/local/production all run the digest-pinned 18.4 — the 15→18 migration record lives in `docs/ops/postgres-18-migration-runbook.md`)
 - **Vector DB**: Qdrant 1.15+
 - **Cache**: Redis 7+
 - **Graph Memory**: NetworkX 3.0+

--- a/docs/ops/postgres-18-migration-runbook.md
+++ b/docs/ops/postgres-18-migration-runbook.md
@@ -5,6 +5,11 @@ Operator runbook for migrating the single-server production stack from
 **stateful cutover with downtime**, not a rolling deploy — schedule a
 maintenance window.
 
+> **Status**: executed against production on 2026-07-16 — evidence recorded on
+> #1311 (rollback-window close-out tracked in its follow-up issue). The
+> guard-window warnings below are retained as a record for future
+> major-version migrations.
+
 The pinned image lives in `docker-compose.prod.yml` (multi-arch
 manifest-list digest, resolved 2026-07-16 from Docker Hub). This runbook
 never hardcodes it — the Conventions section derives it from the compose

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":dependencyDashboard"],
+  "enabledManagers": ["docker-compose", "github-actions"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 8am on monday"],
+  "prConcurrentLimit": 2,
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Out of scope (#1310): action `uses:` bumps — only Docker images ride this config. Without this rule the github-actions manager would also propose actions/* SHA updates.",
+      "matchManagers": ["github-actions"],
+      "matchDatasources": ["github-tags", "github-releases", "github-runners", "node-version"],
+      "enabled": false
+    },
+    {
+      "description": "Deferred (#1310 non-goal): non-postgres images (qdrant/redis/caddy floating tags) — extending pin+bump coverage to them is a separate decision.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["!postgres"],
+      "enabled": false
+    },
+    {
+      "description": "Group the postgres digest pin across both compose files and all workflow service blocks into one atomic PR (#1310). pinDigests keeps the tag@sha256 form on tag bumps (18.5, …); CVE respins of the same tag arrive as digest updates.",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "groupName": "postgres image",
+      "pinDigests": true
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":dependencyDashboard"],
+  "extends": ["config:recommended"],
   "enabledManagers": ["docker-compose", "github-actions"],
   "timezone": "Asia/Tokyo",
   "schedule": ["before 8am on monday"],
@@ -8,23 +8,18 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
-      "description": "Out of scope (#1310): action `uses:` bumps — only Docker images ride this config. Without this rule the github-actions manager would also propose actions/* SHA updates.",
-      "matchManagers": ["github-actions"],
-      "matchDatasources": ["github-tags", "github-releases", "github-runners", "node-version"],
+      "description": "Default-deny (#1310): nothing rides this config unless a later rule explicitly re-enables it. Structural on purpose — enumerating the managers' non-docker datasources would silently leak when Renovate adds one (e.g. github-digest for SHA-pinned actions).",
+      "matchManagers": ["docker-compose", "github-actions"],
       "enabled": false
     },
     {
-      "description": "Deferred (#1310 non-goal): non-postgres images (qdrant/redis/caddy floating tags) — extending pin+bump coverage to them is a separate decision.",
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["!postgres"],
-      "enabled": false
-    },
-    {
-      "description": "Group the postgres digest pin across both compose files and all workflow service blocks into one atomic PR (#1310). pinDigests keeps the tag@sha256 form on tag bumps (18.5, …); CVE respins of the same tag arrive as digest updates.",
+      "description": "The one enabled dependency (#1310): group the postgres digest pin across both compose files and all workflow service blocks into one atomic weekly PR. Majors are deliberately excluded — a PostgreSQL major is a stateful dump/restore cutover (docs/ops/postgres-18-migration-runbook.md), never a compose bump. pinDigests auto-pins any future unpinned postgres reference (already-pinned tag@sha256 sites keep their form on bumps regardless). To extend coverage (qdrant/redis/caddy), copy this rule — the explicit enabled: true is required to override the default-deny above.",
       "matchDatasources": ["docker"],
       "matchPackageNames": ["postgres"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
       "groupName": "postgres image",
-      "pinDigests": true
+      "pinDigests": true,
+      "enabled": true
     }
   ]
 }

--- a/terraform/single-server/scripts/tests/postgres_pin_consistency.bats
+++ b/terraform/single-server/scripts/tests/postgres_pin_consistency.bats
@@ -1,0 +1,40 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Regression guard for the #1310 pin-divergence hazard: the postgres image is
+# digest-pinned as a LITERAL in six sites across four files (the ci.yml YAML
+# anchor was inlined so Renovate's github-actions manager detects every site).
+# YAML no longer enforces that the literals agree — this test does. The
+# Renovate packageRule group keeps them moving together once the bot is
+# active; this guard catches a stray hand-edit of a single site in the
+# meantime and forever. Static conformance — no docker, no network.
+# =============================================================================
+
+REPO_ROOT="$BATS_TEST_DIRNAME/../../../.."
+
+PIN_FILES=(
+    "docker-compose.yml"
+    "terraform/single-server/docker-compose.prod.yml"
+    ".github/workflows/ci.yml"
+    ".github/workflows/eval-nightly.yml"
+)
+
+@test "postgres image pin is identical across every site" {
+    cd "$REPO_ROOT"
+    for f in "${PIN_FILES[@]}"; do [ -r "$f" ]; done
+    run bash -o pipefail -c \
+        'grep -hoE "postgres:[0-9][^\"[:space:]]*@sha256:[a-f0-9]{64}" "$@" | sort -u | wc -l' \
+        _ "${PIN_FILES[@]}"
+    [ "$status" -eq 0 ]
+    [ "$output" -eq 1 ]
+}
+
+@test "all six pin sites are present (guard not vacuous)" {
+    # 2 compose files + 3 ci.yml service blocks + eval-nightly. If a service
+    # block is added or removed, update this floor deliberately.
+    cd "$REPO_ROOT"
+    run bash -o pipefail -c \
+        'grep -hoE "postgres:[0-9][^\"[:space:]]*@sha256:[a-f0-9]{64}" "$@" | wc -l' \
+        _ "${PIN_FILES[@]}"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 6 ]
+}


### PR DESCRIPTION
## Summary

Adds a minimal, tightly-scoped `renovate.json` so the postgres digest pin introduced in #1302 stays maintained automatically — closing the patch-posture regression where CVE respins of `18.4-alpine` were silently missed.

- **Structural default-deny scoping**: both enabled managers (`docker-compose`, `github-actions`) are `enabled: false` by default; a single rule re-enables exactly the `postgres` docker package. New Renovate datasources (e.g. `github-digest` for SHA-pinned actions) cannot leak PRs past the scope — no npm/pip/actions bumps, per the issue's non-goals.
- **One atomic grouped PR**: `groupName` ties all 6 pin sites (2 compose files + 3 `ci.yml` service blocks + `eval-nightly.yml`) together; weekly schedule (Mon before 08:00 JST), `prConcurrentLimit: 2`.
- **Majors excluded deliberately**: a PostgreSQL major is a stateful dump/restore cutover per `docs/ops/postgres-18-migration-runbook.md`, never a compose bump. Only `minor`/`patch`/`digest`/`pin` ride this config.
- **`ci.yml` YAML anchor inlined into 3 literal pins**: Renovate's `github-actions` manager reliably detects plain `image:` values; anchored values are not guaranteed to be detected. The anchor's job (keeping the three blocks in sync) moves to the grouped Renovate PR **plus** a new bats guard.
- **New pin-consistency bats guard** (`terraform/single-server/scripts/tests/postgres_pin_consistency.bats`, runs in the existing CI `shell` job): asserts all six sites carry one identical `postgres:*@sha256:` literal — restoring (and widening, from 3 sites to 6) the parse-time sync guarantee the anchor provided.
- **Docs**: `backend/README.md` PostgreSQL floor 15+ → 18+ (deferred AC of #1311; production cutover executed 2026-07-16) and the runbook is stamped with the execution record.

## ⚠️ Activation prerequisite (operator action)

This config is inert until the **Mend Renovate GitHub App** (https://github.com/apps/renovate) is installed on `kagura-ai/memory-cloud`. After install:
- AC 1 verifies immediately: the onboarding PR / Dependency Dashboard must list the postgres image from all 4 files (6 sites) under the single "postgres image" group — and **nothing else**.
- ACs 2–3 (CVE respin / 18.5 → one grouped PR) verify on the first real upstream event.

## Code review

Pre-PR review ran at xhigh effort (7 finder angles). All actionable findings addressed in the head commits: structural default-deny replacing the enumerated datasource denylist (the `github-digest` leak vector), major-version exclusion, redundant `:dependencyDashboard` dropped, `pinDigests` description corrected, pin-consistency guard added, commit scope fixed. `renovate-config-validator`: passes.

Closes #1310. Refs #1311 (README floor AC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
