### PR TITLE
fix(workers): rotate_secret decrypt-failure recovery + sticky retiring teardown (#1356)

### DIFF
--- a/backend/src/models/worker_app.py
+++ b/backend/src/models/worker_app.py
@@ -95,3 +95,14 @@ class WorkerAppIdentity(Base):
     def get_retiring_signing_secret(self) -> str | None:
         """Decrypt the retiring secret for the internal worker bootstrap only."""
         return self._decrypt_secret(self.retiring_signing_secret_encrypted)
+
+    def clear_retiring_secret(self) -> None:
+        """Tear down the whole retiring window (#1356).
+
+        The three columns are one invariant — a half-cleared window (e.g.
+        ciphertext gone but ``retiring_valid_until`` set) would desync the
+        bootstrap window check and ``identity_collection_revision``.
+        """
+        self.retiring_signing_secret_encrypted = None
+        self.retiring_secret_revision = None
+        self.retiring_valid_until = None

--- a/backend/src/services/worker_app_identity.py
+++ b/backend/src/services/worker_app_identity.py
@@ -11,6 +11,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from models.worker_app import WorkerAppIdentity
 from utils.datetime import utcnow
 from utils.exceptions import ConflictError, NotFoundException, ValidationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 MAX_RETIRING_WINDOW_SECONDS = 86_400
 
@@ -119,6 +122,16 @@ class WorkerAppIdentityService:
                     "A signing secret must be configured before enabling an app identity",
                     field="status",
                 )
+            # #1356: a real status transition tears down the retiring window.
+            # Disabling revokes ALL acceptance (sticky revocation — the armed
+            # previous secret must not survive to be revived by a later
+            # re-enable), and enabling purges retiring material a row may
+            # still carry from before this rule existed. A same-status PATCH
+            # is not a transition and keeps a legitimately armed window.
+            if status != identity.status:
+                identity.set_retiring_signing_secret(None)
+                identity.retiring_secret_revision = None
+                identity.retiring_valid_until = None
             identity.status = status
         identity.updated_by = actor_id
         identity.config_version += 1
@@ -140,7 +153,24 @@ class WorkerAppIdentityService:
                 field="retiring_for_seconds",
             )
         identity = await self._require_identity(platform, app_key)
-        previous_secret = identity.get_active_signing_secret()
+        # #1356: rotate is the documented recovery path when the stored
+        # ciphertext can no longer be decrypted (Fernet key rotation,
+        # corruption) — it must not 500 on the OLD material it is about to
+        # replace. Drop the unrecoverable previous secret (no retiring
+        # window; the fleet could never verify against it anyway) and let
+        # the new-secret write below BE the recovery. Ids/enums only in the
+        # audit event — never secret material or ciphertext.
+        try:
+            previous_secret = identity.get_active_signing_secret()
+        except Exception as exc:
+            previous_secret = None
+            logger.warning(
+                "worker_app_previous_secret_undecryptable",
+                platform=identity.platform,
+                app_key=identity.app_key,
+                active_secret_revision=identity.active_secret_revision,
+                error_type=type(exc).__name__,
+            )
         previous_revision = identity.active_secret_revision
         # Arm the retiring window only when the identity is currently ACTIVE.
         # On a disabled identity the previous secret is revoked material — it

--- a/backend/src/services/worker_app_identity.py
+++ b/backend/src/services/worker_app_identity.py
@@ -122,16 +122,45 @@ class WorkerAppIdentityService:
                     "A signing secret must be configured before enabling an app identity",
                     field="status",
                 )
+            if status == "active" and status != identity.status:
+                # #1356: enabling a row whose stored ciphertext no longer
+                # decrypts (Fernet key rotation / corruption) would return
+                # 200 while the fleet silently serves the app secretless.
+                # Fail loudly and point the operator at the recovery path.
+                try:
+                    identity.get_active_signing_secret()
+                except ValueError as exc:
+                    raise ValidationError(
+                        "The stored signing secret cannot be decrypted; "
+                        "rotate the secret before enabling this app identity",
+                        field="status",
+                    ) from exc
             # #1356: a real status transition tears down the retiring window.
             # Disabling revokes ALL acceptance (sticky revocation — the armed
             # previous secret must not survive to be revived by a later
             # re-enable), and enabling purges retiring material a row may
