### PR TITLE
fix(api): usage-log FK fallback + calibration vector-type crash

### DIFF
--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -42,6 +42,7 @@ async def handle_get_context_info(
     from db.base import get_db
 
     start_time = time.time()
+    current_context_id = None
     async for db in get_db():
         try:
             from services.memory_service import MemoryService
@@ -201,7 +202,8 @@ async def handle_get_context_info(
                 "get_context_info",
                 start_time,
                 500,
-                args.get("context_id"),
+                # #1318: resolved-or-None — never the raw request value.
+                current_context_id,
                 workspace_id,
             )
             logger.error(f"get_context_info_failed: {e}", exc_info=True)

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -186,7 +186,10 @@ async def handle_get_context_info(
                 "get_context_info",
                 start_time,
                 404,
-                args.get("context_id"),
+                # #1318: the requested context_id failed resolution — it must
+                # not be stamped as the usage_stats FK (nonexistent UUIDs
+                # violate the constraint and drop the whole usage row).
+                None,
                 workspace_id,
             )
             return e.to_response()

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -166,6 +166,7 @@ async def handle_list_edges(
     limit = args.get("limit")
 
     start_time = time.time()
+    current_context_id = None
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
@@ -221,14 +222,14 @@ async def handle_list_edges(
             )
         except _ContextNotFoundError as e:
             await db.rollback()
-            await _log_tool_usage(
-                db, user_id, "list_edges", start_time, 404, args.get("context_id"), workspace_id
-            )
+            # #1318: the requested context_id failed resolution — do not
+            # stamp it as the usage_stats FK.
+            await _log_tool_usage(db, user_id, "list_edges", start_time, 404, None, workspace_id)
             return e.to_response()
         except Exception:
             await db.rollback()
             await _log_tool_usage(
-                db, user_id, "list_edges", start_time, 500, args.get("context_id"), workspace_id
+                db, user_id, "list_edges", start_time, 500, current_context_id, workspace_id
             )
             raise
 
@@ -268,6 +269,7 @@ async def handle_create_edge(
     from repositories.neural_edge import NeuralEdgeRepository
 
     start_time = time.time()
+    current_context_id = None
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
@@ -308,7 +310,7 @@ async def handle_create_edge(
         except Exception:
             await db.rollback()
             await _log_tool_usage(
-                db, user_id, "create_edge", start_time, 500, args.get("context_id"), workspace_id
+                db, user_id, "create_edge", start_time, 500, current_context_id, workspace_id
             )
             raise
 
@@ -355,6 +357,7 @@ async def handle_update_edge(
     from repositories.neural_edge import NeuralEdgeRepository
 
     start_time = time.time()
+    current_context_id = None
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
@@ -415,7 +418,7 @@ async def handle_update_edge(
         except Exception:
             await db.rollback()
             await _log_tool_usage(
-                db, user_id, "update_edge", start_time, 500, args.get("context_id"), workspace_id
+                db, user_id, "update_edge", start_time, 500, current_context_id, workspace_id
             )
             raise
 
@@ -436,6 +439,7 @@ async def handle_delete_edge(
     from repositories.neural_edge import NeuralEdgeRepository
 
     start_time = time.time()
+    current_context_id = None
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
@@ -480,7 +484,7 @@ async def handle_delete_edge(
         except Exception:
             await db.rollback()
             await _log_tool_usage(
-                db, user_id, "delete_edge", start_time, 500, args.get("context_id"), workspace_id
+                db, user_id, "delete_edge", start_time, 500, current_context_id, workspace_id
             )
             raise
 

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -497,7 +497,11 @@ async def compute_calibration(
     # cross-topic associations clear the bar. Reuse the already-fetched vectors;
     # random pairs need no extra Qdrant round-trip. Skip (leaving the runtime on
     # its absolute fallback) when too few pairs to estimate the upper tail.
-    pair_scores = measure_random_pair(vectors, SAMPLE_RANDOM_PAIRS)
+    # #1319: fetch_vectors returns dict[str, list[float]] (measure_top_k
+    # consumes it keyed), but measure_random_pair expects the bare vector
+    # list — passing the dict made np.asarray call float(dict) and the whole
+    # calibration (both kinds) rolled back on every run.
+    pair_scores = measure_random_pair(list(vectors.values()), SAMPLE_RANDOM_PAIRS)
     pair_observations = len(pair_scores)
     pair_percentiles = compute_percentiles(pair_scores)
     if pair_percentiles and pair_observations >= EDGE_GATE_MIN_PAIR_OBSERVATIONS:

--- a/backend/src/utils/usage_logger.py
+++ b/backend/src/utils/usage_logger.py
@@ -5,6 +5,7 @@ Issue #48 - Usage Statistics - Plan Limits & Usage Tracking
 """
 
 from sqlalchemy import insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import UsageStats
@@ -57,10 +58,10 @@ async def log_usage(
         flow, but callers chaining dependent writes, e.g. #1228 attribution
         rows, need the signal).
     """
-    try:
-        # Use utcnow() for timezone-naive datetime (matches DB schema)
-        now = utcnow()
+    # Use utcnow() for timezone-naive datetime (matches DB schema)
+    now = utcnow()
 
+    async def _insert(ctx_id: str | None) -> None:
         await db.execute(
             insert(UsageStats).values(
                 user_id=user_id,
@@ -70,23 +71,47 @@ async def log_usage(
                 response_time_ms=response_time_ms,
                 created_at=now,
                 date=now.date(),
-                context_id=context_id,  # Bugfix: Add context_id
+                context_id=ctx_id,  # Bugfix: Add context_id
                 workspace_id=workspace_id,  # Bugfix: Add workspace_id
                 api_key_id=api_key_id,  # Issue #626
             )
         )
         await db.commit()
 
-        logger.debug(
-            "usage_logged",
+    try:
+        await _insert(context_id)
+    except IntegrityError as e:
+        # #1318: callers may stamp an unvalidated context_id (e.g. a
+        # nonexistent UUID straight from the request), violating the
+        # usage_stats→contexts FK. Preserve the usage/quota event without
+        # the context attribution instead of dropping the row.
+        await db.rollback()
+        if context_id is None:
+            logger.error(
+                "usage_logging_failed",
+                error=str(e),
+                user_id=user_id,
+                endpoint=endpoint,
+            )
+            return False
+        try:
+            await _insert(None)
+        except Exception as retry_err:
+            await db.rollback()
+            logger.error(
+                "usage_logging_failed",
+                error=str(retry_err),
+                user_id=user_id,
+                endpoint=endpoint,
+            )
+            return False
+        logger.warning(
+            "usage_logging_context_fk_fallback",
+            context_id=context_id,
             user_id=user_id,
             endpoint=endpoint,
-            method=method,
-            status=status_code,
-            response_time_ms=response_time_ms,
         )
         return True
-
     except Exception as e:
         await db.rollback()
         logger.error(
@@ -97,3 +122,13 @@ async def log_usage(
         )
         # Don't raise - logging should not break the main flow
         return False
+
+    logger.debug(
+        "usage_logged",
+        user_id=user_id,
+        endpoint=endpoint,
+        method=method,
+        status=status_code,
+        response_time_ms=response_time_ms,
+    )
+    return True

--- a/backend/src/utils/usage_logger.py
+++ b/backend/src/utils/usage_logger.py
@@ -53,10 +53,20 @@ async def log_usage(
         await log_usage(db, user_id, "mcp:recall", "MCP", 200, 80)
 
     Returns:
-        True when the row was written; False when the insert failed (the
-        error is logged and swallowed — logging must never break the main
-        flow, but callers chaining dependent writes, e.g. #1228 attribution
-        rows, need the signal).
+        True when the row was written WITH the requested attribution; False
+        when the insert failed outright OR the row was preserved only via the
+        #1318 NULL-context fallback (errors are logged and swallowed —
+        logging must never break the main flow). Callers chaining
+        attribution-dependent writes (#1228 ContextReadAttribution rows) key
+        on this: a degraded row must NOT get secondary attributions, or the
+        primary context's read becomes invisible while secondaries are
+        attributed.
+
+    Note:
+        The FK fallback rolls back the session before retrying. Callers pass
+        a dedicated session today (middleware and _log_tool_usage both use a
+        fresh get_db()); do NOT call this on a shared session holding
+        pending business writes.
     """
     # Use utcnow() for timezone-naive datetime (matches DB schema)
     now = utcnow()
@@ -101,6 +111,7 @@ async def log_usage(
             logger.error(
                 "usage_logging_failed",
                 error=str(retry_err),
+                original_error=str(e),
                 user_id=user_id,
                 endpoint=endpoint,
             )
@@ -111,7 +122,9 @@ async def log_usage(
             user_id=user_id,
             endpoint=endpoint,
         )
-        return True
+        # Row preserved but WITHOUT the requested context attribution —
+        # report False so #1228 attribution writes are skipped (see Returns).
+        return False
     except Exception as e:
         await db.rollback()
         logger.error(

--- a/backend/tests/tasks/test_neural_calibration.py
+++ b/backend/tests/tasks/test_neural_calibration.py
@@ -84,3 +84,60 @@ async def test_delete_calibration_issues_delete_without_commit():
     )
     db.execute.assert_awaited_once()
     db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_compute_calibration_passes_vector_list_to_measure_random_pair(monkeypatch):
+    """#1319: fetch_vectors returns dict[str, list[float]]; measure_random_pair
+    expects a bare vector list. Passing the dict made np.asarray call
+    float(dict) and every calibration run failed pre-commit (neither kind
+    persisted). The edge_gate sampling must receive list(vectors.values())."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+    from uuid import uuid4
+
+    import tasks.neural_calibration as nc
+
+    sampled = [SimpleNamespace(id=uuid4()) for _ in range(3)]
+    vectors_by_id = {str(m.id): [0.1 * (i + 1), 0.2] for i, m in enumerate(sampled)}
+    captured: dict = {}
+
+    def fake_measure_random_pair(vectors, n_pairs):
+        captured["vectors"] = vectors
+        return [0.2] * nc.EDGE_GATE_MIN_PAIR_OBSERVATIONS
+
+    async def fake_sample_memories(db, ctx_id, n):
+        return sampled
+
+    async def fake_fetch_vectors(qdrant, collection, ids):
+        return vectors_by_id
+
+    async def fake_measure_top_k(mems, vectors, collection, k):
+        assert vectors is vectors_by_id  # top-k keeps consuming the dict form
+        return [0.5] * nc.BOOTSTRAP_MIN_OBSERVATIONS, nc.BOOTSTRAP_MIN_MEMORIES
+
+    script = SimpleNamespace(
+        compute_percentiles=lambda scores: dict(_PCTS),
+        fetch_vectors=fake_fetch_vectors,
+        measure_top_k=fake_measure_top_k,
+        measure_random_pair=fake_measure_random_pair,
+        sample_memories=fake_sample_memories,
+    )
+    monkeypatch.setattr(nc, "_load_measure_script", lambda: script)
+    monkeypatch.setattr(nc, "get_qdrant_client", lambda: MagicMock())
+    monkeypatch.setattr(
+        nc.NeuralMemoryConfig,
+        "from_db",
+        AsyncMock(return_value=SimpleNamespace(calibration_ttl_days=30)),
+    )
+    upsert = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(nc, "_upsert_calibration", upsert)
+
+    db = _mock_db()
+    row = await nc.compute_calibration(db, "text-embedding-3-small", 512, uuid4())
+
+    assert row is upsert.return_value
+    assert isinstance(captured["vectors"], list)
+    assert captured["vectors"] == list(vectors_by_id.values())
+    assert upsert.await_count == 2  # knn_seed + edge_gate both staged
+    db.commit.assert_awaited_once()

--- a/backend/tests/utils/test_usage_logger.py
+++ b/backend/tests/utils/test_usage_logger.py
@@ -35,7 +35,10 @@ async def test_success_returns_true():
 
 @pytest.mark.asyncio
 async def test_fk_violation_falls_back_to_null_context():
-    """#1318: FK violation on a stamped context_id retries with NULL."""
+    """#1318: FK violation on a stamped context_id retries with NULL — the
+    usage/quota row is preserved, but the return is False so #1228
+    attribution-dependent writes are skipped (the primary context's read was
+    NOT recorded as requested)."""
     db = _db([_fk_error(), None])
 
     result = await log_usage(
@@ -46,11 +49,12 @@ async def test_fk_violation_falls_back_to_null_context():
         context_id="00000000-0000-0000-0000-000000000000",
     )
 
-    assert result is True
+    assert result is False
     assert db.execute.await_count == 2
     retry_stmt = db.execute.await_args_list[1].args[0]
     assert retry_stmt.compile().params["context_id"] is None
     db.rollback.assert_awaited_once()
+    db.commit.assert_awaited_once()  # the NULL-context retry did commit
 
 
 @pytest.mark.asyncio

--- a/backend/tests/utils/test_usage_logger.py
+++ b/backend/tests/utils/test_usage_logger.py
@@ -1,0 +1,76 @@
+"""Tests for the shared usage logger (#1318).
+
+An MCP tool called with a nonexistent context_id returns a clean 404 to the
+client, but the usage row INSERT then violates the usage_stats→contexts FK.
+log_usage must preserve the usage/quota event (context attribution dropped)
+instead of dropping the whole row.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from utils.usage_logger import log_usage
+
+
+def _fk_error() -> IntegrityError:
+    return IntegrityError("INSERT INTO usage_stats ...", {}, Exception("fk violation"))
+
+
+def _db(execute_side_effect) -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=execute_side_effect)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_success_returns_true():
+    db = _db([None])
+    assert await log_usage(db, "u", "mcp:recall", context_id="ctx") is True
+    db.commit.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_fk_violation_falls_back_to_null_context():
+    """#1318: FK violation on a stamped context_id retries with NULL."""
+    db = _db([_fk_error(), None])
+
+    result = await log_usage(
+        db,
+        "u",
+        "mcp:get_context_info",
+        status_code=404,
+        context_id="00000000-0000-0000-0000-000000000000",
+    )
+
+    assert result is True
+    assert db.execute.await_count == 2
+    retry_stmt = db.execute.await_args_list[1].args[0]
+    assert retry_stmt.compile().params["context_id"] is None
+    db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_fk_violation_without_context_returns_false():
+    """No context to drop — the IntegrityError is a real failure."""
+    db = _db([_fk_error()])
+    assert await log_usage(db, "u", "mcp:recall", context_id=None) is False
+    assert db.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_failure_returns_false():
+    db = _db([_fk_error(), RuntimeError("db down")])
+    result = await log_usage(db, "u", "mcp:recall", context_id="ctx")
+    assert result is False
+    assert db.rollback.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_generic_failure_returns_false():
+    db = _db([RuntimeError("boom")])
+    assert await log_usage(db, "u", "mcp:recall", context_id="ctx") is False
+    db.rollback.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes #1318, Closes #1319. Two server-side error-log findings from the v0.51.1 live MCP verification run, both reproducible in production logs.

### usage_stats FK violation (#1318)
Any MCP call with a nonexistent context_id returned a clean 404 to the client, but the usage INSERT stamped the raw, unvalidated request id → `usage_stats_context_id_fkey` violation → `usage_logging_failed` error log **and the whole usage/quota row was dropped**.

- `get_context_info`'s 404 handler no longer stamps the known-unresolved id
- `log_usage` now catches `IntegrityError`, rolls back, and retries with `context_id=NULL` (column is nullable / `ondelete="SET NULL"`), preserving the event for any caller that stamps an invalid id (logged as `usage_logging_context_fk_fallback` warning)

### calibration crash (#1319)
`fetch_vectors()` returns `dict[str, list[float]]`; `measure_random_pair()` expects the bare vector list. Passing the dict made `np.asarray(<dict>)` call `float(dict)` → every calibration run failed **pre-commit, so neither calibration kind (knn_seed / edge_gate) ever persisted** — kNN-seed auto-association stayed disabled and the semantic edge gate ran on its uncalibrated fallback, with `calibration_task_failed` on every qualifying remember(). Fixed by passing `list(vectors.values())`.

## Tests

- New `tests/utils/test_usage_logger.py`: success / FK-fallback (asserts the retry INSERT carries `context_id=None`) / no-context FK / retry-failure / generic-failure
- New `test_compute_calibration_passes_vector_list_to_measure_random_pair`: drives `compute_calibration` with a faked measurement module; pins the list-shaped edge_gate sampling, both upserts staged, single commit

`pytest tests/mcp_server tests/tasks tests/utils` — 811 passed. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
