### PR TITLE
chore(workers): add revision context to worker_app_updated event (#1339)

### DIFF
--- a/backend/src/api/routes/worker_apps.py
+++ b/backend/src/api/routes/worker_apps.py
@@ -28,6 +28,7 @@ from services.worker_app_identity import (
     WorkerAppIdentityService,
     identity_revision,
 )
+from utils.datetime import to_utc_iso
 from utils.exceptions import ConflictError, MemoryCloudException, WorkerAppOperationError
 from utils.logger import get_logger
 
@@ -194,10 +195,11 @@ async def update_worker_app(
         # "provided", not "changed" — the route never sees the old value.
         display_name_provided=request.display_name is not None,
         # Revision context so an enable/disable can be correlated with the
-        # secret material that was active/retiring at that moment.
+        # secret material that was active/retiring at that moment. Serialized
+        # to a string — a raw datetime would break the JSON log renderer.
         active_secret_revision=identity.active_secret_revision,
         retiring_secret_revision=identity.retiring_secret_revision,
-        retiring_valid_until=identity.retiring_valid_until,
+        retiring_valid_until=to_utc_iso(identity.retiring_valid_until),
     )
     return _admin_response(identity)
 

--- a/backend/src/api/routes/worker_apps.py
+++ b/backend/src/api/routes/worker_apps.py
@@ -193,6 +193,11 @@ async def update_worker_app(
         status=identity.status,
         # "provided", not "changed" — the route never sees the old value.
         display_name_provided=request.display_name is not None,
+        # Revision context so an enable/disable can be correlated with the
+        # secret material that was active/retiring at that moment.
+        active_secret_revision=identity.active_secret_revision,
+        retiring_secret_revision=identity.retiring_secret_revision,
+        retiring_valid_until=identity.retiring_valid_until,
     )
     return _admin_response(identity)
 

--- a/backend/tests/api/test_worker_apps.py
+++ b/backend/tests/api/test_worker_apps.py
@@ -177,15 +177,23 @@ async def test_update_success_event_carries_revision_context():
         patch("api.routes.worker_apps.logger") as mock_logger,
     ):
         service_cls.return_value.update_identity = AsyncMock(
-            return_value=_identity(status="disabled")
+            return_value=_identity(
+                status="disabled",
+                retiring_valid_until=datetime(2026, 7, 17, 12, 0, 0),
+            )
         )
         await _update(db)
 
-    fields = mock_logger.info.call_args.kwargs
+    events = [
+        c for c in mock_logger.info.call_args_list if c.args and c.args[0] == "worker_app_updated"
+    ]
+    assert len(events) == 1, "expected one 'worker_app_updated' success event"
+    fields = events[0].kwargs
     assert fields["status"] == "disabled"
     assert fields["active_secret_revision"] == 2
     assert fields["retiring_secret_revision"] == 1
-    assert "retiring_valid_until" in fields
+    # Serialized for the JSON log renderer — never a raw datetime.
+    assert fields["retiring_valid_until"] == "2026-07-17T12:00:00Z"
     _assert_no_secret_material(mock_logger)
 
 

--- a/backend/tests/api/test_worker_apps.py
+++ b/backend/tests/api/test_worker_apps.py
@@ -168,6 +168,28 @@ async def test_lifecycle_success_emits_audit_event_without_secret(call, service_
 
 
 @pytest.mark.asyncio
+async def test_update_success_event_carries_revision_context():
+    """A status flip (enable/disable) must be correlatable with the secret
+    material active/retiring at that moment (Copilot on PR #1340/#1342)."""
+    db = _db()
+    with (
+        patch("api.routes.worker_apps.WorkerAppIdentityService") as service_cls,
+        patch("api.routes.worker_apps.logger") as mock_logger,
+    ):
+        service_cls.return_value.update_identity = AsyncMock(
+            return_value=_identity(status="disabled")
+        )
+        await _update(db)
+
+    fields = mock_logger.info.call_args.kwargs
+    assert fields["status"] == "disabled"
+    assert fields["active_secret_revision"] == 2
+    assert fields["retiring_secret_revision"] == 1
+    assert "retiring_valid_until" in fields
+    _assert_no_secret_material(mock_logger)
+
+
+@pytest.mark.asyncio
 async def test_rotate_success_event_carries_revisions_and_window():
     db = _db()
     with (


### PR DESCRIPTION
## Summary

Follow-up to #1342 (and #1339). Carries over the one improvement from the superseded PR #1340 that the merged implementation lacks — Copilot flagged it on both PRs: `worker_app_updated` carried no secret-revision context, so an enable/disable could not be correlated with the material that was active/retiring at that moment.

- `worker_app_updated` now logs `active_secret_revision`, `retiring_secret_revision`, and `retiring_valid_until` (non-secret fields, consistent with `worker_app_secret_rotated`)
- New disable-path test pins the fields and runs the existing no-secret-material sweep

## Testing

- `tests/api/test_worker_apps.py` + `tests/utils/test_logger_exc_info.py`: 12 passed locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
