### PR TITLE
feat(mcp,db): HOW-MUCH axis — measurement history lane (#1333)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,7 +62,7 @@
 | **Neural Memory Graph** | Hebbian 学習がバックグラウンドで知識グラフを構築。`explore()` がそれを辿り偶発的発見を提供 |
 | **Agent Memory Substrate** | 単なる知識ストアを超えて — delivery mode (pin / 時刻トリガ)、サーバー署名の trust boundary、agent state レーン、retrieval feedback シグナル。自律エージェントのループに必要なプリミティブ群 |
 | **Agent Control Plane (preview)** | Workspace スコープの Agent Registry、減算的な context binding、agent-bound member key、ライフサイクル kill switch、1 呼出の session bootstrap。v0.49.0 で導入 |
-| **61 の MCP ツール** | Memory、Agent Substrate、Agent Control Plane、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
+| **63 の MCP ツール** | Memory、Agent Substrate、Agent Control Plane、Neural edges、Contexts、Tags、Files (R2)、Analyses (メモリー分析)、Resources、Secrets、Sleep Maintenance、Usage、API-Key Bindings |
 | **マルチプロバイダ** | 埋め込みに OpenAI かセルフホスト (Ollama、vLLM — ローカル・非公開・コストゼロ) |
 | **チーム対応** | Workspace、RBAC、context 分離、共有メモリ |
 | **Web UI** | Next.js ダッシュボード — context、検索設定、メンバー管理 |
@@ -294,7 +294,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP ツール
 
-13 カテゴリ・全 61 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
+13 カテゴリ・全 63 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
 
 ### Memory (7)
 
@@ -308,7 +308,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `forget` | ソフト削除 (30 日保持) | Member+ |
 | `explore` | Neural Memory graph で関連メモリ発見 | Viewer+ |
 
-### Agent Substrate (5)
+### Agent Substrate (7)
 
 自律エージェントのループに必要なプリミティブ群 — 詳細は [Concepts › Agent Memory Substrate](docs/concepts.md#agent-memory-substrate)。
 
@@ -318,6 +318,8 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `recall_upcoming` | 近日の Time Memory (`type="time"`、`delivery_mode="on_trigger"`) を列挙 | Viewer+ |
 | `set_state` | エージェントの scratch state を upsert (key→value、任意 TTL、recall から除外) | Editor+ |
 | `get_state` | state を 1 件取得、または context の全 live state を列挙 | Viewer+ |
+| `record_measurement` | metric の系列に数値観測を 1 件 append (HOW-MUCH レーン、recall から除外・Sleep 対象外) | Editor+ |
+| `recall_series` | metric の系列を day/week/month でバケット集計 (avg/min/max/sum/count/last) | Viewer+ |
 | `feedback` | recall したメモリが有用だったかを記録 (append-only シグナル) | Viewer+ |
 
 ### Agent Control Plane (10、preview)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
 | **Agent Memory Substrate** | Beyond a knowledge store: delivery modes (pinned / time-triggered), a server-stamped trust boundary, an agent state lane, and a retrieval-feedback signal — the primitives an autonomous agent loop needs. |
 | **Agent Control Plane (preview)** | Workspace-scoped Agent Registry, subtractive context bindings, agent-bound member keys, lifecycle kill switches, and one-call session bootstrap. Introduced in v0.49.0. |
-| **61 MCP Tools** | Memory, Agent Substrate, Agent Control Plane, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
+| **63 MCP Tools** | Memory, Agent Substrate, Agent Control Plane, Neural edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings |
 | **Multi-Provider** | OpenAI or self-hosted (Ollama, vLLM — local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |
@@ -419,7 +419,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP Tools
 
-61 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+63 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
 
 ### Memory (7)
 
@@ -433,7 +433,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `forget` | Soft-delete a memory (30-day retention) | Member+ |
 | `explore` | Discover related memories via Neural Memory graph | Viewer+ |
 
-### Agent Substrate (5)
+### Agent Substrate (7)
 
 The primitives an autonomous agent loop needs beyond a knowledge store — see [Concepts › Agent Memory Substrate](docs/concepts.md#agent-memory-substrate).
 
@@ -443,6 +443,8 @@ The primitives an autonomous agent loop needs beyond a knowledge store — see [
 | `recall_upcoming` | List upcoming Time Memories (`type="time"`, `delivery_mode="on_trigger"`) | Viewer+ |
 | `set_state` | Upsert agent scratch state (key→value, optional TTL; excluded from recall) | Editor+ |
 | `get_state` | Read one state key, or list all live state for a context | Viewer+ |
+| `record_measurement` | Append one numeric observation to a metric's series (HOW-MUCH lane; excluded from recall, untouched by Sleep) | Editor+ |
+| `recall_series` | Read a metric's series bucketed by day/week/month with avg/min/max/sum/count/last | Viewer+ |
 | `feedback` | Record whether a recalled memory was helpful (append-only signal) | Viewer+ |
 
 ### Agent Control Plane (10, preview)

--- a/backend/alembic/versions/e71_1333_measurements.py
+++ b/backend/alembic/versions/e71_1333_measurements.py
@@ -1,0 +1,52 @@
+"""Add measurements table — HOW-MUCH measurement history lane (#1333).
+
+A dedicated append-only numeric time-series store, kept out of ``memories`` so
+it is structurally excluded from recall and untouchable by Sleep consolidation
+(a merged/rewritten series would be destroyed data). One row per observation of
+(context_id, metric) at measured_at; the composite index backs the
+recall_series bucket scan.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "e71_1333_measurements"
+down_revision = "e70_1348_worker_runtime"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "measurements",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "context_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("metric", sa.String(length=64), nullable=False),
+        sa.Column("measured_at", sa.DateTime(), nullable=False),
+        sa.Column("value", sa.Numeric(), nullable=False),
+        sa.Column("unit", sa.String(length=32), nullable=True),
+        sa.Column("details", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "idx_measurements_context_metric_measured_at",
+        "measurements",
+        ["context_id", "metric", "measured_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_measurements_context_metric_measured_at", table_name="measurements")
+    op.drop_table("measurements")

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -185,6 +185,7 @@ def _build_registry() -> dict[str, Any]:
         handle_init_file_upload,
         handle_list_files,
     )
+    from mcp_server.tools.measurement import handle_recall_series, handle_record_measurement
     from mcp_server.tools.resource import (
         handle_get_resource_impact,
         handle_get_resource_schema,
@@ -225,6 +226,9 @@ def _build_registry() -> dict[str, Any]:
         # Issue #889: agent session-state lane (TTL, recall-excluded)
         "set_state": handle_set_state,
         "get_state": handle_get_state,
+        # Issue #1333: HOW-MUCH measurement lane (append-only, recall-excluded)
+        "record_measurement": handle_record_measurement,
+        "recall_series": handle_recall_series,
         # Issue #888: retrieval feedback signal (append-only, recall-excluded)
         "feedback": handle_feedback,
         "get_context_info": handle_get_context_info,

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2331,8 +2331,10 @@ Returns: {status, measurement_id, metric, measured_at, value, unit}.""",
                         "description": "Series name, e.g. 'weight_kg' (max 64 chars). Reuse the exact same name to extend a series.",
                     },
                     "value": {
-                        "type": "number",
-                        "description": "The observed value. Must be a finite number (NaN/inf rejected).",
+                        "anyOf": [{"type": "number"}, {"type": "string"}],
+                        "description": "The observed value. Must be a finite number "
+                        "(NaN/inf rejected). Numeric strings are accepted and "
+                        "coerced (#1322 client compat — prefer sending a number).",
                     },
                     "measured_at": {
                         "type": "string",

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2305,6 +2305,97 @@ Returns: {status, key, value, found}. found is false (value null) when the key i
                 "required": ["context_id"],
             },
         },
+        {
+            "name": "record_measurement",
+            "description": """Append one numeric observation to a metric's series (Issue #1333).
+
+The HOW-MUCH lane: an append-only numeric time-series store (weight, revenue,
+reps, glucose, ...). It is SEPARATE from memories: measurements are NOT
+embedded, are structurally excluded from recall(), and are never merged or
+rewritten by Sleep consolidation — the series stays intact forever.
+
+Use this for raw numbers, NOT prose (use remember() for milestone notes like
+"hit goal weight"). Each call appends a new row; nothing is upserted.
+
+Returns: {status, measurement_id, metric, measured_at, value, unit}.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target context UUID (the series is scoped to this context).",
+                    },
+                    "metric": {
+                        "type": "string",
+                        "description": "Series name, e.g. 'weight_kg' (max 64 chars). Reuse the exact same name to extend a series.",
+                    },
+                    "value": {
+                        "type": "number",
+                        "description": "The observed value. Must be a finite number (NaN/inf rejected).",
+                    },
+                    "measured_at": {
+                        "type": "string",
+                        "description": "Optional ISO 8601 observation time (UTC assumed if naive). Defaults to now; pass it to backdate imports.",
+                    },
+                    "unit": {
+                        "type": "string",
+                        "description": "Optional display unit, e.g. 'kg' (max 32 chars).",
+                    },
+                    "details": {
+                        "type": "object",
+                        "description": "Optional JSON metadata (device, source, notes).",
+                    },
+                },
+                "required": ["context_id", "metric", "value"],
+            },
+        },
+        {
+            "name": "recall_series",
+            "readOnly": True,
+            "description": """Read a metric's measurement series, bucketed and aggregated (Issue #1333).
+
+Deterministic HOW-MUCH query over the measurement lane (see record_measurement):
+buckets one metric's observations by period and aggregates each bucket. Empty
+buckets are omitted. The window is capped at 365 days per call; the default
+window is the last 30 days ending now.
+
+Returns: {status, metric, period, agg, series: [{bucket, value, count}], count}.
+bucket is the ISO start of the period; count is the observations in the bucket.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target context UUID.",
+                    },
+                    "metric": {
+                        "type": "string",
+                        "description": "Series name as passed to record_measurement (max 64 chars).",
+                    },
+                    "period": {
+                        "type": "string",
+                        "enum": ["day", "week", "month"],
+                        "description": "Bucket size (default 'day').",
+                    },
+                    "agg": {
+                        "type": "string",
+                        "enum": ["avg", "min", "max", "sum", "count", "last"],
+                        "description": "Per-bucket aggregate (default 'avg'). 'last' = most recent value in the bucket.",
+                    },
+                    "start": {
+                        "type": "string",
+                        "description": "Optional ISO 8601 window start, inclusive (default: end - 30 days). Window capped at 365 days.",
+                    },
+                    "end": {
+                        "type": "string",
+                        "description": "Optional ISO 8601 window end, exclusive (default: now).",
+                    },
+                },
+                "required": ["context_id", "metric"],
+            },
+        },
         # Issue #1274 (RFC-0002 P0-1): Agent Registry — owner/admin-gated CRUD
         # over the workspace-scoped agents table. Agents are resources, not
         # principals: enforcement attaches to member keys in P0-2.

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -2386,11 +2386,11 @@ bucket is the ISO start of the period; count is the observations in the bucket."
                     },
                     "start": {
                         "type": "string",
-                        "description": "Optional ISO 8601 window start, inclusive (default: end - 30 days). Window capped at 365 days.",
+                        "description": "Optional ISO 8601 window start, inclusive (default: end - 30 days). Window capped at 365 days. Naive timestamps are interpreted as UTC and buckets align to UTC boundaries (a local-time day may span two buckets); pass an offset (e.g. +09:00) to have it normalized.",
                     },
                     "end": {
                         "type": "string",
-                        "description": "Optional ISO 8601 window end, exclusive (default: now).",
+                        "description": "Optional ISO 8601 window end, exclusive (default: now). Naive = UTC (see start).",
                     },
                 },
                 "required": ["context_id", "metric"],

