### PR TITLE
feat(api): bbox geo filter + location on GET /memory/list (#1334)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -449,6 +449,14 @@ async def explore(
 # ============================================================================
 
 
+class MemoryListItemLocation(BaseModel):
+    """WHERE-axis coordinates of a list item (#1334), sourced from the
+    ``location_lat`` / ``location_lon`` generated columns."""
+
+    lat: float
+    lon: float
+
+
 class MemoryListItem(BaseModel):
     """Memory list item."""
 
@@ -459,6 +467,7 @@ class MemoryListItem(BaseModel):
     importance: float
     created_at: str
     updated_at: str
+    location: MemoryListItemLocation | None = None
 
 
 class MemoryListResponse(BaseModel):
@@ -595,6 +604,19 @@ async def list_memories(
         description="Time Memory (#877) window upper bound (naive ISO). Omit for "
         "an open-ended (future) window.",
     ),
+    lat_min: float | None = Query(
+        None,
+        ge=-90,
+        le=90,
+        description="WHERE-axis (#1334) bbox lower latitude bound (degrees). "
+        "Each bbox bound applies independently and only matches memories with "
+        "a location (generated columns from details.location). An "
+        "antimeridian-crossing box (lon_min > lon_max) is not supported and "
+        "yields an empty result.",
+    ),
+    lat_max: float | None = Query(None, ge=-90, le=90, description="Bbox upper latitude bound."),
+    lon_min: float | None = Query(None, ge=-180, le=180, description="Bbox lower longitude bound."),
+    lon_max: float | None = Query(None, ge=-180, le=180, description="Bbox upper longitude bound."),
     order_by: str = Query(
         "created_at",
         pattern="^(created_at|trigger_from)$",
@@ -761,6 +783,25 @@ async def list_memories(
         for wf in window_filters:
             query = query.where(wf)
 
+        # WHERE-axis bbox filter (#1334), built once and applied to BOTH
+        # queries (anti-drift, same rationale as tag_filter / window_filters).
+        # Each bound applies independently (time-axis mirror), so one-sided
+        # queries work; a range comparison is never true for NULL, so any geo
+        # bound naturally restricts results to memories that have a location.
+        # isinstance (not `is not None`) skips the unset Query() FieldInfo
+        # sentinel that direct-call unit tests pass.
+        geo_filters = []
+        if isinstance(lat_min, int | float):
+            geo_filters.append(Memory.location_lat >= lat_min)
+        if isinstance(lat_max, int | float):
+            geo_filters.append(Memory.location_lat <= lat_max)
+        if isinstance(lon_min, int | float):
+            geo_filters.append(Memory.location_lon >= lon_min)
+        if isinstance(lon_max, int | float):
+            geo_filters.append(Memory.location_lon <= lon_max)
+        for gf in geo_filters:
+            query = query.where(gf)
+
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.deleted_at.is_(None))
         if binding_predicate is not None:
@@ -779,6 +820,8 @@ async def list_memories(
             count_query = count_query.where(tag_filter)
         for wf in window_filters:
             count_query = count_query.where(wf)
+        for gf in geo_filters:
+            count_query = count_query.where(gf)
         count_result = await db.execute(count_query)
         total = count_result.scalar() or 0
 
@@ -799,6 +842,10 @@ async def list_memories(
         # fresh rows that haven't been touched since insert. The frontend
         # renders both as the row "updated" timestamp, so created_at is the
         # correct fallback rather than null/empty.
+        # ``location`` (#1334) surfaces the generated columns so the UI can
+        # plot pins. A half-populated pair (raw-SQL writer artifact where the
+        # e69 regex guard NULLed one coordinate) serializes as None rather
+        # than a partial point.
         memory_items = [
             MemoryListItem(
                 id=str(m.id),
@@ -808,6 +855,11 @@ async def list_memories(
                 importance=m.importance,
                 created_at=to_utc_iso(m.created_at) or "",
                 updated_at=to_utc_iso(m.updated_at or m.created_at) or "",
+                location=(
+                    MemoryListItemLocation(lat=m.location_lat, lon=m.location_lon)
+                    if m.location_lat is not None and m.location_lon is not None
+                    else None
+                ),
             )
             for m in memories
         ]

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -823,8 +823,10 @@ async def list_memories(
             # where the e69 regex guard NULLed one coordinate) would match a
             # one-sided bound yet serialize location=None below — require
             # both columns so filter and serialization semantics agree
-            # (mirrors services/geo_memory.py's explicit IS NOT NULL; also
-            # matches the partial index predicate exactly).
+            # (mirrors services/geo_memory.py's explicit IS NOT NULL; the
+            # explicit location_lat IS NOT NULL also keeps the query
+            # eligible for the partial index, whose predicate covers lat
+            # and deleted_at only).
             geo_filters.append(Memory.location_lat.is_not(None))
             geo_filters.append(Memory.location_lon.is_not(None))
         for gf in geo_filters:

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser
@@ -609,14 +609,24 @@ async def list_memories(
         ge=-90,
         le=90,
         description="WHERE-axis (#1334) bbox lower latitude bound (degrees). "
-        "Each bbox bound applies independently and only matches memories with "
-        "a location (generated columns from details.location). An "
-        "antimeridian-crossing box (lon_min > lon_max) is not supported and "
-        "yields an empty result.",
+        "Any bbox bound restricts results to memories with a complete "
+        "location (generated columns from details.location); bounds may be "
+        "one-sided.",
     ),
     lat_max: float | None = Query(None, ge=-90, le=90, description="Bbox upper latitude bound."),
-    lon_min: float | None = Query(None, ge=-180, le=180, description="Bbox lower longitude bound."),
-    lon_max: float | None = Query(None, ge=-180, le=180, description="Bbox upper longitude bound."),
+    lon_min: float | None = Query(
+        None,
+        ge=-180,
+        le=180,
+        description="Bbox lower longitude bound. lon_min > lon_max selects the "
+        "antimeridian-crossing (±180°) box: lon >= lon_min OR lon <= lon_max.",
+    ),
+    lon_max: float | None = Query(
+        None,
+        ge=-180,
+        le=180,
+        description="Bbox upper longitude bound (see lon_min for the antimeridian-crossing form).",
+    ),
     order_by: str = Query(
         "created_at",
         pattern="^(created_at|trigger_from)$",
@@ -785,20 +795,38 @@ async def list_memories(
 
         # WHERE-axis bbox filter (#1334), built once and applied to BOTH
         # queries (anti-drift, same rationale as tag_filter / window_filters).
-        # Each bound applies independently (time-axis mirror), so one-sided
-        # queries work; a range comparison is never true for NULL, so any geo
-        # bound naturally restricts results to memories that have a location.
-        # isinstance (not `is not None`) skips the unset Query() FieldInfo
-        # sentinel that direct-call unit tests pass.
+        # Bounds may be one-sided (time-axis mirror). isinstance (not
+        # `is not None`) skips the unset Query() FieldInfo sentinel that
+        # direct-call unit tests pass.
         geo_filters = []
         if isinstance(lat_min, int | float):
             geo_filters.append(Memory.location_lat >= lat_min)
         if isinstance(lat_max, int | float):
             geo_filters.append(Memory.location_lat <= lat_max)
-        if isinstance(lon_min, int | float):
-            geo_filters.append(Memory.location_lon >= lon_min)
-        if isinstance(lon_max, int | float):
-            geo_filters.append(Memory.location_lon <= lon_max)
+        lon_lo = lon_min if isinstance(lon_min, int | float) else None
+        lon_hi = lon_max if isinstance(lon_max, int | float) else None
+        if lon_lo is not None and lon_hi is not None and lon_lo > lon_hi:
+            # Antimeridian-crossing box (map viewport panned across ±180°):
+            # the wrapped range is the union of the two edge ranges, same
+            # two-ranges-ORed convention as utils.geo_location.bbox_lon_ranges
+            # (#1331). Without this branch the AND of the two bounds is
+            # unsatisfiable and a valid viewport silently returns empty.
+            geo_filters.append(or_(Memory.location_lon >= lon_lo, Memory.location_lon <= lon_hi))
+        else:
+            if lon_lo is not None:
+                geo_filters.append(Memory.location_lon >= lon_lo)
+            if lon_hi is not None:
+                geo_filters.append(Memory.location_lon <= lon_hi)
+        if geo_filters:
+            # Pair-completeness: a bbox-filtered result must contain only
+            # plottable rows. A half-populated pair (raw-SQL writer artifact
+            # where the e69 regex guard NULLed one coordinate) would match a
+            # one-sided bound yet serialize location=None below — require
+            # both columns so filter and serialization semantics agree
+            # (mirrors services/geo_memory.py's explicit IS NOT NULL; also
+            # matches the partial index predicate exactly).
+            geo_filters.append(Memory.location_lat.is_not(None))
+            geo_filters.append(Memory.location_lon.is_not(None))
         for gf in geo_filters:
             query = query.where(gf)
 

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -28,6 +28,10 @@ def _mock_memory_row():
     mem.importance = 0.8
     mem.created_at = datetime(2026, 4, 1)
     mem.updated_at = datetime(2026, 4, 2)
+    # Explicit None (a bare MagicMock attribute is truthy) so the #1334
+    # location serialization takes the no-location branch.
+    mem.location_lat = None
+    mem.location_lon = None
     return mem
 
 

--- a/backend/tests/api/test_memory_list_geo.py
+++ b/backend/tests/api/test_memory_list_geo.py
@@ -1,0 +1,166 @@
+"""Tests for the WHERE-axis bbox filter + location field on GET /memory/list (#1334).
+
+Follows the direct-call + mock-db + compiled-SQL-shape convention of
+test_memory_list.py / test_memory_list_time.py: the endpoint is unit-tested by
+inspecting the emitted SQL (WHERE predicates), not via an HTTP round-trip. The
+generated columns' actual population behavior against PostgreSQL is covered by
+tests/integration/test_location_cols_migration.py.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from api.routes.memory import list_memories
+
+MOCK_USER = {"user_id": "test_user_123"}
+
+
+def _mock_memory_row(lat: float | None = None, lon: float | None = None):
+    mem = MagicMock()
+    mem.id = uuid4()
+    mem.summary = "Test memory"
+    mem.type = "note"
+    mem.scope = "persistent"
+    mem.importance = 0.8
+    mem.created_at = datetime(2026, 4, 1)
+    mem.updated_at = datetime(2026, 4, 2)
+    mem.location_lat = lat
+    mem.location_lon = lon
+    return mem
+
+
+def _db_with_rows(total: int = 0, rows: list | None = None):
+    mock_db = AsyncMock()
+    count_result = MagicMock()
+    count_result.scalar.return_value = total
+    rows_result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = rows or []
+    rows_result.scalars.return_value = scalars
+    mock_db.execute.side_effect = [count_result, rows_result]
+    return mock_db
+
+
+def _where_sql(mock_db, call_index: int) -> str:
+    stmt = mock_db.execute.call_args_list[call_index].args[0]
+    return str(stmt.whereclause.compile(compile_kwargs={"literal_binds": False}))
+
+
+@pytest.mark.asyncio
+async def test_bbox_predicates_applied_to_both_queries():
+    """All four bbox bounds add range predicates on the generated columns to
+    BOTH the count and data queries (anti-drift: same rationale as tag_filter
+    and the time-axis window_filters)."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        lat_min=-10.0,
+        lat_max=10.0,
+        lon_min=100.0,
+        lon_max=120.0,
+        limit=50,
+        offset=0,
+    )
+    for call_index in (0, 1):  # 0 = count query, 1 = data query
+        sql = _where_sql(mock_db, call_index)
+        assert "memories.location_lat >=" in sql, sql
+        assert "memories.location_lat <=" in sql, sql
+        assert "memories.location_lon >=" in sql, sql
+        assert "memories.location_lon <=" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_one_sided_bound_applied_independently():
+    """Each bound applies independently (time-axis mirror): lat_min alone adds
+    only the lat lower-bound predicate — no lat upper bound, no lon bounds."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        lat_min=35.0,
+        limit=50,
+        offset=0,
+    )
+    for call_index in (0, 1):
+        sql = _where_sql(mock_db, call_index)
+        assert "memories.location_lat >=" in sql, sql
+        assert "memories.location_lat <=" not in sql, sql
+        assert "location_lon" not in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_no_geo_params_no_predicates():
+    """Without bbox params the queries carry no location predicate (backward
+    compatible — rows without location stay visible)."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        limit=50,
+        offset=0,
+    )
+    for call_index in (0, 1):
+        assert "location_" not in _where_sql(mock_db, call_index)
+
+
+@pytest.mark.asyncio
+async def test_location_included_in_response_items():
+    """Rows expose the generated columns as a nullable ``location`` object so
+    the UI can plot pins; rows without coordinates serialize location=None."""
+    located = _mock_memory_row(lat=35.6812345, lon=139.7671234)
+    bare = _mock_memory_row()
+    mock_db = _db_with_rows(total=2, rows=[located, bare])
+    response = await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        limit=50,
+        offset=0,
+    )
+    assert response.memories[0].location is not None
+    assert response.memories[0].location.lat == pytest.approx(35.6812345)
+    assert response.memories[0].location.lon == pytest.approx(139.7671234)
+    assert response.memories[1].location is None
+
+
+@pytest.mark.asyncio
+async def test_location_omitted_when_only_one_coordinate_present():
+    """A half-populated pair (raw-SQL writer artifact: one coordinate NULLed by
+    the e69 regex guard) must not serialize a partial location object."""
+    half = _mock_memory_row(lat=35.6812345, lon=None)
+    mock_db = _db_with_rows(total=1, rows=[half])
+    response = await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        limit=50,
+        offset=0,
+    )
+    assert response.memories[0].location is None

--- a/backend/tests/api/test_memory_list_geo.py
+++ b/backend/tests/api/test_memory_list_geo.py
@@ -81,7 +81,7 @@ async def test_bbox_predicates_applied_to_both_queries():
 @pytest.mark.asyncio
 async def test_one_sided_bound_applied_independently():
     """Each bound applies independently (time-axis mirror): lat_min alone adds
-    only the lat lower-bound predicate — no lat upper bound, no lon bounds."""
+    only the lat lower-bound predicate — no lat upper bound, no lon range."""
     mock_db = _db_with_rows()
     await list_memories(
         user=MOCK_USER,
@@ -99,7 +99,59 @@ async def test_one_sided_bound_applied_independently():
         sql = _where_sql(mock_db, call_index)
         assert "memories.location_lat >=" in sql, sql
         assert "memories.location_lat <=" not in sql, sql
-        assert "location_lon" not in sql, sql
+        assert "memories.location_lon >=" not in sql, sql
+        assert "memories.location_lon <=" not in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_any_geo_bound_requires_complete_coordinate_pair():
+    """Any active bbox bound also requires BOTH generated columns non-NULL, so
+    a half-populated pair (e69 regex-guard artifact) can never match a
+    one-sided bound while serializing location=None — filter and serialization
+    semantics must agree."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        lat_min=35.0,
+        limit=50,
+        offset=0,
+    )
+    for call_index in (0, 1):
+        sql = _where_sql(mock_db, call_index)
+        assert "memories.location_lat IS NOT NULL" in sql, sql
+        assert "memories.location_lon IS NOT NULL" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_antimeridian_crossing_box_emits_wrapped_or_range():
+    """lon_min > lon_max selects the ±180°-crossing box as an OR of the two
+    edge ranges (bbox_lon_ranges convention) instead of an unsatisfiable AND
+    that would silently return an empty result for a valid map viewport."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        lon_min=170.0,
+        lon_max=-170.0,
+        limit=50,
+        offset=0,
+    )
+    for call_index in (0, 1):
+        sql = _where_sql(mock_db, call_index)
+        assert "memories.location_lon >=" in sql, sql
+        assert "memories.location_lon <=" in sql, sql
+        assert " OR " in sql, sql
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -37,6 +37,15 @@ export interface ListMemoriesParams {
   tagsMatch?: "any" | "all";
   limit?: number;
   offset?: number;
+  /**
+   * #1334 WHERE-axis bbox filter (degrees). Bounds may be one-sided; any
+   * bound restricts results to memories with a complete location.
+   * lonMin > lonMax selects the antimeridian-crossing (±180°) box.
+   */
+  latMin?: number;
+  latMax?: number;
+  lonMin?: number;
+  lonMax?: number;
 }
 
 /**
@@ -64,6 +73,11 @@ export async function getMemories(
   // Only send tags_match when "all" — default "any" keeps the URL clean and
   // matches the backend default (#618 behavior preserved).
   if (params.tagsMatch === "all") searchParams.set("tags_match", "all");
+  // #1334 bbox bounds — `!= null` (not truthiness) so 0 stays a valid bound.
+  if (params.latMin != null) searchParams.set("lat_min", String(params.latMin));
+  if (params.latMax != null) searchParams.set("lat_max", String(params.latMax));
+  if (params.lonMin != null) searchParams.set("lon_min", String(params.lonMin));
+  if (params.lonMax != null) searchParams.set("lon_max", String(params.lonMax));
   searchParams.set("limit", String(params.limit ?? 50));
   searchParams.set("offset", String(params.offset ?? 0));
 

--- a/frontend/src/lib/types/memory.ts
+++ b/frontend/src/lib/types/memory.ts
@@ -31,7 +31,10 @@ export interface MemoryListItem {
   importance: number;
   created_at: string;
   updated_at: string;
-  location?: MemoryListItemLocation | null;
+  // Always present on the wire (FastAPI serializes null without
+  // response_model_exclude_none) — non-optional so the type matches the
+  // actual contract.
+  location: MemoryListItemLocation | null;
 }
 
 // Issue #440: a single declared_link reference surfaced in MemoryReference.

--- a/frontend/src/lib/types/memory.ts
+++ b/frontend/src/lib/types/memory.ts
@@ -12,7 +12,15 @@ export type MemoryScope = "working" | "persistent";
 export type MemoryType = string;
 export type KnownMemoryType = "normal" | "coding";
 
-// Exact mirror of backend `MemoryListItem` (routes/memory.py:324) — the row
+// WHERE-axis (#1334) coordinates of a list row. Mirror of backend
+// `MemoryListItemLocation` — present only when both generated columns
+// (location_lat/location_lon) are populated.
+export interface MemoryListItemLocation {
+  lat: number;
+  lon: number;
+}
+
+// Exact mirror of backend `MemoryListItem` (routes/memory.py) — the row
 // shape returned by the UUID-addressed `GET /api/v1/memory/list` endpoint.
 // `type` is `string` (not `KnownMemoryType`) to match the backend column.
 export interface MemoryListItem {
@@ -23,6 +31,7 @@ export interface MemoryListItem {
   importance: number;
   created_at: string;
   updated_at: string;
+  location?: MemoryListItemLocation | null;
 }
 
 // Issue #440: a single declared_link reference surfaced in MemoryReference.


### PR DESCRIPTION
Closes #1334

## Summary

WHERE-axis follow-up: `GET /api/v1/memory/list` gains bbox geo filter params (`lat_min`/`lat_max`/`lon_min`/`lon_max`) mirroring the time-axis `trigger_from`/`trigger_until` precedent, and `MemoryListItem` gains a nullable `location {lat, lon}` sourced from the e69 generated columns so the UI can plot pins.

- **Anti-drift**: geo predicates are built once and applied to BOTH the data and count queries (`tag_filter`/`window_filters` precedent).
- **Pair-completeness**: any active bbox bound also requires both `location_lat`/`location_lon` non-NULL — a half-populated pair (raw-SQL writer artifact where the e69 regex guard NULLed one coordinate) can never match a filter while serializing `location: null`. The predicate now matches the partial index (`location_lat IS NOT NULL AND deleted_at IS NULL`) verbatim.
- **Antimeridian**: `lon_min > lon_max` selects the ±180°-crossing box as `lon >= lon_min OR lon <= lon_max` (the `utils.geo_location.bbox_lon_ranges` two-ranges-ORed convention) instead of an unsatisfiable AND silently returning empty for a valid map viewport.
- **Bounds validation**: declarative `Query(ge/le)` (−90..90 / −180..180) → 422 on out-of-range.
- **Frontend mirrors**: `MemoryListItem.location` + `ListMemoriesParams` bbox params (`!= null` guards so 0° stays a valid bound). No UI surface yet — map view is deferred per the issue.

## Review

- Gate1 (design): green via /ask → CIO.
- /code-review (high effort, 8 angles / 4 finder agents): 2 CONFIRMED correctness findings (pair-completeness, antimeridian silent-empty) + frontend mirror gap — all fixed in the second commit. Deferred as follow-up: extracting the 3× duplicated direct-call test scaffolding (`_db_with_rows`/`_where_sql`) into a shared helper.

## Tests

- `tests/api/test_memory_list_geo.py` (new, 7 pins): both-queries bbox shape, one-sided independence, pair-completeness NULL guards, antimeridian OR shape, no-params backward compat, location serialization (full pair / absent / half-populated).
- TDD red→green: signature tests failed with `TypeError` before implementation.
- Suite: backend `tests/api/` 1075 passed / 15 xfailed / 3 skipped (0 failed); frontend 781/782 (the 1 failure — `useSystemFeatures` fail-closed — reproduces identically on main, pre-existing and unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDnEwGpK7semEzr42hushN