### PR TITLE
fix(db): accept exponent coordinates in e69 location guard (#1344)

### DIFF
--- a/backend/alembic/versions/e69_1331_location_cols.py
+++ b/backend/alembic/versions/e69_1331_location_cols.py
@@ -5,9 +5,14 @@ columns' TEXT trick (::timestamp is only STABLE), ``::double precision`` is
 IMMUTABLE, so these are real numeric STORED generated columns. The regex
 guard NULLs malformed details.location values instead of failing the INSERT
 (raw-SQL defense); MemoryService._apply_location's normalize_location is the
-writer-side contract (validation + 7-decimal fixed-point write-back) and
-JSONB renders numerics via ``numeric`` (never exponent notation), so
-well-formed writes always match the guard.
+writer-side contract (validation + 7-decimal fixed-point write-back).
+
+``memories.details`` is PostgreSQL json (NOT jsonb) — inserted text is
+stored VERBATIM, so numerics reach ``->>`` exactly as the writer serialized
+them. The app path (json.dumps) renders 0 < |value| < 1e-4 in exponent
+notation (``5e-05``), so the guard accepts exponent forms (#1344); the
+2-digit exponent cap keeps every accepted lexeme castable without
+double-precision overflow ("malformed -> NULL, never error").
 
 NOTE: adding STORED generated columns rewrites the table — check the prod
 ``memories`` row count before applying (e30_877 was the same shape and
@@ -30,7 +35,7 @@ def upgrade() -> None:
         r"""
         ALTER TABLE memories
         ADD COLUMN location_lat DOUBLE PRECISION
-        GENERATED ALWAYS AS (CASE WHEN details->'location'->>'lat' ~ '^-?[0-9]+(\.[0-9]+)?$'
+        GENERATED ALWAYS AS (CASE WHEN details->'location'->>'lat' ~ '^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]{1,2})?$'
         THEN (details->'location'->>'lat')::double precision ELSE NULL END) STORED
         """
     )
@@ -38,7 +43,7 @@ def upgrade() -> None:
         r"""
         ALTER TABLE memories
         ADD COLUMN location_lon DOUBLE PRECISION
-        GENERATED ALWAYS AS (CASE WHEN details->'location'->>'lon' ~ '^-?[0-9]+(\.[0-9]+)?$'
+        GENERATED ALWAYS AS (CASE WHEN details->'location'->>'lon' ~ '^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]{1,2})?$'
         THEN (details->'location'->>'lon')::double precision ELSE NULL END) STORED
         """
     )

--- a/backend/alembic/versions/e69_1331_location_cols.py
+++ b/backend/alembic/versions/e69_1331_location_cols.py
@@ -10,9 +10,12 @@ writer-side contract (validation + 7-decimal fixed-point write-back).
 ``memories.details`` is PostgreSQL json (NOT jsonb) — inserted text is
 stored VERBATIM, so numerics reach ``->>`` exactly as the writer serialized
 them. The app path (json.dumps) renders 0 < |value| < 1e-4 in exponent
-notation (``5e-05``), so the guard accepts exponent forms (#1344); the
-2-digit exponent cap keeps every accepted lexeme castable without
-double-precision overflow ("malformed -> NULL, never error").
+notation (``5e-05``), so the guard accepts exponent forms (#1344). The
+2-digit exponent cap rejects the exponent-driven extremes: ``1e309`` would
+error at the ``::double precision`` cast (breaking "malformed -> NULL,
+never error") and ``1e123`` would cast and then abort the INSERT on the
+range CHECK. (A 300+-digit plain-decimal lexeme can still error at the
+cast — raw-SQL-only and unchanged from pre-#1344.)
 
 NOTE: adding STORED generated columns rewrites the table — check the prod
 ``memories`` row count before applying (e30_877 was the same shape and

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -315,9 +315,12 @@ class Memory(Base):
     # (NOT jsonb) — inserted text is stored VERBATIM, and the app write path
     # (json.dumps) renders 0 < |value| < 1e-4 in exponent notation
     # (``5e-05``), so the guard must accept exponent forms too (#1344). The
-    # exponent is capped at 2 digits so every accepted lexeme casts without
-    # double-precision overflow, preserving the "malformed -> NULL, never
-    # error" contract. Partial btree (location_lat, location_lon) WHERE
+    # 2-digit exponent cap rejects the exponent-driven extremes: ``1e309``
+    # would error at the ``::double precision`` cast (breaking the
+    # "malformed -> NULL, never error" contract) and ``1e123`` would cast
+    # and then abort the INSERT on the range CHECK. (A 300+-digit
+    # plain-decimal lexeme can still error at the cast — raw-SQL-only and
+    # unchanged from pre-#1344.) Partial btree (location_lat, location_lon) WHERE
     # location_lat IS NOT NULL AND deleted_at IS NULL is created in migration
     # e69_1331_location_cols.
     location_lat: Mapped[float | None] = mapped_column(

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -311,15 +311,20 @@ class Memory(Base):
     # MemoryService._apply_location on every write path). Unlike the time
     # axis' TEXT trick, ``::double precision`` is IMMUTABLE, so these are real
     # numeric columns. The regex guard NULLs malformed values instead of
-    # failing the INSERT (raw-SQL defense); JSONB renders numerics via
-    # ``numeric`` (never exponent notation), so writer-normalized values
-    # always match. Partial btree (location_lat, location_lon) WHERE
+    # failing the INSERT (raw-SQL defense). ``details`` is PostgreSQL json
+    # (NOT jsonb) — inserted text is stored VERBATIM, and the app write path
+    # (json.dumps) renders 0 < |value| < 1e-4 in exponent notation
+    # (``5e-05``), so the guard must accept exponent forms too (#1344). The
+    # exponent is capped at 2 digits so every accepted lexeme casts without
+    # double-precision overflow, preserving the "malformed -> NULL, never
+    # error" contract. Partial btree (location_lat, location_lon) WHERE
     # location_lat IS NOT NULL AND deleted_at IS NULL is created in migration
     # e69_1331_location_cols.
     location_lat: Mapped[float | None] = mapped_column(
         Double,
         Computed(
-            r"CASE WHEN details->'location'->>'lat' ~ '^-?[0-9]+(\.[0-9]+)?$' "
+            r"CASE WHEN details->'location'->>'lat' ~ "
+            r"'^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]{1,2})?$' "
             "THEN (details->'location'->>'lat')::double precision ELSE NULL END",
             persisted=True,
         ),
@@ -328,7 +333,8 @@ class Memory(Base):
     location_lon: Mapped[float | None] = mapped_column(
         Double,
         Computed(
-            r"CASE WHEN details->'location'->>'lon' ~ '^-?[0-9]+(\.[0-9]+)?$' "
+            r"CASE WHEN details->'location'->>'lon' ~ "
+            r"'^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]{1,2})?$' "
             "THEN (details->'location'->>'lon')::double precision ELSE NULL END",
             persisted=True,
         ),

--- a/backend/tests/integration/test_location_cols_migration.py
+++ b/backend/tests/integration/test_location_cols_migration.py
@@ -5,9 +5,9 @@ including the regex guard's malformed-value → NULL behavior and the
 valid_location_range CHECK (raw-SQL defense).
 
 Two insert paths on purpose (#1344): ``memories.details`` is PostgreSQL json
-(NOT jsonb), which stores inserted text VERBATIM. ``CAST(:d AS JSON)``
+(NOT jsonb), which stores inserted text VERBATIM. ``CAST(:details AS JSON)``
 reproduces the app write path (json.dumps text lands unchanged — exponent
-notation included), while ``CAST(:d AS JSONB)`` canonicalizes numerics
+notation included), while ``CAST(:details AS JSONB)`` canonicalizes numerics
 before the json assignment and models raw-SQL writers that round-trip
 through jsonb. The guard must behave on BOTH.
 """
@@ -149,17 +149,20 @@ async def test_exponent_notation_survives_json_verbatim_storage(db_session):
 
 @pytest.mark.asyncio
 async def test_exponent_cap_nulls_absurd_exponents_instead_of_erroring(db_session):
-    # The 2-digit exponent cap keeps every regex-accepted lexeme castable:
-    # a 3+-digit exponent ("1e123") would overflow double precision at cast
-    # time, so the guard must classify it as malformed → NULL, never error.
-    mem_id = await _insert(
-        db_session,
-        '{"location": {"lat": 1e123, "lon": 5.0}}',
-        verbatim=True,
-    )
-    row = await _cols(db_session, mem_id)
-    assert row.location_lat is None
-    assert row.location_lon == pytest.approx(5.0)
+    # The 2-digit exponent cap classifies 3+-digit exponents as malformed →
+    # NULL. Without the cap, "1e309" would raise an out-of-range error at the
+    # ::double precision cast (breaking "malformed → NULL, never error"),
+    # and "1e123" — within double range but absurd as a coordinate — would
+    # cast and then abort the INSERT on the range CHECK instead of NULLing.
+    for lexeme in ("1e123", "1e309"):
+        mem_id = await _insert(
+            db_session,
+            f'{{"location": {{"lat": {lexeme}, "lon": 5.0}}}}',
+            verbatim=True,
+        )
+        row = await _cols(db_session, mem_id)
+        assert row.location_lat is None, lexeme
+        assert row.location_lon == pytest.approx(5.0)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_location_cols_migration.py
+++ b/backend/tests/integration/test_location_cols_migration.py
@@ -3,6 +3,13 @@
 Mirrors test_time_trigger_migration.py: raw INSERT → generated-column SELECT,
 including the regex guard's malformed-value → NULL behavior and the
 valid_location_range CHECK (raw-SQL defense).
+
+Two insert paths on purpose (#1344): ``memories.details`` is PostgreSQL json
+(NOT jsonb), which stores inserted text VERBATIM. ``CAST(:d AS JSON)``
+reproduces the app write path (json.dumps text lands unchanged — exponent
+notation included), while ``CAST(:d AS JSONB)`` canonicalizes numerics
+before the json assignment and models raw-SQL writers that round-trip
+through jsonb. The guard must behave on BOTH.
 """
 
 import uuid
@@ -11,23 +18,30 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 
-_INSERT = text(
-    """
-    INSERT INTO memories
-      (id, user_id, summary, content, type, importance, confidence,
-       scope, embedding_status, client, source, long_term,
-       access_count, details)
-    VALUES
-      (:id, 'u1', 'geo row', 'geo row', 'note', 0.5, 1.0,
-       'working', 'success', 'test', 'mcp_remember', false, 0,
-       CAST(:details AS JSONB))
-    """
-)
+
+def _insert_stmt(cast: str):
+    return text(
+        f"""
+        INSERT INTO memories
+          (id, user_id, summary, content, type, importance, confidence,
+           scope, embedding_status, client, source, long_term,
+           access_count, details)
+        VALUES
+          (:id, 'u1', 'geo row', 'geo row', 'note', 0.5, 1.0,
+           'working', 'success', 'test', 'mcp_remember', false, 0,
+           CAST(:details AS {cast}))
+        """
+    )
 
 
-async def _insert(db_session, details_json: str) -> uuid.UUID:
+_INSERT = _insert_stmt("JSONB")
+_INSERT_VERBATIM = _insert_stmt("JSON")
+
+
+async def _insert(db_session, details_json: str, *, verbatim: bool = False) -> uuid.UUID:
     mem_id = uuid.uuid4()
-    await db_session.execute(_INSERT, {"id": mem_id, "details": details_json})
+    stmt = _INSERT_VERBATIM if verbatim else _INSERT
+    await db_session.execute(stmt, {"id": mem_id, "details": details_json})
     return mem_id
 
 
@@ -65,7 +79,7 @@ async def test_malformed_values_null_instead_of_failing_insert(db_session):
     for details in (
         '{"location": "Tokyo office"}',
         '{"location": {"lat": {"deep": 1}, "lon": []}}',
-        '{"location": {"lat": "one", "lon": "1e2"}}',
+        '{"location": {"lat": "one", "lon": "north"}}',
     ):
         mem_id = await _insert(db_session, details)
         row = await _cols(db_session, mem_id)
@@ -76,14 +90,15 @@ async def test_malformed_values_null_instead_of_failing_insert(db_session):
 @pytest.mark.asyncio
 async def test_numeric_looking_string_populates_via_raw_sql(db_session):
     # ``->>`` renders JSON strings and numbers identically, so a raw-SQL
-    # insert of {"lat": "35.6"} DOES populate the column (regex matches).
-    # The service-layer 422 (normalize_location rejects string numerics) is
-    # the real contract; this pins the raw-path behavior so nobody assumes
-    # the regex guard distinguishes the two.
-    mem_id = await _insert(db_session, '{"location": {"lat": "35.6", "lon": "139.7"}}')
+    # insert of {"lat": "35.6"} DOES populate the column (regex matches) —
+    # and since #1344 widened the guard, exponent-notation strings ("1e2")
+    # do too. The service-layer 422 (normalize_location rejects string
+    # numerics) is the real contract; this pins the raw-path behavior so
+    # nobody assumes the regex guard distinguishes the two.
+    mem_id = await _insert(db_session, '{"location": {"lat": "35.6", "lon": "1e2"}}')
     row = await _cols(db_session, mem_id)
     assert row.location_lat == pytest.approx(35.6)
-    assert row.location_lon == pytest.approx(139.7)
+    assert row.location_lon == pytest.approx(100.0)
 
 
 @pytest.mark.asyncio
@@ -95,16 +110,56 @@ async def test_negative_and_integer_coordinates_cast(db_session):
 
 
 @pytest.mark.asyncio
-async def test_tiny_coordinate_survives_jsonb_rendering(db_session):
-    # The regex guard's contract rests on JSONB rendering numerics via
-    # ``numeric`` (never exponent notation): a ~1e-7-scale coordinate — whose
-    # Python repr IS exponential — must still populate the column. If details
-    # ever migrates off JSONB or serialization changes, this pin catches the
-    # silent NULL-out.
+async def test_tiny_coordinate_survives_jsonb_canonicalization(db_session):
+    # jsonb round-trip path: CAST(... AS JSONB) canonicalizes 1e-7 to
+    # 0.0000001 before the json-column assignment, so the plain-decimal arm
+    # of the regex matches. Models raw-SQL writers that go through jsonb.
     mem_id = await _insert(db_session, '{"location": {"lat": 1e-7, "lon": -0.0000001}}')
     row = await _cols(db_session, mem_id)
     assert row.location_lat == pytest.approx(1e-7)
     assert row.location_lon == pytest.approx(-1e-7)
+
+
+@pytest.mark.asyncio
+async def test_exponent_notation_survives_json_verbatim_storage(db_session):
+    # #1344 regression pin — the APP path. details is json (not jsonb): the
+    # inserted text is stored verbatim, and json.dumps renders any
+    # 0 < |value| < 1e-4 coordinate in exponent notation ("5e-05"). The regex
+    # guard must accept it or the row silently vanishes from recall_nearby
+    # (write succeeds, generated column NULL). Pre-#1344 this pin fails with
+    # location_lon NULL.
+    mem_id = await _insert(
+        db_session,
+        '{"location": {"lat": 51.4779, "lon": 5e-05}}',
+        verbatim=True,
+    )
+    row = await _cols(db_session, mem_id)
+    assert row.location_lat == pytest.approx(51.4779)
+    assert row.location_lon == pytest.approx(5e-05)
+
+    mem_id = await _insert(
+        db_session,
+        '{"location": {"lat": 1e-07, "lon": -1.23e-05}}',
+        verbatim=True,
+    )
+    row = await _cols(db_session, mem_id)
+    assert row.location_lat == pytest.approx(1e-07)
+    assert row.location_lon == pytest.approx(-1.23e-05)
+
+
+@pytest.mark.asyncio
+async def test_exponent_cap_nulls_absurd_exponents_instead_of_erroring(db_session):
+    # The 2-digit exponent cap keeps every regex-accepted lexeme castable:
+    # a 3+-digit exponent ("1e123") would overflow double precision at cast
+    # time, so the guard must classify it as malformed → NULL, never error.
+    mem_id = await _insert(
+        db_session,
+        '{"location": {"lat": 1e123, "lon": 5.0}}',
+        verbatim=True,
+    )
+    row = await _cols(db_session, mem_id)
+    assert row.location_lat is None
+    assert row.location_lon == pytest.approx(5.0)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_recall_nearby_e2e.py
+++ b/backend/tests/integration/test_recall_nearby_e2e.py
@@ -251,3 +251,34 @@ async def test_nearby_applies_binding_row_filter(geo_env, db_session):
     # The troubleshooting-typed row is subtracted (#1299); notes remain.
     assert str(geo_env["timed"]) not in ids
     assert str(geo_env["near"]) in ids
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_nearby_finds_sub_1e4_coordinate_written_via_orm(geo_env, db_session):
+    # #1344: the ORM serializes details via json.dumps, which renders
+    # 0 < |value| < 1e-4 in exponent notation ("5e-05"); the json (not jsonb)
+    # column stores that text verbatim. The generated-column regex must accept
+    # it or a memory ~5 m off the prime meridian silently vanishes from
+    # recall_nearby while the write reports success.
+    greenwich = Memory(
+        id=uuid.uuid4(),
+        user_id=geo_env["uid"],
+        workspace_id=geo_env["ws_id"],
+        context_id=geo_env["ctx"],
+        summary="5m east of the prime meridian",
+        content="5m east of the prime meridian",
+        type="note",
+        client="test",
+        tags=[],
+        source_type=SOURCE_TYPE_MANUAL,
+        details={"location": {"lat": 51.4779, "lon": 0.00005}},
+    )
+    db_session.add(greenwich)
+    await db_session.flush()
+
+    results = await query_nearby_memories(
+        db_session, geo_env["ctx"], lat=51.4779, lon=0.0, radius_m=1000, k=10
+    )
+    hits = {r["memory_id"]: r for r in results}
+    assert str(greenwich.id) in hits
+    assert hits[str(greenwich.id)]["distance_m"] == pytest.approx(3.5, abs=1.5)

--- a/docs/design/2026-07-17-location-axis-design.md
+++ b/docs/design/2026-07-17-location-axis-design.md
@@ -49,7 +49,7 @@ details.location = {
   - lat/lon は int/float のみ受理。**bool を明示拒否**（`_require_int` の bool-is-int 罠の float 版）、**文字列数値も拒否**（MCP arg coercion は details 内部を再帰しないため、`"35.6"` を黙って通すと生成列 NULL → recall_nearby から不可視。早期 422 が正）
   - NaN / ±Inf 拒否、範囲検証
   - **未知キーは拒否**（許可キー: lat / lon / label / text。将来 accuracy_m / altitude 等はサーバ側バージョンアップで追加）
-  - 正規化時に **7桁固定小数へ丸めて書き戻し**（≈1cm 精度）— JSONB 数値の指数表記を排除し、生成列 regex ガードと書き手を契約で結ぶ
+  - 正規化時に **7桁固定小数へ丸めて書き戻し**（≈1cm 精度）。~~JSONB 数値の指数表記を排除し~~ **(#1344 訂正)** `memories.details` は json 型（jsonb ではない）で挿入テキストを逐語保存するため、`json.dumps` は `0 < |値| < 1e-4` を指数表記（`5e-05`）で出力し、丸めでは排除できない。生成列 regex ガード側が指数表記を受理する（下記 §5）
 - **ゲート**: `details` に `location` キーが存在する時のみ検証発火。非 dict（例: 既存データの `{"location": "Tokyo office"}` 文字列）や不正 shape は ValueError → 422。**実装前に prod の details に別 shape の location キーが存在しないかを確認する**（存在すれば移行判断を追加）
 - **正典は `details.location` のみ**。`context.location` は禁止（context JSONB は Qdrant payload に複製されるため座標が第2ストアへ漏れる）— ツール説明と docs に明記
 
@@ -58,11 +58,11 @@ details.location = {
 - 生成列（`models/memory.py` の resource_version パターン L264-271 を踏襲）:
   ```sql
   location_lat  DOUBLE PRECISION GENERATED ALWAYS AS (
-    CASE WHEN details->'location'->>'lat' ~ '^-?[0-9]+(\.[0-9]+)?$'
+    CASE WHEN details->'location'->>'lat' ~ '^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]{1,2})?$'
          THEN (details->'location'->>'lat')::double precision ELSE NULL END) STORED
   -- location_lon 同型
   ```
-  float キャストは IMMUTABLE のため本物の数値列が持てる（time 軸の TEXT 固定幅トリックは ::timestamp が STABLE だったための回避であり、ここでは不要）。regex ガードにより不正値は NULL 化し INSERT を落とさない（raw SQL 経路の防御）
+  float キャストは IMMUTABLE のため本物の数値列が持てる（time 軸の TEXT 固定幅トリックは ::timestamp が STABLE だったための回避であり、ここでは不要）。regex ガードにより不正値は NULL 化し INSERT を落とさない（raw SQL 経路の防御）。**指数表記の受理は #1344 で追加**（details は json 型・逐語保存のため app 経路の `5e-05` が届く）— exponent 2 桁上限で、regex を通った字句は必ず double precision に overflow なくキャストできる
 - 部分 btree: `idx_memories_location (location_lat, location_lon) WHERE location_lat IS NOT NULL AND deleted_at IS NULL` — **述語に tombstone 条件を含める**（`idx_memories_delivery_always` L398 と同型。time index L407 に無い改良で、述語漏れが seq scan として即可視化される）
 - CHECK `valid_location_range`: IS NOT NULL ガード付きで lat ∈ [-90,90] AND lon ∈ [-180,180]（CHECK は NULL で通過するため明示ガード必須 — e30_877 L44-63 の教訓）。ORM `__table_args__` と migration にバイト同一で記述（`test_schema_drift.py` / `test_create_all_vs_alembic_drift.py` が自動照合）
 - migration: `down_revision` は実装時点の head を確認（調査時点では `e67_1281_agent_ws`）。STORED 生成列追加はテーブル書換を伴う — **prod の memories 行数を事前確認**（e30_877 は同型で本番通過済み）


### PR DESCRIPTION
Closes #1344

## Problem
`memories.details` is PostgreSQL **json** (not jsonb) — inserted text is stored verbatim. The app write path (`json.dumps`) renders any `0 < |value| < 1e-4` coordinate in exponent notation (`5e-05`), which the e69 generated-column regex `^-?[0-9]+(\.[0-9]+)?$` rejected → `location_lat/lon` silently NULL → the write succeeds but `recall_nearby` never returns the row (a ~11 m band along the equator / prime meridian, e.g. Greenwich).

The existing pin test masked this by inserting through `CAST(:details AS JSONB)`, whose jsonb round-trip canonicalizes `1e-7` → `0.0000001` before the json-column assignment — a path the app never takes. The e69/model docstrings' "JSONB renders numerics via numeric" premise is false for this schema.

## Fix
- Widen the guard in **both** e69 and the model Computed (parity pinned by `test_create_all_vs_alembic_drift.py`, passing) to `^-?[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]{1,2})?$`. The 2-digit exponent cap keeps every accepted lexeme castable without double-precision overflow, preserving the "malformed → NULL, never error" contract.
- e69 edited **in place**: production has not applied it (v0.53.0 ships it today); local/CI DBs are rebuilt from scratch.
- Docstrings + design doc corrected to the json-verbatim reality.

## Tests (red→green verified)
- New `CAST(:details AS JSON)` app-fidelity insert path: `5e-05` / `1e-07` / `-1.23e-05` survive; `1e123` (3-digit exponent) NULLs instead of erroring.
- ORM-path e2e: memory 5 m east of the prime meridian written via the real serializer is found by `query_nearby_memories` at ~3.5 m.
- Both new pins **fail under the old regex** (verified against an old-regex DB) and pass with the fix.
- Full geo suite: 23 integration + 62 unit passed; lint & pyright clean (0 errors, identical to main).

## Prod evidence
- `information_schema`: prod `details` column type = `json`; rows with `details->'location'`: **0**; `memories`: 5,725 rows / 27 MB (e69 rewrite is trivial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDnEwGpK7semEzr42hushN