### PR TITLE
docs: recall_nearby in README + worker-apps admin reference (#1346)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@
 | **Neural Memory Graph** | Hebbian 学習がバックグラウンドで知識グラフを構築。`explore()` がそれを辿り偶発的発見を提供 |
 | **Agent Memory Substrate** | 単なる知識ストアを超えて — delivery mode (pin / 時刻トリガ)、サーバー署名の trust boundary、agent state レーン、retrieval feedback シグナル。自律エージェントのループに必要なプリミティブ群 |
 | **Agent Control Plane (preview)** | Workspace スコープの Agent Registry、減算的な context binding、agent-bound member key、ライフサイクル kill switch、1 呼出の session bootstrap。v0.49.0 で導入 |
-| **60 の MCP ツール** | Memory、Agent Substrate、Agent Control Plane、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
+| **61 の MCP ツール** | Memory、Agent Substrate、Agent Control Plane、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
 | **マルチプロバイダ** | 埋め込みに OpenAI かセルフホスト (Ollama、vLLM — ローカル・非公開・コストゼロ) |
 | **チーム対応** | Workspace、RBAC、context 分離、共有メモリ |
 | **Web UI** | Next.js ダッシュボード — context、検索設定、メンバー管理 |
@@ -294,14 +294,15 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP ツール
 
-13 カテゴリ・全 60 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
+13 カテゴリ・全 61 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
 
-### Memory (6)
+### Memory (7)
 
 | ツール | 説明 | 必要ロール |
 |--------|------|------------|
 | `remember` | 新規メモリ保存 (summary + content + type、任意で `delivery_mode`) | Member+ |
 | `recall` | Hybrid Search でメモリ検索 (`trust_tier` フィルタ対応) | Viewer+ |
+| `recall_nearby` | 決定論の WHERE 軸クエリ — `details.location` を持つメモリを指定地点から `radius_m` 以内・近い順に返す | Viewer+ |
 | `reference` | メモリの 3 層詳細取得 | Viewer+ |
 | `update_memory` | メモリ更新 / 外部 ID で upsert | Member+ |
 | `forget` | ソフト削除 (30 日保持) | Member+ |
@@ -336,7 +337,7 @@ v0.49.0 の control plane は既存の workspace RBAC を土台にする。Agent
 | `unbind_agent_context` | binding を削除 (enforce mode では default-deny) | Owner/Admin |
 | `get_agent_bootstrap` | session start 用に context guide + pinned + 任意の trusted recall + upcoming + state を合成 | Agent-bound key または Owner/Admin |
 
-> **Preview 境界:** memory type/source 単位の filter は schema 予約済みで、fail-closed として `null` のみ受け付ける。`traceparent` と W3C baggage による `agent_id` / `session_id` / `run_id` correlation は実装済みだが、server-side span export は P0 の対象外。`memory_access_events` は bootstrap、load-pinned、feedback、recall、reference、remember で稼働し、`update`/`forget` emission と deny/`would_deny` 永続化は [#1286](https://github.com/kagura-ai/memory-cloud/issues/1286) で継続する。
+> **Preview 境界:** memory type/source 単位の filter は enforce モードの agent に対し、メモリ読取レーン (recall、recall_nearby、reference、forget、explore、load_pinned、upcoming) で [#1299](https://github.com/kagura-ai/memory-cloud/issues/1299)、列挙/集計面 (list、stats、access-patterns、get_cluster) で [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301) から強制される — `null` = 全 type 許可、`[]` = deny-all。shadow モードはフィルタせず `would_deny` を記録する。`traceparent` と W3C baggage による `agent_id` / `session_id` / `run_id` correlation は実装済みだが、server-side span export は P0 の対象外。`memory_access_events` は bootstrap、load-pinned、feedback、recall、reference、remember、update、forget で稼働し、binding deny / `would_deny` を永続化する。
 
 ### Neural Edges (4)
 

--- a/README.md
+++ b/README.md
@@ -419,14 +419,15 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP Tools
 
-60 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+61 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
 
-### Memory (6)
+### Memory (7)
 
 | Tool | Description | Required Role |
 |------|------------|---------------|
 | `remember` | Store a new memory (summary + content + type; optional `delivery_mode`) | Member+ |
 | `recall` | Search memories with Hybrid Search (supports `trust_tier` filter) | Viewer+ |
+| `recall_nearby` | Deterministic WHERE-axis query — memories with `details.location` within `radius_m` of a point, nearest first | Viewer+ |
 | `reference` | Get full 3-layer details of a memory | Viewer+ |
 | `update_memory` | Update an existing memory in-place or upsert by external ID | Member+ |
 | `forget` | Soft-delete a memory (30-day retention) | Member+ |
@@ -461,7 +462,7 @@ The v0.49.0 control plane builds on existing workspace RBAC: agents are registry
 | `unbind_agent_context` | Remove a binding (default-deny in enforce mode) | Owner/Admin |
 | `get_agent_bootstrap` | Compose context guide + pinned + optional trusted recall + upcoming + state for session start | Agent-bound key or Owner/Admin |
 
-> **Preview boundary:** per-memory type/source filters are enforced on the memory-read lanes (recall, reference, forget, explore, load_pinned, upcoming) for enforce-mode agents as of [#1299](https://github.com/kagura-ai/memory-cloud/issues/1299) — `null` = all types, `[]` = deny-all; shadow mode records `would_deny` without filtering. `traceparent` plus W3C baggage correlation for `agent_id` / `session_id` / `run_id` is implemented, but server-side span export remains out of scope for P0. `memory_access_events` is live for bootstrap, load-pinned, feedback, recall, reference, remember, update, and forget with binding deny / `would_deny` persistence.
+> **Preview boundary:** per-memory type/source filters are enforced on the memory-read lanes (recall, recall_nearby, reference, forget, explore, load_pinned, upcoming) for enforce-mode agents as of [#1299](https://github.com/kagura-ai/memory-cloud/issues/1299) — and on the enumeration/aggregate surfaces (list, stats, access-patterns, get_cluster) as of [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301) — `null` = all types, `[]` = deny-all; shadow mode records `would_deny` without filtering. `traceparent` plus W3C baggage correlation for `agent_id` / `session_id` / `run_id` is implemented, but server-side span export remains out of scope for P0. `memory_access_events` is live for bootstrap, load-pinned, feedback, recall, reference, remember, update, and forget with binding deny / `would_deny` persistence.
 
 ### Neural Edges (4)
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
 | **Agent Memory Substrate** | Beyond a knowledge store: delivery modes (pinned / time-triggered), a server-stamped trust boundary, an agent state lane, and a retrieval-feedback signal — the primitives an autonomous agent loop needs. |
 | **Agent Control Plane (preview)** | Workspace-scoped Agent Registry, subtractive context bindings, agent-bound member keys, lifecycle kill switches, and one-call session bootstrap. Introduced in v0.49.0. |
-| **60 MCP Tools** | Memory, Agent Substrate, Agent Control Plane, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
+| **61 MCP Tools** | Memory, Agent Substrate, Agent Control Plane, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
 | **Multi-Provider** | OpenAI or self-hosted (Ollama, vLLM — local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1037,6 +1037,17 @@ See [Memory Health Report](ops/memory-health-report.md) for every metric and thr
 
 Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, reranker weights) are persisted in `neural_config` and exposed under `/api/v1/admin/neural-config`. The fields are editable from the admin UI's Neural Config page.
 
+### Worker App Identities
+
+System-admin (`role=admin`) lifecycle API for platform worker app identities (Slack / Discord / Teams bridge apps) — [#1315](https://github.com/kagura-ai/memory-cloud/issues/1315). Signing secrets are **write-only**: responses expose `has_active_secret` and revision metadata, never the secret or its ciphertext. Lifecycle mutations emit post-commit audit log events ([#1339](https://github.com/kagura-ai/memory-cloud/issues/1339)).
+
+| Endpoint                                                          | Purpose                                                       |
+|-------------------------------------------------------------------|---------------------------------------------------------------|
+| `GET /api/v1/admin/worker-apps`                                   | List identities with lifecycle metadata (`status`, `revision`, active/retiring secret revisions). |
+| `POST /api/v1/admin/worker-apps`                                  | Create an identity: `platform` (`slack`/`discord`/`teams`), `app_key`, `display_name`, `signing_secret`. |
+| `PATCH /api/v1/admin/worker-apps/{platform}/{app_key}`            | Update `display_name` and/or `status` (`active` / `disabled`); at least one field required. |
+| `POST /api/v1/admin/worker-apps/{platform}/{app_key}/rotate-secret` | Rotate the signing secret; the previous secret stays verifiable for `retiring_for_seconds` (default 3600). |
+
 ---
 
 ## MCP Tools


### PR DESCRIPTION
Closes #1346

Docs catch-up for the v0.53.0 surface, found during the pre-deploy final inspection:

- **README**: `recall_nearby` was missing from the MCP tool table — added (Memory 6 → 7, total 60 → 61; verified against the 61 unique tool names in `mcp_server/tools/_definitions.py`). The #1299 preview-boundary read-lane list now names `recall_nearby` (binding row filter applies, pinned by `test_recall_nearby_e2e.py::test_nearby_applies_binding_row_filter`) and the #1301 enumeration/aggregate surfaces.
- **docs/api-reference.md**: new **Worker App Identities** section under Admin APIs for the #1315 lifecycle endpoints (`GET`/`POST /admin/worker-apps`, `PATCH`, `rotate-secret`) — system-admin only (`require_admin` = `role=admin`), write-only secrets (`has_active_secret` + revisions in responses), #1339 audit events.

Docs-only; no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDnEwGpK7semEzr42hushN