### PR TITLE
fix(api): attribute fallback prior_usages to their own provider/model

### DIFF
--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -161,6 +161,12 @@ class ClusterLabel:
     breakdown: LLMCallBreakdown | None
     failed: bool = False
     empty: bool = False
+    # #1289: paid tokens from fallback-chain attempts that failed on a
+    # DIFFERENT (provider, model) than the winner, one entry per pair, so
+    # the per-model sleep_report_llm_usage rows attribute those tokens to
+    # the model that actually billed them. Same-pair attempts stay folded
+    # into ``breakdown``. The reporter sums both, so cost is unchanged.
+    prior_breakdowns: tuple[LLMCallBreakdown, ...] = ()
 
 
 def _select_representatives(
@@ -297,18 +303,26 @@ async def _label_one_cluster(
         label_confidence = 0.0
 
     breakdown = accumulate_llm_response(None, result.response)
-    # #1247: fold in paid tokens burned by any earlier fallback-chain
-    # attempts that failed (e.g. a model whose output failed to parse) so
+    # #1247: paid tokens burned by earlier fallback-chain attempts (e.g. a
+    # model whose output failed to parse) are never dropped, so
     # cost_actual_cents reflects EVERY billed call, not just the winner.
-    # Keyed by the winning (provider, model); the reporter aggregates all
-    # cluster breakdowns under the run's frozen rate, so summing tokens
-    # here is what the cost ledger needs.
+    # #1289: each attempt is attributed to the (provider, model) that
+    # actually billed it — an LLMResponse carries its own provider/model,
+    # so no LLMService shape change was needed. Same-pair attempts fold
+    # into the winner's breakdown; different-pair attempts get one entry
+    # per pair in ``prior_breakdowns``.
+    winner_pair = (result.response.provider, result.response.model)
+    prior_by_pair: dict[tuple[str, str], LLMCallBreakdown] = {}
     for prior in result.prior_usages:
-        breakdown.add_call(
-            input_tokens=prior.input_tokens,
-            output_tokens=prior.output_tokens,
-            cached_input_tokens=prior.cached_input_tokens,
-        )
+        if (prior.provider, prior.model) == winner_pair:
+            breakdown.add_call(
+                input_tokens=prior.input_tokens,
+                output_tokens=prior.output_tokens,
+                cached_input_tokens=prior.cached_input_tokens,
+            )
+        else:
+            pair = (prior.provider, prior.model)
+            prior_by_pair[pair] = accumulate_llm_response(prior_by_pair.get(pair), prior)
 
     return ClusterLabel(
         cluster_index=cluster_index,
@@ -318,6 +332,7 @@ async def _label_one_cluster(
         representative_memory_ids=filtered_reps,
         breakdown=breakdown,
         failed=False,
+        prior_breakdowns=tuple(prior_by_pair.values()),
     )
 
 

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -138,14 +138,18 @@ def _aggregate_breakdown_totals(
     total_cached = 0
     total_calls = 0
     for cl in cluster_labels:
-        b = cl.breakdown
-        if b is None:
-            continue
-        breakdowns.append(b)
-        total_input += b.input_tokens
-        total_output += b.output_tokens
-        total_cached += b.cached_input_tokens
-        total_calls += b.calls
+        # #1289: prior_breakdowns carry fallback-attempt usage attributed
+        # to its own (provider, model). Including them here keeps the
+        # totals — and thus cost_actual_cents — counting every billed
+        # call, exactly as when they were folded into the winner.
+        for b in (cl.breakdown, *cl.prior_breakdowns):
+            if b is None:
+                continue
+            breakdowns.append(b)
+            total_input += b.input_tokens
+            total_output += b.output_tokens
+            total_cached += b.cached_input_tokens
+            total_calls += b.calls
     return breakdowns, _CostTotals(
         input_tokens=total_input,
         output_tokens=total_output,

--- a/backend/tests/services/analysis/test_labeler_coverage.py
+++ b/backend/tests/services/analysis/test_labeler_coverage.py
@@ -375,6 +375,108 @@ class TestLabelOneCluster:
         assert cl.breakdown.calls == 2
         assert cl.breakdown.input_tokens == 20 + 60
         assert cl.breakdown.output_tokens == 10 + 30
+        # #1289: same (provider, model) as the winner — folds into the
+        # winner's entry, never a separate prior entry (no double count).
+        assert cl.prior_breakdowns == ()
+
+    async def test_failed_attempt_on_other_model_attributed_to_itself(self, monkeypatch) -> None:
+        """#1289: a fallback attempt billed on a DIFFERENT (provider, model)
+        than the winner gets its own breakdown entry instead of skewing the
+        winner's sleep_report_llm_usage row; totals stay sum-invariant."""
+        import asyncio
+
+        winner = _llm_response(parsed={"label": "L", "label_confidence": 0.5})
+        failed_usage = LLMResponse(
+            parsed={},
+            total_tokens=90,
+            input_tokens=60,
+            output_tokens=30,
+            cached_input_tokens=0,
+            provider="openai",
+            model="gpt-5.5",
+        )
+
+        async def _fake(**_kwargs):  # noqa: ANN003
+            return CallResult(
+                parsed=winner.parsed,
+                response=winner,
+                prior_usages=(failed_usage,),
+            )
+
+        monkeypatch.setattr(labeler, "call_with_fallback", _fake)
+
+        cl = await _label_one_cluster(
+            cluster_index=0,
+            reps=[_mem()],
+            user_id="u",
+            workspace_id="w",
+            context_id=None,
+            sem=asyncio.Semaphore(1),
+        )
+
+        assert cl.breakdown is not None
+        # The winner's row is untouched by the failed attempt...
+        assert cl.breakdown.model == "gpt-5-nano"
+        assert cl.breakdown.calls == 1
+        assert cl.breakdown.input_tokens == 20
+        assert cl.breakdown.output_tokens == 10
+        # ...the failed attempt is attributed to the model that billed it...
+        assert len(cl.prior_breakdowns) == 1
+        prior = cl.prior_breakdowns[0]
+        assert (prior.provider, prior.model) == ("openai", "gpt-5.5")
+        assert prior.calls == 1
+        assert prior.input_tokens == 60
+        assert prior.output_tokens == 30
+        # ...and the ledger stays sum-invariant vs the old fold-into-winner.
+        entries = [cl.breakdown, *cl.prior_breakdowns]
+        assert sum(b.input_tokens for b in entries) == 20 + 60
+        assert sum(b.output_tokens for b in entries) == 10 + 30
+        assert sum(b.calls for b in entries) == 2
+
+    async def test_two_failed_attempts_same_pair_merge_into_one_prior_entry(
+        self, monkeypatch
+    ) -> None:
+        """#1289: multiple billed attempts on the same non-winner pair
+        accumulate into ONE prior entry (calls=2), not one entry each."""
+        import asyncio
+
+        winner = _llm_response(parsed={"label": "L", "label_confidence": 0.5})
+
+        def _failed(input_tokens: int, output_tokens: int) -> LLMResponse:
+            return LLMResponse(
+                parsed={},
+                total_tokens=input_tokens + output_tokens,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_input_tokens=0,
+                provider="openai",
+                model="gpt-5.5",
+            )
+
+        async def _fake(**_kwargs):  # noqa: ANN003
+            return CallResult(
+                parsed=winner.parsed,
+                response=winner,
+                prior_usages=(_failed(30, 10), _failed(60, 30)),
+            )
+
+        monkeypatch.setattr(labeler, "call_with_fallback", _fake)
+
+        cl = await _label_one_cluster(
+            cluster_index=0,
+            reps=[_mem()],
+            user_id="u",
+            workspace_id="w",
+            context_id=None,
+            sem=asyncio.Semaphore(1),
+        )
+
+        assert len(cl.prior_breakdowns) == 1
+        prior = cl.prior_breakdowns[0]
+        assert prior.model == "gpt-5.5"
+        assert prior.calls == 2
+        assert prior.input_tokens == 90
+        assert prior.output_tokens == 40
 
     async def test_confidence_clamped_above_one(self, monkeypatch) -> None:
         """A confidence > 1 is clamped to 1.0."""

--- a/backend/tests/services/analysis/test_reporter_coverage.py
+++ b/backend/tests/services/analysis/test_reporter_coverage.py
@@ -83,6 +83,7 @@ def _cluster_label(
     representative_memory_ids: list[str] | None = None,
     breakdown: LLMCallBreakdown | None = None,
     failed: bool = False,
+    prior_breakdowns: tuple[LLMCallBreakdown, ...] = (),
 ) -> ClusterLabel:
     return ClusterLabel(
         cluster_index=cluster_index,
@@ -94,6 +95,7 @@ def _cluster_label(
         else [],
         breakdown=breakdown,
         failed=failed,
+        prior_breakdowns=prior_breakdowns,
     )
 
 
@@ -160,6 +162,32 @@ class TestAggregateBreakdownTotals:
         assert totals.output_tokens == 60
         assert totals.cached_input_tokens == 20
         assert totals.calls == 3
+
+    def test_prior_breakdowns_ride_totals_and_entry_list(self):
+        """#1289: fallback-attempt entries (attributed to their own model)
+        are collected as rows AND summed into totals — sum-invariant with
+        the pre-#1289 fold-into-winner shape, so cost_actual_cents cannot
+        move."""
+        labels = [
+            _cluster_label(
+                cluster_index=0,
+                breakdown=_breakdown(
+                    input_tokens=100, output_tokens=20, cached_input_tokens=5, calls=1
+                ),
+                prior_breakdowns=(
+                    _breakdown(model="gpt-5.5", input_tokens=60, output_tokens=30, calls=1),
+                ),
+            ),
+            # A cluster that failed all models: no entries of either kind.
+            _cluster_label(cluster_index=1, breakdown=None, failed=True),
+        ]
+        breakdowns, totals = _aggregate_breakdown_totals(labels)
+        assert len(breakdowns) == 2
+        assert {b.model for b in breakdowns} == {"gpt-5-nano", "gpt-5.5"}
+        assert totals.input_tokens == 160
+        assert totals.output_tokens == 50
+        assert totals.cached_input_tokens == 5
+        assert totals.calls == 2
 
 
 class TestComputeActualCostCents:


### PR DESCRIPTION
## Summary

Closes #1289 (v0.51.0). The #1247 fold keyed failed-fallback-attempt tokens to the **winning** `(provider, model)`, skewing the per-model `sleep_report_llm_usage` rows (`phase=cluster_labeling`) whenever the fallback chain switched models.

**The issue's deferral premise was stale**: it assumed `result.prior_usages` needed to be reshaped to carry `(provider, model)` — but `LLMResponse` already carries both fields, so no `LLMService` plumbing change is needed. The fix is fully local:

- `ClusterLabel` gains an additive `prior_breakdowns: tuple[LLMCallBreakdown, ...] = ()` — one entry per distinct non-winner pair, built with the existing `accumulate_llm_response` helper. Same-pair attempts keep folding into the winner's entry (behavior preserved, no double count).
- `_aggregate_breakdown_totals` iterates `(cl.breakdown, *cl.prior_breakdowns)`: **totals — and therefore `cost_actual_cents` — are sum-invariant** (single frozen rate × aggregate tokens, unchanged); only the per-model row attribution becomes truthful.
- The sleep reporter already writes one row per breakdown entry with no per-pair merge assumption, so the extra entries are schema-compatible. The `breakdown <= legacy` divergence invariant holds (both sides include prior tokens, as before).

## Tests (4 new / extended, 67 passing locally)

- same-pair fold preserved + `prior_breakdowns == ()` (no double count)
- cross-model attempt → own entry, winner untouched, explicit sum-invariance asserts
- two same-pair non-winner attempts merge into one entry (`calls=2`)
- reporter totals include prior entries (row list + `_CostTotals`)

Gate1: green (CFO lens — cost-ledger invariance verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)