-            # still carry from before this rule existed. A same-status PATCH
-            # is not a transition and keeps a legitimately armed window.
-            if status != identity.status:
-                identity.set_retiring_signing_secret(None)
-                identity.retiring_secret_revision = None
-                identity.retiring_valid_until = None
+            # still carry from before this rule existed. A same-status
+            # PATCH to "disabled" also purges (operator lever to scrub
+            # revoked material from legacy rows without re-enabling); an
+            # active→active PATCH is not a transition and keeps a
+            # legitimately armed rotation window.
+            if status != identity.status or status == "disabled":
+                if identity.retiring_secret_revision is not None or (
+                    identity.retiring_signing_secret_encrypted is not None
+                ):
+                    # Audit the teardown BEFORE clearing so the #1343
+                    # correlation (which retiring revision a disable
+                    # revoked) survives — the route only sees post-clear
+                    # state. Ids/enums only, never secret material.
+                    logger.info(
+                        "worker_app_retiring_window_cleared",
+                        platform=identity.platform,
+                        app_key=identity.app_key,
+                        from_status=identity.status,
+                        to_status=status,
+                        retiring_secret_revision=identity.retiring_secret_revision,
+                    )
+                identity.clear_retiring_secret()
             identity.status = status
         identity.updated_by = actor_id
         identity.config_version += 1
@@ -162,7 +191,11 @@ class WorkerAppIdentityService:
         # audit event — never secret material or ciphertext.
         try:
             previous_secret = identity.get_active_signing_secret()
