### PR TITLE
chore(workers): audit logging + failure diagnostics for secret lifecycle (#1339)

### DIFF
--- a/backend/src/api/routes/worker_apps.py
+++ b/backend/src/api/routes/worker_apps.py
@@ -20,6 +20,9 @@ from services.worker_app_identity import (
     identity_revision,
 )
 from utils.exceptions import ConflictError, MemoryCloudException, WorkerAppOperationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/admin/worker-apps", tags=["admin-worker-apps"])
 
@@ -114,7 +117,26 @@ async def create_worker_app(
         raise ConflictError("Worker app identity already exists") from exc
     except Exception as exc:
         await db.rollback()
+        # #1339: WorkerAppOperationError deliberately carries a fixed client
+        # message; the underlying cause must land in the server log or a
+        # failed lifecycle write is undiagnosable. Tracebacks never contain
+        # secret material (request bodies are not in the trace context).
+        logger.error(
+            "worker_app_create_failed",
+            requested_by=admin["user_id"],
+            platform=request.platform,
+            app_key=request.app_key,
+            exc_info=True,
+        )
         raise WorkerAppOperationError("create") from exc
+    logger.info(
+        "worker_app_created",
+        requested_by=admin["user_id"],
+        platform=identity.platform,
+        app_key=identity.app_key,
+        app_status=identity.status,
+        active_secret_revision=identity.active_secret_revision,
+    )
     return _admin_response(identity)
 
 
@@ -141,7 +163,23 @@ async def update_worker_app(
         raise
     except Exception as exc:
         await db.rollback()
+        logger.error(
+            "worker_app_update_failed",
+            requested_by=admin["user_id"],
+            platform=platform,
+            app_key=app_key,
+            exc_info=True,
+        )
         raise WorkerAppOperationError("update") from exc
+    logger.info(
+        "worker_app_updated",
+        requested_by=admin["user_id"],
+        platform=identity.platform,
+        app_key=identity.app_key,
+        app_status=identity.status,
+        display_name_changed=request.display_name is not None,
+        status_changed=request.status is not None,
+    )
     return _admin_response(identity)
 
 
@@ -168,5 +206,22 @@ async def rotate_worker_app_secret(
         raise
     except Exception as exc:
         await db.rollback()
+        logger.error(
+            "worker_app_rotate_failed",
+            requested_by=admin["user_id"],
+            platform=platform,
+            app_key=app_key,
+            exc_info=True,
+        )
         raise WorkerAppOperationError("rotate") from exc
+    logger.info(
+        "worker_app_secret_rotated",
+        requested_by=admin["user_id"],
+        platform=identity.platform,
+        app_key=identity.app_key,
+        app_status=identity.status,
+        active_secret_revision=identity.active_secret_revision,
+        retiring_secret_revision=identity.retiring_secret_revision,
+        retiring_for_seconds=request.retiring_for_seconds,
+    )
     return _admin_response(identity)

--- a/backend/src/api/routes/worker_apps.py
+++ b/backend/src/api/routes/worker_apps.py
@@ -179,6 +179,11 @@ async def update_worker_app(
         app_status=identity.status,
         display_name_changed=request.display_name is not None,
         status_changed=request.status is not None,
+        # Revisions/window let an enable/disable be correlated with the
+        # secret material that was active/retiring at that moment.
+        active_secret_revision=identity.active_secret_revision,
+        retiring_secret_revision=identity.retiring_secret_revision,
+        retiring_valid_until=identity.retiring_valid_until,
     )
     return _admin_response(identity)
 

--- a/backend/tests/api/test_worker_apps.py
+++ b/backend/tests/api/test_worker_apps.py
@@ -9,8 +9,10 @@ import pytest
 from api.routes.worker_apps import (
     WorkerAppCreateRequest,
     WorkerAppRotateSecretRequest,
+    WorkerAppUpdateRequest,
     create_worker_app,
     rotate_worker_app_secret,
+    update_worker_app,
 )
 from models.worker_app import WorkerAppIdentity
 from utils.exceptions import WorkerAppOperationError
@@ -117,6 +119,54 @@ async def test_create_logs_audit_event_without_secret_material():
     assert kwargs["app_key"] == "sales"
     assert kwargs["active_secret_revision"] == 1
     _assert_no_secret_material(mock_logger, ["plaintext-secret", "ciphertext-material"])
+
+
+@pytest.mark.asyncio
+async def test_update_logs_audit_event_with_revision_context():
+    """#1339: a disable (or any update) emits worker_app_updated carrying the
+    secret revisions/retiring window active at that moment, so a status flip
+    can be correlated with the material it revoked — never the secret itself."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+    identity = WorkerAppIdentity(
+        id=uuid4(),
+        platform="slack",
+        app_key="sales",
+        display_name="Sales app",
+        status="disabled",
+        active_secret_revision=5,
+        retiring_secret_revision=4,
+        config_version=6,
+        created_at=datetime(2026, 7, 17),
+        updated_at=datetime(2026, 7, 17),
+    )
+    identity.active_signing_secret_encrypted = "ciphertext-material"
+
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.update_identity = AsyncMock(return_value=identity)
+        await update_worker_app(
+            WorkerAppUpdateRequest(status="disabled"),
+            "slack",
+            "sales",
+            {"user_id": "admin-3"},
+            db,
+        )
+
+    mock_logger.info.assert_called_once()
+    event, kwargs = mock_logger.info.call_args.args[0], mock_logger.info.call_args.kwargs
+    assert event == "worker_app_updated"
+    assert kwargs["requested_by"] == "admin-3"
+    assert kwargs["app_status"] == "disabled"
+    assert kwargs["status_changed"] is True
+    assert kwargs["display_name_changed"] is False
+    assert kwargs["active_secret_revision"] == 5
+    assert kwargs["retiring_secret_revision"] == 4
+    _assert_no_secret_material(mock_logger, ["ciphertext-material"])
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_worker_apps.py
+++ b/backend/tests/api/test_worker_apps.py
@@ -1,4 +1,4 @@
-"""System-admin worker app lifecycle API tests (#1315)."""
+"""System-admin worker app lifecycle API tests (#1315, #1339)."""
 
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -6,8 +6,26 @@ from uuid import uuid4
 
 import pytest
 
-from api.routes.worker_apps import WorkerAppCreateRequest, create_worker_app
+from api.routes.worker_apps import (
+    WorkerAppCreateRequest,
+    WorkerAppRotateSecretRequest,
+    create_worker_app,
+    rotate_worker_app_secret,
+)
 from models.worker_app import WorkerAppIdentity
+from utils.exceptions import WorkerAppOperationError
+
+
+def _assert_no_secret_material(mock_logger, secret_values):
+    """No log call may carry secret plaintext/ciphertext in event or kwargs."""
+    for call in [*mock_logger.info.call_args_list, *mock_logger.error.call_args_list]:
+        rendered = (
+            " ".join(str(arg) for arg in call.args)
+            + " "
+            + " ".join(f"{k}={v}" for k, v in call.kwargs.items())
+        )
+        for secret in secret_values:
+            assert secret not in rendered
 
 
 @pytest.mark.asyncio
@@ -53,3 +71,131 @@ async def test_admin_create_response_never_exposes_signing_secret():
         signing_secret="plaintext-secret",
         actor_id="admin-1",
     )
+
+
+@pytest.mark.asyncio
+async def test_create_logs_audit_event_without_secret_material():
+    """#1339: create emits a structlog audit event (actor + non-secret fields
+    only) after commit — secret plaintext/ciphertext never reaches a log."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+    identity = WorkerAppIdentity(
+        id=uuid4(),
+        platform="slack",
+        app_key="sales",
+        display_name="Sales app",
+        status="active",
+        active_secret_revision=1,
+        config_version=1,
+        created_at=datetime(2026, 7, 17),
+        updated_at=datetime(2026, 7, 17),
+    )
+    identity.active_signing_secret_encrypted = "ciphertext-material"
+
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.create_identity = AsyncMock(return_value=identity)
+        await create_worker_app(
+            WorkerAppCreateRequest(
+                platform="slack",
+                app_key="sales",
+                display_name="Sales app",
+                signing_secret="plaintext-secret",
+            ),
+            {"user_id": "admin-1"},
+            db,
+        )
+
+    mock_logger.info.assert_called_once()
+    event, kwargs = mock_logger.info.call_args.args[0], mock_logger.info.call_args.kwargs
+    assert event == "worker_app_created"
+    assert kwargs["requested_by"] == "admin-1"
+    assert kwargs["app_key"] == "sales"
+    assert kwargs["active_secret_revision"] == 1
+    _assert_no_secret_material(mock_logger, ["plaintext-secret", "ciphertext-material"])
+
+
+@pytest.mark.asyncio
+async def test_rotate_logs_audit_event_without_secret_material():
+    """#1339: rotate-secret emits an audit event carrying actor, revisions and
+    the retiring window — never the secret itself."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+    identity = WorkerAppIdentity(
+        id=uuid4(),
+        platform="slack",
+        app_key="sales",
+        display_name="Sales app",
+        status="active",
+        active_secret_revision=5,
+        retiring_secret_revision=4,
+        config_version=3,
+        created_at=datetime(2026, 7, 17),
+        updated_at=datetime(2026, 7, 17),
+    )
+
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.rotate_secret = AsyncMock(return_value=identity)
+        await rotate_worker_app_secret(
+            WorkerAppRotateSecretRequest(
+                signing_secret="rotated-plaintext", retiring_for_seconds=600
+            ),
+            "slack",
+            "sales",
+            {"user_id": "admin-2"},
+            db,
+        )
+
+    mock_logger.info.assert_called_once()
+    event, kwargs = mock_logger.info.call_args.args[0], mock_logger.info.call_args.kwargs
+    assert event == "worker_app_secret_rotated"
+    assert kwargs["requested_by"] == "admin-2"
+    assert kwargs["active_secret_revision"] == 5
+    assert kwargs["retiring_secret_revision"] == 4
+    assert kwargs["retiring_for_seconds"] == 600
+    _assert_no_secret_material(mock_logger, ["rotated-plaintext"])
+
+
+@pytest.mark.asyncio
+async def test_rotate_failure_logs_cause_with_exc_info():
+    """#1339: an unexpected failure is mapped to the fixed-message
+    WorkerAppOperationError for the client, but the server log captures the
+    underlying cause via exc_info (with actor/app context, no secret)."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.rotate_secret = AsyncMock(
+            side_effect=RuntimeError("encryption backend unavailable")
+        )
+        with pytest.raises(WorkerAppOperationError):
+            await rotate_worker_app_secret(
+                WorkerAppRotateSecretRequest(signing_secret="rotated-plaintext"),
+                "slack",
+                "sales",
+                {"user_id": "admin-2"},
+                db,
+            )
+
+    mock_logger.error.assert_called_once()
+    event, kwargs = mock_logger.error.call_args.args[0], mock_logger.error.call_args.kwargs
+    assert event == "worker_app_rotate_failed"
+    assert kwargs["requested_by"] == "admin-2"
+    assert kwargs["app_key"] == "sales"
+    assert kwargs["exc_info"] is True
+    _assert_no_secret_material(mock_logger, ["rotated-plaintext"])
+    db.rollback.assert_awaited_once()


### PR DESCRIPTION
## Summary

Closes #1339 — the two info-severity observability follow-ups from the PR #1337 adversarial review.

**Audit trail.** `POST /admin/worker-apps`, `PATCH .../{platform}/{app_key}`, and `POST .../rotate-secret` now emit structlog events after commit, following the `system_admins.py` convention: `worker_app_created` / `worker_app_updated` / `worker_app_secret_rotated` with `requested_by`, platform, app_key, status, secret revision(s), and the retiring window. Non-secret fields only — plaintext and ciphertext never reach a log call, pinned by test.

**Failure diagnostics.** The unexpected-exception arms now log `worker_app_*_failed` with `exc_info=True` (plus actor/app context) before mapping to the fixed-message `WorkerAppOperationError` — previously the chained cause was swallowed (the global handler logs only error_code/message/status/path), making a failed production rotation undiagnosable. Tracebacks carry no secret material; request bodies are not in the trace context.

Scoped deliberately to the worker_apps routes — the global `memory_cloud_exception_handler` is untouched.

## Testing

- `tests/api/test_worker_apps.py`: 4 tests — audit-event emission for create and rotate, exc_info failure diagnostics, and a `_assert_no_secret_material` sweep over every log call in each test.
- Full worker-related suites green locally (35 passed: test_workers, test_worker_apps, test_worker_app_identity, test_connector_provisioning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
