### PR TITLE
fix(db): user-forgotten tombstone purge + erasure asymmetry (#1336)

### DIFF
--- a/backend/src/db/lance_store.py
+++ b/backend/src/db/lance_store.py
@@ -27,9 +27,10 @@ Design (mirrors the Qdrant data path so no higher layer changes):
 
 PREVIEW limitations (documented, not silently dropped):
 
-* ``copy_context_points`` / ``delete_user_points`` (GDPR cross-collection) /
-  the admin BM25-drift scroll are not implemented for this backend and raise
-  :class:`NotImplementedError`.
+* ``copy_context_points`` / the admin BM25-drift scroll are not implemented
+  for this backend and raise :class:`NotImplementedError`.
+  (``delete_user_points`` — GDPR cross-collection erasure — IS implemented
+  as of #1336.)
 * Cosine ``_distance`` is converted to a similarity score via ``1 - distance``.
 * End-to-end behavior requires ``lancedb`` installed (``pip install
   'kagura-memory[lite]'``) and is pending live validation; the SQL filter
@@ -648,6 +649,40 @@ class LanceVectorStore:
             await asyncio.to_thread(_run)
         except Exception as e:
             raise QdrantError(f"Failed to delete memory from LanceDB: {e}") from e
+
+    def _collection_names(self) -> list[str]:
+        """All kagura_memories* tables in the store (per-model variants included)."""
+        with self._lock:
+            db = self._connect()
+            return [name for name in db.table_names() if name.startswith(DEFAULT_COLLECTION)]
+
+    async def delete_user_points(self, user_id: str) -> dict[str, int]:
+        """Hard-delete every point authored by ``user_id`` across collections.
+
+        GDPR erasure path (#1336): closes the documented preview gap where
+        ``delete_user_points`` raised NotImplementedError on this backend and
+        erased users' vectors stayed at rest. ``user_id`` is an OAuth2 sub
+        (not a UUID) — quote-escaped like every literal in this module.
+        """
+        where = f"user_id = {_sql_str(user_id)}"
+
+        def _run() -> dict[str, int]:
+            deleted: dict[str, int] = {}
+            with self._lock:
+                for name in self._collection_names():
+                    tbl = self._open(name)
+                    if tbl is None:
+                        continue
+                    count = tbl.count_rows(filter=where)
+                    if count:
+                        tbl.delete(where)
+                    deleted[name] = int(count)
+            return deleted
+
+        try:
+            return await asyncio.to_thread(_run)
+        except Exception as e:
+            raise QdrantError(f"Failed to delete user points from LanceDB: {e}") from e
 
     async def delete_context_points(
         self,

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1243,11 +1243,12 @@ async def delete_user_points(user_id: str) -> dict[str, int]:
         >>> deleted
         {'kagura_memories': 38, 'kagura_memories_voyage_2_1024': 4}
     """
-    if _active_store() is not None:
-        raise NotImplementedError(
-            "delete_user_points (cross-collection GDPR erasure) is not supported "
-            "by the LanceDB backend (preview)."
-        )
+    _store = _active_store()
+    if _store is not None:
+        # #1336: the Lance backend now implements the cross-collection GDPR
+        # erasure — the preview NotImplementedError left erased users'
+        # vectors at rest on self-hosted Lite installs.
+        return await _store.delete_user_points(user_id)
 
     client = get_qdrant_client()
     deleted_per_collection: dict[str, int] = {}

--- a/backend/src/db/vector_store.py
+++ b/backend/src/db/vector_store.py
@@ -104,6 +104,8 @@ class VectorStore(Protocol):
         collection_name: str = DEFAULT_COLLECTION,
     ) -> None: ...
 
+    async def delete_user_points(self, user_id: str) -> dict[str, int]: ...
+
     async def delete_context_points(
         self,
         workspace_id: str,

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -257,6 +257,11 @@ class NeuralMemoryConfig:
     # forever (pre-#1209 behavior). When > 0 the merge_retention phase
     # hard-deletes losers past the window; undo/rollback only work inside it.
     sleep_merge_retention_days: int = 0
+    # #1336: user-forget tombstone retention window in days. 0 = disabled =
+    # retain forever (pre-#1336 behavior). When > 0 the forget_retention
+    # phase hard-deletes user-forgotten rows (details incl. coordinates)
+    # past the window; merge losers keep their own window above.
+    sleep_forget_retention_days: int = 0
     # #1208: shadow-mode dedup — merges record a supersedes edge and leave the
     # loser alive-but-shadowed instead of soft-deleting it. Default OFF =
     # update-by-removal (pre-#1208 behavior).
@@ -471,6 +476,11 @@ class NeuralMemoryConfig:
                 f"sleep_merge_retention_days must be >= 0 (0 = retain forever), "
                 f"got {self.sleep_merge_retention_days}"
             )
+        if self.sleep_forget_retention_days < 0:
+            raise ValueError(
+                f"sleep_forget_retention_days must be >= 0 (0 = retain forever), "
+                f"got {self.sleep_forget_retention_days}"
+            )
         if not self.sleep_edge_discovery_sample_size > 0:
             raise ValueError(
                 f"sleep_edge_discovery_sample_size must be positive, "
@@ -607,6 +617,7 @@ class NeuralMemoryConfig:
             sleep_dedup_enabled=get_bool("SLEEP_DEDUP_ENABLED", True),
             sleep_dedup_similarity_threshold=get_float("SLEEP_DEDUP_SIMILARITY_THRESHOLD", 0.92),
             sleep_merge_retention_days=get_int("SLEEP_MERGE_RETENTION_DAYS", 0),
+            sleep_forget_retention_days=get_int("SLEEP_FORGET_RETENTION_DAYS", 0),
             sleep_dedup_supersede_enabled=get_bool("SLEEP_DEDUP_SUPERSEDE_ENABLED", False),
             sleep_edge_discovery_enabled=get_bool("SLEEP_EDGE_DISCOVERY_ENABLED", True),
             sleep_edge_discovery_sample_size=get_int("SLEEP_EDGE_DISCOVERY_SAMPLE_SIZE", 30),
@@ -847,6 +858,10 @@ class NeuralMemoryConfig:
             sleep_merge_retention_days=configs.get(
                 "sleep_merge_retention_days",
                 base_config.sleep_merge_retention_days,
+            ),
+            sleep_forget_retention_days=configs.get(
+                "sleep_forget_retention_days",
+                base_config.sleep_forget_retention_days,
             ),
             sleep_dedup_supersede_enabled=configs.get(
                 "sleep_dedup_supersede_enabled",

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -1043,7 +1043,7 @@ class AccountErasureService:
         # in co-owned/transferred workspaces (the sole-owner cascade above
         # already wiped the rest). Their Qdrant points were deleted in step 1
         # but the PG rows kept details (coordinates included) and the raw
-        # user_id. Pseudonymize the subject link and NULL the details JSONB —
+        # user_id. Pseudonymize the subject link and NULL the details column (PostgreSQL json) —
         # which also NULLs the generated columns (location_lat/lon,
         # trigger_from/until) derived from it. Runs AFTER the workspace
         # cascade so the count reflects only survivors.
@@ -1124,7 +1124,9 @@ class AccountErasureService:
         compliance, the sub is unrecoverable) and ``details`` is NULLed —
         the memory text remains workspace content, but structured personal
         payload (coordinates, triggers, arbitrary detail keys) is removed
-        at rest. Tombstoned rows of the subject are scrubbed too.
+        at rest. Tombstoned rows of the subject are HARD-DELETED first (not
+        scrubbed): their points are already gone and a pseudonymized
+        tombstone would be unpurgeable by any retention run.
         """
         # Tombstoned rows first: they are invisible to every member already
         # and their Qdrant points were removed in step 1 (delete_user_points),

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -49,6 +49,7 @@ from models.agent import Agent, AgentContextBinding
 from models.auth import (
     APIKey,
     AuditLog,
+    Context,
     ExternalAPIKey,
     OAuth2AuthorizationCode,
     OAuth2Client,
@@ -70,6 +71,7 @@ from models.erasure import (
     VALID_REASON_CODES,
     ErasureRequest,
 )
+from models.memory import Memory
 from services.email_service import EmailService, get_email_service
 from services.system_admin_service import SystemAdminService
 from services.workspace_locks import lock_workspace_for_update
@@ -1037,6 +1039,16 @@ class AccountErasureService:
             AgentContextBinding, AgentContextBinding.created_by, user_id
         )
 
+        # #1336 Gap 2: author memories that OUTLIVE the erased subject — rows
+        # in co-owned/transferred workspaces (the sole-owner cascade above
+        # already wiped the rest). Their Qdrant points were deleted in step 1
+        # but the PG rows kept details (coordinates included) and the raw
+        # user_id. Pseudonymize the subject link and NULL the details JSONB —
+        # which also NULLs the generated columns (location_lat/lon,
+        # trigger_from/until) derived from it. Runs AFTER the workspace
+        # cascade so the count reflects only survivors.
+        counts["memories_scrubbed"] = await self._scrub_surviving_memories(user_id)
+
         # memory_access_events (#1278, RFC-0002 P0-5): no-FK append-only audit
         # rows survive entity deletion, so the subject's rows must be
         # pseudonymized + scrubbed here. The append-only trigger permits UPDATE
@@ -1104,19 +1116,61 @@ class AccountErasureService:
         )
         return result.rowcount or 0
 
-    async def _pseudonymize_field(self, model: Any, column: Any, user_id: str) -> int:
+    async def _scrub_surviving_memories(self, user_id: str) -> int:
+        """Scrub author memories that outlive the erased subject (#1336).
+
+        ``user_id`` becomes the salted pseudonym (the plan_changes/agents
+        legal-retention convention: same-user correlation stays possible for
+        compliance, the sub is unrecoverable) and ``details`` is NULLed —
+        the memory text remains workspace content, but structured personal
+        payload (coordinates, triggers, arbitrary detail keys) is removed
+        at rest. Tombstoned rows of the subject are scrubbed too.
+        """
+        # Tombstoned rows first: they are invisible to every member already
+        # and their Qdrant points were removed in step 1 (delete_user_points),
+        # so hard-DELETE beats scrubbing — a pseudonymized tombstone would be
+        # unpurgeable forever (no sleep run ever executes for the pseudonym,
+        # so no retention window matches it).
+        await self.db.execute(
+            delete(Memory).where(Memory.user_id == user_id, Memory.deleted_at.is_not(None))
+        )
+        scrubbed = await self._pseudonymize_field(
+            Memory, Memory.user_id, user_id, extra_values={"details": None}
+        )
+        # The subject's raw sub also survives in OTHER rows' deleted_by
+        # (forget()/context-delete stamp the actor) and contexts.deleted_by.
+        # Clear to NULL — the member-removal precedent
+        # (member_credentials_service) — so no raw sub outlives erasure.
+        await self.db.execute(
+            update(Memory).where(Memory.deleted_by == user_id).values(deleted_by=None)
+        )
+        await self.db.execute(
+            update(Context).where(Context.deleted_by == user_id).values(deleted_by=None)
+        )
+        return scrubbed
+
+    async def _pseudonymize_field(
+        self,
+        model: Any,
+        column: Any,
+        user_id: str,
+        extra_values: dict[str, Any] | None = None,
+    ) -> int:
         """SHA256-pseudonymize a column across all matching rows.
 
         Used for legal-retention tables (e.g. plan_changes) where the row
         must survive but the personal-data link to the deleted user must
-        not.
+        not. ``extra_values`` lets a caller scrub additional columns in the
+        same UPDATE (#1336: memories.details) so the pseudonym convention
+        stays single-sourced here.
         """
         pseudonym = sha256_hex(user_id, salt=_audit_salt())
+        values: dict[Any, Any] = {column: pseudonym}
+        if extra_values:
+            values.update(extra_values)
         result = cast(
             CursorResult[Any],
-            await self.db.execute(
-                update(model).where(column == user_id).values({column: pseudonym})
-            ),
+            await self.db.execute(update(model).where(column == user_id).values(values)),
         )
         return result.rowcount or 0
 

--- a/backend/src/services/sleep/forget_retention.py
+++ b/backend/src/services/sleep/forget_retention.py
@@ -1,0 +1,89 @@
+"""User-forget tombstone retention purge (#1336) — the merge_retention mirror
+for rows soft-deleted by ``forget()``.
+
+``forget()`` soft-deletes (``deleted_at`` + ``deleted_by=<user sub>``) and
+already hard-deletes the Qdrant point and neural edges — but nothing ever
+reaped the residual PG row, so a "forgotten" memory's ``details`` (home
+coordinates included, via the WHERE axis) persisted at rest forever. When
+``sleep_forget_retention_days > 0``, user-forgotten tombstones older than
+the window are hard-deleted, audited as one batch-summary action.
+
+Selection is the complement of merge_retention's: ``deleted_by`` is the
+forgetting user's sub (or NULL on legacy rows), never the
+``sleep_maintenance`` merge sentinel — merge losers keep their own window
+(``sleep_merge_retention_days``) and undo path. The sweep mechanics
+(TOCTOU-guarded DELETE, budget exemption, batch audit) are shared with
+merge_retention via ``purge_tombstones`` so the two phases cannot drift.
+
+Default is **0 = disabled = retain forever** (pre-#1336 behavior).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from neural.config import NeuralMemoryConfig
+    from services.sleep.reporter import SleepBudget, SleepReporter
+
+from models.auth import Context
+from models.memory import Memory
+from services.sleep.merge_retention import _MERGE_DELETED_BY, purge_tombstones
+from services.sleep.reporter import PhaseResult
+
+
+class ForgetRetentionPhase:
+    """Hard-delete user-forgotten tombstones past the declared window."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def execute(
+        self,
+        config: NeuralMemoryConfig,
+        user_id: str,
+        workspace_id: str | None,
+        context_id: str | None,
+        budget: SleepBudget,
+        *,
+        reporter: SleepReporter | None = None,
+        report_id: UUID | None = None,
+    ) -> PhaseResult:
+        """Purge user-forgotten rows older than ``sleep_forget_retention_days``.
+
+        No-op (skipped) when the retention window is disabled (<= 0).
+        """
+        # NULL deleted_by = legacy user-forget rows that predate the column
+        # being written; the sentinel exclusion keeps merge losers on their
+        # own retention window.
+        not_merge_loser = or_(
+            Memory.deleted_by.is_(None),
+            Memory.deleted_by != _MERGE_DELETED_BY,
+        )
+        # Context soft-delete (#84 recovery design) tombstones its memories
+        # with deleted_by=<user sub> too — but deliberately KEEPS their
+        # Qdrant points for recovery, and they are indistinguishable from
+        # forget() rows by deleted_by alone. Purging them would orphan live
+        # vectors (full payloads immortal at rest, no PG row left to find
+        # them by) and silently destroy context recovery. Restrict the sweep
+        # to memories whose context is alive: forget() tombstones in live
+        # contexts had their points and edges deleted at soft-delete time,
+        # so the PG row is the only residue.
+        in_live_context = Memory.context_id.in_(
+            select(Context.id).where(Context.deleted_at.is_(None))
+        )
+        return await purge_tombstones(
+            self.db,
+            phase_name="forget_retention",
+            deleted_by_predicate=and_(not_merge_loser, in_live_context),
+            retention_days=int(getattr(config, "sleep_forget_retention_days", 0) or 0),
+            user_id=user_id,
+            workspace_id=workspace_id,
+            context_id=context_id,
+            reporter=reporter,
+            report_id=report_id,
+        )

--- a/backend/src/services/sleep/forget_retention.py
+++ b/backend/src/services/sleep/forget_retention.py
@@ -59,7 +59,13 @@ class ForgetRetentionPhase:
         """
         # NULL deleted_by = legacy user-forget rows that predate the column
         # being written; the sentinel exclusion keeps merge losers on their
-        # own retention window.
+        # own retention window. deleted_by is deliberately NOT pinned to
+        # this run's user sub: forget() records the ACTOR, so a teammate's
+        # forget on this user's memory writes the teammate's sub — pinning
+        # would strand those tombstones forever (no sleep run ever matches
+        # them). With the live-context guard below, every remaining
+        # non-merge tombstone is a forget() row whose point and edges were
+        # already deleted at soft-delete time.
         not_merge_loser = or_(
             Memory.deleted_by.is_(None),
             Memory.deleted_by != _MERGE_DELETED_BY,

--- a/backend/src/services/sleep/merge_retention.py
+++ b/backend/src/services/sleep/merge_retention.py
@@ -41,6 +41,107 @@ logger = get_logger(__name__)
 _MERGE_DELETED_BY = "sleep_maintenance"
 
 
+async def purge_tombstones(
+    db: AsyncSession,
+    *,
+    phase_name: str,
+    deleted_by_predicate,
+    retention_days: int,
+    user_id: str,
+    workspace_id: str | None,
+    context_id: str | None,
+    reporter: SleepReporter | None = None,
+    report_id: UUID | None = None,
+) -> PhaseResult:
+    """Shared retention sweep for soft-deleted memory rows (#1209 / #1336).
+
+    One implementation for both tombstone classes (merge losers /
+    user-forgotten rows) so the TOCTOU guard, budget exemption, and
+    batch-audit contract cannot drift between the two phases — only the
+    ``deleted_by_predicate`` and config key differ.
+    """
+    result = PhaseResult(phase_name=phase_name)
+
+    if retention_days <= 0:
+        result.skipped = True
+        result.skip_reason = "retention_disabled"
+        return result
+
+    cutoff = utcnow() - timedelta(days=retention_days)
+
+    stmt = select(Memory.id).where(
+        Memory.user_id == user_id,
+        deleted_by_predicate,
+        Memory.deleted_at.is_not(None),
+        Memory.deleted_at < cutoff,
+    )
+    if workspace_id:
+        stmt = stmt.where(Memory.workspace_id == UUID(workspace_id))
+    if context_id:
+        stmt = stmt.where(Memory.context_id == UUID(context_id))
+
+    ids = [row[0] for row in (await db.execute(stmt)).all()]
+    if not ids:
+        result.details = {
+            "purged": 0,
+            "retention_days": retention_days,
+            "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+        }
+        return result
+
+    # Re-assert the full purge predicate in the DELETE itself (not just
+    # the ids): a concurrent restore commits in its own session, and a
+    # bare id-DELETE under READ COMMITTED would hard-delete the memory
+    # that was just restored (TOCTOU between our SELECT and this DELETE).
+    # With the predicate repeated, a restored row (deleted_at IS NULL) no
+    # longer matches and survives.
+    await db.execute(
+        delete(Memory).where(
+            Memory.id.in_(ids),
+            deleted_by_predicate,
+            Memory.deleted_at.is_not(None),
+            Memory.deleted_at < cutoff,
+        )
+    )
+
+    # Deliberately NOT counted into memories_processed: the orchestrator
+    # consumes the shared per-run budget from that field, and purging an
+    # unbounded historical backlog of dead rows must not starve the
+    # live-memory phases (importance_reeval / consolidation) that run
+    # after this one. The purge volume is reported in details + the
+    # batch audit action instead.
+    result.memories_processed = 0
+    result.details = {
+        "purged": len(ids),
+        "retention_days": retention_days,
+        "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+    }
+
+    # Batch-summary audit action (deliberately NOT per-row): the purge is
+    # the moment reversibility ends, so it must be visible in the same
+    # audit log the deletions live in.
+    if reporter and report_id:
+        await reporter.add_action(
+            report_id=report_id,
+            phase=phase_name,
+            action_type="purge",
+            details={
+                "purged": len(ids),
+                "retention_days": retention_days,
+                "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+            },
+        )
+
+    logger.info(
+        f"{phase_name}_purged",
+        purged=len(ids),
+        retention_days=retention_days,
+        user_id=user_id,
+        context_id=context_id,
+    )
+    return result
+
+
 class MergeRetentionPhase:
     """Hard-delete merge losers past the declared retention window."""
 
@@ -62,84 +163,14 @@ class MergeRetentionPhase:
 
         No-op (skipped) when the retention window is disabled (<= 0).
         """
-        result = PhaseResult(phase_name="merge_retention")
-
-        retention_days = int(getattr(config, "sleep_merge_retention_days", 0) or 0)
-        if retention_days <= 0:
-            result.skipped = True
-            result.skip_reason = "retention_disabled"
-            return result
-
-        cutoff = utcnow() - timedelta(days=retention_days)
-
-        stmt = select(Memory.id).where(
-            Memory.user_id == user_id,
-            Memory.deleted_by == _MERGE_DELETED_BY,
-            Memory.deleted_at.is_not(None),
-            Memory.deleted_at < cutoff,
-        )
-        if workspace_id:
-            stmt = stmt.where(Memory.workspace_id == UUID(workspace_id))
-        if context_id:
-            stmt = stmt.where(Memory.context_id == UUID(context_id))
-
-        ids = [row[0] for row in (await self.db.execute(stmt)).all()]
-        if not ids:
-            result.details = {
-                "purged": 0,
-                "retention_days": retention_days,
-                "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
-            }
-            return result
-
-        # Re-assert the full purge predicate in the DELETE itself (not just
-        # the ids): a concurrent per-merge undo commits in its own session,
-        # and a bare id-DELETE under READ COMMITTED would hard-delete the
-        # memory the admin just restored (TOCTOU between our SELECT and this
-        # DELETE). With the predicate repeated, a restored row (deleted_at
-        # IS NULL) no longer matches and survives.
-        await self.db.execute(
-            delete(Memory).where(
-                Memory.id.in_(ids),
-                Memory.deleted_by == _MERGE_DELETED_BY,
-                Memory.deleted_at.is_not(None),
-                Memory.deleted_at < cutoff,
-            )
-        )
-
-        # Deliberately NOT counted into memories_processed: the orchestrator
-        # consumes the shared per-run budget from that field, and purging an
-        # unbounded historical backlog of dead rows must not starve the
-        # live-memory phases (importance_reeval / consolidation) that run
-        # after this one. The purge volume is reported in details + the
-        # batch audit action instead.
-        result.memories_processed = 0
-        result.details = {
-            "purged": len(ids),
-            "retention_days": retention_days,
-            "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
-        }
-
-        # Batch-summary audit action (deliberately NOT per-row): the purge is
-        # the moment reversibility ends, so it must be visible in the same
-        # audit log the merges live in.
-        if reporter and report_id:
-            await reporter.add_action(
-                report_id=report_id,
-                phase="merge_retention",
-                action_type="purge",
-                details={
-                    "purged": len(ids),
-                    "retention_days": retention_days,
-                    "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
-                },
-            )
-
-        logger.info(
-            "merge_retention_purged",
-            purged=len(ids),
-            retention_days=retention_days,
+        return await purge_tombstones(
+            self.db,
+            phase_name="merge_retention",
+            deleted_by_predicate=(Memory.deleted_by == _MERGE_DELETED_BY),
+            retention_days=int(getattr(config, "sleep_merge_retention_days", 0) or 0),
             user_id=user_id,
+            workspace_id=workspace_id,
             context_id=context_id,
+            reporter=reporter,
+            report_id=report_id,
         )
-        return result

--- a/backend/src/services/sleep/orchestrator.py
+++ b/backend/src/services/sleep/orchestrator.py
@@ -26,6 +26,7 @@ from services.llm_service import LLMService
 from services.sleep.consolidation import ConsolidationPhase
 from services.sleep.dedup_merge import DedupMergePhase
 from services.sleep.edge_discovery import EdgeDiscoveryPhase
+from services.sleep.forget_retention import ForgetRetentionPhase
 from services.sleep.importance_reeval import ImportanceReevalPhase
 from services.sleep.merge_retention import MergeRetentionPhase
 from services.sleep.reindex import ReindexPhase
@@ -42,6 +43,7 @@ FULL_PHASES = {
     "edge_discovery",
     "dedup_merge",
     "merge_retention",
+    "forget_retention",
     "importance_reeval",
     "consolidation",
 }
@@ -127,6 +129,7 @@ class SleepOrchestrator:
             ("edge_discovery", lambda: EdgeDiscoveryPhase(self.db, self.llm_service, em, cn)),
             ("dedup_merge", lambda: DedupMergePhase(self.db, self.llm_service, em, cn)),
             ("merge_retention", lambda: MergeRetentionPhase(self.db)),
+            ("forget_retention", lambda: ForgetRetentionPhase(self.db)),
             ("importance_reeval", lambda: ImportanceReevalPhase(self.db, self.llm_service, cn)),
             ("consolidation", lambda: ConsolidationPhase(self.db, self.llm_service, cn)),
         ]

--- a/backend/tests/db/test_lance_store_filter.py
+++ b/backend/tests/db/test_lance_store_filter.py
@@ -288,3 +288,37 @@ async def test_search_semantic_malformed_near_is_a_value_error():
 
     with pytest.raises(ValueError, match="lat"):
         await store.search_semantic(USER, [0.1], WS, CTX, filters={"near": {"lat": 95, "lon": 0}})
+
+
+async def test_delete_user_points_removes_rows_across_collections():
+    """#1336 Gap: GDPR erasure must work on the Lance backend too — the
+    NotImplementedError left erased users' vectors at rest."""
+    from db.lance_store import LanceVectorStore
+
+    deleted_filters: list[tuple[str, str]] = []
+
+    class _DeletableTable:
+        def __init__(self, name: str, rows: int):
+            self._name = name
+            self._rows = rows
+
+        def count_rows(self, filter=None):  # noqa: A002 - lancedb API name
+            return self._rows
+
+        def delete(self, where):
+            deleted_filters.append((self._name, where))
+
+    tables = {"kagura_memories": _DeletableTable("kagura_memories", 3)}
+
+    store = LanceVectorStore.__new__(LanceVectorStore)
+    store._lock = __import__("threading").Lock()
+    store._open = lambda name, dim=0: tables.get(name)
+    store._collection_names = lambda: list(tables)
+
+    result = await store.delete_user_points("google-oauth2|erased")
+
+    assert result == {"kagura_memories": 3}
+    assert len(deleted_filters) == 1
+    name, where = deleted_filters[0]
+    assert name == "kagura_memories"
+    assert "user_id = 'google-oauth2|erased'" in where

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -481,3 +481,47 @@ class TestFromDbSleepLLMPrecedence:
         assert not [
             c for c in spy.warning.call_args_list if c.args[0] == "sleep_llm_config_mismatch"
         ]
+
+
+class TestForgetRetentionConfigPlumbing:
+    """#1336 review: the config key must survive the from_db merge — a field
+    missing from the merged-kwargs list silently pins the dataclass default
+    and ships the phase as dead code."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_cache(self):
+        NeuralMemoryConfig.invalidate_cache()
+        yield
+        NeuralMemoryConfig.invalidate_cache()
+
+    @staticmethod
+    def _db(rows: dict):
+        class _Row:
+            def __init__(self, key, value):
+                self.key = key
+                self._value = value
+
+            def get_typed_value(self):
+                return self._value
+
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [_Row(k, v) for k, v in rows.items()]
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    async def test_env_value_survives_from_db_merge(self, monkeypatch):
+        monkeypatch.setenv("SLEEP_FORGET_RETENTION_DAYS", "30")
+        config = await NeuralMemoryConfig.from_db(self._db({}))
+        assert config.sleep_forget_retention_days == 30
+
+    async def test_db_override_wins(self, monkeypatch):
+        monkeypatch.delenv("SLEEP_FORGET_RETENTION_DAYS", raising=False)
+        config = await NeuralMemoryConfig.from_db(self._db({"sleep_forget_retention_days": 14}))
+        assert config.sleep_forget_retention_days == 14
+
+    def test_negative_value_rejected(self):
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="sleep_forget_retention_days"):
+            NeuralMemoryConfig(sleep_forget_retention_days=-1)

--- a/backend/tests/services/sleep/test_forget_retention.py
+++ b/backend/tests/services/sleep/test_forget_retention.py
@@ -1,0 +1,126 @@
+"""#1336 Gap 1: user-forgotten tombstone retention purge phase.
+
+Pins (mirroring test_merge_retention.py):
+
+1. Default (``sleep_forget_retention_days = 0``) is DISABLED — forget()
+   tombstones are retained forever unless the operator declares a window
+   (pre-#1336 behavior preserved).
+2. When enabled, only USER-forgotten rows (``deleted_by`` is the user's sub,
+   or NULL on legacy rows — never the ``sleep_maintenance`` merge sentinel)
+   older than the cutoff are purged, and the purge is audited as ONE
+   batch-summary action.
+3. Nothing to purge → no audit action.
+
+forget() already removed the Qdrant point and neural edges at soft-delete
+time, so the phase only reaps the residual PG row — the tombstone whose
+``details`` (coordinates included) would otherwise persist at rest forever.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.sleep.forget_retention import ForgetRetentionPhase
+
+
+def _config(days: int) -> MagicMock:
+    cfg = MagicMock()
+    cfg.sleep_forget_retention_days = days
+    return cfg
+
+
+def _budget() -> MagicMock:
+    budget = MagicMock()
+    budget.exhausted = False
+    return budget
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_skips() -> None:
+    db = AsyncMock()
+    phase = ForgetRetentionPhase(db)
+    result = await phase.execute(_config(0), "user", None, None, _budget())
+    assert result.skipped is True
+    assert result.skip_reason == "retention_disabled"
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_purges_user_forgotten_rows_and_audits_batch_summary() -> None:
+    db = AsyncMock()
+    purged_ids = [uuid4(), uuid4()]
+    select_result = MagicMock()
+    select_result.all.return_value = [(mid,) for mid in purged_ids]
+    db.execute.side_effect = [select_result, MagicMock()]  # select, delete
+
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+    report_id = uuid4()
+
+    phase = ForgetRetentionPhase(db)
+    result = await phase.execute(
+        _config(30), "user", None, None, _budget(), reporter=reporter, report_id=report_id
+    )
+
+    assert result.skipped is False
+    # Purged dead rows must NOT consume the shared per-run budget (same
+    # rationale as merge_retention: a first-enable backlog purge must not
+    # starve the live-memory phases).
+    assert result.memories_processed == 0
+    assert result.details["purged"] == 2
+    assert result.details["retention_days"] == 30
+
+    # The selection must EXCLUDE merge losers (they have their own window)
+    # and INCLUDE legacy NULL deleted_by tombstones.
+    select_sql = str(db.execute.await_args_list[0].args[0])
+    assert "deleted_by" in select_sql
+    delete_sql = str(db.execute.await_args_list[1].args[0])
+    # TOCTOU guard: the DELETE re-asserts the predicate, not just ids.
+    assert "deleted_at" in delete_sql
+
+    reporter.add_action.assert_awaited_once()
+    kwargs = reporter.add_action.await_args.kwargs
+    assert kwargs["phase"] == "forget_retention"
+    assert kwargs["action_type"] == "purge"
+    assert kwargs["details"]["purged"] == 2
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_purge_records_no_action() -> None:
+    db = AsyncMock()
+    select_result = MagicMock()
+    select_result.all.return_value = []
+    db.execute.return_value = select_result
+
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+
+    phase = ForgetRetentionPhase(db)
+    result = await phase.execute(
+        _config(7), "user", None, None, _budget(), reporter=reporter, report_id=uuid4()
+    )
+
+    assert result.skipped is False
+    assert result.details["purged"] == 0
+    reporter.add_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_selection_excludes_soft_deleted_contexts() -> None:
+    """#1336 review: context soft-delete (#84 recovery design) tombstones
+    memories with deleted_by=<user sub> too, but deliberately KEEPS their
+    Qdrant points — purging those PG rows would orphan live vectors and
+    destroy context recovery. The sweep must be restricted to memories in
+    live contexts."""
+    db = AsyncMock()
+    select_result = MagicMock()
+    select_result.all.return_value = []
+    db.execute.return_value = select_result
+
+    phase = ForgetRetentionPhase(db)
+    await phase.execute(_config(7), "user", None, None, _budget())
+
+    select_sql = str(db.execute.await_args_list[0].args[0])
+    assert "IN (SELECT contexts.id" in select_sql
+    assert "contexts.deleted_at IS NULL" in select_sql

--- a/backend/tests/services/test_erasure_memory_scrub.py
+++ b/backend/tests/services/test_erasure_memory_scrub.py
@@ -1,0 +1,49 @@
+"""#1336 Gap 2: erasure-time scrub of surviving author memories.
+
+Account erasure deletes the subject's Qdrant points but historically left
+their PG memory rows in co-owned/transferred workspaces intact — details
+(coordinates included) plus the raw user_id. The scrub pass pseudonymizes
+``user_id`` (salted SHA256, the plan_changes/agents convention) and NULLs
+``details`` — which also NULLs the generated columns (location_lat/lon,
+trigger_from/until) since they derive from details.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.account_erasure_service import AccountErasureService
+
+
+@pytest.mark.asyncio
+async def test_scrub_surviving_memories_pseudonymizes_and_nulls_details() -> None:
+    db = MagicMock()
+    cursor = MagicMock()
+    cursor.rowcount = 4
+    db.execute = AsyncMock(return_value=cursor)
+
+    service = AccountErasureService.__new__(AccountErasureService)
+    service.db = db
+
+    with patch("services.account_erasure_service._audit_salt", return_value="salt"):
+        count = await service._scrub_surviving_memories("google-oauth2|erased")
+
+    assert count == 4
+    statements = [c.args[0] for c in db.execute.await_args_list]
+    sqls = [str(stmt) for stmt in statements]
+    # 1) Tombstones hard-deleted (points already gone via delete_user_points;
+    #    a pseudonymized tombstone would be unpurgeable by any retention run).
+    assert any("DELETE FROM memories" in q and "deleted_at IS NOT NULL" in q for q in sqls)
+    # 2) Survivors: user_id pseudonymized + details NULLed in one UPDATE.
+    scrub = next(
+        stmt
+        for stmt, q in zip(statements, sqls, strict=True)
+        if "UPDATE memories" in q and "details" in q
+    )
+    compiled = scrub.compile()
+    assert compiled.params["details"] is None
+    assert compiled.params["user_id"] != "google-oauth2|erased"
+    # 3) The raw sub is cleared from OTHER rows' deleted_by (memories and
+    #    contexts) — no raw sub outlives erasure anywhere.
+    assert any("UPDATE memories" in q and "deleted_by" in q for q in sqls)
+    assert any("UPDATE contexts" in q and "deleted_by" in q for q in sqls)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -344,8 +344,9 @@ pre-tokenized FTS text. Semantic + BM25 hybrid fusion is unchanged.
 
 - **Single-writer only.** Not for multi-process / SaaS topologies.
 - These operations raise `NotImplementedError` on the lance backend: context
-  copy (`copy_context_points`), cross-collection GDPR erasure
-  (`delete_user_points`), and the admin BM25-drift reverse-lookup scroll.
+  copy (`copy_context_points`) and the admin BM25-drift reverse-lookup scroll.
+  Cross-collection GDPR erasure (`delete_user_points`) IS supported as of
+  #1336 (per-table SQL delete across `kagura_memories*`).
 - End-to-end LanceDB behavior is pending live validation; the backend selector
   and the SQL isolation/escaping filter are unit-tested independently of
   LanceDB.

--- a/docs/ops/erasure-runbook.md
+++ b/docs/ops/erasure-runbook.md
@@ -40,6 +40,8 @@ GDPR Art.12(3) の「受領後 1 ヶ月以内」応答義務を満たすため�
 
 `db.qdrant.delete_user_points(user_id)` が `kagura_memories*` 全 collection (per-model variant 含む) で `Filter(must=[FieldCondition(key="user_id", match=user_id)])` による bulk delete を実行。
 
+> Lance backend (Lite): 同エントリポイントが `LanceStore.delete_user_points` に委譲され、`kagura_memories*` 各テーブルへ `user_id = :sub` の SQL delete を発行する(#1336)。確認は Qdrant collection ではなく Lance テーブルの行数で行う。
+
 > ⚠️ **Multi-tenant 設計の trade-off**: 共有 workspace 内でユーザーが author の point も削除される。GDPR 上の data subject = author のため意図的な挙動。共有 workspace co-owner には事前同意 (Privacy Policy / ToS) が前提。
 
 ### 2.3 Workspace ownership (Step 3)
@@ -68,6 +70,7 @@ FK の依存逆順で削除:
 | `workspace_invitations` | `invited_by = :uid OR email = :email` | |
 | `plan_changes.changed_by` | SHA256 pseudonymize | legal retention 維持 |
 | `workspaces` | `owner_user_id = :uid` | step 3 後の sole-owner のみ。cascade で contexts/memories/etc. |
+| `memories` (残存行) | `user_id` を SHA256 pseudonymize + `details = NULL` | #1336: 共有/移譲 workspace に残る本人著メモリの scrub。details の NULL 化で生成列 (location_lat/lon, trigger_from/until) も自動 NULL。tombstone 行も対象 |
 | `users` | `user_id = :uid` | 最後 |
 
 ### 2.5 Audit logs (Step 5)


### PR DESCRIPTION
Closes #1336

## Summary

Two privacy gaps the WHERE axis (#1331) escalated — "forgotten" coordinates persisting at rest forever:

**Gap 1 — forget() tombstones were never reaped.** New `forget_retention` sleep phase purges user-forgotten rows (`deleted_by` = user sub, or NULL legacy) past a declared window. `sleep_forget_retention_days` config (default **0 = retain forever** = current behavior), env `SLEEP_FORGET_RETENTION_DAYS`, per-context DB override via the `from_db` merge. The sweep mechanics (TOCTOU-guarded DELETE, budget exemption, batch-summary audit) are shared with merge_retention via a new `purge_tombstones` helper so the two phases cannot drift.

**Gap 2 — account erasure left author memories in co-owned/transferred workspaces** with `details` (coordinates included) + raw `user_id` (only Qdrant points were deleted). `_delete_postgres` now: hard-deletes the subject's tombstones (their points are already gone; a pseudonymized tombstone would be unpurgeable by any retention run), pseudonymizes surviving rows' `user_id` (salted SHA256 via the shared `_pseudonymize_field`, extended with `extra_values`) + NULLs `details` (generated columns NULL automatically), and clears the raw sub from OTHER rows' `memories.deleted_by` / `contexts.deleted_by` (member-removal precedent). Runbook §2.2/§2.4 updated.

**Bonus gap closed**: `LanceStore.delete_user_points` implemented (per-collection SQL delete, `delete_context_points` shape) and `db.qdrant.delete_user_points` delegates instead of raising `NotImplementedError` — GDPR erasure now works on the Lance preview backend. `docs/deployment.md` preview-limitations updated.

## Review (8-angle, 2 finder agents) — all findings addressed

- **CONFIRMED: config key missing from the `from_db` merged-kwargs list** — the phase would have shipped as dead code (env value silently discarded). Fixed + functional pins on the merge.
- **CONFIRMED: context soft-delete tombstones (#84 recovery design) would have been swept** — their Qdrant points are deliberately kept, so purging the PG rows would orphan live vectors (immortal payloads with no row left to find them) and destroy context recovery. The sweep is now restricted to memories in live contexts (pinned).
- Raw sub survival in `deleted_by` after erasure (fixed above); erasure-scrubbed tombstones being unpurgeable (fixed via tombstone hard-delete); stale `docs/deployment.md` claim; duplication consolidations (`purge_tombstones`, `_pseudonymize_field extra_values`).

## Tests

`tests/services/sleep/test_forget_retention.py` (4 pins incl. context-liveness), `tests/services/test_erasure_memory_scrub.py`, `tests/neural/test_config.py::TestForgetRetentionConfigPlumbing` (3), Lance `delete_user_points` pin, merge_retention suite still green post-refactor. Broad: services+neural+db+tasks **2509 passed**; ruff/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDnEwGpK7semEzr42hushN