-        except Exception as exc:
+        except ValueError as exc:
+            # utils.encryption.decrypt maps every real decryption failure
+            # (InvalidToken: wrong key / tampered) to ValueError — same
+            # contract the bootstrap lane in routes/workers.py relies on.
+            # Anything else is a programming error and must keep surfacing.
             previous_secret = None
             logger.warning(
                 "worker_app_previous_secret_undecryptable",
@@ -187,9 +220,7 @@ class WorkerAppIdentityService:
             identity.retiring_secret_revision = previous_revision
             identity.retiring_valid_until = utcnow() + timedelta(seconds=retiring_for_seconds)
         else:
-            identity.set_retiring_signing_secret(None)
-            identity.retiring_secret_revision = None
-            identity.retiring_valid_until = None
+            identity.clear_retiring_secret()
 
         identity.set_active_signing_secret(signing_secret)
         identity.active_secret_revision = (previous_revision or 0) + 1

--- a/backend/src/services/worker_app_identity.py
+++ b/backend/src/services/worker_app_identity.py
@@ -145,8 +145,13 @@ class WorkerAppIdentityService:
             # active→active PATCH is not a transition and keeps a
             # legitimately armed rotation window.
             if status != identity.status or status == "disabled":
-                if identity.retiring_secret_revision is not None or (
-                    identity.retiring_signing_secret_encrypted is not None
+                # Any of the three window columns set → audit (the trio is
+                # one invariant; a half-populated legacy row must not be
+                # cleared silently). Copilot review on #1361.
+                if (
+                    identity.retiring_secret_revision is not None
+                    or identity.retiring_signing_secret_encrypted is not None
+                    or identity.retiring_valid_until is not None
                 ):
                     # Audit the teardown BEFORE clearing so the #1343
                     # correlation (which retiring revision a disable

--- a/backend/tests/services/test_worker_app_identity.py
+++ b/backend/tests/services/test_worker_app_identity.py
@@ -1,7 +1,7 @@
 """Lifecycle tests for worker app secret rotation (#1315)."""
 
 from datetime import timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -153,6 +153,161 @@ async def test_rotate_unconfigured_identity_preserves_status(_fernet_env):
     assert result.active_secret_revision == 1
     assert result.retiring_signing_secret_encrypted is None
     assert result.retiring_valid_until is None
+
+
+@pytest.mark.asyncio
+async def test_rotate_recovers_when_previous_ciphertext_undecryptable(_fernet_env):
+    """#1356: rotate is the documented recovery path after a Fernet key
+    rotation or ciphertext corruption — it must not 500 on the stored
+    ciphertext. The unrecoverable previous secret is dropped (no retiring
+    window) and the new secret is stored; that write IS the recovery."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="active",
+        active_secret_revision=4,
+        config_version=8,
+    )
+    # Stored ciphertext that the current API_KEY_SECRET cannot decrypt.
+    identity.active_signing_secret_encrypted = "gAAAAA-not-decryptable-with-current-key"
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    with patch("services.worker_app_identity.logger") as mock_logger:
+        result = await service.rotate_secret(
+            platform="slack",
+            app_key="sales",
+            signing_secret="new-secret",
+            retiring_for_seconds=3600,
+            actor_id="admin-1",
+        )
+
+    assert result.get_active_signing_secret() == "new-secret"
+    assert result.active_secret_revision == 5
+    assert result.retiring_signing_secret_encrypted is None
+    assert result.retiring_secret_revision is None
+    assert result.retiring_valid_until is None
+    assert result.config_version == 9
+    assert result.status == "active"
+    # Audit: the drop is recorded, ids/enums only — never secret material.
+    assert mock_logger.warning.call_count == 1
+    kwargs = mock_logger.warning.call_args.kwargs
+    assert mock_logger.warning.call_args.args[0] == "worker_app_previous_secret_undecryptable"
+    assert kwargs["platform"] == "slack"
+    assert kwargs["app_key"] == "sales"
+    for value in kwargs.values():
+        assert "new-secret" not in str(value)
+        assert "gAAAAA" not in str(value)
+
+
+@pytest.mark.asyncio
+async def test_disable_clears_retiring_window(_fernet_env):
+    """#1356: disabling revokes ALL secret material acceptance — the armed
+    retiring secret must not survive to be revived by a later re-enable."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="active",
+        active_secret_revision=5,
+        config_version=9,
+    )
+    identity.set_active_signing_secret("current")
+    identity.set_retiring_signing_secret("previous")
+    identity.retiring_secret_revision = 4
+    identity.retiring_valid_until = utcnow() + timedelta(hours=1)
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    result = await service.update_identity(
+        platform="slack",
+        app_key="sales",
+        actor_id="admin-1",
+        status="disabled",
+    )
+
+    assert result.status == "disabled"
+    assert result.retiring_signing_secret_encrypted is None
+    assert result.retiring_secret_revision is None
+    assert result.retiring_valid_until is None
+
+
+@pytest.mark.asyncio
+async def test_reenable_clears_stale_retiring_window(_fernet_env):
+    """#1356: rows disabled before this fix may still carry retiring
+    material — the enable transition must purge it so the old secret does
+    not resurface in the worker bootstrap."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="disabled",
+        active_secret_revision=5,
+        config_version=9,
+    )
+    identity.set_active_signing_secret("current")
+    identity.set_retiring_signing_secret("revoked-old")
+    identity.retiring_secret_revision = 4
+    identity.retiring_valid_until = utcnow() + timedelta(hours=1)
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    result = await service.update_identity(
+        platform="slack",
+        app_key="sales",
+        actor_id="admin-1",
+        status="active",
+    )
+
+    assert result.status == "active"
+    assert result.retiring_signing_secret_encrypted is None
+    assert result.retiring_secret_revision is None
+    assert result.retiring_valid_until is None
+
+
+@pytest.mark.asyncio
+async def test_status_noop_update_keeps_retiring_window(_fernet_env):
+    """A same-status PATCH (e.g. display_name edit sent with status=active)
+    is not a transition — it must not tear down a legitimately armed
+    rotation window mid-migration."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="active",
+        active_secret_revision=5,
+        config_version=9,
+    )
+    identity.set_active_signing_secret("current")
+    identity.set_retiring_signing_secret("previous")
+    identity.retiring_secret_revision = 4
+    valid_until = utcnow() + timedelta(hours=1)
+    identity.retiring_valid_until = valid_until
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    result = await service.update_identity(
+        platform="slack",
+        app_key="sales",
+        actor_id="admin-1",
+        status="active",
+        display_name="Sales EMEA",
+    )
+
+    assert result.status == "active"
+    assert result.display_name == "Sales EMEA"
+    assert result.get_retiring_signing_secret() == "previous"
+    assert result.retiring_secret_revision == 4
+    assert result.retiring_valid_until == valid_until
 
 
 def test_bootstrap_revision_changes_when_retiring_window_expires():

--- a/backend/tests/services/test_worker_app_identity.py
+++ b/backend/tests/services/test_worker_app_identity.py
@@ -273,6 +273,115 @@ async def test_reenable_clears_stale_retiring_window(_fernet_env):
 
 
 @pytest.mark.asyncio
