### PR TITLE
feat(auth): binding row filter on enumeration/update surfaces (#1301)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -31,6 +31,7 @@ from models.schemas import (
     RememberRequest,
     RememberResponse,
 )
+from services.agent_binding_service import binding_memory_sql_predicate
 from services.memory_service import MemoryService
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
@@ -686,12 +687,11 @@ async def list_memories(
             ]
             tags_normalized = cleaned or None
 
-        # #1301: per-memory type/source binding filter, SQL form — applied to
-        # BOTH the page query and the count query below so ``total`` never
-        # acts as an existence oracle over denied rows and pagination stays
-        # exact. None for non-agent credentials and shadow-mode scopes.
-        from services.agent_binding_service import binding_memory_sql_predicate
-
+        # #1301: agent-binding read filter, SQL form (P0-2 context default-deny
+        # + per-memory type/source subtraction) — applied to BOTH the page
+        # query and the count query below so ``total`` never acts as an
+        # existence oracle over denied rows and pagination stays exact. None
+        # for non-agent credentials and shadow-mode scopes.
         binding_predicate = await binding_memory_sql_predicate(db)
 
         # Build query. Exclude soft-deleted rows — POST /forget sets
@@ -897,12 +897,10 @@ async def get_access_patterns(
         if target_context_id:
             base_filter.append(Memory.context_id == target_context_id)
 
-        # #1301: subtract denied type/source rows from the most-accessed page
-        # AND every aggregate (type distribution, recent count) — a grouped
-        # count over denied types is an existence oracle. None for non-agent
-        # credentials and shadow-mode scopes.
-        from services.agent_binding_service import binding_memory_sql_predicate
-
+        # #1301: agent-binding read filter (context default-deny + type/source
+        # subtraction) on the most-accessed page AND every aggregate — a
+        # grouped count over denied rows is an existence oracle. None for
+        # non-agent credentials and shadow-mode scopes.
         binding_predicate = await binding_memory_sql_predicate(db)
         if binding_predicate is not None:
             base_filter.append(binding_predicate)

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -686,10 +686,20 @@ async def list_memories(
             ]
             tags_normalized = cleaned or None
 
+        # #1301: per-memory type/source binding filter, SQL form — applied to
+        # BOTH the page query and the count query below so ``total`` never
+        # acts as an existence oracle over denied rows and pagination stays
+        # exact. None for non-agent credentials and shadow-mode scopes.
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        binding_predicate = await binding_memory_sql_predicate(db)
+
         # Build query. Exclude soft-deleted rows — POST /forget sets
         # ``deleted_at`` rather than removing the row, and the list view
         # must not surface tombstones.
         query = select(Memory).where(Memory.deleted_at.is_(None))
+        if binding_predicate is not None:
+            query = query.where(binding_predicate)
         if owner_filter is not None:
             query = query.where(Memory.user_id == owner_filter)
 
@@ -753,6 +763,8 @@ async def list_memories(
 
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.deleted_at.is_(None))
+        if binding_predicate is not None:
+            count_query = count_query.where(binding_predicate)
         if owner_filter is not None:
             count_query = count_query.where(Memory.user_id == owner_filter)
         if scope:
@@ -884,6 +896,16 @@ async def get_access_patterns(
             base_filter.append(Memory.workspace_id == target_workspace_id)
         if target_context_id:
             base_filter.append(Memory.context_id == target_context_id)
+
+        # #1301: subtract denied type/source rows from the most-accessed page
+        # AND every aggregate (type distribution, recent count) — a grouped
+        # count over denied types is an existence oracle. None for non-agent
+        # credentials and shadow-mode scopes.
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        binding_predicate = await binding_memory_sql_predicate(db)
+        if binding_predicate is not None:
+            base_filter.append(binding_predicate)
 
         # Most accessed memories (TOP 10)
         most_accessed_result = await db.execute(

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -241,25 +241,32 @@ async def emit_row_filter_would_deny(
 
 
 async def binding_memory_sql_predicate(db: AsyncSession) -> Any | None:
-    """SQL form of the per-memory type/source binding filter (#1301).
+    """SQL form of the agent-binding read filter over ``Memory`` (#1301).
 
     For SELECT/aggregate surfaces that never materialize full memory rows
     (the ``/memory/list`` count + page pair, the access-patterns aggregates,
     the stats ``GROUP BY``\\ s), post-filtering with
     :func:`filter_memory_rows_by_binding` would leave the counts acting as an
     existence oracle over denied rows and make pagination drift from
-    ``total``. This builds the same subtraction as
-    :meth:`BindingRowFilter.permits` as a WHERE clause over ``Memory``
-    instead — one bulk binding SELECT per request, applied identically to the
-    count and the row query. Contexts without a restricting binding are
-    untouched (the context-level gate is the upstream chokepoints' job, same
-    as the row lever).
+    ``total``. This encodes the read lanes' full subtractive decision as a
+    WHERE clause instead — one bulk binding SELECT per request, applied
+    identically to the count and the row query:
 
-    Returns ``None`` (apply nothing) for non-agent credentials, shadow-mode
-    scopes, and agents whose bindings restrict nothing. Shadow here is a pure
-    no-op: these surfaces sit outside the MAE operation vocabulary, so the
-    enforcement ramp observes would-deny volume through the recall /
-    load_pinned lanes, not here.
+    - **Context membership (P0-2 default-deny)**: rows outside the agent's
+      readable bound set (no binding, or ``can_read=False``) are subtracted.
+      The SCOPED forms of these surfaces are already context-gated at the
+      ``resolve_context_for_workspace_read`` chokepoint (#1275 uniform 404);
+      the membership gate here is what covers the UNSCOPED forms (no
+      ``context_id`` → no chokepoint) and cross-context aggregates.
+      ``context_id IS NULL`` rows fall out of the ``IN`` gate too
+      (fail-closed: a NULL context is not a bound one).
+    - **Per-memory type/source subtraction (#1299)**: the same subtraction as
+      :meth:`BindingRowFilter.permits`, one clause per restricting binding.
+
+    Returns ``None`` (apply nothing) for non-agent credentials and
+    shadow-mode scopes. Shadow here is a pure no-op: these surfaces sit
+    outside the MAE operation vocabulary, so the enforcement ramp observes
+    would-deny volume through the recall / load_pinned lanes, not here.
     """
     from sqlalchemy import and_, false, not_, or_
 
@@ -273,8 +280,15 @@ async def binding_memory_sql_predicate(db: AsyncSession) -> Any | None:
     result = await db.execute(
         select(AgentContextBinding).where(AgentContextBinding.agent_id == scope.agent_id)
     )
+    bindings = result.scalars().all()
+
+    readable_ids = [binding.context_id for binding in bindings if binding.can_read]
+    membership_gate = Memory.context_id.in_(readable_ids) if readable_ids else false()
+
     denied_clauses = []
-    for binding in result.scalars().all():
+    for binding in bindings:
+        if not binding.can_read:
+            continue  # already excluded by the membership gate
         row_filter = BindingRowFilter.from_binding(binding)
         if row_filter is None:
             continue
@@ -287,8 +301,8 @@ async def binding_memory_sql_predicate(db: AsyncSession) -> Any | None:
             dims.append(Memory.source_type.in_(allowed_sources) if allowed_sources else false())
         denied_clauses.append(and_(Memory.context_id == binding.context_id, not_(and_(*dims))))
     if not denied_clauses:
-        return None
-    return not_(or_(*denied_clauses))
+        return membership_gate
+    return and_(membership_gate, not_(or_(*denied_clauses)))
 
 
 async def filter_memory_rows_by_binding(

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -240,6 +240,57 @@ async def emit_row_filter_would_deny(
     )
 
 
+async def binding_memory_sql_predicate(db: AsyncSession) -> Any | None:
+    """SQL form of the per-memory type/source binding filter (#1301).
+
+    For SELECT/aggregate surfaces that never materialize full memory rows
+    (the ``/memory/list`` count + page pair, the access-patterns aggregates,
+    the stats ``GROUP BY``\\ s), post-filtering with
+    :func:`filter_memory_rows_by_binding` would leave the counts acting as an
+    existence oracle over denied rows and make pagination drift from
+    ``total``. This builds the same subtraction as
+    :meth:`BindingRowFilter.permits` as a WHERE clause over ``Memory``
+    instead — one bulk binding SELECT per request, applied identically to the
+    count and the row query. Contexts without a restricting binding are
+    untouched (the context-level gate is the upstream chokepoints' job, same
+    as the row lever).
+
+    Returns ``None`` (apply nothing) for non-agent credentials, shadow-mode
+    scopes, and agents whose bindings restrict nothing. Shadow here is a pure
+    no-op: these surfaces sit outside the MAE operation vocabulary, so the
+    enforcement ramp observes would-deny volume through the recall /
+    load_pinned lanes, not here.
+    """
+    from sqlalchemy import and_, false, not_, or_
+
+    from auth.agent_scope import get_agent_scope
+    from models.memory import Memory
+
+    scope = get_agent_scope()
+    if scope is None or scope.enforcement_mode == AGENT_ENFORCEMENT_SHADOW:
+        return None
+
+    result = await db.execute(
+        select(AgentContextBinding).where(AgentContextBinding.agent_id == scope.agent_id)
+    )
+    denied_clauses = []
+    for binding in result.scalars().all():
+        row_filter = BindingRowFilter.from_binding(binding)
+        if row_filter is None:
+            continue
+        dims = []
+        if row_filter.allowed_memory_types is not None:
+            allowed_types = sorted(row_filter.allowed_memory_types)
+            dims.append(Memory.type.in_(allowed_types) if allowed_types else false())
+        if row_filter.allowed_source_types is not None:
+            allowed_sources = sorted(row_filter.allowed_source_types)
+            dims.append(Memory.source_type.in_(allowed_sources) if allowed_sources else false())
+        denied_clauses.append(and_(Memory.context_id == binding.context_id, not_(and_(*dims))))
+    if not denied_clauses:
+        return None
+    return not_(or_(*denied_clauses))
+
+
 async def filter_memory_rows_by_binding(
     db: AsyncSession,
     rows: list[Any],

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -488,8 +488,8 @@ async def get_cluster(
     # drop for enforce-mode agents (shadow keeps them; outside the MAE
     # vocabulary, so shadow is log-only). Applied AFTER the keyset cursor is
     # derived, so pagination advances over denied rows instead of stalling.
-    # ``cluster.count`` stays the stored whole-cluster size (metadata-only
-    # aggregate, same severity class as stats counts).
+    # ``count`` / ``property_stats`` are handled separately below (recomputed
+    # over permitted rows for enforce-mode agents).
     from services.agent_binding_service import filter_memory_rows_by_binding
 
     rows, _ = await filter_memory_rows_by_binding(db, rows, operation=None, user_id=None)
@@ -562,6 +562,13 @@ async def get_cluster(
     # (tags/importance/time histograms) are dropped fail-closed rather than
     # recomputed — they would otherwise leak denied rows' content and
     # contradict the recomputed count.
+    #
+    # The recompute runs for EVERY enforce-mode agent (the predicate is
+    # non-None even for a non-restricting binding, since it carries the
+    # membership gate): deliberate — deriving "could this agent be
+    # restricted for THIS cluster's context" would need the run's context
+    # (not in hand here, and rows may be an empty page), and the cost is one
+    # indexed GROUP BY over a single cluster's assignments, agent-only.
     count = int(cluster.count)
     property_stats = cluster.property_stats or {}
     from services.agent_binding_service import binding_memory_sql_predicate

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -530,7 +530,6 @@ async def get_cluster(
                 )
             )
         ).all()
-        # #1301: same subtraction for representatives as for members.
         rep_rows, _ = await filter_memory_rows_by_binding(
             db, list(rep_rows), operation=None, user_id=None
         )
@@ -554,16 +553,52 @@ async def get_cluster(
     else:
         representatives = []
 
+    # #1301: ``count`` and ``property_stats["types"]`` are whole-cluster
+    # stored aggregates — the same grouped-count existence oracle over denied
+    # types that stats.by_type was. For enforce-mode agents with an active
+    # binding filter, recompute both over the rows the binding permits (one
+    # GROUP BY). Non-type facets in property_stats are not type/source-labeled
+    # and stay as stored.
+    count = int(cluster.count)
+    property_stats = cluster.property_stats or {}
+    from services.agent_binding_service import binding_memory_sql_predicate
+
+    binding_predicate = await binding_memory_sql_predicate(db)
+    if binding_predicate is not None:
+        type_rows = (
+            await db.execute(
+                select(Memory.type, func.count(Memory.id))
+                .join(
+                    MemoryAnalysisAssignment,
+                    MemoryAnalysisAssignment.memory_id == Memory.id,
+                )
+                .where(
+                    and_(
+                        MemoryAnalysisAssignment.analysis_id == run_id,
+                        MemoryAnalysisAssignment.cluster_id == cluster.id,
+                        Memory.deleted_at.is_(None),
+                        Memory.workspace_id == workspace_id,
+                        binding_predicate,
+                    )
+                )
+                .group_by(Memory.type)
+            )
+        ).all()
+        filtered_types = {row[0]: int(row[1]) for row in type_rows}
+        count = sum(filtered_types.values())
+        if "types" in property_stats:
+            property_stats = {**property_stats, "types": filtered_types}
+
     return {
         "run_id": str(run_id),
         "cluster_index": cluster_index,
         "cluster_id": str(cluster.id),
         "label": cluster.label,
         "description": cluster.description,
-        "count": int(cluster.count),
+        "count": count,
         "label_confidence": float(cluster.label_confidence),
         "centroid_2d": list(cluster.centroid_2d) if cluster.centroid_2d else None,
-        "property_stats": cluster.property_stats or {},
+        "property_stats": property_stats,
         "representatives": representatives,
         "memories": memories_out,
         "next_cursor": next_cursor,

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -451,6 +451,11 @@ async def get_cluster(
             Memory.summary,
             Memory.tags,
             Memory.importance,
+            # #1301: the row-filter lever below needs context_id/type/
+            # source_type on each row; they never reach the response.
+            Memory.context_id,
+            Memory.type,
+            Memory.source_type,
         )
         .join(
             MemoryAnalysisAssignment,
@@ -479,6 +484,16 @@ async def get_cluster(
         rows = rows[:page_size]
         next_cursor = str(rows[-1].id)
 
+    # #1301: cluster members expose L1 summaries — denied type/source rows
+    # drop for enforce-mode agents (shadow keeps them; outside the MAE
+    # vocabulary, so shadow is log-only). Applied AFTER the keyset cursor is
+    # derived, so pagination advances over denied rows instead of stalling.
+    # ``cluster.count`` stays the stored whole-cluster size (metadata-only
+    # aggregate, same severity class as stats counts).
+    from services.agent_binding_service import filter_memory_rows_by_binding
+
+    rows, _ = await filter_memory_rows_by_binding(db, rows, operation=None, user_id=None)
+
     memories_out = [
         {
             "memory_id": str(row.id),
@@ -496,7 +511,15 @@ async def get_cluster(
     if rep_ids:
         rep_rows = (
             await db.execute(
-                select(Memory.id, Memory.summary, Memory.tags, Memory.importance).where(
+                select(
+                    Memory.id,
+                    Memory.summary,
+                    Memory.tags,
+                    Memory.importance,
+                    Memory.context_id,
+                    Memory.type,
+                    Memory.source_type,
+                ).where(
                     and_(
                         Memory.id.in_(rep_ids),
                         Memory.deleted_at.is_(None),
@@ -507,6 +530,10 @@ async def get_cluster(
                 )
             )
         ).all()
+        # #1301: same subtraction for representatives as for members.
+        rep_rows, _ = await filter_memory_rows_by_binding(
+            db, list(rep_rows), operation=None, user_id=None
+        )
         # Preserve the order from ``representative_memory_ids`` so the UI
         # gets stable "top-k" semantics across repeated calls.
         rep_by_id = {r.id: r for r in rep_rows}

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -553,12 +553,15 @@ async def get_cluster(
     else:
         representatives = []
 
-    # #1301: ``count`` and ``property_stats["types"]`` are whole-cluster
-    # stored aggregates — the same grouped-count existence oracle over denied
-    # types that stats.by_type was. For enforce-mode agents with an active
-    # binding filter, recompute both over the rows the binding permits (one
-    # GROUP BY). Non-type facets in property_stats are not type/source-labeled
-    # and stay as stored.
+    # #1301: ``count`` and ``property_stats`` are whole-cluster stored
+    # aggregates — ``types`` is the same grouped-count existence oracle over
+    # denied types that stats.by_type was, and ``tags`` carries verbatim tag
+    # strings from every member row. For enforce-mode agents with an active
+    # binding filter, recompute count/types over the rows the binding permits
+    # (one GROUP BY); when any row was subtracted, the remaining facets
+    # (tags/importance/time histograms) are dropped fail-closed rather than
+    # recomputed — they would otherwise leak denied rows' content and
+    # contradict the recomputed count.
     count = int(cluster.count)
     property_stats = cluster.property_stats or {}
     from services.agent_binding_service import binding_memory_sql_predicate
@@ -585,8 +588,11 @@ async def get_cluster(
             )
         ).all()
         filtered_types = {row[0]: int(row[1]) for row in type_rows}
-        count = sum(filtered_types.values())
-        if "types" in property_stats:
+        filtered_count = sum(filtered_types.values())
+        if filtered_count != count:
+            count = filtered_count
+            property_stats = {"types": filtered_types}
+        elif "types" in property_stats:
             property_stats = {**property_stats, "types": filtered_types}
 
     return {

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -3191,6 +3191,13 @@ class MemoryService:
         Returns:
             ForgetResponse with deleted count and IDs
         """
+        if _skip_binding_row_filter and not request.memory_id:
+            raise ValueError(
+                "_skip_binding_row_filter only covers the memory_id branch; "
+                "forget(query=...) resolves victims through recall(), where "
+                "the flag cannot propagate — combining them would silently "
+                "skip the rows the maintenance delete was meant to clean up."
+            )
         # Single Collection Migration: Extract isolation params (optimized).
         # Issue #1275: forget is a WRITE — gate the declared context against
         # the agent binding (no-op for non-agent credentials).

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -570,6 +570,11 @@ class MemoryService:
             access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
             operation="update",  # #1286 (P0-5): deny-capture audit identity
             memory_id=request.memory_id,
+            # #1301: id-addressed update of a read-denied row must be a
+            # uniform 404 (reference/forget doctrine) — REST PATCH and this
+            # MCP-reachable path stay in parity (#1291/#1292).
+            memory_type=memory.type,
+            memory_source_type=memory.source_type,
         )
         if not can_access:
             raise NotFoundException("Memory", str(request.memory_id))
@@ -774,6 +779,12 @@ class MemoryService:
             access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
             operation="update",  # #1286 (P0-5): deny-capture audit identity
             memory_id=memory_id,
+            # #1301: the PATCH response echoes full L3 content — a no-op PATCH
+            # on a read-denied row would read it back. Threading type/source
+            # makes the id-addressed op uniformly 404 on denied rows, the same
+            # doctrine as reference/forget (#1299).
+            memory_type=memory.type,
+            memory_source_type=memory.source_type,
         )
         if not can_access:
             raise NotFoundException("Memory", str(memory_id))
@@ -1063,13 +1074,18 @@ class MemoryService:
             current_workspace_id=current_workspace_id,
         )
 
-        # Only forget old memory after new one is successfully created
+        # Only forget old memory after new one is successfully created.
+        # #1301: this delete is system maintenance (replacing the row the
+        # caller addressed by external_id), not an agent read — the #1299
+        # per-memory read filter must not silently no-op it, or a denied-type
+        # existing row survives as a live duplicate alongside the new row.
         operation = "created"
         if existing:
             await self.forget(
                 ForgetRequest(memory_id=existing.id),
                 user_id=user_id,
                 current_context_id=current_context_id,
+                _skip_binding_row_filter=True,
             )
             operation = "replaced"
 
@@ -3154,6 +3170,8 @@ class MemoryService:
         user_id: str,
         current_context_id: UUID | None = None,
         key_workspace_id: UUID | None = None,  # Issue #963/#1281: pure key scope
+        *,
+        _skip_binding_row_filter: bool = False,
     ) -> ForgetResponse:
         """Delete memory (single or multiple via query).
 
@@ -3163,6 +3181,12 @@ class MemoryService:
             request: Forget request (memory_id or query)
             user_id: User ID
             current_context_id: Current context UUID (Issue #82)
+            _skip_binding_row_filter: INTERNAL maintenance callers only
+                (#1301) — the upsert replacement delete. Skips the #1299
+                per-memory type/source read filter while keeping the
+                context-level write gate, so replacing a denied-type row
+                cannot silently no-op and leave a live duplicate per
+                external_id. Never expose through transport layers.
 
         Returns:
             ForgetResponse with deleted count and IDs
@@ -3204,8 +3228,11 @@ class MemoryService:
                     access="write",  # #1275: WRITE path — can_read-only binding must not permit mutation
                     operation="forget",  # #1286 (P0-5): the denied row is the ONLY
                     memory_id=request.memory_id,  # record — this deny is a silent empty success
-                    memory_type=memory.type,  # #1299: per-memory type/source filter
-                    memory_source_type=memory.source_type,
+                    # #1299: per-memory type/source filter; #1301 lets the
+                    # internal upsert replacement delete opt out (context-level
+                    # gate above still applies).
+                    memory_type=None if _skip_binding_row_filter else memory.type,
+                    memory_source_type=None if _skip_binding_row_filter else memory.source_type,
                 )
 
                 if not can_access:
@@ -3766,6 +3793,18 @@ class MemoryService:
             base_conditions.append(Memory.workspace_id == UUID(workspace_id))
         if context_id:
             base_conditions.append(Memory.context_id == UUID(context_id))
+
+        # #1301: per-memory type/source binding filter, SQL form. Every
+        # aggregate below shares base_conditions, so an enforce-mode agent
+        # sees counts over exactly the rows it can read — by_type must not be
+        # an existence oracle over denied types. Covers the REST /memory/stats
+        # route and MCP get_context_info by construction (service layer,
+        # #1291/#1292 parity). None for non-agent / shadow scopes.
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        binding_predicate = await binding_memory_sql_predicate(self.db)
+        if binding_predicate is not None:
+            base_conditions.append(binding_predicate)
 
         # Total count (exclude soft-deleted)
         total_result = await self.db.execute(

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -943,11 +943,14 @@ class PermissionService:
         Issue #1299: the **read-lane** callers (reference, forget-by-id,
         explore seed) additionally thread the fetched row's own ``memory_type``
         / ``memory_source_type`` so the binding's per-memory type/source
-        filter applies. Write-lane callers (update / patch) leave them
-        ``None`` — the mutation stays governed by ``write_policy`` only, per
-        the F1 P1 scope. ``forget`` is a read-lane op in this sense (the
-        issue's four filtered ops are recall/reference/forget/explore), so it
-        threads the row even though its ``access`` is ``"write"``.
+        filter applies. #1301 extended the same threading to the id-addressed
+        **update** paths (PATCH / in-place update): a no-op update on a
+        read-denied row would otherwise read back the L3 content the read
+        lanes hide, so those ops are uniformly 404 on denied rows too. The
+        one deliberate exception is the upsert's internal replacement
+        forget (``_skip_binding_row_filter``), which passes ``None`` — see
+        MemoryService.forget. Whether a mutation may run at all stays
+        governed by ``write_policy``.
 
         #1286 item 2 (P0-5): ``operation`` / ``memory_id`` are the
         audit-identity passthrough. The binding-shaped deny is persisted
@@ -968,8 +971,9 @@ class PermissionService:
             memory_id: The requested memory id — rides ``event_metadata`` as
                 an unverified claim on deny rows.
             memory_type: The fetched row's own ``type`` (#1299) — read-lane
-                callers thread it so the binding's per-memory type filter
-                applies; write-lane callers leave it ``None``.
+                AND id-addressed update callers (#1301) thread it so the
+                binding's per-memory type filter applies; only internal
+                maintenance callers leave it ``None``.
             memory_source_type: The fetched row's own ``source_type`` (#1299),
                 same threading rule.
 

--- a/backend/tests/integration/test_binding_type_filter_e2e.py
+++ b/backend/tests/integration/test_binding_type_filter_e2e.py
@@ -102,7 +102,13 @@ async def env(db_session):
         owner_user_id=uid,
         enforcement_mode="shadow",
     )
-    db_session.add_all([agent_filtered, agent_deny_all, agent_shadow])
+    # #1301: read-denied at the CONTEXT level (can_read=False, no arrays) —
+    # the enumeration surfaces must subtract this whole context, not just
+    # type/source-denied rows.
+    agent_no_read = Agent(
+        workspace_id=ws_id, name=f"noread-{uuid.uuid4().hex[:6]}", owner_user_id=uid
+    )
+    db_session.add_all([agent_filtered, agent_deny_all, agent_shadow, agent_no_read])
     await db_session.flush()
 
     svc = AgentBindingService(db_session)
@@ -135,6 +141,20 @@ async def env(db_session):
         allowed_memory_types=["note"],
         allowed_source_types=["manual"],
     )
+    await svc.create_binding(
+        agent=agent_no_read,
+        context_id=ctx.id,
+        created_by=uid,
+        can_read=False,
+        write_policy="direct",
+        is_default=True,
+    )
+
+    # #1301: a second context the agents have NO binding on — default-deny
+    # must keep its rows out of the unscoped enumeration/aggregate surfaces.
+    ctx_unbound = Context(id=uuid.uuid4(), workspace_id=ws_id, name="unbound", created_by=uid)
+    db_session.add(ctx_unbound)
+    await db_session.flush()
 
     def _mem(summary, *, mtype, source, delivery=None, details=None):
         return Memory(
@@ -164,7 +184,19 @@ async def env(db_session):
         details={"trigger": {"from": "2026-07-01T00:00:00", "until": "2027-01-01T00:00:00"}},
     )
     mem_api = _mem("note api", mtype="note", source=SOURCE_TYPE_API)
-    db_session.add_all([mem_note, mem_time, mem_api])
+    mem_unbound = Memory(
+        id=uuid.uuid4(),
+        user_id=uid,
+        workspace_id=ws_id,
+        context_id=ctx_unbound.id,
+        summary="unbound context row",
+        content="content of unbound row",
+        type="note",
+        client="test",
+        tags=[],
+        source_type=SOURCE_TYPE_MANUAL,
+    )
+    db_session.add_all([mem_note, mem_time, mem_api, mem_unbound])
     await db_session.flush()
 
     # Graph edge for the explore-neighbor pin: note -> time.
@@ -184,12 +216,15 @@ async def env(db_session):
         "uid": uid,
         "ws_id": ws_id,
         "ctx": ctx.id,
+        "ctx_unbound": ctx_unbound.id,
         "agent_filtered": agent_filtered.id,
         "agent_deny_all": agent_deny_all.id,
         "agent_shadow": agent_shadow.id,
+        "agent_no_read": agent_no_read.id,
         "mem_note": mem_note.id,
         "mem_time": mem_time.id,
         "mem_api": mem_api.id,
+        "mem_unbound": mem_unbound.id,
     }
 
     # Audit writer commits on an independent session — clean by workspace.
@@ -531,15 +566,72 @@ async def test_list_route_shadow_unchanged(env, db_session):
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_access_patterns_enforce_filters_rows_and_distribution(env, db_session):
-    from api.routes.memory import get_access_patterns
+async def test_list_route_enforce_excludes_unbound_context(env, db_session):
+    # Unscoped "my memories" view: the non-agent owner sees rows from every
+    # context; an enforce-mode agent must not enumerate contexts it has no
+    # binding on (P0-2 default-deny — recall 404s these outright).
+    baseline = await _list_route(env, db_session, context_id=None)
+    assert env["mem_unbound"] in {uuid.UUID(m.id) for m in baseline.memories}
+    assert baseline.total == 4
+
+    _scope(env, "agent_filtered")
+    response = await _list_route(env, db_session, context_id=None)
+    assert {uuid.UUID(m.id) for m in response.memories} == {env["mem_note"]}
+    assert response.total == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_route_scoped_can_read_false_uniform_404(env, db_session):
+    # Scoped list goes through resolve_context_for_workspace_read, whose
+    # #1275 agent gate already denies can_read=False with the uniform 404.
+    _scope(env, "agent_no_read")
+    with pytest.raises(NotFoundException):
+        await _list_route(env, db_session)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_route_unscoped_can_read_false_context_empty(env, db_session):
+    # The UNSCOPED list has no context chokepoint — the SQL predicate's
+    # membership gate must subtract the read-denied context's rows itself.
+    _scope(env, "agent_no_read")
+    response = await _list_route(env, db_session, context_id=None)
+    assert response.memories == []
+    assert response.total == 0
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stats_enforce_excludes_unbound_and_no_read_contexts(env, db_session):
+    svc = MemoryService(db_session)
+
+    # Workspace-wide stats: unbound-context rows must not be counted.
+    _scope(env, "agent_filtered")
+    stats = await svc.get_stats(env["uid"], workspace_id=str(env["ws_id"]))
+    assert stats.by_type == {"note": 1}
+    assert stats.total_count == 1
+
+    # can_read=False: the bound context contributes nothing either.
+    _scope(env, "agent_no_read")
+    stats = await svc.get_stats(env["uid"], workspace_id=str(env["ws_id"]))
+    assert stats.total_count == 0
+    assert stats.by_type == {}
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def access_seeded(env, db_session):
+    """most_accessed only surfaces rows with last_used_at set."""
     from utils.datetime import utcnow
 
-    # most_accessed only surfaces rows with last_used_at set.
     for key in ("mem_note", "mem_time", "mem_api"):
         row = await db_session.get(Memory, env[key])
         row.last_used_at = utcnow()
     await db_session.flush()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_access_patterns_enforce_filters_rows_and_distribution(
+    env, access_seeded, db_session
+):
+    from api.routes.memory import get_access_patterns
 
     baseline = await get_access_patterns(
         user={"user_id": env["uid"]}, context_id=env["ctx"], db=db_session, days=30
@@ -558,14 +650,8 @@ async def test_access_patterns_enforce_filters_rows_and_distribution(env, db_ses
 
 
 @pytest.mark.asyncio(loop_scope="session")
-async def test_access_patterns_shadow_unchanged(env, db_session):
+async def test_access_patterns_shadow_unchanged(env, access_seeded, db_session):
     from api.routes.memory import get_access_patterns
-    from utils.datetime import utcnow
-
-    for key in ("mem_note", "mem_time", "mem_api"):
-        row = await db_session.get(Memory, env[key])
-        row.last_used_at = utcnow()
-    await db_session.flush()
 
     _scope(env, "agent_shadow", mode="shadow")
     response = await get_access_patterns(
@@ -573,6 +659,23 @@ async def test_access_patterns_shadow_unchanged(env, db_session):
     )
     assert response["type_distribution"] == {"note": 2, "time": 1}
     assert len(response["most_accessed"]) == 3
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_access_patterns_unscoped_can_read_false_context_empty(
+    env, access_seeded, db_session
+):
+    from api.routes.memory import get_access_patterns
+
+    # Unscoped access-patterns has no context chokepoint (scoped goes through
+    # the resolver's #1275 gate) — the membership gate must empty it.
+    _scope(env, "agent_no_read")
+    response = await get_access_patterns(
+        user={"user_id": env["uid"]}, context_id=None, db=db_session, days=30
+    )
+    assert response["most_accessed"] == []
+    assert response["type_distribution"] == {}
+    assert response["recent_access_count"] == 0
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -591,7 +694,11 @@ async def test_stats_enforce_intersects_all_aggregates(env, db_session):
     # Only note/manual survives — the aggregate is not an existence oracle.
     assert stats.by_type == {"note": 1}
     assert stats.total_count == 1
-    assert stats.working_count + stats.persistent_count == 1
+    # All seeded rows are scope='working' (direct inserts bypass
+    # pin-on-write): the filtered working-count must be 1, not the
+    # unfiltered 3 — this pins the scope sub-count query independently.
+    assert stats.working_count == 1
+    assert stats.persistent_count == 0
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -665,7 +772,7 @@ async def cluster_env(env, db_session):
         count=3,
         centroid_2d=[0.0, 0.0],
         representative_memory_ids=[env["mem_time"], env["mem_note"]],
-        property_stats={},
+        property_stats={"types": {"note": 2, "time": 1}, "avg_importance": 0.5},
         label_confidence=0.9,
     )
     db_session.add(cluster)
@@ -710,6 +817,13 @@ async def test_get_cluster_enforce_filters_members_and_representatives(
     )
     assert {m["memory_id"] for m in filtered["memories"]} == {str(env["mem_note"])}
     assert {r["memory_id"] for r in filtered["representatives"]} == {str(env["mem_note"])}
+    # The stored whole-cluster aggregates are the same grouped-count
+    # existence oracle stats.by_type was — they must be recomputed over the
+    # rows the agent can read (mem_api is source-denied, so note counts 1).
+    assert filtered["count"] == 1
+    assert filtered["property_stats"]["types"] == {"note": 1}
+    # Non-type facets stay as stored (not type/source-labeled).
+    assert filtered["property_stats"]["avg_importance"] == 0.5
 
 
 @pytest.mark.asyncio(loop_scope="session")
@@ -722,6 +836,24 @@ async def test_get_cluster_shadow_unchanged(env, cluster_env, db_session):
     )
     assert len(response["memories"]) == 3
     assert len(response["representatives"]) == 2
+    assert response["count"] == 3
+    assert response["property_stats"]["types"] == {"note": 2, "time": 1}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_forget_skip_flag_rejected_for_query_mode(env, db_session):
+    # The internal bypass only covers the memory_id branch; forget(query=...)
+    # resolves victims through recall() where the flag cannot propagate. A
+    # caller combining them would get silent partial maintenance — reject it
+    # loudly instead.
+    svc = MemoryService(db_session)
+    with pytest.raises(ValueError, match="_skip_binding_row_filter"):
+        await svc.forget(
+            ForgetRequest(query="anything"),
+            env["uid"],
+            current_context_id=env["ctx"],
+            _skip_binding_row_filter=True,
+        )
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/integration/test_binding_type_filter_e2e.py
+++ b/backend/tests/integration/test_binding_type_filter_e2e.py
@@ -821,9 +821,9 @@ async def test_get_cluster_enforce_filters_members_and_representatives(
     # existence oracle stats.by_type was — they must be recomputed over the
     # rows the agent can read (mem_api is source-denied, so note counts 1).
     assert filtered["count"] == 1
-    assert filtered["property_stats"]["types"] == {"note": 1}
-    # Non-type facets stay as stored (not type/source-labeled).
-    assert filtered["property_stats"]["avg_importance"] == 0.5
+    # Rows were subtracted → the remaining stored facets (tags carry
+    # verbatim tag strings of denied rows) drop fail-closed.
+    assert filtered["property_stats"] == {"types": {"note": 1}}
 
 
 @pytest.mark.asyncio(loop_scope="session")

--- a/backend/tests/integration/test_binding_type_filter_e2e.py
+++ b/backend/tests/integration/test_binding_type_filter_e2e.py
@@ -465,3 +465,336 @@ async def test_upcoming_time_lane_filtered(env, db_session):
         db_session, env["ctx"], q_from=None, q_until=None, k=10
     )
     assert filtered == []
+
+
+# ---------------------------------------------------------------------------
+# #1301: enumeration / aggregate / update-response read surfaces.
+# Same env, same doctrine: enforce subtracts, shadow changes nothing
+# observable, non-agent credentials are untouched. These surfaces are
+# outside the MAE operation vocabulary, so enforcement here is log-only
+# (no would_deny rows) — the recall/load_pinned lanes above pin the
+# audit shape for the ramp.
+# ---------------------------------------------------------------------------
+
+
+async def _list_route(env, db_session, **overrides):
+    """Call the /memory/list route handler directly (route-owned SQL —
+    there is no service method to test below it)."""
+    from api.routes.memory import list_memories
+
+    kwargs = {
+        "user": {"user_id": env["uid"]},
+        "db": db_session,
+        "scope": None,
+        "type": None,
+        "context_id": env["ctx"],
+        "q": None,
+        "tags": None,
+        "tags_match": "any",
+        "trigger_from": None,
+        "trigger_until": None,
+        "order_by": "created_at",
+        "limit": 50,
+        "offset": 0,
+    }
+    kwargs.update(overrides)
+    return await list_memories(**kwargs)
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_route_no_scope_returns_all_rows(env, db_session):
+    response = await _list_route(env, db_session)
+    assert {uuid.UUID(m.id) for m in response.memories} == {
+        env["mem_note"],
+        env["mem_time"],
+        env["mem_api"],
+    }
+    assert response.total == 3
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_route_enforce_filters_rows_and_total(env, db_session):
+    _scope(env, "agent_filtered")
+    response = await _list_route(env, db_session)
+    assert {uuid.UUID(m.id) for m in response.memories} == {env["mem_note"]}
+    # total must not act as an existence oracle over denied rows.
+    assert response.total == 1
+    assert response.has_more is False
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_list_route_shadow_unchanged(env, db_session):
+    _scope(env, "agent_shadow", mode="shadow")
+    response = await _list_route(env, db_session)
+    assert len(response.memories) == 3
+    assert response.total == 3
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_access_patterns_enforce_filters_rows_and_distribution(env, db_session):
+    from api.routes.memory import get_access_patterns
+    from utils.datetime import utcnow
+
+    # most_accessed only surfaces rows with last_used_at set.
+    for key in ("mem_note", "mem_time", "mem_api"):
+        row = await db_session.get(Memory, env[key])
+        row.last_used_at = utcnow()
+    await db_session.flush()
+
+    baseline = await get_access_patterns(
+        user={"user_id": env["uid"]}, context_id=env["ctx"], db=db_session, days=30
+    )
+    assert baseline["type_distribution"] == {"note": 2, "time": 1}
+    assert len(baseline["most_accessed"]) == 3
+
+    _scope(env, "agent_filtered")
+    filtered = await get_access_patterns(
+        user={"user_id": env["uid"]}, context_id=env["ctx"], db=db_session, days=30
+    )
+    # mem_time is type-denied, mem_api is source-denied.
+    assert filtered["type_distribution"] == {"note": 1}
+    assert {m["memory_id"] for m in filtered["most_accessed"]} == {str(env["mem_note"])}
+    assert filtered["recent_access_count"] == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_access_patterns_shadow_unchanged(env, db_session):
+    from api.routes.memory import get_access_patterns
+    from utils.datetime import utcnow
+
+    for key in ("mem_note", "mem_time", "mem_api"):
+        row = await db_session.get(Memory, env[key])
+        row.last_used_at = utcnow()
+    await db_session.flush()
+
+    _scope(env, "agent_shadow", mode="shadow")
+    response = await get_access_patterns(
+        user={"user_id": env["uid"]}, context_id=env["ctx"], db=db_session, days=30
+    )
+    assert response["type_distribution"] == {"note": 2, "time": 1}
+    assert len(response["most_accessed"]) == 3
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stats_enforce_intersects_all_aggregates(env, db_session):
+    svc = MemoryService(db_session)
+    baseline = await svc.get_stats(
+        env["uid"], workspace_id=str(env["ws_id"]), context_id=str(env["ctx"])
+    )
+    assert baseline.by_type == {"note": 2, "time": 1}
+    assert baseline.total_count == 3
+
+    _scope(env, "agent_filtered")
+    stats = await svc.get_stats(
+        env["uid"], workspace_id=str(env["ws_id"]), context_id=str(env["ctx"])
+    )
+    # Only note/manual survives — the aggregate is not an existence oracle.
+    assert stats.by_type == {"note": 1}
+    assert stats.total_count == 1
+    assert stats.working_count + stats.persistent_count == 1
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stats_deny_all_agent_sees_zero(env, db_session):
+    _scope(env, "agent_deny_all")
+    stats = await MemoryService(db_session).get_stats(
+        env["uid"], workspace_id=str(env["ws_id"]), context_id=str(env["ctx"])
+    )
+    assert stats.total_count == 0
+    assert stats.by_type == {}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_stats_shadow_unchanged(env, db_session):
+    _scope(env, "agent_shadow", mode="shadow")
+    stats = await MemoryService(db_session).get_stats(
+        env["uid"], workspace_id=str(env["ws_id"]), context_id=str(env["ctx"])
+    )
+    assert stats.by_type == {"note": 2, "time": 1}
+    assert stats.total_count == 3
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def cluster_env(env, db_session):
+    """A succeeded analysis run whose single cluster contains all three
+    env memories, with the type-denied row as a representative."""
+    from datetime import datetime
+
+    from models.analysis import (
+        MemoryAnalysis,
+        MemoryAnalysisAssignment,
+        MemoryAnalysisCluster,
+    )
+    from models.llm_pricing import LLMPricing
+    from utils.datetime import utcnow
+
+    pricing = LLMPricing(
+        provider="openai",
+        model="gpt-5-nano",
+        unit_type="input_tokens",
+        price_per_unit=0.20,
+        effective_from=datetime(2026, 1, 1),
+    )
+    db_session.add(pricing)
+    await db_session.flush()
+
+    run = MemoryAnalysis(
+        id=uuid.uuid4(),
+        workspace_id=env["ws_id"],
+        context_id=env["ctx"],
+        triggered_by=env["uid"],
+        status="succeeded",
+        started_at=utcnow(),
+        finished_at=utcnow(),
+        model_id=pricing.id,
+        model_snapshot={"model": "gpt-5-nano", "rates": {}},
+        embedding_model="text-embedding-3-small",
+        params={},
+        input_count=3,
+        paid_by="byok",
+    )
+    db_session.add(run)
+    await db_session.flush()
+
+    cluster = MemoryAnalysisCluster(
+        id=uuid.uuid4(),
+        analysis_id=run.id,
+        cluster_index=0,
+        label="all rows",
+        description=None,
+        count=3,
+        centroid_2d=[0.0, 0.0],
+        representative_memory_ids=[env["mem_time"], env["mem_note"]],
+        property_stats={},
+        label_confidence=0.9,
+    )
+    db_session.add(cluster)
+    await db_session.flush()
+
+    for i, key in enumerate(("mem_note", "mem_time", "mem_api")):
+        db_session.add(
+            MemoryAnalysisAssignment(
+                analysis_id=run.id,
+                memory_id=env[key],
+                cluster_id=cluster.id,
+                x=float(i),
+                y=0.0,
+            )
+        )
+    await db_session.flush()
+    return {"run_id": run.id}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_cluster_enforce_filters_members_and_representatives(
+    env, cluster_env, db_session
+):
+    from services.analysis import query_service
+
+    baseline = await query_service.get_cluster(
+        db_session, workspace_id=env["ws_id"], run_id=cluster_env["run_id"], cluster_index=0
+    )
+    assert {m["memory_id"] for m in baseline["memories"]} == {
+        str(env["mem_note"]),
+        str(env["mem_time"]),
+        str(env["mem_api"]),
+    }
+    assert {r["memory_id"] for r in baseline["representatives"]} == {
+        str(env["mem_time"]),
+        str(env["mem_note"]),
+    }
+
+    _scope(env, "agent_filtered")
+    filtered = await query_service.get_cluster(
+        db_session, workspace_id=env["ws_id"], run_id=cluster_env["run_id"], cluster_index=0
+    )
+    assert {m["memory_id"] for m in filtered["memories"]} == {str(env["mem_note"])}
+    assert {r["memory_id"] for r in filtered["representatives"]} == {str(env["mem_note"])}
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_get_cluster_shadow_unchanged(env, cluster_env, db_session):
+    from services.analysis import query_service
+
+    _scope(env, "agent_shadow", mode="shadow")
+    response = await query_service.get_cluster(
+        db_session, workspace_id=env["ws_id"], run_id=cluster_env["run_id"], cluster_index=0
+    )
+    assert len(response["memories"]) == 3
+    assert len(response["representatives"]) == 2
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_patch_denied_type_uniform_404(env, db_session):
+    from models.schemas import PatchMemoryRequest
+
+    _scope(env, "agent_filtered")
+    svc = MemoryService(db_session)
+    # A no-op PATCH on a read-denied row must not read it back — id-addressed
+    # ops on denied rows are uniformly 404 (the #1299 forget/reference doctrine).
+    with pytest.raises(NotFoundException):
+        await svc.patch_memory(env["mem_time"], PatchMemoryRequest(importance=0.9), env["uid"])
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_update_in_place_denied_type_uniform_404(env, db_session):
+    from models.schemas import UpdateMemoryRequest
+
+    _scope(env, "agent_filtered")
+    svc = MemoryService(db_session)
+    with pytest.raises(NotFoundException):
+        await svc.update_memory(
+            UpdateMemoryRequest(memory_id=env["mem_api"], importance=0.9),
+            user_id=env["uid"],
+            current_context_id=env["ctx"],
+        )
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_upsert_replacement_forget_bypasses_row_filter(env, db_session):
+    """#1301: the upsert's internal replacement delete is maintenance, not an
+    agent read — a denied-type existing row must still be replaced, never
+    left as a live duplicate alongside the new row."""
+    from unittest.mock import patch
+
+    from models.schemas import RememberResponse, UpdateMemoryRequest
+
+    ext = f"ext-{uuid.uuid4().hex[:8]}"
+    old = Memory(
+        id=uuid.uuid4(),
+        user_id=env["uid"],
+        workspace_id=env["ws_id"],
+        context_id=env["ctx"],
+        summary="old external row",
+        content="old content",
+        type="note",
+        client="test",
+        tags=[],
+        source_type=SOURCE_TYPE_API,  # source-denied for agent_filtered
+        details={"resource_id": ext},
+    )
+    db_session.add(old)
+    await db_session.flush()
+
+    _scope(env, "agent_filtered")
+    svc = MemoryService(db_session)
+    svc.remember = AsyncMock(return_value=RememberResponse(memory_id=uuid.uuid4(), scope="working"))
+    with patch("services.memory_service.delete_memory_from_qdrant", new=AsyncMock()):
+        response = await svc.update_memory(
+            UpdateMemoryRequest(
+                external_id=ext,
+                summary="replacement summary text",
+                content="replacement content",
+                type="note",
+            ),
+            user_id=env["uid"],
+            current_context_id=env["ctx"],
+            current_workspace_id=env["ws_id"],
+        )
+
+    assert response.operation == "replaced"
+    refreshed = await db_session.get(Memory, old.id)
+    assert refreshed.deleted_at is not None, (
+        "internal replacement forget must bypass the per-memory read filter — "
+        "a denied-type row left live creates duplicates per external_id"
+    )

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -929,3 +929,89 @@ class TestEmitRowFilterWouldDeny:
                 denied_memory_ids=[],
             )
         emit.assert_not_awaited()
+
+
+class TestBindingMemorySqlPredicate:
+    """#1301: the SQL form of the row filter for count/aggregate surfaces
+    (/memory/list, access-patterns, stats). Behavior is pinned end to end in
+    tests/integration/test_binding_type_filter_e2e.py; these pin the
+    structural no-op contract (when NO clause may be applied)."""
+
+    def _db_with_bindings(self, bindings):
+        db = MagicMock()
+        scalars = MagicMock(all=MagicMock(return_value=bindings))
+        db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=scalars)))
+        return db
+
+    @pytest.mark.asyncio
+    async def test_non_agent_credential_returns_none_without_query(self):
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        set_agent_scope(None)
+        db = MagicMock()
+        db.execute = AsyncMock()
+        assert await binding_memory_sql_predicate(db) is None
+        db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_shadow_scope_returns_none_without_query(self):
+        # Shadow must change nothing observable — and these surfaces are
+        # outside the MAE vocabulary, so shadow here is a pure no-op.
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        set_agent_scope(_scope(mode="shadow", workspace_id=uuid.uuid4()))
+        try:
+            db = MagicMock()
+            db.execute = AsyncMock()
+            assert await binding_memory_sql_predicate(db) is None
+            db.execute.assert_not_awaited()
+        finally:
+            set_agent_scope(None)
+
+    @pytest.mark.asyncio
+    async def test_non_restricting_bindings_return_none(self):
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
+        try:
+            db = self._db_with_bindings([_binding()])  # both arrays NULL
+            assert await binding_memory_sql_predicate(db) is None
+        finally:
+            set_agent_scope(None)
+
+    @pytest.mark.asyncio
+    async def test_enforce_predicate_mirrors_permits_semantics(self):
+        # One clause per restricting context; []=deny-all compiles to a
+        # constant-false allow (is-not-None doctrine, never truthiness).
+        from sqlalchemy.dialects import postgresql
+
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        ctx_a, ctx_b = uuid.uuid4(), uuid.uuid4()
+        set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
+        try:
+            db = self._db_with_bindings(
+                [
+                    _binding(context_id=ctx_a, allowed_memory_types=["note"]),
+                    _binding(context_id=ctx_b, allowed_source_types=[]),
+                ]
+            )
+            predicate = await binding_memory_sql_predicate(db)
+            assert predicate is not None
+            sql = str(
+                predicate.compile(
+                    dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+                )
+            )
+            assert sql.startswith("NOT (")
+            assert f"memories.context_id = '{ctx_a}' AND (memories.type NOT IN ('note'))" in sql
+            # []=deny-all: NOT(false) folds to true, leaving the bare context
+            # clause — every row of that context is denied, never IN ().
+            assert f"memories.context_id = '{ctx_b}'" in sql
+            assert f"'{ctx_b}' AND" not in sql
+        finally:
+            set_agent_scope(None)

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -69,6 +69,15 @@ def _scope(agent_id=None, mode="enforce", workspace_id=None) -> AgentScope:
     )
 
 
+def _db_with_bindings(bindings):
+    """MagicMock db whose binding SELECT returns ``bindings`` (shared by the
+    row-lever and SQL-predicate test classes)."""
+    db = MagicMock()
+    scalars = MagicMock(all=MagicMock(return_value=bindings))
+    db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=scalars)))
+    return db
+
+
 def _service(execute_results: list | None = None) -> AgentBindingService:
     db = MagicMock()
     db.flush = AsyncMock()
@@ -742,12 +751,6 @@ class TestFilterMemoryRowsByBinding:
 
         return SimpleNamespace(id=uuid.uuid4(), context_id=ctx, type=mtype, source_type=source)
 
-    def _db_with_bindings(self, bindings):
-        db = MagicMock()
-        scalars = MagicMock(all=MagicMock(return_value=bindings))
-        db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=scalars)))
-        return db
-
     @pytest.mark.asyncio
     async def test_non_agent_credential_is_structural_noop(self):
         from auth.agent_scope import set_agent_scope
@@ -772,7 +775,7 @@ class TestFilterMemoryRowsByBinding:
         ctx_a, ctx_b = uuid.uuid4(), uuid.uuid4()
         set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
         try:
-            db = self._db_with_bindings([_binding(context_id=ctx_a, allowed_memory_types=["note"])])
+            db = _db_with_bindings([_binding(context_id=ctx_a, allowed_memory_types=["note"])])
             note_a = self._row(ctx_a, "note")
             time_a = self._row(ctx_a, "time")
             time_b = self._row(ctx_b, "time")  # ctx_b unrestricted
@@ -798,7 +801,7 @@ class TestFilterMemoryRowsByBinding:
         ctx_a, ctx_b = uuid.uuid4(), uuid.uuid4()
         set_agent_scope(_scope(mode="shadow", workspace_id=uuid.uuid4()))
         try:
-            db = self._db_with_bindings(
+            db = _db_with_bindings(
                 [
                     _binding(context_id=ctx_a, allowed_memory_types=["note"]),
                     _binding(context_id=ctx_b, allowed_source_types=["manual"]),
@@ -833,7 +836,7 @@ class TestFilterMemoryRowsByBinding:
         ctx = uuid.uuid4()
         set_agent_scope(_scope(mode="shadow", workspace_id=uuid.uuid4()))
         try:
-            db = self._db_with_bindings([_binding(context_id=ctx, allowed_memory_types=[])])
+            db = _db_with_bindings([_binding(context_id=ctx, allowed_memory_types=[])])
             rows = [self._row(ctx)]
             with patch(
                 "services.agent_binding_service.emit_row_filter_would_deny", AsyncMock()
@@ -855,7 +858,7 @@ class TestFilterMemoryRowsByBinding:
         ctx = uuid.uuid4()
         set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
         try:
-            db = self._db_with_bindings([_binding(context_id=ctx)])  # arrays NULL
+            db = _db_with_bindings([_binding(context_id=ctx)])  # arrays NULL
             rows = [self._row(ctx, "anything", source="connector")]
             kept, denied = await filter_memory_rows_by_binding(
                 db, rows, operation="recall", user_id="u"
@@ -937,12 +940,6 @@ class TestBindingMemorySqlPredicate:
     tests/integration/test_binding_type_filter_e2e.py; these pin the
     structural no-op contract (when NO clause may be applied)."""
 
-    def _db_with_bindings(self, bindings):
-        db = MagicMock()
-        scalars = MagicMock(all=MagicMock(return_value=bindings))
-        db.execute = AsyncMock(return_value=MagicMock(scalars=MagicMock(return_value=scalars)))
-        return db
-
     @pytest.mark.asyncio
     async def test_non_agent_credential_returns_none_without_query(self):
         from auth.agent_scope import set_agent_scope
@@ -970,31 +967,76 @@ class TestBindingMemorySqlPredicate:
         finally:
             set_agent_scope(None)
 
+    @staticmethod
+    def _compile(predicate) -> str:
+        from sqlalchemy.dialects import postgresql
+
+        return str(
+            predicate.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+        )
+
     @pytest.mark.asyncio
-    async def test_non_restricting_bindings_return_none(self):
+    async def test_non_restricting_binding_still_gates_context_membership(self):
+        # can_read=True with NULL arrays restricts no rows INSIDE the bound
+        # context, but P0-2 default-deny still confines the agent to its
+        # bound set — the predicate is the membership gate, never None.
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        ctx = uuid.uuid4()
+        set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
+        try:
+            db = _db_with_bindings([_binding(context_id=ctx)])  # both arrays NULL
+            predicate = await binding_memory_sql_predicate(db)
+            assert predicate is not None
+            assert self._compile(predicate) == f"memories.context_id IN ('{ctx}')"
+        finally:
+            set_agent_scope(None)
+
+    @pytest.mark.asyncio
+    async def test_zero_bindings_deny_everything(self):
         from auth.agent_scope import set_agent_scope
         from services.agent_binding_service import binding_memory_sql_predicate
 
         set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
         try:
-            db = self._db_with_bindings([_binding()])  # both arrays NULL
-            assert await binding_memory_sql_predicate(db) is None
+            predicate = await binding_memory_sql_predicate(_db_with_bindings([]))
+            assert predicate is not None
+            assert self._compile(predicate) == "false"
+        finally:
+            set_agent_scope(None)
+
+    @pytest.mark.asyncio
+    async def test_can_read_false_context_excluded_from_membership_gate(self):
+        from auth.agent_scope import set_agent_scope
+        from services.agent_binding_service import binding_memory_sql_predicate
+
+        ctx_ro, ctx_no = uuid.uuid4(), uuid.uuid4()
+        set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
+        try:
+            db = _db_with_bindings(
+                [
+                    _binding(context_id=ctx_ro),
+                    _binding(context_id=ctx_no, can_read=False),
+                ]
+            )
+            sql = self._compile(await binding_memory_sql_predicate(db))
+            assert sql == f"memories.context_id IN ('{ctx_ro}')"
         finally:
             set_agent_scope(None)
 
     @pytest.mark.asyncio
     async def test_enforce_predicate_mirrors_permits_semantics(self):
-        # One clause per restricting context; []=deny-all compiles to a
-        # constant-false allow (is-not-None doctrine, never truthiness).
-        from sqlalchemy.dialects import postgresql
-
+        # Membership gate over readable contexts, AND one subtraction clause
+        # per restricting context; []=deny-all compiles to a constant-false
+        # allow (is-not-None doctrine, never truthiness).
         from auth.agent_scope import set_agent_scope
         from services.agent_binding_service import binding_memory_sql_predicate
 
         ctx_a, ctx_b = uuid.uuid4(), uuid.uuid4()
         set_agent_scope(_scope(mode="enforce", workspace_id=uuid.uuid4()))
         try:
-            db = self._db_with_bindings(
+            db = _db_with_bindings(
                 [
                     _binding(context_id=ctx_a, allowed_memory_types=["note"]),
                     _binding(context_id=ctx_b, allowed_source_types=[]),
@@ -1002,16 +1044,12 @@ class TestBindingMemorySqlPredicate:
             )
             predicate = await binding_memory_sql_predicate(db)
             assert predicate is not None
-            sql = str(
-                predicate.compile(
-                    dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
-                )
-            )
-            assert sql.startswith("NOT (")
+            sql = self._compile(predicate)
+            assert "memories.context_id IN (" in sql
+            assert str(ctx_a) in sql and str(ctx_b) in sql
             assert f"memories.context_id = '{ctx_a}' AND (memories.type NOT IN ('note'))" in sql
             # []=deny-all: NOT(false) folds to true, leaving the bare context
             # clause — every row of that context is denied, never IN ().
-            assert f"memories.context_id = '{ctx_b}'" in sql
-            assert f"'{ctx_b}' AND" not in sql
+            assert f"OR memories.context_id = '{ctx_b}'" in sql
         finally:
             set_agent_scope(None)

--- a/backend/tests/services/test_agent_binding_service.py
+++ b/backend/tests/services/test_agent_binding_service.py
@@ -989,7 +989,12 @@ class TestBindingMemorySqlPredicate:
             db = _db_with_bindings([_binding(context_id=ctx)])  # both arrays NULL
             predicate = await binding_memory_sql_predicate(db)
             assert predicate is not None
-            assert self._compile(predicate) == f"memories.context_id IN ('{ctx}')"
+            sql = self._compile(predicate)
+            # Rendering-tolerant: the contract is a membership gate over the
+            # bound context and nothing else (no type/source subtraction).
+            assert f"memories.context_id IN ('{ctx}')" in sql
+            assert "memories.type" not in sql
+            assert "memories.source_type" not in sql
         finally:
             set_agent_scope(None)
 
@@ -1002,7 +1007,11 @@ class TestBindingMemorySqlPredicate:
         try:
             predicate = await binding_memory_sql_predicate(_db_with_bindings([]))
             assert predicate is not None
-            assert self._compile(predicate) == "false"
+            # Rendering-tolerant constant-false check: no column can satisfy
+            # the predicate (SQLA may render `false` or an equivalent).
+            sql = self._compile(predicate)
+            assert "memories." not in sql
+            assert sql.lower() in ("false", "0 = 1", "1 != 1")
         finally:
             set_agent_scope(None)
 

--- a/docs/design/agent-registry-and-bindings.md
+++ b/docs/design/agent-registry-and-bindings.md
@@ -137,12 +137,20 @@ Semantics (normative):
   - **Enumeration / aggregate surfaces (closed by
     [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301)):** `GET /memory/list`,
     `GET /memory/access-patterns`, and `GET /memory/stats` (with its MCP mirror
-    `get_context_info`) subtract denied rows via the SQL form of the same filter
+    `get_context_info`) subtract denied rows via the SQL form of the binding read filter
     (`binding_memory_sql_predicate`) applied identically to page and count queries, so
     totals and grouped counts (`by_type`, type distribution) are not an existence oracle
-    over denied types. MCP `get_cluster` filters member and representative rows through the
-    shared row lever (`cluster.count` remains the stored whole-cluster size — a
-    metadata-only aggregate). These surfaces sit outside the MAE operation vocabulary:
+    over denied types. The SQL form carries **both** dimensions: the P0-2 context-level
+    default-deny (rows in unbound or `can_read=False` contexts are subtracted) **and**
+    the per-memory type/source subtraction. The scoped forms of these surfaces are
+    already context-gated at the `resolve_context_for_workspace_read` chokepoint (#1275
+    uniform 404); the predicate's membership gate is what covers the **unscoped** forms
+    (no `context_id` → no chokepoint) and cross-context aggregates, which previously
+    enumerated unbound contexts' rows.
+    MCP `get_cluster` (context-gated in its handler via `agent_binding_permits`) filters
+    member and representative rows through the shared row lever, and recomputes `count` +
+    `property_stats.types` over permitted rows for enforce-mode agents (non-type facets
+    stay stored aggregates). These surfaces sit outside the MAE operation vocabulary:
     shadow mode is a pure no-op there (no `would_deny` aggregates); the enforcement ramp
     observes would-deny volume through the `recall` / `load_pinned` lanes.
   - **Internal maintenance carve-out (#1301):** the upsert-by-`external_id` replacement

--- a/docs/design/agent-registry-and-bindings.md
+++ b/docs/design/agent-registry-and-bindings.md
@@ -128,15 +128,28 @@ Semantics (normative):
   identically for these operations by construction (#1291/#1292 lesson). Shadow-mode
   credentials are not filtered; row-filter violations land as `would_deny` aggregates in
   `memory_access_events` with `filter_kind='type_source'`. The write lane (`remember` /
-  `update` / `patch`) stays governed by `write_policy` only.
-  - **Known scope limit (tracked as [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301)):**
-    the per-memory dimension is applied to the memory-read lanes above, not yet to every
-    enumeration / aggregate / update-response surface (`GET /memory/list`,
-    `GET /memory/access-patterns`, `GET /memory/stats`, MCP `get_cluster`, and the
-    `PATCH /memory/{id}` response body). Those surfaces still enforce the P0-2 **context-level**
-    binding gate; extending the row filter to them (the #1291/#1292-class audit widened to
-    non-CRUD read surfaces) is #1301. Operators must not rely on the type/source filter to hide
-    denied-type rows on those endpoints yet.
+  `update` / `patch`) stays governed by `write_policy` for whether the **mutation** may run;
+  as of [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301) the id-addressed
+  update paths (`PATCH /memory/{id}`, MCP-reachable in-place update) additionally thread the
+  target row's `type`/`source_type` through the row filter, so updating a read-denied row is
+  a uniform 404 (the reference/forget doctrine — a no-op PATCH must not read back L3 content
+  the read lanes would hide).
+  - **Enumeration / aggregate surfaces (closed by
+    [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301)):** `GET /memory/list`,
+    `GET /memory/access-patterns`, and `GET /memory/stats` (with its MCP mirror
+    `get_context_info`) subtract denied rows via the SQL form of the same filter
+    (`binding_memory_sql_predicate`) applied identically to page and count queries, so
+    totals and grouped counts (`by_type`, type distribution) are not an existence oracle
+    over denied types. MCP `get_cluster` filters member and representative rows through the
+    shared row lever (`cluster.count` remains the stored whole-cluster size — a
+    metadata-only aggregate). These surfaces sit outside the MAE operation vocabulary:
+    shadow mode is a pure no-op there (no `would_deny` aggregates); the enforcement ramp
+    observes would-deny volume through the `recall` / `load_pinned` lanes.
+  - **Internal maintenance carve-out (#1301):** the upsert-by-`external_id` replacement
+    delete calls `forget` with the per-memory filter skipped (context-level write gate still
+    applies) — otherwise replacing a denied-type row would silently no-op and leave a live
+    duplicate per `external_id`. The flag is service-internal and not reachable from any
+    transport layer.
 - **`is_default` is the single source of truth for the bootstrap default binding.** At most
   one binding per agent is default, guaranteed by the partial unique index
   `(agent_id) WHERE is_default`. `agents.default_context_id` was rejected as a second source


### PR DESCRIPTION
Closes #1301

## Summary

Extends the #1299 per-memory `allowed_memory_types` / `allowed_source_types` binding filter to the agent-reachable **enumeration, aggregate, and update-response** read surfaces, closing the scope limit recorded in `docs/design/agent-registry-and-bindings.md`.

## Changes

- **New `binding_memory_sql_predicate()`** (`agent_binding_service.py`) — the SQL form of the binding read filter for surfaces that never materialize full rows. Carries **both** dimensions:
  - P0-2 **context membership** (default-deny): rows in unbound / `can_read=False` contexts are subtracted. The scoped forms were already gated at the `resolve_context_for_workspace_read` chokepoint (#1275 uniform 404); the membership gate covers the **unscoped** forms and cross-context aggregates, which previously enumerated unbound contexts' rows. `context_id IS NULL` rows fall out fail-closed.
  - Per-memory **type/source subtraction**, mirroring `BindingRowFilter.permits` (`[]`=deny-all keeps the is-not-None doctrine).
- **`GET /memory/list`**: predicate applied to page + count queries — `total` is not an existence oracle, pagination stays exact.
- **`GET /memory/access-patterns`**: predicate on the most-accessed page and every aggregate (type distribution, recent count).
- **`MemoryService.get_stats`**: predicate in `base_conditions` — covers REST `/memory/stats` and MCP `get_context_info` by construction.
- **MCP `get_cluster`**: member/representative rows pass through `filter_memory_rows_by_binding`; `count` + `property_stats.types` recomputed over permitted rows; when any row was subtracted the remaining facets (`tags` carries verbatim tag strings of denied rows) drop fail-closed.
- **`PATCH /memory/{id}` + MCP-reachable in-place update**: thread the target row's `type`/`source_type` through `can_access_memory` — updating a read-denied row is a uniform 404 (reference/forget doctrine, REST/MCP parity), closing the no-op-PATCH L3 read-back.
- **`_upsert_by_external_id` replacement forget**: internal `_skip_binding_row_filter` carve-out (context-level write gate still applies) so replacing a denied-type row can't silently no-op and leave a live duplicate per `external_id`. Guarded: combining the flag with `forget(query=...)` raises (`recall()`-based candidate resolution can't honor it).
- No migration. These surfaces sit outside the MAE operation vocabulary: shadow mode is a pure no-op (ramp observability stays on the `recall`/`load_pinned` lanes).

## Review

10-angle code review (xhigh) + adversarial verify + sweep ran on this branch; confirmed findings were fixed in the follow-up commits (context default-deny in the predicate, NULL-context three-valued-logic divergence, cluster aggregate oracle incl. `property_stats.tags` content leak, forget-flag/query-mode guard, non-vacuous stats assertion).

**Known limitations / follow-up candidates** (deliberately out of scope):

1. Pre-existing: PATCH response echoes L3 content for `can_read=False` + `write_policy='direct'` bindings (context-dim read denial; the type/source dim is closed here).
2. `/list` & `/access-patterns` filtering lives at the route layer (route-owned SQL) — extracting a service-layer query builder would restore single-enforcement-site by construction.
3. Shadow mode emits no `would_deny` signal on these surfaces (MAE vocabulary expansion candidate).
4. SQL predicate and `BindingRowFilter.permits` are two encodings of one decision — unit pins mitigate drift; a shared builder would remove it.
5. `memories.source_type` is unindexed; relevant if source-restricted bindings become common on large contexts.

## Test plan

- 21 e2e pins in `tests/integration/test_binding_type_filter_e2e.py` (enforce / shadow / deny-all / can_read=False / unbound-context per surface, upsert replacement, forget guard) — all green.
- 8 unit pins for the SQL predicate (structural no-op contract, membership gate, permits-mirror compile shape).
- `make lint` clean; backend unit suite green (2757 tests); adjacent suites (memory list/stats routes, analysis query service, MCP recall_upcoming) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
