### PR TITLE
chore(workers): audit logging for app-identity secret lifecycle (#1339)

### DIFF
--- a/backend/src/api/routes/worker_apps.py
+++ b/backend/src/api/routes/worker_apps.py
@@ -1,4 +1,13 @@
-"""System-admin lifecycle API for worker app identities (#1315)."""
+"""System-admin lifecycle API for worker app identities (#1315).
+
+Audit discipline (#1339): every lifecycle mutation (create / update /
+rotate-secret) emits a structlog success event AFTER commit with the actor
+and non-secret fields only, and the unexpected-exception arms log the
+underlying cause with ``exc_info=True`` before collapsing it into
+``WorkerAppOperationError`` (whose fixed message the generic handler logs
+without the chained cause). Secret material and ciphertext must never
+appear in any log call — pinned by tests/api/test_worker_apps.py.
+"""
 
 from __future__ import annotations
 
@@ -20,6 +29,9 @@ from services.worker_app_identity import (
     identity_revision,
 )
 from utils.exceptions import ConflictError, MemoryCloudException, WorkerAppOperationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/admin/worker-apps", tags=["admin-worker-apps"])
 
@@ -114,7 +126,29 @@ async def create_worker_app(
         raise ConflictError("Worker app identity already exists") from exc
     except Exception as exc:
         await db.rollback()
+        # #1339: the generic exception handler logs only the fixed
+        # WorkerAppOperationError message — capture the real cause here or a
+        # failed lifecycle write is undiagnosable. Tracebacks carry no
+        # request body, so no secret material reaches the log.
+        logger.error(
+            "worker_app_operation_failed",
+            operation="create",
+            actor=admin["user_id"],
+            platform=request.platform,
+            app_key=request.app_key,
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         raise WorkerAppOperationError("create") from exc
+    # #1339: post-commit audit event — non-secret fields only.
+    logger.info(
+        "worker_app_created",
+        actor=admin["user_id"],
+        platform=identity.platform,
+        app_key=identity.app_key,
+        status=identity.status,
+        active_secret_revision=identity.active_secret_revision,
+    )
     return _admin_response(identity)
 
 
@@ -141,7 +175,25 @@ async def update_worker_app(
         raise
     except Exception as exc:
         await db.rollback()
+        logger.error(
+            "worker_app_operation_failed",
+            operation="update",
+            actor=admin["user_id"],
+            platform=platform,
+            app_key=app_key,
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         raise WorkerAppOperationError("update") from exc
+    logger.info(
+        "worker_app_updated",
+        actor=admin["user_id"],
+        platform=identity.platform,
+        app_key=identity.app_key,
+        status=identity.status,
+        # "provided", not "changed" — the route never sees the old value.
+        display_name_provided=request.display_name is not None,
+    )
     return _admin_response(identity)
 
 
@@ -168,5 +220,24 @@ async def rotate_worker_app_secret(
         raise
     except Exception as exc:
         await db.rollback()
+        logger.error(
+            "worker_app_operation_failed",
+            operation="rotate",
+            actor=admin["user_id"],
+            platform=platform,
+            app_key=app_key,
+            error_type=type(exc).__name__,
+            exc_info=True,
+        )
         raise WorkerAppOperationError("rotate") from exc
+    logger.info(
+        "worker_app_secret_rotated",
+        actor=admin["user_id"],
+        platform=identity.platform,
+        app_key=identity.app_key,
+        status=identity.status,
+        active_secret_revision=identity.active_secret_revision,
+        retiring_secret_revision=identity.retiring_secret_revision,
+        retiring_for_seconds=request.retiring_for_seconds,
+    )
     return _admin_response(identity)

--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -48,7 +48,14 @@ def setup_logger(log_level: str = "INFO", enable_colors: bool = True) -> None:
             )
         )
     else:
-        # JSON output for production
+        # JSON output for production. format_exc_info is load-bearing (#1339):
+        # without it, exc_info=True serializes as a bare boolean and the
+        # traceback is silently dropped — every exc_info caller (worker-app
+        # lifecycle failure arms, the unhandled-exception handler) would emit
+        # undiagnosable errors in production. The ConsoleRenderer branch above
+        # renders exceptions itself and must NOT get this processor (structlog
+        # docs: ConsoleRenderer + format_exc_info double-render).
+        processors.append(structlog.processors.format_exc_info)
         processors.append(structlog.processors.JSONRenderer())
 
     structlog.configure(

--- a/backend/tests/api/test_worker_apps.py
+++ b/backend/tests/api/test_worker_apps.py
@@ -53,3 +53,187 @@ async def test_admin_create_response_never_exposes_signing_secret():
         signing_secret="plaintext-secret",
         actor_id="admin-1",
     )
+
+
+# ---------------------------------------------------------------------------
+# #1339: audit logging + failure diagnostics for the secret lifecycle.
+# ---------------------------------------------------------------------------
+
+SECRET = "plaintext-secret"  # noqa: S105 — test fixture value
+CIPHERTEXT = "ciphertext"
+
+
+def _db():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+def _identity(**overrides) -> WorkerAppIdentity:
+    identity = WorkerAppIdentity(
+        id=uuid4(),
+        platform="slack",
+        app_key="sales",
+        display_name="Sales app",
+        status="active",
+        active_secret_revision=2,
+        retiring_secret_revision=1,
+        config_version=3,
+        created_at=datetime(2026, 7, 17),
+        updated_at=datetime(2026, 7, 17),
+    )
+    identity.active_signing_secret_encrypted = CIPHERTEXT
+    for key, value in overrides.items():
+        setattr(identity, key, value)
+    return identity
+
+
+def _assert_no_secret_material(mock_logger):
+    """AC: no secret material or ciphertext in ANY log call."""
+    for call in mock_logger.mock_calls:
+        rendered = repr(call)
+        assert SECRET not in rendered
+        assert CIPHERTEXT not in rendered
+
+
+async def _create(db):
+    from api.routes.worker_apps import create_worker_app
+
+    return await create_worker_app(
+        WorkerAppCreateRequest(
+            platform="slack",
+            app_key="sales",
+            display_name="Sales app",
+            signing_secret=SECRET,
+        ),
+        {"user_id": "admin-1"},
+        db,
+    )
+
+
+async def _update(db):
+    from api.routes.worker_apps import WorkerAppUpdateRequest, update_worker_app
+
+    return await update_worker_app(
+        WorkerAppUpdateRequest(status="disabled"),
+        "slack",
+        "sales",
+        {"user_id": "admin-1"},
+        db,
+    )
+
+
+async def _rotate(db):
+    from api.routes.worker_apps import (
+        WorkerAppRotateSecretRequest,
+        rotate_worker_app_secret,
+    )
+
+    return await rotate_worker_app_secret(
+        WorkerAppRotateSecretRequest(signing_secret=SECRET, retiring_for_seconds=1800),
+        "slack",
+        "sales",
+        {"user_id": "admin-1"},
+        db,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("call", "service_method", "event"),
+    [
+        (_create, "create_identity", "worker_app_created"),
+        (_update, "update_identity", "worker_app_updated"),
+        (_rotate, "rotate_secret", "worker_app_secret_rotated"),
+    ],
+)
+async def test_lifecycle_success_emits_audit_event_without_secret(call, service_method, event):
+    db = _db()
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        setattr(service_cls.return_value, service_method, AsyncMock(return_value=_identity()))
+        await call(db)
+
+    events = [c for c in mock_logger.info.call_args_list if c.args and c.args[0] == event]
+    assert len(events) == 1, f"expected one '{event}' success event"
+    fields = events[0].kwargs
+    assert fields["actor"] == "admin-1"
+    assert fields["platform"] == "slack"
+    assert fields["app_key"] == "sales"
+    _assert_no_secret_material(mock_logger)
+
+
+@pytest.mark.asyncio
+async def test_rotate_success_event_carries_revisions_and_window():
+    db = _db()
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.rotate_secret = AsyncMock(return_value=_identity())
+        await _rotate(db)
+
+    fields = mock_logger.info.call_args.kwargs
+    assert fields["active_secret_revision"] == 2
+    assert fields["retiring_secret_revision"] == 1
+    assert fields["retiring_for_seconds"] == 1800
+    _assert_no_secret_material(mock_logger)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("call", "service_method", "operation"),
+    [
+        (_create, "create_identity", "create"),
+        (_update, "update_identity", "update"),
+        (_rotate, "rotate_secret", "rotate"),
+    ],
+)
+async def test_unexpected_failure_logs_cause_with_exc_info(call, service_method, operation):
+    from utils.exceptions import WorkerAppOperationError
+
+    db = _db()
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        setattr(
+            service_cls.return_value,
+            service_method,
+            AsyncMock(side_effect=RuntimeError("db exploded")),
+        )
+        with pytest.raises(WorkerAppOperationError):
+            await call(db)
+
+    assert mock_logger.error.call_count == 1
+    kwargs = mock_logger.error.call_args.kwargs
+    assert kwargs.get("exc_info") is True
+    assert kwargs["actor"] == "admin-1"
+    assert kwargs["platform"] == "slack"
+    assert kwargs["app_key"] == "sales"
+    assert kwargs["operation"] == operation
+    _assert_no_secret_material(mock_logger)
+
+
+@pytest.mark.asyncio
+async def test_expected_domain_errors_do_not_log_exc_info():
+    # ConflictError / MemoryCloudException arms re-raise untouched — the
+    # exc_info diagnostics are for the UNEXPECTED arm only.
+    from utils.exceptions import ConflictError
+
+    db = _db()
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.create_identity = AsyncMock(
+            side_effect=ConflictError("already exists")
+        )
+        with pytest.raises(ConflictError):
+            await _create(db)
+
+    mock_logger.error.assert_not_called()

--- a/backend/tests/utils/test_logger_exc_info.py
+++ b/backend/tests/utils/test_logger_exc_info.py
@@ -1,0 +1,33 @@
+"""Pin the production (JSON) log path's exception rendering (#1339).
+
+Without ``format_exc_info`` ahead of the JSONRenderer, ``exc_info=True``
+serializes as a bare boolean and the traceback is silently dropped — the
+failure-diagnostics contract of the worker-app lifecycle arms (and every
+other ``exc_info`` caller) would be void in production. The console branch
+renders exceptions itself and must NOT get the processor (double-render).
+"""
+
+from unittest.mock import patch
+
+import structlog
+
+from utils.logger import setup_logger
+
+
+def _captured_processors(enable_colors: bool):
+    with patch.object(structlog, "configure") as configure:
+        setup_logger(enable_colors=enable_colors)
+    return configure.call_args.kwargs["processors"]
+
+
+def test_json_path_renders_exc_info():
+    processors = _captured_processors(enable_colors=False)
+    assert structlog.processors.format_exc_info in processors
+    # Must run BEFORE the renderer or the rendered field never materializes.
+    assert processors.index(structlog.processors.format_exc_info) < len(processors) - 1
+    assert isinstance(processors[-1], type(structlog.processors.JSONRenderer()))
+
+
+def test_console_path_has_no_format_exc_info():
+    processors = _captured_processors(enable_colors=True)
+    assert structlog.processors.format_exc_info not in processors

--- a/backend/tests/utils/test_logger_exc_info.py
+++ b/backend/tests/utils/test_logger_exc_info.py
@@ -14,20 +14,24 @@ import structlog
 from utils.logger import setup_logger
 
 
-def _captured_processors(enable_colors: bool):
+def _captured_processors(enable_colors: bool, monkeypatch):
+    # setup_logger's branch is ALSO gated by LOG_COLORIZE — pin it per
+    # branch so the test is deterministic regardless of the environment
+    # (CI commonly sets LOG_COLORIZE=false).
+    monkeypatch.setenv("LOG_COLORIZE", "true" if enable_colors else "false")
     with patch.object(structlog, "configure") as configure:
         setup_logger(enable_colors=enable_colors)
     return configure.call_args.kwargs["processors"]
 
 
-def test_json_path_renders_exc_info():
-    processors = _captured_processors(enable_colors=False)
+def test_json_path_renders_exc_info(monkeypatch):
+    processors = _captured_processors(False, monkeypatch)
     assert structlog.processors.format_exc_info in processors
     # Must run BEFORE the renderer or the rendered field never materializes.
     assert processors.index(structlog.processors.format_exc_info) < len(processors) - 1
     assert isinstance(processors[-1], type(structlog.processors.JSONRenderer()))
 
 
-def test_console_path_has_no_format_exc_info():
-    processors = _captured_processors(enable_colors=True)
+def test_console_path_has_no_format_exc_info(monkeypatch):
+    processors = _captured_processors(True, monkeypatch)
     assert structlog.processors.format_exc_info not in processors


### PR DESCRIPTION
Closes #1339

## Summary

The two deferred info-severity findings from the #1315 adversarial review: worker app-identity secret-lifecycle mutations were invisible in server logs, on success and on failure.

## Changes

- **Audit events** (post-commit, non-secret fields only): `worker_app_created` / `worker_app_updated` / `worker_app_secret_rotated` with actor, platform, app_key, status, secret revision(s), and retiring window. Secret material / ciphertext never reach any log call — pinned across every `mock_call` in the tests.
- **Failure diagnostics**: the unexpected-exception arms log the underlying cause with `exc_info=True` + actor/platform/app_key/operation/`error_type` before collapsing into `WorkerAppOperationError` (whose fixed message is all the generic handler records). Expected domain errors (`ConflictError` / `MemoryCloudException`) stay log-free by design (pinned).
- **Review finding fixed**: the production JSON log path silently dropped `exc_info` — `utils/logger.py`'s processor chain had no `format_exc_info`, so a bare boolean reached `JSONRenderer` and tracebacks vanished (voiding this change's diagnostics AND the existing unhandled-exception handler's). Added `structlog.processors.format_exc_info` to the JSON branch only (the console renderer formats exceptions itself — adding it there would double-render); pinned by `tests/utils/test_logger_exc_info.py`. Verified the dev traceback formatter renders traceback text without frame locals, so no secret can ride a trace.

## Test plan

- 9 new tests: success-event emission per operation (fields + no-secret sweep), rotate revisions/window fields, `exc_info` failure arms per operation, expected-domain-errors-stay-silent, JSON/console processor-chain pins.
- `make lint` clean; worker-app suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