+async def test_rotate_undecryptable_on_disabled_identity_stays_disabled(_fernet_env):
+    """Composition of the two #1356 behaviors: decrypt-failure recovery must
+    not bypass sticky revocation — rotate on a disabled identity with
+    rotated-away ciphertext succeeds, stays disabled, arms nothing."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="disabled",
+        active_secret_revision=3,
+        config_version=5,
+    )
+    identity.active_signing_secret_encrypted = "gAAAAA-not-decryptable-with-current-key"
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    result = await service.rotate_secret(
+        platform="slack",
+        app_key="sales",
+        signing_secret="fresh-secret",
+        retiring_for_seconds=3600,
+        actor_id="admin-1",
+    )
+
+    assert result.status == "disabled"
+    assert result.get_active_signing_secret() == "fresh-secret"
+    assert result.active_secret_revision == 4
+    assert result.retiring_signing_secret_encrypted is None
+    assert result.retiring_valid_until is None
+
+
+@pytest.mark.asyncio
+async def test_enable_rejects_undecryptable_ciphertext(_fernet_env):
+    """#1356: enabling must not 200 when the fleet would be served nothing —
+    an undecryptable stored secret fails loudly, pointing at rotate."""
+    from utils.exceptions import ValidationError
+
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="disabled",
+        active_secret_revision=3,
+        config_version=5,
+    )
+    identity.active_signing_secret_encrypted = "gAAAAA-not-decryptable-with-current-key"
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    with pytest.raises(ValidationError):
+        await service.update_identity(
+            platform="slack",
+            app_key="sales",
+            actor_id="admin-1",
+            status="active",
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_noop_update_purges_stale_retiring_material(_fernet_env):
+    """#1356: PATCH status=disabled on an already-disabled legacy row is the
+    operator lever to scrub revoked retiring material at rest."""
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="disabled",
+        active_secret_revision=5,
+        config_version=9,
+    )
+    identity.set_active_signing_secret("current")
+    identity.set_retiring_signing_secret("revoked-old")
+    identity.retiring_secret_revision = 4
+    identity.retiring_valid_until = utcnow() + timedelta(hours=1)
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    with patch("services.worker_app_identity.logger") as mock_logger:
+        result = await service.update_identity(
+            platform="slack",
+            app_key="sales",
+            actor_id="admin-1",
+            status="disabled",
+        )
+
+    assert result.status == "disabled"
+    assert result.retiring_signing_secret_encrypted is None
+    assert result.retiring_secret_revision is None
+    assert result.retiring_valid_until is None
+    # #1343 correlation: the teardown audit carries the PRE-clear revision.
+    cleared = [
+        c
+        for c in mock_logger.info.call_args_list
+        if c.args and c.args[0] == "worker_app_retiring_window_cleared"
+    ]
+    assert len(cleared) == 1
+    assert cleared[0].kwargs["retiring_secret_revision"] == 4
+    for value in cleared[0].kwargs.values():
+        assert "revoked-old" not in str(value)
+        assert "current" not in str(value)
+
+
+@pytest.mark.asyncio
 async def test_status_noop_update_keeps_retiring_window(_fernet_env):
     """A same-status PATCH (e.g. display_name edit sent with status=active)
     is not a transition — it must not tear down a legitimately armed


### PR DESCRIPTION
Closes #1356

## Summary
- `rotate_secret` no longer 500s when the stored active ciphertext cannot be decrypted (Fernet key rotation / corruption): the unrecoverable previous secret is dropped (**no retiring window**) and the new-secret write becomes the recovery path. `worker_app_previous_secret_undecryptable` audit event (ids/enums only).
- `update_identity` tears down the retiring window on any real status transition: **disable makes revocation sticky** for the armed retiring secret; **enable purges stale retiring material** from pre-fix rows. `PATCH status=disabled` on an already-disabled row is the operator lever to scrub legacy revoked material. An active→active PATCH keeps a legitimately armed window.
- Enable now rejects an undecryptable stored secret with a rotate-first `ValidationError` instead of returning 200 while the fleet is served secretless.
- `worker_app_retiring_window_cleared` audit event carries the **pre-clear** retiring revision so the #1343 correlation survives.
- Model-level `clear_retiring_secret()` single-sources the three-column teardown.

## Review
gate1 green (inline CSO/CTO). 3 parallel finder agents (8 angles) → 6 findings, all addressed pre-PR: ValueError narrowing, audit correlation, purge lever, enable guard, trio helper, disabled-rotate test.

## Tests
- rotate with undecryptable ciphertext: active (recovery + audit pin) and disabled (sticky composition)
- disable→enable revives nothing; noop-active keeps window; disabled purge lever + pre-clear audit pin
- enable rejects undecryptable ciphertext
- 39 passed (services + API worker suites); lint clean; no new pyright errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)