--- a/backend/src/mcp_server/tools/measurement.py
+++ b/backend/src/mcp_server/tools/measurement.py
@@ -1,0 +1,211 @@
+"""MCP tools for the HOW-MUCH measurement lane (Issue #1333).
+
+``record_measurement`` / ``recall_series`` over the dedicated ``measurements``
+table — an append-only numeric time-series lane that is structurally excluded
+from ``recall()`` and untouchable by Sleep consolidation.
+
+Access control composes the same proven helpers as the state lane (#889):
+``_resolve_context_for_read`` verifies the caller can reach the context at all
+(uniform ``context_not_found`` on deny — CWE-639), and, for the write tool,
+``_check_viewer_permission`` blocks read-only viewers plus the #1275
+subtractive agent-binding WRITE gate.
+"""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import (
+    _check_viewer_permission,
+    _ContextNotFoundError,
+    _error_response,
+    _resolve_context_for_read,
+    _resolve_context_id,
+    _success_response,
+)
+from utils.datetime import to_utc_iso
+
+# Matches the measurements.metric column length (VARCHAR(64)). Enforced in the
+# handlers too so an overlong metric returns a structured error, not a DB 500.
+_METRIC_MAX_LEN = 64
+
+
+def _validate_metric_arg(metric: Any) -> list[TextContent] | None:
+    """Return an error response if ``metric`` is not a valid series name."""
+    if not isinstance(metric, str) or not metric:
+        return _error_response("validation_error", "'metric' must be a non-empty string")
+    if len(metric) > _METRIC_MAX_LEN:
+        return _error_response(
+            "validation_error", f"'metric' must be at most {_METRIC_MAX_LEN} characters"
+        )
+    return None
+
+
+def _parse_iso_arg(raw: Any, field: str) -> datetime:
+    """Parse an ISO-8601 argument (``Z`` suffix accepted).
+
+    Raises:
+        ValueError: When the value is not a parseable ISO-8601 string.
+    """
+    if not isinstance(raw, str):
+        raise ValueError(f"'{field}' must be an ISO 8601 datetime string")
+    try:
+        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        raise ValueError(f"'{field}' is not a valid ISO 8601 datetime: {raw!r}") from None
+
+
+async def handle_record_measurement(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Append one numeric observation to a metric's series (plain INSERT)."""
+    if "metric" not in args or "value" not in args:
+        return _error_response("missing_fields", "Missing required fields: metric, value")
+    # These handlers have no pydantic request model, so validate the loosely
+    # typed args explicitly rather than letting bad values reach SQL.
+    metric = args["metric"]
+    metric_error = _validate_metric_arg(metric)
+    if metric_error:
+        return metric_error
+    value = args["value"]
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return _error_response("validation_error", "'value' must be a number")
+    measured_at: datetime | None = None
+    if args.get("measured_at") is not None:
+        try:
+            measured_at = _parse_iso_arg(args["measured_at"], "measured_at")
+        except ValueError as exc:
+            return _error_response("validation_error", str(exc))
+    unit = args.get("unit")
+    details = args.get("details")
+
+    from db.base import get_db
+    from services.measurement_service import MeasurementService
+
+    async for db in get_db():
+        # Defense-in-depth: the dispatcher already validates context_id for
+        # non-exempt tools, but guard here too so a direct handler call returns
+        # a structured error instead of raising KeyError/ValueError.
+        raw_ctx = args.get("context_id")
+        if not raw_ctx:
+            return _error_response("missing_fields", "Missing required field: context_id")
+        try:
+            context_id = _resolve_context_id(str(raw_ctx))
+        except ValueError as exc:
+            return _error_response("invalid_context_id_format", str(exc))
+        try:
+            # Verify the caller can reach the context (IDOR guard) ...
+            context = await _resolve_context_for_read(db, user_id, context_id)
+        except _ContextNotFoundError as exc:
+            return exc.to_response()
+        # ... and is not a read-only viewer (write gate, mirrors set_state).
+        # workspace_id is often None under OAuth2 / session-cookie MCP auth —
+        # fall back to the resolved context's workspace so the gate always
+        # fires against the authoritative workspace.
+        effective_workspace_id = workspace_id or context.workspace_id
+        perm_error = await _check_viewer_permission(
+            db, user_id, effective_workspace_id, "record measurement"
+        )
+        if perm_error:
+            return perm_error
+
+        # Issue #1275: recording is a WRITE against the context — apply the
+        # subtractive binding gate so a read-only-bound agent (can_read=true,
+        # write_policy='deny') cannot append measurements in a context whose
+        # binding forbids writes. _resolve_context_for_read above only checks
+        # the READ side. No-op for non-agent credentials.
+        from services.agent_binding_service import ACCESS_WRITE, agent_binding_permits
+
+        if not await agent_binding_permits(db, context_id, ACCESS_WRITE):
+            return _ContextNotFoundError(context_id, "Context not found.").to_response()
+
+        try:
+            row = await MeasurementService(db).record(
+                context_id,
+                metric,
+                value,
+                measured_at=measured_at,
+                unit=unit,
+                details=details,
+            )
+        except ValueError as exc:
+            return _error_response("validation_error", str(exc))
+        return _success_response(
+            measurement_id=str(row.id),
+            metric=row.metric,
+            measured_at=to_utc_iso(row.measured_at),
+            value=float(row.value),
+            unit=row.unit,
+        )
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_recall_series(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Read one metric's series bucketed by period with an aggregate."""
+    if "metric" not in args:
+        return _error_response("missing_fields", "Missing required field: metric")
+    metric = args["metric"]
+    metric_error = _validate_metric_arg(metric)
+    if metric_error:
+        return metric_error
+    period = args.get("period", "day")
+    agg = args.get("agg", "avg")
+    start: datetime | None = None
+    end: datetime | None = None
+    try:
+        if args.get("start") is not None:
+            start = _parse_iso_arg(args["start"], "start")
+        if args.get("end") is not None:
+            end = _parse_iso_arg(args["end"], "end")
+    except ValueError as exc:
+        return _error_response("validation_error", str(exc))
+
+    from db.base import get_db
+    from services.measurement_service import MeasurementService
+
+    async for db in get_db():
+        # Defense-in-depth context_id guard (see handle_record_measurement).
+        raw_ctx = args.get("context_id")
+        if not raw_ctx:
+            return _error_response("missing_fields", "Missing required field: context_id")
+        try:
+            context_id = _resolve_context_id(str(raw_ctx))
+        except ValueError as exc:
+            return _error_response("invalid_context_id_format", str(exc))
+        try:
+            await _resolve_context_for_read(db, user_id, context_id)
+        except _ContextNotFoundError as exc:
+            return exc.to_response()
+
+        try:
+            series = await MeasurementService(db).recall_series(
+                context_id,
+                metric,
+                period=period,
+                agg=agg,
+                start=start,
+                end=end,
+            )
+        except ValueError as exc:
+            return _error_response("validation_error", str(exc))
+        return _success_response(
+            metric=metric,
+            period=period,
+            agg=agg,
+            series=[
+                {
+                    "bucket": to_utc_iso(item["bucket"]),
+                    "value": item["value"],
+                    "count": item["count"],
+                }
+                for item in series
+            ],
+            count=len(series),
+        )
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/measurement.py
+++ b/backend/src/mcp_server/tools/measurement.py
@@ -25,11 +25,11 @@ from mcp_server.tools._helpers import (
     _resolve_context_id,
     _success_response,
 )
-from utils.datetime import to_utc_iso
 
 # Matches the measurements.metric column length (VARCHAR(64)). Enforced in the
 # handlers too so an overlong metric returns a structured error, not a DB 500.
-_METRIC_MAX_LEN = 64
+from services.measurement_service import METRIC_MAX_LEN as _METRIC_MAX_LEN
+from utils.datetime import to_utc_iso
 
 
 def _validate_metric_arg(metric: Any) -> list[TextContent] | None:
@@ -70,6 +70,15 @@ async def handle_record_measurement(
     if metric_error:
         return metric_error
     value = args["value"]
+    # #1322 parity: some MCP clients JSON-stringify scalar args, and
+    # _arg_coercion leaves numbers to pydantic — which this handler doesn't
+    # have. Coerce numeric strings here so the tool behaves like every
+    # pydantic-backed tool would.
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except ValueError:
+            return _error_response("validation_error", "'value' must be a number")
     if isinstance(value, bool) or not isinstance(value, int | float):
         return _error_response("validation_error", "'value' must be a number")
     measured_at: datetime | None = None

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -14,6 +14,7 @@ import models.analysis  # noqa: F401
 import models.file_objects  # noqa: F401  # Issue #485: file storage
 import models.llm_call_log  # noqa: F401  # Issue #474: comprehensive call ledger
 import models.llm_pricing  # noqa: F401
+import models.measurement  # noqa: F401  # Issue #1333: HOW-MUCH measurement lane
 import models.memory_access_event  # noqa: F401  # Issue #1278: agent access audit (P0-5)
 import models.retrieval_feedback  # noqa: F401  # Issue #888: retrieval feedback signal
 import models.secrets  # noqa: F401  # Issue #1128: zero-knowledge secret store

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -32,6 +32,7 @@ RAW_EXPORTABLE_TABLES: frozenset[str] = frozenset(
         "attachments",  # user file metadata (blobs in R2)
         "file_objects",  # R2 object records for user uploads (#485)
         "agent_states",  # user-set key/value run state (#889)
+        "measurements",  # user-recorded numeric time series (#1333)
         "contexts",  # user-authored container name/description
         "resources",  # connected source-of-truth resources
         "resource_events",  # ingested raw source events

--- a/backend/src/models/measurement.py
+++ b/backend/src/models/measurement.py
@@ -1,0 +1,72 @@
+"""HOW-MUCH axis: measurement history lane (Issue #1333).
+
+An append-only numeric time-series store, kept in a **dedicated** table — NOT
+in ``memories`` — so it never pollutes the knowledge ``recall()`` space and,
+critically, so Sleep consolidation can never merge or rewrite a series.
+Measurements are not embedded and not semantically searched; they are
+structurally excluded from recall by living in their own table.
+
+One row per observation of ``(context_id, metric)`` at ``measured_at``.
+Milestone-marker memories ("hit goal weight") remain a caller concern via
+``remember()`` — this lane stores only the raw numbers.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, Index, Numeric, String, func, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+
+class Measurement(Base):
+    """One append-only measurement observation (Issue #1333).
+
+    ``value`` is ``Numeric`` (exact, no float drift at rest); aggregation
+    casts to float8 at read time. ``details`` holds free-form observation
+    metadata (device, source, notes) — intentionally NOT indexed for content
+    search; this lane is a numeric series store, not a knowledge store.
+    """
+
+    __tablename__ = "measurements"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    context_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    metric: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Naive UTC by convention (TIMESTAMP WITHOUT TIME ZONE); the engine pins
+    # the session to UTC so utils.datetime.utcnow() values round-trip
+    # unambiguously. Observation time — distinct from created_at (row insert
+    # time) so backdated imports keep their true series position.
+    measured_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    value: Mapped[Decimal] = mapped_column(Numeric, nullable=False)
+    unit: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    details: Mapped[Any | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        # Series scan: recall_series filters on (context_id, metric) and
+        # bucket-orders by measured_at — one index covers the whole read path.
+        Index(
+            "idx_measurements_context_metric_measured_at",
+            "context_id",
+            "metric",
+            "measured_at",
+        ),
+    )

--- a/backend/src/services/measurement_service.py
+++ b/backend/src/services/measurement_service.py
@@ -1,0 +1,227 @@
+"""HOW-MUCH measurement lane service (Issue #1333).
+
+Append-only writes and bucketed reads over the dedicated ``measurements``
+table — a numeric time-series lane structurally excluded from ``recall()``
+(it lives in its own table, not ``memories``, and is never embedded) and
+untouchable by Sleep consolidation.
+
+``record`` is a plain INSERT (no upsert — a series is history, not state).
+``recall_series`` buckets with PostgreSQL ``date_trunc`` and aggregates with
+an allowlist-gated aggregate, capped to a bounded lookback window.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.measurement import Measurement
+from utils.datetime import utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Matches the measurements.metric column length (VARCHAR(64)).
+METRIC_MAX_LEN = 64
+# Matches the measurements.unit column length (VARCHAR(32)).
+UNIT_MAX_LEN = 32
+
+# Allowed period values map to PostgreSQL ``date_trunc`` precision tokens.
+# Bound to a literal allowlist before reaching the SQL — even though the
+# value is bound (not interpolated), passing arbitrary strings would 500
+# the query when ``date_trunc`` rejects them. (Precedent:
+# ``services.cost_aggregation_service.VALID_PERIODS``.)
+VALID_PERIODS: tuple[str, ...] = ("day", "week", "month")
+
+# Aggregate name → SQL fragment. The fragment is selected from this module
+# constant by allowlisted key — user input never reaches the SQL text, only
+# the key lookup. ``::float8`` so asyncpg returns floats, not Decimals.
+_AGG_SQL: dict[str, str] = {
+    "avg": "AVG(value)::float8",
+    "min": "MIN(value)::float8",
+    "max": "MAX(value)::float8",
+    "sum": "SUM(value)::float8",
+    "count": "COUNT(value)::float8",
+    "last": "(ARRAY_AGG(value ORDER BY measured_at DESC))[1]::float8",
+}
+VALID_AGGS: tuple[str, ...] = tuple(_AGG_SQL)
+
+# Maximum span of a single series request, in days. Defense-in-depth window
+# cap mirroring ``cost_aggregation_service.MAX_LOOKBACK_DAYS`` (#528): a
+# non-UI caller (curl / SDK / MCP) must not be able to scan years of
+# ``measurements`` in one query.
+MAX_LOOKBACK_DAYS = 365
+
+# Default half-open window when the caller gives no bounds: [now - 30d, now).
+DEFAULT_WINDOW_DAYS = 30
+
+
+def window_exceeds_cap(start: datetime, end: datetime) -> bool:
+    """True if the half-open window ``[start, end)`` is wider than the cap.
+
+    ``> timedelta`` (not ``.days >``) rejects a sub-day overage too, which a
+    direct service caller could pass (same rationale as
+    ``cost_aggregation_service.window_exceeds_cap``).
+    """
+    return end - start > timedelta(days=MAX_LOOKBACK_DAYS)
+
+
+def _to_naive_utc(dt: datetime) -> datetime:
+    """Normalize an aware datetime to the project's naive-UTC convention."""
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
+    return dt
+
+
+def _validate_metric(metric: Any) -> str:
+    """Return ``metric`` if it is a non-empty string within the column cap."""
+    if not isinstance(metric, str) or not metric:
+        raise ValueError("'metric' must be a non-empty string")
+    if len(metric) > METRIC_MAX_LEN:
+        raise ValueError(f"'metric' must be at most {METRIC_MAX_LEN} characters")
+    return metric
+
+
+class MeasurementService:
+    """Record and aggregate numeric measurement series, scoped to a context."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def record(
+        self,
+        context_id: UUID,
+        metric: str,
+        value: float,
+        *,
+        measured_at: datetime | None = None,
+        unit: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> Measurement:
+        """Append one measurement observation (plain INSERT, never upsert).
+
+        Args:
+            context_id: Owning context (rows cascade with it).
+            metric: Series name, e.g. ``"weight_kg"`` (max 64 chars).
+            value: Finite number. Bools, NaN and infinities are rejected.
+            measured_at: Observation time; defaults to now (UTC). Aware
+                datetimes are normalized to naive UTC.
+            unit: Optional display unit (max 32 chars).
+            details: Optional free-form JSON metadata (device, source, ...).
+
+        Returns:
+            The persisted ``Measurement`` row.
+
+        Raises:
+            ValueError: On any invalid argument.
+        """
+        _validate_metric(metric)
+        # bool is an int subclass — reject explicitly before the isinstance
+        # check; NaN/inf are numbers but poison every aggregate.
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise ValueError("'value' must be a number")
+        if not math.isfinite(value):
+            raise ValueError("'value' must be finite (NaN and infinity are rejected)")
+        if unit is not None:
+            if not isinstance(unit, str) or not unit:
+                raise ValueError("'unit' must be a non-empty string when provided")
+            if len(unit) > UNIT_MAX_LEN:
+                raise ValueError(f"'unit' must be at most {UNIT_MAX_LEN} characters")
+        if details is not None and not isinstance(details, dict):
+            raise ValueError("'details' must be an object when provided")
+        if measured_at is not None and not isinstance(measured_at, datetime):
+            raise ValueError("'measured_at' must be a datetime when provided")
+
+        row = Measurement(
+            context_id=context_id,
+            metric=metric,
+            measured_at=_to_naive_utc(measured_at) if measured_at is not None else utcnow(),
+            value=value,
+            unit=unit,
+            details=details,
+        )
+        self.db.add(row)
+        await self.db.commit()
+        logger.info(
+            "measurement_recorded",
+            context_id=str(context_id),
+            metric=metric,
+        )
+        return row
+
+    async def recall_series(
+        self,
+        context_id: UUID,
+        metric: str,
+        *,
+        period: str = "day",
+        agg: str = "avg",
+        start: datetime | None = None,
+        end: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """Aggregate one metric's series into time buckets.
+
+        Args:
+            context_id: Owning context.
+            metric: Series name to aggregate.
+            period: Bucket size — one of ``VALID_PERIODS``.
+            agg: Aggregate — one of ``VALID_AGGS`` (``last`` = most recent
+                value in the bucket by ``measured_at``).
+            start: Window start (inclusive); defaults to ``end - 30 days``.
+            end: Window end (exclusive); defaults to now (UTC).
+
+        Returns:
+            ``[{"bucket": datetime, "value": float, "count": int}, ...]``
+            ordered by bucket ascending. Empty buckets are omitted.
+
+        Raises:
+            ValueError: On bad metric/period/agg or an inverted/oversized
+                window (maps to ``validation_error`` at the MCP boundary).
+        """
+        _validate_metric(metric)
+        if period not in VALID_PERIODS:
+            raise ValueError(f"Invalid period {period!r}. Valid: {', '.join(VALID_PERIODS)}")
+        if agg not in _AGG_SQL:
+            raise ValueError(f"Invalid agg {agg!r}. Valid: {', '.join(VALID_AGGS)}")
+
+        end_at = _to_naive_utc(end) if end is not None else utcnow()
+        start_at = (
+            _to_naive_utc(start)
+            if start is not None
+            else end_at - timedelta(days=DEFAULT_WINDOW_DAYS)
+        )
+        if start_at >= end_at:
+            raise ValueError("'start' must be before 'end'")
+        if window_exceeds_cap(start_at, end_at):
+            raise ValueError(f"Window too wide: maximum lookback is {MAX_LOOKBACK_DAYS} days")
+
+        # The aggregate fragment comes from the module-constant _AGG_SQL map
+        # keyed by the allowlisted ``agg`` — never from user input. Everything
+        # user-controlled (period, metric, window, context) is a bind param.
+        sql = (
+            "SELECT date_trunc(:period, measured_at) AS bucket, "
+            + _AGG_SQL[agg]
+            + " AS value, COUNT(*)::bigint AS count "
+            "FROM measurements "
+            "WHERE context_id = :context_id AND metric = :metric "
+            "AND measured_at >= :start AND measured_at < :end "
+            "GROUP BY bucket ORDER BY bucket ASC"
+        )
+        rows = (
+            await self.db.execute(
+                text(sql),
+                {
+                    "period": period,
+                    "context_id": context_id,
+                    "metric": metric,
+                    "start": start_at,
+                    "end": end_at,
+                },
+            )
+        ).all()
+        return [{"bucket": row.bucket, "value": row.value, "count": row.count} for row in rows]

--- a/backend/src/services/measurement_service.py
+++ b/backend/src/services/measurement_service.py
@@ -125,7 +125,14 @@ class MeasurementService:
         # check; NaN/inf are numbers but poison every aggregate.
         if isinstance(value, bool) or not isinstance(value, int | float):
             raise ValueError("'value' must be a number")
-        if not math.isfinite(value):
+        try:
+            finite = math.isfinite(value)
+        except OverflowError as exc:
+            # A JSON integer is arbitrary-precision; one beyond float range
+            # makes isfinite() raise OverflowError, which the MCP boundary
+            # does not map — normalize to the documented validation error.
+            raise ValueError("'value' must be finite (NaN and infinity are rejected)") from exc
+        if not finite:
             raise ValueError("'value' must be finite (NaN and infinity are rejected)")
         if unit is not None:
             if not isinstance(unit, str) or not unit:
@@ -147,10 +154,12 @@ class MeasurementService:
         )
         self.db.add(row)
         await self.db.commit()
+        # Ids only — metric names are free-form user data and must not land
+        # in log aggregation (memory_service convention: ids/enums only).
         logger.info(
             "measurement_recorded",
             context_id=str(context_id),
-            metric=metric,
+            measurement_id=str(row.id),
         )
         return row
 

--- a/backend/tests/integration/test_e71_1333_measurements_migration.py
+++ b/backend/tests/integration/test_e71_1333_measurements_migration.py
@@ -1,0 +1,111 @@
+"""Integration pins for #1333 — the ``measurements`` table at the DB level.
+
+Covers what the mocked-session unit tests cannot: the PostgreSQL defaults
+(``gen_random_uuid()`` id, ``now()`` created_at), the NOT NULL constraints,
+the FK CASCADE on context delete, and the series-scan index
+``idx_measurements_context_metric_measured_at`` — all against the schema at
+alembic head (mirrors tests/integration/test_e44_1065_host_arbitration_migration.py).
+Runs under ``make test-integration`` (needs the kagura_test DB).
+"""
+
+import datetime
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+# Static SQL (no f-strings — project rule forbids interpolated SQL).
+_INSERT_MINIMAL = (
+    "INSERT INTO measurements (context_id, metric, measured_at, value) "
+    "VALUES (:ctx, :metric, now(), :val) RETURNING id, created_at"
+)
+_INSERT_FULL = (
+    "INSERT INTO measurements (context_id, metric, measured_at, value, unit, details) "
+    "VALUES (:ctx, :metric, :at, :val, :unit, CAST(:details AS jsonb))"
+)
+_SELECT_BY_CTX = (
+    "SELECT metric, value, unit FROM measurements WHERE context_id = :ctx ORDER BY measured_at"
+)
+_COUNT_BY_CTX = "SELECT COUNT(*) FROM measurements WHERE context_id = :ctx"
+_DELETE_CONTEXT = "DELETE FROM contexts WHERE id = :ctx"
+_SELECT_INDEXES = "SELECT indexname FROM pg_indexes WHERE tablename = 'measurements'"
+_INSERT_NULL_VALUE = (
+    "INSERT INTO measurements (context_id, metric, measured_at) VALUES (:ctx, :metric, now())"
+)
+
+
+async def _ctx(db_session):
+    """Create a workspace + context and return the context id."""
+    ws, ctx, owner = uuid.uuid4(), uuid.uuid4(), "u-1333"
+    await db_session.execute(
+        text("INSERT INTO workspaces (id, name, owner_user_id) VALUES (:id, :n, :o)"),
+        {"id": ws, "n": "ws-1333", "o": owner},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by) VALUES (:id, :ws, :n, :by)"
+        ),
+        {"id": ctx, "ws": ws, "n": "ctx-1333", "by": owner},
+    )
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_defaults_populate_id_and_created_at(db_session):
+    """id (gen_random_uuid) and created_at (now()) backfill server-side."""
+    ctx = await _ctx(db_session)
+    row = (
+        await db_session.execute(
+            text(_INSERT_MINIMAL), {"ctx": ctx, "metric": "weight_kg", "val": 72.5}
+        )
+    ).one()
+    assert isinstance(row.id, uuid.UUID)
+    assert row.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_full_insert_round_trips(db_session):
+    ctx = await _ctx(db_session)
+    await db_session.execute(
+        text(_INSERT_FULL),
+        {
+            "ctx": ctx,
+            "metric": "weight_kg",
+            "at": datetime.datetime(2026, 7, 17, 8, 0, 0),  # noqa: DTZ001 — naive UTC by convention
+            "val": 72.5,
+            "unit": "kg",
+            "details": '{"device": "scale"}',
+        },
+    )
+    rows = (await db_session.execute(text(_SELECT_BY_CTX), {"ctx": ctx})).all()
+    assert len(rows) == 1
+    assert rows[0].metric == "weight_kg"
+    assert float(rows[0].value) == 72.5
+    assert rows[0].unit == "kg"
+
+
+@pytest.mark.asyncio
+async def test_value_is_not_nullable(db_session):
+    ctx = await _ctx(db_session)
+    with pytest.raises(IntegrityError):
+        await db_session.execute(text(_INSERT_NULL_VALUE), {"ctx": ctx, "metric": "weight_kg"})
+
+
+@pytest.mark.asyncio
+async def test_context_delete_cascades(db_session):
+    """The lane must never orphan rows — measurements die with their context."""
+    ctx = await _ctx(db_session)
+    await db_session.execute(
+        text(_INSERT_MINIMAL), {"ctx": ctx, "metric": "weight_kg", "val": 72.5}
+    )
+    await db_session.execute(text(_DELETE_CONTEXT), {"ctx": ctx})
+    count = (await db_session.execute(text(_COUNT_BY_CTX), {"ctx": ctx})).scalar_one()
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_series_scan_index_exists(db_session):
+    """The (context_id, metric, measured_at) index backs recall_series."""
+    names = {r.indexname for r in (await db_session.execute(text(_SELECT_INDEXES))).all()}
+    assert "idx_measurements_context_metric_measured_at" in names

--- a/backend/tests/mcp_server/test_measurement_tools.py
+++ b/backend/tests/mcp_server/test_measurement_tools.py
@@ -134,8 +134,11 @@ class TestRecordMeasurement:
 
     @pytest.mark.asyncio
     async def test_non_number_value_is_rejected(self):
+        # "72.5" is NOT here: numeric strings coerce (#1322 parity — some
+        # MCP clients stringify scalars and this handler has no pydantic
+        # model to do the coercion).
         svc = MagicMock(record=AsyncMock())
-        for bad in (True, "72.5", [1], {"v": 1}):
+        for bad in (True, "abc", [1], {"v": 1}):
             with ExitStack() as stack:
                 _enter(stack, service=svc)
                 result = await handle_record_measurement(
@@ -404,3 +407,25 @@ class TestRegistration:
         for name in ("record_measurement", "recall_series"):
             assert name not in _TOOLS_WITHOUT_CONTEXT_ID
             assert name not in _RATE_LIMIT_EXEMPT_TOOLS
+
+
+@pytest.mark.asyncio
+async def test_numeric_string_value_coerces_like_pydantic_tools():
+    """#1322 parity: clients that JSON-stringify scalars get the same
+    acceptance a pydantic-backed tool would give."""
+    from contextlib import ExitStack
+    from unittest.mock import AsyncMock, MagicMock
+    from uuid import uuid4
+
+    svc = MagicMock(record=AsyncMock(return_value=_row()))
+    with ExitStack() as stack:
+        _enter(stack, service=svc)
+        result = await handle_record_measurement(
+            args={"context_id": CTX, "metric": "weight_kg", "value": "72.5"},
+            user_id="u",
+            workspace_id=uuid4(),
+        )
+    assert _payload(result)["status"] == "success"
+    assert svc.record.await_args.kwargs.get("value") == pytest.approx(72.5) or (
+        len(svc.record.await_args.args) > 2 and svc.record.await_args.args[2] == pytest.approx(72.5)
+    )

--- a/backend/tests/mcp_server/test_measurement_tools.py
+++ b/backend/tests/mcp_server/test_measurement_tools.py
@@ -1,0 +1,406 @@
+"""Unit tests for the HOW-MUCH measurement-lane MCP handlers (Issue #1333).
+
+Pins the access-control composition (IDOR guard + write gate + #1275 binding
+gate) and the arg/dispatch contract of ``handle_record_measurement`` /
+``handle_recall_series`` without a database — the service is mocked. Mirrors
+tests/mcp_server/test_state_tools.py. DB-backed behaviour is covered in
+tests/services/test_measurement_service.py and the migration test.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools._helpers import _ContextNotFoundError, _error_response
+from mcp_server.tools.measurement import handle_recall_series, handle_record_measurement
+
+CTX = str(uuid4())
+
+
+def _payload(result):
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+def _enter(stack, *, service, resolve_raises=None, viewer_error=None, binding_permits=True):
+    """Enter the standard patch set and return the mocked service."""
+
+    async def gen():
+        yield AsyncMock()
+
+    resolve = AsyncMock(side_effect=resolve_raises) if resolve_raises else AsyncMock()
+    stack.enter_context(patch("db.base.get_db", new=gen))
+    stack.enter_context(
+        patch("mcp_server.tools.measurement._resolve_context_for_read", new=resolve)
+    )
+    stack.enter_context(
+        patch(
+            "mcp_server.tools.measurement._check_viewer_permission",
+            new=AsyncMock(return_value=viewer_error),
+        )
+    )
+    # #1275: record_measurement applies the WRITE binding gate. Default
+    # permits (no agent scope); tests pass binding_permits=False to simulate
+    # a write-denied agent binding.
+    stack.enter_context(
+        patch(
+            "services.agent_binding_service.agent_binding_permits",
+            new=AsyncMock(return_value=binding_permits),
+        )
+    )
+    stack.enter_context(
+        patch("services.measurement_service.MeasurementService", return_value=service)
+    )
+    return service
+
+
+def _row(**overrides):
+    row = MagicMock()
+    row.id = overrides.get("id", uuid4())
+    row.metric = overrides.get("metric", "weight_kg")
+    row.measured_at = overrides.get("measured_at", datetime(2026, 7, 17, 8, 0))
+    row.value = overrides.get("value", Decimal("72.5"))
+    row.unit = overrides.get("unit", "kg")
+    return row
+
+
+class TestRecordMeasurement:
+    @pytest.mark.asyncio
+    async def test_missing_fields_returns_error(self):
+        for args in (
+            {"context_id": CTX, "metric": "weight_kg"},
+            {"context_id": CTX, "value": 1.0},
+        ):
+            result = await handle_record_measurement(args=args, user_id="u", workspace_id=uuid4())
+            assert _payload(result)["error"] == "missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_missing_context_id_returns_error(self):
+        svc = MagicMock(record=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_record_measurement(
+                args={"metric": "weight_kg", "value": 1.0}, user_id="u", workspace_id=uuid4()
+            )
+        assert _payload(result)["error"] == "missing_fields"
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invalid_context_id_returns_error(self):
+        svc = MagicMock(record=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_record_measurement(
+                args={"context_id": "not-a-uuid", "metric": "weight_kg", "value": 1.0},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "invalid_context_id_format"
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_context_not_found_short_circuits(self):
+        svc = MagicMock(record=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc, resolve_raises=_ContextNotFoundError(uuid4(), "nope"))
+            result = await handle_record_measurement(
+                args={"context_id": CTX, "metric": "weight_kg", "value": 1.0},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "context_not_found"
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bad_metric_is_rejected(self):
+        svc = MagicMock(record=AsyncMock())
+        for bad in ("", "m" * 65, 42):
+            with ExitStack() as stack:
+                _enter(stack, service=svc)
+                result = await handle_record_measurement(
+                    args={"context_id": CTX, "metric": bad, "value": 1.0},
+                    user_id="u",
+                    workspace_id=uuid4(),
+                )
+            assert _payload(result)["error"] == "validation_error", bad
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_non_number_value_is_rejected(self):
+        svc = MagicMock(record=AsyncMock())
+        for bad in (True, "72.5", [1], {"v": 1}):
+            with ExitStack() as stack:
+                _enter(stack, service=svc)
+                result = await handle_record_measurement(
+                    args={"context_id": CTX, "metric": "weight_kg", "value": bad},
+                    user_id="u",
+                    workspace_id=uuid4(),
+                )
+            assert _payload(result)["error"] == "validation_error", bad
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unparseable_measured_at_is_rejected(self):
+        svc = MagicMock(record=AsyncMock())
+        for bad in ("yesterday", 1234, ""):
+            with ExitStack() as stack:
+                _enter(stack, service=svc)
+                result = await handle_record_measurement(
+                    args={
+                        "context_id": CTX,
+                        "metric": "weight_kg",
+                        "value": 1.0,
+                        "measured_at": bad,
+                    },
+                    user_id="u",
+                    workspace_id=uuid4(),
+                )
+            assert _payload(result)["error"] == "validation_error", bad
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_viewer_is_blocked_from_writing(self):
+        svc = MagicMock(record=AsyncMock())
+        blocked = _error_response("permission_denied", "viewers cannot write")
+        with ExitStack() as stack:
+            _enter(stack, service=svc, viewer_error=blocked)
+            result = await handle_record_measurement(
+                args={"context_id": CTX, "metric": "weight_kg", "value": 1.0},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "permission_denied"
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_viewer_gate_uses_context_workspace_when_workspace_id_none(self):
+        # Regression precedent (#889): with workspace_id=None (OAuth2/session
+        # MCP auth), the write gate must still fire against the resolved
+        # context's workspace.
+        svc = MagicMock(record=AsyncMock())
+        ctx_ws = uuid4()
+        blocked = _error_response("permission_denied", "viewers cannot write")
+        viewer = AsyncMock(return_value=blocked)
+
+        async def gen():
+            yield AsyncMock()
+
+        with ExitStack() as stack:
+            resolved = AsyncMock(return_value=MagicMock(workspace_id=ctx_ws))
+            stack.enter_context(patch("db.base.get_db", new=gen))
+            stack.enter_context(
+                patch("mcp_server.tools.measurement._resolve_context_for_read", new=resolved)
+            )
+            stack.enter_context(
+                patch("mcp_server.tools.measurement._check_viewer_permission", new=viewer)
+            )
+            stack.enter_context(
+                patch("services.measurement_service.MeasurementService", return_value=svc)
+            )
+            result = await handle_record_measurement(
+                args={"context_id": CTX, "metric": "weight_kg", "value": 1.0},
+                user_id="u",
+                workspace_id=None,
+            )
+        assert _payload(result)["error"] == "permission_denied"
+        assert viewer.await_args.args[2] == ctx_ws
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_denied_agent_binding_blocks_record(self):
+        """#1275: record_measurement is a WRITE — a read-only-bound agent must
+        be blocked with the uniform context_not_found."""
+        svc = MagicMock(record=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc, binding_permits=False)
+            result = await handle_record_measurement(
+                args={"context_id": CTX, "metric": "weight_kg", "value": 1.0},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "context_not_found"
+        svc.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_service_validation_error_maps_to_validation_error(self):
+        svc = MagicMock(record=AsyncMock(side_effect=ValueError("value must be finite")))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_record_measurement(
+                args={"context_id": CTX, "metric": "weight_kg", "value": 1.0},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_recorded_measurement(self):
+        row = _row()
+        svc = MagicMock(record=AsyncMock(return_value=row))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_record_measurement(
+                args={
+                    "context_id": CTX,
+                    "metric": "weight_kg",
+                    "value": 72.5,
+                    "unit": "kg",
+                    "measured_at": "2026-07-17T08:00:00Z",
+                    "details": {"device": "scale"},
+                },
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        body = _payload(result)
+        assert body["status"] == "success"
+        assert body["measurement_id"] == str(row.id)
+        assert body["metric"] == "weight_kg"
+        assert body["value"] == 72.5
+        assert body["unit"] == "kg"
+        assert body["measured_at"].endswith("Z")
+        svc.record.assert_awaited_once()
+        kwargs = svc.record.call_args.kwargs
+        assert kwargs["unit"] == "kg"
+        assert kwargs["details"] == {"device": "scale"}
+        assert kwargs["measured_at"] is not None
+
+
+class TestRecallSeries:
+    @pytest.mark.asyncio
+    async def test_missing_metric_returns_error(self):
+        result = await handle_recall_series(
+            args={"context_id": CTX}, user_id="u", workspace_id=uuid4()
+        )
+        assert _payload(result)["error"] == "missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_missing_context_id_returns_error(self):
+        svc = MagicMock(recall_series=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_recall_series(
+                args={"metric": "weight_kg"}, user_id="u", workspace_id=uuid4()
+            )
+        assert _payload(result)["error"] == "missing_fields"
+        svc.recall_series.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_context_not_found_short_circuits(self):
+        svc = MagicMock(recall_series=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc, resolve_raises=_ContextNotFoundError(uuid4(), "nope"))
+            result = await handle_recall_series(
+                args={"context_id": CTX, "metric": "weight_kg"},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "context_not_found"
+        svc.recall_series.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_service_value_error_maps_to_validation_error(self):
+        svc = MagicMock(recall_series=AsyncMock(side_effect=ValueError("Invalid period")))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_recall_series(
+                args={"context_id": CTX, "metric": "weight_kg", "period": "hour"},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_start_is_rejected(self):
+        svc = MagicMock(recall_series=AsyncMock())
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_recall_series(
+                args={"context_id": CTX, "metric": "weight_kg", "start": "last tuesday"},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        assert _payload(result)["error"] == "validation_error"
+        svc.recall_series.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_serializes_buckets_as_utc_iso(self):
+        svc = MagicMock(
+            recall_series=AsyncMock(
+                return_value=[
+                    {"bucket": datetime(2026, 7, 1), "value": 71.2, "count": 3},
+                    {"bucket": datetime(2026, 7, 2), "value": 70.8, "count": 1},
+                ]
+            )
+        )
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_recall_series(
+                args={"context_id": CTX, "metric": "weight_kg", "period": "day", "agg": "avg"},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        body = _payload(result)
+        assert body["status"] == "success"
+        assert body["metric"] == "weight_kg"
+        assert body["period"] == "day"
+        assert body["agg"] == "avg"
+        assert body["count"] == 2
+        assert body["series"] == [
+            {"bucket": "2026-07-01T00:00:00Z", "value": 71.2, "count": 3},
+            {"bucket": "2026-07-02T00:00:00Z", "value": 70.8, "count": 1},
+        ]
+        kwargs = svc.recall_series.call_args.kwargs
+        assert kwargs["period"] == "day"
+        assert kwargs["agg"] == "avg"
+
+    @pytest.mark.asyncio
+    async def test_defaults_period_day_agg_avg(self):
+        svc = MagicMock(recall_series=AsyncMock(return_value=[]))
+        with ExitStack() as stack:
+            _enter(stack, service=svc)
+            result = await handle_recall_series(
+                args={"context_id": CTX, "metric": "weight_kg"},
+                user_id="u",
+                workspace_id=uuid4(),
+            )
+        body = _payload(result)
+        assert body["period"] == "day"
+        assert body["agg"] == "avg"
+        kwargs = svc.recall_series.call_args.kwargs
+        assert kwargs["period"] == "day"
+        assert kwargs["agg"] == "avg"
+        assert kwargs["start"] is None
+        assert kwargs["end"] is None
+
+
+class TestRegistration:
+    def test_tools_are_defined_and_dispatchable(self):
+        from mcp_server.tools import _build_registry
+        from mcp_server.tools._definitions import get_tool_definitions
+
+        names = {d["name"] for d in get_tool_definitions()}
+        assert {"record_measurement", "recall_series"} <= names
+        registry = _build_registry()
+        assert registry["record_measurement"] is handle_record_measurement
+        assert registry["recall_series"] is handle_recall_series
+
+    def test_recall_series_is_read_only(self):
+        from mcp_server.tools._definitions import get_tool_definitions
+
+        by_name = {d["name"]: d for d in get_tool_definitions()}
+        assert by_name["recall_series"].get("readOnly") is True
+        assert by_name["record_measurement"].get("readOnly") is not True
+
+    def test_tools_require_context_id_and_are_rate_limited(self):
+        from mcp_server.tools import _RATE_LIMIT_EXEMPT_TOOLS, _TOOLS_WITHOUT_CONTEXT_ID
+
+        for name in ("record_measurement", "recall_series"):
+            assert name not in _TOOLS_WITHOUT_CONTEXT_ID
+            assert name not in _RATE_LIMIT_EXEMPT_TOOLS

--- a/backend/tests/services/test_measurement_service.py
+++ b/backend/tests/services/test_measurement_service.py
@@ -1,0 +1,222 @@
+"""Unit tests for MeasurementService (Issue #1333).
+
+Pins the validation contract (metric length, finite-number values, period/agg
+allowlists, window cap) and the SQL shape of ``recall_series`` (date_trunc +
+GROUP BY with every dynamic piece bound, never interpolated) without a
+database — the session is mocked. DB-backed behaviour (defaults, FK cascade,
+index) is covered in tests/integration/test_e71_1333_measurements_migration.py.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.measurement_service import (
+    DEFAULT_WINDOW_DAYS,
+    MAX_LOOKBACK_DAYS,
+    METRIC_MAX_LEN,
+    VALID_AGGS,
+    VALID_PERIODS,
+    MeasurementService,
+)
+from utils.datetime import utcnow
+
+CTX = uuid4()
+
+
+def _db(rows: list | None = None) -> MagicMock:
+    """Mock AsyncSession: add/commit for record, execute().all() for series."""
+    result = MagicMock()
+    result.all.return_value = rows or []
+    return MagicMock(
+        add=MagicMock(),
+        commit=AsyncMock(),
+        execute=AsyncMock(return_value=result),
+    )
+
+
+class TestRecord:
+    @pytest.mark.asyncio
+    async def test_rejects_bad_metric(self):
+        db = _db()
+        svc = MeasurementService(db)
+        for bad in ("", "m" * (METRIC_MAX_LEN + 1), 42, None):
+            with pytest.raises(ValueError):
+                await svc.record(CTX, bad, 1.0)  # type: ignore[arg-type]
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_finite_and_non_number_values(self):
+        db = _db()
+        svc = MeasurementService(db)
+        for bad in (True, False, float("inf"), float("-inf"), float("nan"), "72.5", None):
+            with pytest.raises(ValueError):
+                await svc.record(CTX, "weight_kg", bad)  # type: ignore[arg-type]
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_unit(self):
+        db = _db()
+        svc = MeasurementService(db)
+        for bad in ("u" * 33, "", 7):
+            with pytest.raises(ValueError):
+                await svc.record(CTX, "weight_kg", 1.0, unit=bad)  # type: ignore[arg-type]
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_dict_details(self):
+        db = _db()
+        svc = MeasurementService(db)
+        with pytest.raises(ValueError):
+            await svc.record(CTX, "weight_kg", 1.0, details=["not", "a", "dict"])  # type: ignore[arg-type]
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_defaults_measured_at_to_now(self):
+        db = _db()
+        row = await MeasurementService(db).record(
+            CTX, "weight_kg", 72.5, unit="kg", details={"device": "scale"}
+        )
+        db.add.assert_called_once_with(row)
+        db.commit.assert_awaited_once()
+        assert row.context_id == CTX
+        assert row.metric == "weight_kg"
+        assert row.value == 72.5
+        assert row.unit == "kg"
+        assert row.details == {"device": "scale"}
+        # naive UTC, defaulted to "now"
+        assert row.measured_at.tzinfo is None
+        assert abs((utcnow() - row.measured_at).total_seconds()) < 5
+
+    @pytest.mark.asyncio
+    async def test_aware_measured_at_is_normalized_to_naive_utc(self):
+        db = _db()
+        aware = datetime(2026, 7, 1, 12, 30, tzinfo=UTC)
+        row = await MeasurementService(db).record(CTX, "weight_kg", 70, measured_at=aware)
+        assert row.measured_at == datetime(2026, 7, 1, 12, 30)
+        assert row.measured_at.tzinfo is None
+
+    @pytest.mark.asyncio
+    async def test_int_value_is_accepted(self):
+        db = _db()
+        row = await MeasurementService(db).record(CTX, "steps", 10000)
+        assert row.value == 10000
+
+
+class TestRecallSeriesValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_period(self):
+        db = _db()
+        svc = MeasurementService(db)
+        for bad in ("hour", "DAY", "day; DROP TABLE measurements", ""):
+            with pytest.raises(ValueError):
+                await svc.recall_series(CTX, "weight_kg", period=bad)
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_agg(self):
+        db = _db()
+        svc = MeasurementService(db)
+        for bad in ("median", "AVG", "avg)--", ""):
+            with pytest.raises(ValueError):
+                await svc.recall_series(CTX, "weight_kg", agg=bad)
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_metric(self):
+        db = _db()
+        with pytest.raises(ValueError):
+            await MeasurementService(db).recall_series(CTX, "m" * (METRIC_MAX_LEN + 1))
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_inverted_window(self):
+        db = _db()
+        end = utcnow()
+        with pytest.raises(ValueError):
+            await MeasurementService(db).recall_series(
+                CTX, "weight_kg", start=end, end=end - timedelta(days=1)
+            )
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rejects_window_wider_than_cap(self):
+        db = _db()
+        end = utcnow()
+        with pytest.raises(ValueError):
+            await MeasurementService(db).recall_series(
+                CTX, "weight_kg", start=end - timedelta(days=MAX_LOOKBACK_DAYS, seconds=1), end=end
+            )
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_accepts_window_exactly_at_cap(self):
+        db = _db()
+        end = utcnow()
+        await MeasurementService(db).recall_series(
+            CTX, "weight_kg", start=end - timedelta(days=MAX_LOOKBACK_DAYS), end=end
+        )
+        db.execute.assert_awaited_once()
+
+    def test_allowlists_are_pinned(self):
+        assert VALID_PERIODS == ("day", "week", "month")
+        assert set(VALID_AGGS) >= {"avg", "min", "max", "sum", "count"}
+
+
+class TestRecallSeriesSQL:
+    @pytest.mark.asyncio
+    async def test_sql_shape_and_bound_params(self):
+        db = _db()
+        await MeasurementService(db).recall_series(CTX, "weight_kg", period="week", agg="max")
+        stmt, params = db.execute.await_args.args
+        sql = str(stmt)
+        # date_trunc bucketing with the period BOUND (allowlist-gated), not
+        # interpolated; grouped and ordered by bucket.
+        assert "date_trunc(:period" in sql
+        assert "GROUP BY" in sql
+        assert "ORDER BY" in sql
+        # every dynamic piece is a bind param — the metric never appears in SQL
+        assert "weight_kg" not in sql
+        assert ":metric" in sql and ":context_id" in sql
+        assert ":start" in sql and ":end" in sql
+        assert params["period"] == "week"
+        assert params["metric"] == "weight_kg"
+        assert params["context_id"] == CTX
+        assert "MAX" in sql.upper()
+
+    @pytest.mark.asyncio
+    async def test_default_window_is_30_days_ending_now(self):
+        db = _db()
+        await MeasurementService(db).recall_series(CTX, "weight_kg")
+        _, params = db.execute.await_args.args
+        assert params["end"] - params["start"] == timedelta(days=DEFAULT_WINDOW_DAYS)
+        assert abs((utcnow() - params["end"]).total_seconds()) < 5
+
+    @pytest.mark.asyncio
+    async def test_rows_map_to_bucket_value_count(self):
+        rows = [
+            SimpleNamespace(bucket=datetime(2026, 7, 1), value=71.2, count=3),
+            SimpleNamespace(bucket=datetime(2026, 7, 2), value=70.8, count=1),
+        ]
+        db = _db(rows)
+        series = await MeasurementService(db).recall_series(CTX, "weight_kg")
+        assert series == [
+            {"bucket": datetime(2026, 7, 1), "value": 71.2, "count": 3},
+            {"bucket": datetime(2026, 7, 2), "value": 70.8, "count": 1},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_aware_window_bounds_are_normalized_to_naive_utc(self):
+        db = _db()
+        start = datetime(2026, 6, 1, tzinfo=UTC)
+        end = datetime(2026, 7, 1, tzinfo=UTC)
+        await MeasurementService(db).recall_series(CTX, "weight_kg", start=start, end=end)
+        _, params = db.execute.await_args.args
+        assert params["start"] == datetime(2026, 6, 1)
+        assert params["start"].tzinfo is None
+        assert params["end"] == datetime(2026, 7, 1)

--- a/backend/tests/services/test_measurement_service.py
+++ b/backend/tests/services/test_measurement_service.py
@@ -220,3 +220,51 @@ class TestRecallSeriesSQL:
         assert params["start"] == datetime(2026, 6, 1)
         assert params["start"].tzinfo is None
         assert params["end"] == datetime(2026, 7, 1)
+
+
+class TestCrossModulePins:
+    """#1333 review: clones and schemas must not drift silently."""
+
+    def test_window_cap_matches_cost_aggregation(self):
+        # The measurement window constants clone cost_aggregation_service's
+        # (importing would couple the lanes) — this pin is what makes the
+        # clone safe: tune one, and this fails until the other follows.
+        from services import cost_aggregation_service as cost
+        from services import measurement_service as meas
+
+        assert meas.VALID_PERIODS == cost.VALID_PERIODS
+        assert meas.MAX_LOOKBACK_DAYS == cost.MAX_LOOKBACK_DAYS
+
+    def test_tool_schema_enums_match_service_allowlists_exactly(self):
+        # A schema/service mismatch either 500s an advertised value or hides
+        # an implemented one.
+        from mcp_server.tools._definitions import get_tool_definitions
+        from services.measurement_service import VALID_AGGS, VALID_PERIODS
+
+        tools = {t["name"]: t for t in get_tool_definitions()}
+        props = tools["recall_series"]["inputSchema"]["properties"]
+        assert tuple(props["period"]["enum"]) == VALID_PERIODS
+        assert tuple(props["agg"]["enum"]) == VALID_AGGS
+
+    def test_all_aggs_including_last_are_implemented(self):
+        from services.measurement_service import _AGG_SQL, VALID_AGGS
+
+        assert set(VALID_AGGS) == set(_AGG_SQL)
+        assert "last" in VALID_AGGS
+
+
+class TestReviewHardening:
+    """#1333 review: overflow normalization."""
+
+    @pytest.mark.asyncio
+    async def test_huge_int_value_is_validation_error_not_overflow(self):
+        # JSON ints are arbitrary-precision; math.isfinite(10**400) raises
+        # OverflowError, which the MCP boundary does not map — the service
+        # must normalize it to the documented ValueError.
+        from unittest.mock import MagicMock
+
+        from services.measurement_service import MeasurementService
+
+        service = MeasurementService(MagicMock())
+        with pytest.raises(ValueError, match="finite"):
+            await service.record(uuid4(), "metric", 10**400)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1052,7 +1052,7 @@ System-admin (`role=admin`) lifecycle API for platform worker app identities (Sl
 
 ## MCP Tools
 
-Kagura Memory Cloud provides 62 MCP tools for AI assistants across 13 categories (Memory, Agent Substrate, Agent Control Plane, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
+Kagura Memory Cloud provides 63 MCP tools for AI assistants across 13 categories (Memory, Agent Substrate, Agent Control Plane, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
 
 ### 1. remember
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1052,7 +1052,7 @@ System-admin (`role=admin`) lifecycle API for platform worker app identities (Sl
 
 ## MCP Tools
 
-Kagura Memory Cloud provides 60 MCP tools for AI assistants across 13 categories (Memory, Agent Substrate, Agent Control Plane, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
+Kagura Memory Cloud provides 62 MCP tools for AI assistants across 13 categories (Memory, Agent Substrate, Agent Control Plane, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Secrets, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
 
 ### 1. remember
 

--- a/docs/derived-layer-boundary.md
+++ b/docs/derived-layer-boundary.md
@@ -49,6 +49,7 @@ feature-development time, not discovered at export time.
 | `attachments` | User file metadata (filename, content type, size) |
 | `file_objects` | R2 object records for user uploads (#485) |
 | `agent_states` | User-set key/value run state (#889) |
+| `measurements` | User-recorded numeric time series — metric, value, unit, observation time (#1333) |
 | `contexts` | User-authored container name/description |
 | `resources` | Connected source-of-truth resources |
 | `resource_events` | Ingested raw source events |


### PR DESCRIPTION
Closes #1333

## Summary

The third memory axis: numeric series (weight, cost, eval scores) recorded and queried as a **dedicated append-only lane**, NOT memory rows — sleep's consolidation/dedup would physically destroy reference-zero series rows and near-duplicate-merge numeric points, and per-point embeddings are pure cost (the decided hybrid: raw points here, milestone markers as ordinary memories at the caller's discretion).

- **`measurements` table** (model + reversible migration `e71_1333_measurements`, chained on e70): context-CASCADE FK, `metric` VARCHAR(64), naive-UTC `measured_at`, `NUMERIC value`, optional unit/details; composite index `(context_id, metric, measured_at)`. No embedding; classified RAW_EXPORTABLE in the data-boundary taxonomy; structurally excluded from recall.
- **`MeasurementService`**: `record` (plain INSERT, fail-closed validation — bool/NaN/inf/huge-int rejected as ValueError, aware→naive UTC normalization) and `recall_series` (`date_trunc` bucketing with the cost_aggregation allowlist posture — `:period` bound but allowlist-gated, agg fragment from a module-constant map, 365-day window cap, default 30-day window; aggs avg/min/max/sum/count/last).
- **MCP tools** `record_measurement` / `recall_series` (readOnly): the state-lane (#889) permission stack verbatim — IDOR-uniform not-found, viewer gate with context-workspace fallback, `agent_binding_permits(ACCESS_WRITE)` on the write path (#1275). Rate-limited, context-scoped.
- Docs: README/README.ja tool tables + counts (63); api-reference corrected to the actual 63 (pre-existing off-by-one flagged below).

## Review (8-angle, 2 finder agents) — verified & fixed

Verified clean: all SQL bound/allowlist-gated (injection impossible by construction), permission stack line-for-line parity with state.py, tz normalization pinned, single migration head, empty-series-is-success. Fixed: metric name removed from logs (user data; ids-only convention), OverflowError on arbitrary-precision JSON ints normalized to validation error, numeric-string coercion (#1322 parity), schema↔service enum equality pins + cross-module window-cap pin, METRIC_MAX_LEN single-sourced, naive=UTC documented on start/end.

**Follow-ups (not blockers)**: unbounded append growth needs a retention/quota story (agent_states has TTL; this lane deliberately keeps series forever — file as issue); `recall_series` deliberately NOT rate-limit-exempt unlike sibling deterministic reads (strict default, revisit if loop-critical); pre-existing README(61)/api-reference(60) count mismatch existed before this PR.

## Tests

TDD red proof (2 collection errors) → green: service 21 + tools 24 + migration integration 5 (live Docker DB: defaults, NOT NULL, FK cascade, index). Broad: mcp_server+services 2394 passed; integration 837 passed; boundary/drift/tool-policy guards 232 passed. pyright 0 new errors; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDnEwGpK7semEzr42hushN