### PR TITLE
fix(db): stop read paths from re-stamping memory.updated_at

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -782,10 +782,11 @@ async def list_memories(
         # naive UTC datetimes (DateTime without timezone=True). Tag the
         # serialized form with "Z" so JS clients (which parse naive ISO as
         # local time) don't render JST-shifted relative timestamps.
-        # ``updated_at`` is nullable (only set onupdate), so fall back to
-        # ``created_at`` for fresh rows that haven't been touched since
-        # insert. The frontend renders both as the row "updated" timestamp,
-        # so created_at is the correct fallback rather than null/empty.
+        # ``updated_at`` is nullable (set explicitly by edit paths — #1317
+        # removed the column's onupdate), so fall back to ``created_at`` for
+        # fresh rows that haven't been touched since insert. The frontend
+        # renders both as the row "updated" timestamp, so created_at is the
+        # correct fallback rather than null/empty.
         memory_items = [
             MemoryListItem(
                 id=str(m.id),

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -380,6 +380,11 @@ async def _touch_context_last_used(db: "AsyncSession", context: Any) -> bool:
         update(Context)
         .where(Context.id == context.id)
         .where(or_(Context.last_used_at.is_(None), Context.last_used_at <= now - throttle))
+        # Self-assignment pins updated_at so Context's onupdate does not fire
+        # for this pure access touch. NOTE the sibling model solved the same
+        # problem the other way: Memory.updated_at has NO onupdate at all
+        # (#1317) and edit paths stamp it explicitly — don't "harmonize"
+        # either model without reading #1317 first.
         .values(last_used_at=now, updated_at=Context.updated_at)
     )
     return True

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -217,9 +217,12 @@ class Memory(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
     )
-    updated_at: Mapped[datetime | None] = mapped_column(
-        DateTime, nullable=True, onupdate=func.now()
-    )
+    # #1317: NO ``onupdate`` — ``updated_at`` is the documented staleness cue
+    # ("last time the fact was changed"), so it must move only when an edit
+    # path sets it explicitly (update/patch/upsert, resource re-index, sleep
+    # merge/re-eval all do). With ``onupdate=func.now()`` every read-path
+    # access-stats flush (recall/reference/explore) silently re-stamped it.
+    updated_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Logical Delete (Issue #46 Phase 4)
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1115,14 +1115,13 @@ class MemoryService:
         if not can_access:
             raise NotFoundException("Memory", str(memory_id))
 
-        # Snapshot ``updated_at`` before bumping access stats. The Memory
-        # ORM column declares ``onupdate=func.now()``; a subsequent UPDATE
-        # (issued by ``update_access_stats``) makes SQLAlchemy expire the
-        # in-memory attribute so the next access triggers a sync lazy-load
-        # → ``MissingGreenlet`` outside the original IO context. Reading
-        # the value here is also semantically right: an access bump is
-        # not a meaningful edit, so the dialog's "Updated At" should
-        # reflect the last real change, not "now".
+        # Snapshot ``updated_at`` before bumping access stats. #1317 removed
+        # the column's ``onupdate=func.now()``, so ``update_access_stats`` no
+        # longer touches ``updated_at`` at all — the DB value is now correct
+        # by construction. The snapshot is retained as a cheap guard against
+        # any future in-session dirtying, and reading it here keeps the
+        # semantics explicit: an access bump is not a meaningful edit, so the
+        # dialog's "Updated At" reflects the last real change, not "now".
         snapshot_updated_at = memory.updated_at or memory.created_at
 
         # Update access stats. reference() is the canonical *adoption* signal
@@ -2733,11 +2732,11 @@ class MemoryService:
             if not memory:
                 continue
 
-            # Issue #1047: snapshot updated_at BEFORE update_access_stats. The
-            # Memory.updated_at column declares onupdate=func.now(), so the UPDATE
-            # issued by update_access_stats expires the in-memory attribute — a
-            # later read would then trigger a sync lazy-load → MissingGreenlet in
-            # the async context (the same trap reference() documents and avoids).
+            # Issue #1047: snapshot updated_at BEFORE update_access_stats.
+            # #1317 removed the column's onupdate, so the access-stats flush
+            # no longer touches (or expires) updated_at — the DB value is now
+            # correct by construction; the snapshot stays as a cheap guard
+            # against any future in-session dirtying of the row.
             snapshot_updated_at = memory.updated_at
 
             # Update access stats
@@ -4436,10 +4435,11 @@ def embedding_retry_eligible_clause(now: datetime):
 
     Eligible when it still has retry budget (``embedding_retry_count <
     MAX_EMBEDDING_RETRIES``) and its backoff has elapsed. The backoff is
-    measured from ``updated_at`` (the failure ``UPDATE``'s ``onupdate`` stamps
-    it to the failure time); a NULL ``updated_at`` is treated as immediately
-    eligible so a row can never get permanently stuck ``failed`` — the exact
-    state #979 exists to prevent.
+    measured from ``updated_at`` (the failure ``UPDATE`` stamps it to the
+    failure time EXPLICITLY — #1317 removed the column's ``onupdate``, so
+    nothing stamps it implicitly anymore); a NULL ``updated_at`` is treated as
+    immediately eligible so a row can never get permanently stuck ``failed``
+    — the exact state #979 exists to prevent.
 
     Shared by the sweep prefilter (``tasks/embedding_tasks.py``) and the atomic
     claim in ``process_pending_embedding`` so the two gates cannot drift.
@@ -4654,7 +4654,14 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                 await db.execute(
                     update(Memory)
                     .where(Memory.id == memory_id)
-                    .values(embedding_status="failed", embedding_error=str(e)[:500])
+                    .values(
+                        embedding_status="failed",
+                        embedding_error=str(e)[:500],
+                        # #1317: the column's onupdate is gone — stamp the
+                        # failure time explicitly; the #979 retry backoff
+                        # (embedding_retry_eligible_clause) anchors on it.
+                        updated_at=utcnow(),
+                    )
                 )
                 await db.commit()
             except Exception:

--- a/backend/tests/repositories/test_memory_repository.py
+++ b/backend/tests/repositories/test_memory_repository.py
@@ -80,6 +80,24 @@ class TestMemoryRepository:
         assert sample_memory.reference_count == 1
 
     @pytest.mark.asyncio
+    async def test_update_access_stats_does_not_bump_updated_at(
+        self, repository, sample_memory, db_session
+    ):
+        """#1317: read-path access tracking (recall/reference/explore) must not
+        move the staleness cue — updated_at changes only on explicit edits."""
+        before = sample_memory.updated_at
+        await repository.update_access_stats(sample_memory.id, client="api", count_as_adoption=True)
+        await db_session.refresh(sample_memory)
+
+        assert sample_memory.access_count == 1  # tracking itself still works
+        assert sample_memory.updated_at == before
+
+    def test_updated_at_column_has_no_onupdate(self):
+        """#1317: pin the column declaration — reintroducing onupdate=func.now()
+        would silently re-stamp updated_at on every read-path flush."""
+        assert Memory.__table__.columns["updated_at"].onupdate is None
+
+    @pytest.mark.asyncio
     async def test_update_access_stats_mixed_access_preserves_invariant(
         self, repository, sample_memory, db_session
     ):


### PR DESCRIPTION
## Summary

Closes #1317.

`Memory.updated_at` declared `onupdate=func.now()`, so the access-stats flush performed by **every** recall/reference/explore (`update_access_stats`: access_count / last_used_at / accessed_by_clients) re-stamped it. Verified live: all frequently-recalled memories carry `updated_at` = time of the latest recall, which permanently destroys the documented staleness cue ("last time the fact was changed"). #1047 patched only the *response* snapshot — the DB column still mutated on every read.

## Fix

Drop `onupdate` from the column (client-side default — no migration). Every genuine edit path already sets `updated_at` explicitly (`update_memory`/`patch_memory`, repo `update()`, resource re-index, sleep merge/importance/reindex), so the `onupdate`'s only live effect was the spurious read-path bump.

Semantics settled per the issue: scope promotion (`promote_to_persistent`) also no longer counts as an "edit" — `scope`/`promoted_at` carry that history; `updated_at` now means content/metadata edits only. The #1047 response-snapshot mitigations in recall/reference remain (harmless, and still guard any other in-session dirtying).

## Tests

- Behavioral: `update_access_stats` (adoption path) leaves `updated_at` unchanged while `access_count` increments
- Declaration pin: `Memory.__table__.columns["updated_at"].onupdate is None`
- Sweep: `tests/services + repositories + api + mcp_server` — **3394 passed** (no hidden onupdate dependencies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
