### PR TITLE
fix(mcp): decode stringified state values

### DIFF
--- a/backend/src/mcp_server/tools/_arg_coercion.py
+++ b/backend/src/mcp_server/tools/_arg_coercion.py
@@ -1,7 +1,8 @@
 """JSON-string argument coercion for MCP tool calls.
 
 Issue #197 / #196: some MCP clients serialize complex arguments (arrays,
-objects, booleans) as JSON strings before sending them over the wire:
+objects, booleans, or arbitrary JSON values) as JSON strings before sending
+them over the wire:
 
     {"tags": "[\"a\", \"b\"]"}      instead of  {"tags": ["a", "b"]}
     {"is_private": "true"}           instead of  {"is_private": true}
@@ -82,6 +83,16 @@ def _coerce_to_boolean(value: Any) -> Any:
     return value
 
 
+def _coerce_to_any(value: Any) -> Any:
+    """Decode JSON strings for schema fields that accept any JSON value."""
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except (ValueError, TypeError):
+        return value
+
+
 _COERCERS = {
     "array": _coerce_to_array,
     "object": _coerce_to_object,
@@ -92,10 +103,11 @@ _COERCERS = {
 def coerce_mcp_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
     """Coerce MCP tool arguments to their declared JSON-schema types.
 
-    Only array / object / boolean fields are coerced — these are the types
-    that MCP clients have been observed to serialize as JSON strings. Other
-    types (string, number, integer) are left to pydantic to validate, since
-    pydantic already coerces numeric strings when strict mode is off.
+    Array / object / boolean fields are coerced to their declared type. Fields
+    without a declared type accept any JSON value, so their strings are decoded
+    without restricting the resulting type. Other declared types (string,
+    number, integer) are left to pydantic to validate, since pydantic already
+    coerces numeric strings when strict mode is off.
 
     When any coercion happens the returned dict is a shallow copy of the
     input: top-level keys can be replaced safely but mutable values that
@@ -127,9 +139,12 @@ def coerce_mcp_arguments(tool_name: str, arguments: dict[str, Any]) -> dict[str,
         if not schema:
             continue
         declared_type = schema.get("type")
-        if not isinstance(declared_type, str):
+        if declared_type is None:
+            coercer = _coerce_to_any
+        elif isinstance(declared_type, str):
+            coercer = _COERCERS.get(declared_type)
+        else:
             continue
-        coercer = _COERCERS.get(declared_type)
         if coercer is None:
             continue
         coerced[arg_name] = coercer(value)

--- a/backend/tests/mcp_server/test_arg_coercion.py
+++ b/backend/tests/mcp_server/test_arg_coercion.py
@@ -81,6 +81,30 @@ class TestBooleanCoercion:
         assert result["is_private"] == "maybe"
 
 
+class TestAnyJsonCoercion:
+    def test_json_strings_are_decoded_for_untyped_values(self):
+        cases = (
+            ('{"phase": "running"}', {"phase": "running"}),
+            ("[1, 2]", [1, 2]),
+            ('"text"', "text"),
+            ("42", 42),
+            ("true", True),
+        )
+        for raw, expected in cases:
+            result = coerce_mcp_arguments("set_state", {"value": raw})
+            assert result["value"] == expected
+            assert type(result["value"]) is type(expected)
+
+    def test_native_values_pass_through(self):
+        for value in ({"phase": "running"}, [1, 2], "text", 42, True):
+            result = coerce_mcp_arguments("set_state", {"value": value})
+            assert result["value"] is value
+
+    def test_invalid_json_string_passes_through(self):
+        result = coerce_mcp_arguments("set_state", {"value": "plain text"})
+        assert result["value"] == "plain text"
+
+
 class TestPassThroughCases:
     def test_empty_arguments(self):
         assert coerce_mcp_arguments("remember", {}) == {}


### PR DESCRIPTION
## Related Issue

Closes #1322

## Summary

Decode JSON-stringified values for schema fields that accept arbitrary JSON, so `set_state` preserves object, array, string, number, and boolean types.

## Changes

- Decode valid JSON strings for untyped schema fields while preserving native and invalid string values
- Add round-trip regression coverage for every supported JSON value kind

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passing
- [x] Manual testing completed
- [ ] All tests passing locally (`make test-local`)

Focused result: 51 tests passed. The new regression failed against the original source and passed with this fix.

## Quality Checklist

- [x] Code follows DRY/SOLID principles
- [x] Type hints added (target: 85%+ coverage)
- [x] No lint errors (`make lint`)
- [x] No type errors (`make type-check`)
- [x] No code duplication
- [x] Functions < 50 lines (Single Responsibility)
- [x] Files < 500 lines
- [x] Documentation updated (if needed)

## Screenshots (if applicable)

N/A — backend-only change.

---

To request AI review, comment `/review` on this PR.
