### PR TITLE
fix(api,auth): binding subtraction on REST clusters/positions + cursor oracle (#1357)

### DIFF
--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -431,12 +431,23 @@ async def get_cluster(
 
     page_size = _clamp_limit(limit, DEFAULT_CLUSTER_PAGE_SIZE, MAX_CLUSTER_PAGE_SIZE)
 
+    # #1301/#1357: one bulk binding SELECT per request; None for non-agent
+    # credentials and shadow scopes. Encoding the subtraction in the page
+    # WHERE (rather than post-filtering fetched rows) is what keeps
+    # ``next_cursor`` from ever naming a denied row (existence oracle,
+    # CWE-639) and keeps pagination advancing without fetching denied rows.
+    from services.agent_binding_service import binding_memory_sql_predicate
+
+    binding_predicate = await binding_memory_sql_predicate(db)
+
     # Page through the cluster's memories. Keyset on memory_id (UUID
     # textual order) — opaque cursor that the client should not parse.
     mem_conditions = [
         MemoryAnalysisAssignment.analysis_id == run_id,
         MemoryAnalysisAssignment.cluster_id == cluster.id,
     ]
+    if binding_predicate is not None:
+        mem_conditions.append(binding_predicate)
     if cursor:
         try:
             cursor_uuid = UUID(cursor)
@@ -484,12 +495,11 @@ async def get_cluster(
         rows = rows[:page_size]
         next_cursor = str(rows[-1].id)
 
-    # #1301: cluster members expose L1 summaries — denied type/source rows
-    # drop for enforce-mode agents (shadow keeps them; outside the MAE
-    # vocabulary, so shadow is log-only). Applied AFTER the keyset cursor is
-    # derived, so pagination advances over denied rows instead of stalling.
-    # ``count`` / ``property_stats`` are handled separately below (recomputed
-    # over permitted rows for enforce-mode agents).
+    # #1301: enforce-mode subtraction now happens in the page WHERE above
+    # (#1357) — for enforce agents this row filter finds nothing to drop.
+    # It stays for SHADOW scopes (predicate is None there): rows are kept
+    # unchanged and the would-deny volume is logged (outside the MAE
+    # vocabulary, so shadow is log-only).
     from services.agent_binding_service import filter_memory_rows_by_binding
 
     rows, _ = await filter_memory_rows_by_binding(db, rows, operation=None, user_id=None)
@@ -571,9 +581,6 @@ async def get_cluster(
     # indexed GROUP BY over a single cluster's assignments, agent-only.
     count = int(cluster.count)
     property_stats = cluster.property_stats or {}
-    from services.agent_binding_service import binding_memory_sql_predicate
-
-    binding_predicate = await binding_memory_sql_predicate(db)
     if binding_predicate is not None:
         type_rows = (
             await db.execute(
@@ -623,7 +630,7 @@ async def list_clusters(
     *,
     workspace_id: UUID,
     run_id: UUID,
-) -> list[MemoryAnalysisCluster] | None:
+) -> list[MemoryAnalysisCluster] | list[dict[str, Any]] | None:
     """Return every cluster row for a run, ordered by ``cluster_index``.
 
     Used by the REST surface in #497 to render the cluster list, scatter
@@ -657,7 +664,89 @@ async def list_clusters(
         .where(MemoryAnalysisCluster.analysis_id == run_id)
         .order_by(MemoryAnalysisCluster.cluster_index.asc())
     )
-    return list((await db.execute(stmt)).scalars().all())
+    clusters = list((await db.execute(stmt)).scalars().all())
+
+    # #1357: REST parity with the MCP ``get_cluster`` subtraction (#1301).
+    # For enforce-mode agents the stored per-cluster ``count`` /
+    # ``property_stats.types`` are an existence oracle over denied
+    # type/source rows, and ``representative_memory_ids`` names denied
+    # rows' UUIDs outright. Recompute count/types over permitted rows
+    # (ONE grouped query for the whole run), drop the remaining facets
+    # fail-closed when any row was subtracted (same rule as
+    # ``get_cluster``), and subtract denied representative ids. Plain
+    # dict copies — never mutate the ORM rows (they would flush).
+    from services.agent_binding_service import binding_memory_sql_predicate
+
+    binding_predicate = await binding_memory_sql_predicate(db)
+    if binding_predicate is None or not clusters:
+        return clusters
+
+    type_rows = (
+        await db.execute(
+            select(
+                MemoryAnalysisAssignment.cluster_id,
+                Memory.type,
+                func.count(Memory.id),
+            )
+            .join(Memory, Memory.id == MemoryAnalysisAssignment.memory_id)
+            .where(
+                and_(
+                    MemoryAnalysisAssignment.analysis_id == run_id,
+                    Memory.deleted_at.is_(None),
+                    Memory.workspace_id == workspace_id,
+                    binding_predicate,
+                )
+            )
+            .group_by(MemoryAnalysisAssignment.cluster_id, Memory.type)
+        )
+    ).all()
+    permitted_types: dict[UUID, dict[str, int]] = {}
+    for cluster_id, mem_type, cnt in type_rows:
+        permitted_types.setdefault(cluster_id, {})[mem_type] = int(cnt)
+
+    all_rep_ids = {rid for c in clusters for rid in (c.representative_memory_ids or [])}
+    permitted_rep_ids: set[UUID] = set()
+    if all_rep_ids:
+        rep_id_rows = (
+            await db.execute(
+                select(Memory.id).where(
+                    and_(
+                        Memory.id.in_(all_rep_ids),
+                        Memory.deleted_at.is_(None),
+                        Memory.workspace_id == workspace_id,
+                        binding_predicate,
+                    )
+                )
+            )
+        ).all()
+        permitted_rep_ids = {row[0] for row in rep_id_rows}
+
+    subtracted: list[dict[str, Any]] = []
+    for c in clusters:
+        types = permitted_types.get(c.id, {})
+        filtered_count = sum(types.values())
+        count = int(c.count)
+        stats = dict(c.property_stats or {})
+        if filtered_count != count:
+            count = filtered_count
+            stats = {"types": types}
+        elif "types" in stats:
+            stats = {**stats, "types": types}
+        subtracted.append(
+            {
+                "cluster_index": c.cluster_index,
+                "label": c.label,
+                "description": c.description,
+                "count": count,
+                "centroid_2d": list(c.centroid_2d) if c.centroid_2d else [],
+                "representative_memory_ids": [
+                    rid for rid in (c.representative_memory_ids or []) if rid in permitted_rep_ids
+                ],
+                "property_stats": stats,
+                "label_confidence": float(c.label_confidence),
+            }
+        )
+    return subtracted
 
 
 async def list_positions(
@@ -695,6 +784,11 @@ async def list_positions(
     if boundary is None:
         return None
 
+    from services.agent_binding_service import binding_memory_sql_predicate
+
+    binding_predicate = await binding_memory_sql_predicate(db)
+    position_binding = [binding_predicate] if binding_predicate is not None else []
+
     # Filter out soft-deleted memories so the scatter does not render
     # orphan dots for memories the user has since forgotten — matches
     # ``get_cluster``'s ``Memory.deleted_at.is_(None)`` discipline so
@@ -723,6 +817,9 @@ async def list_positions(
                 MemoryAnalysisAssignment.analysis_id == run_id,
                 Memory.deleted_at.is_(None),
                 Memory.workspace_id == workspace_id,
+                # #1357: enforce-mode agents never see denied rows' memory_id
+                # (or their dot positions) — same lever as get_cluster.
+                *position_binding,
             )
         )
         .order_by(

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -519,6 +519,21 @@ async def get_cluster(
     # memories were soft-deleted post-analysis (model docstring guard).
     rep_ids = list(cluster.representative_memory_ids or [])
     if rep_ids:
+        # #1357: same SQL predicate as the member page — the post-fetch row
+        # filter below only subtracts type/source for BOUND contexts (an
+        # unbound context has no filter row → kept), so a representative
+        # moved to an unbound context after the analysis ran would leak its
+        # summary through the membership gap. All three enforce-mode
+        # subtraction points (page, reps, list_clusters) use the one lever.
+        rep_conditions = [
+            Memory.id.in_(rep_ids),
+            Memory.deleted_at.is_(None),
+            # Same defense-in-depth predicate as the page query
+            # above — Issue #496 Copilot review.
+            Memory.workspace_id == workspace_id,
+        ]
+        if binding_predicate is not None:
+            rep_conditions.append(binding_predicate)
         rep_rows = (
             await db.execute(
                 select(
@@ -529,15 +544,7 @@ async def get_cluster(
                     Memory.context_id,
                     Memory.type,
                     Memory.source_type,
-                ).where(
-                    and_(
-                        Memory.id.in_(rep_ids),
-                        Memory.deleted_at.is_(None),
-                        # Same defense-in-depth predicate as the page query
-                        # above — Issue #496 Copilot review.
-                        Memory.workspace_id == workspace_id,
-                    )
-                )
+                ).where(and_(*rep_conditions))
             )
         ).all()
         rep_rows, _ = await filter_memory_rows_by_binding(
@@ -652,6 +659,14 @@ async def list_clusters(
       otherwise. Cluster count is bounded by
       ``ceil(sqrt(memory_count))`` ≈ 90 clusters on an 8000-memory run,
       so no pagination is offered.
+    - **Enforce-mode agent scope (#1357)**: ``list[dict]`` instead — plain
+      copies shaped like ``ClusterRow`` (``cluster_index`` / ``label`` /
+      ``description`` / ``count`` / ``centroid_2d`` /
+      ``representative_memory_ids`` / ``property_stats`` /
+      ``label_confidence``; no DB ``id`` / ``analysis_id``), with
+      count/types recomputed over permitted rows, other facets dropped
+      fail-closed on subtraction, denied representative ids removed, and
+      clusters with ZERO permitted rows omitted entirely.
     """
     boundary = (
         await db.execute(_live_run_boundary_stmt(run_id, workspace_id))
@@ -725,6 +740,14 @@ async def list_clusters(
     for c in clusters:
         types = permitted_types.get(c.id, {})
         filtered_count = sum(types.values())
+        if filtered_count == 0:
+            # Fail-closed on the ENUMERATION surface: a cluster with zero
+            # permitted rows would still volunteer its LLM label /
+            # description — content synthesized from the denied members —
+            # and the count-0-with-label shape confirms denied rows exist.
+            # Direct drill-down (get_cluster by index) keeps the #1301
+            # contract; the list simply does not advertise it.
+            continue
         count = int(c.count)
         stats = dict(c.property_stats or {})
         if filtered_count != count:

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -992,3 +992,157 @@ async def test_clusters_and_positions_unchanged_without_agent_scope(
         db_session, workspace_id=fixture_workspace_id, run_id=run.id
     )
     assert positions is not None and len(positions) == 4
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_representatives_respect_membership_gate(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1357 review F1: a representative moved to an UNBOUND context after
+    the analysis ran must not leak its summary — the post-fetch row filter
+    alone keeps rows from contexts with no binding row."""
+    from uuid import uuid4 as _uuid4
+
+    from auth.agent_scope import set_agent_scope
+    from models.auth import Context
+
+    run, cluster, mems, _denied = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=0,
+    )
+    other_ctx = Context(
+        id=_uuid4(),
+        workspace_id=fixture_workspace_id,
+        name="unbound_ctx",
+        display_name="Unbound",
+        created_by="test_user",
+        is_private=False,
+    )
+    db_session.add(other_ctx)
+    await db_session.flush()
+    stray = await _make_typed_memory(
+        db_session, workspace_id=fixture_workspace_id, context_id=other_ctx.id, mem_type="note"
+    )
+    cluster.representative_memory_ids = [mems[0].id, stray.id]
+    await db_session.flush()
+
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        detail = await query_service.get_cluster(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            run_id=run.id,
+            cluster_index=0,
+        )
+        assert detail is not None
+        rep_ids = {r["memory_id"] for r in detail["representatives"]}
+        assert str(stray.id) not in rep_ids
+        assert str(mems[0].id) in rep_ids
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_list_clusters_omits_fully_denied_cluster(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1357 review F2: a cluster with ZERO permitted rows must not be
+    enumerated — its LLM label/description are synthesized from denied
+    members, and the count-0-with-label shape is itself an oracle."""
+    from auth.agent_scope import set_agent_scope
+
+    run, _cluster, mems, _denied = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=1,
+        denied=0,
+    )
+    denied_only = await _make_typed_memory(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        mem_type="decision",
+    )
+    cluster2 = await _make_cluster(db_session, run=run, cluster_index=1, label="denied topic")
+    cluster2.count = 1
+    db_session.add(
+        MemoryAnalysisAssignment(
+            analysis_id=run.id, memory_id=denied_only.id, cluster_id=cluster2.id, x=0.0, y=0.0
+        )
+    )
+    await db_session.flush()
+
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        rows = await query_service.list_clusters(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert rows is not None
+        labels = [r["label"] if isinstance(r, dict) else r.label for r in rows]
+        assert labels == ["alpha"]  # the fully-denied cluster is omitted
+    finally:
+        set_agent_scope(None)
+
+    # Human view keeps both.
+    rows = await query_service.list_clusters(
+        db_session, workspace_id=fixture_workspace_id, run_id=run.id
+    )
+    assert rows is not None and len(rows) == 2
+
+
+@pytest.mark.asyncio
+async def test_shadow_scope_keeps_full_view(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """Shadow enforcement must change nothing observable on any of the
+    three surfaces (predicate is None for shadow scopes)."""
+    from auth.agent_scope import AgentScope, set_agent_scope
+
+    run, cluster, mems, denied_mems = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=2,
+    )
+    agent = await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    set_agent_scope(
+        AgentScope(
+            agent_id=agent.id, enforcement_mode="shadow", workspace_id=fixture_workspace_id
+        )
+    )
+    try:
+        rows = await query_service.list_clusters(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert rows is not None and len(rows) == 1
+        first = rows[0]
+        assert (first["count"] if isinstance(first, dict) else first.count) == 4
+        positions = await query_service.list_positions(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert positions is not None and len(positions) == 4
+        detail = await query_service.get_cluster(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            run_id=run.id,
+            cluster_index=0,
+        )
+        assert detail is not None
+        assert len(detail["memories"]) == 4
+        assert detail["count"] == 4
+    finally:
+        set_agent_scope(None)

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -734,3 +734,261 @@ class TestAssignmentMemoryIdIndex:
             if i.name == "idx_memory_analysis_assignments_memory"
         )
         assert [c.name for c in idx.columns] == ["memory_id"]
+
+
+# ===========================================================================
+# #1357 — binding subtraction on REST clusters/positions + cursor oracle
+# ===========================================================================
+
+
+async def _make_typed_memory(
+    db_session, *, workspace_id: UUID, context_id: UUID, mem_type: str
+) -> Memory:
+    mem = await _make_memory(db_session, workspace_id=workspace_id, context_id=context_id)
+    mem.type = mem_type
+    await db_session.flush()
+    return mem
+
+
+async def _enforce_scope(db_session, *, workspace_id: UUID, context_id: UUID):
+    """Insert an enforce-mode agent bound to ``context_id`` with a type
+    restriction (only ``note`` readable) and activate its scope."""
+    from uuid import uuid4 as _uuid4
+
+    from auth.agent_scope import AgentScope, set_agent_scope
+    from models.agent import Agent, AgentContextBinding
+
+    agent = Agent(
+        id=_uuid4(),
+        workspace_id=workspace_id,
+        name=f"binding-bot-{_uuid4().hex[:8]}",
+        owner_user_id="test_user",
+        status="active",
+        enforcement_mode="enforce",
+    )
+    db_session.add(agent)
+    await db_session.flush()
+    db_session.add(
+        AgentContextBinding(
+            id=_uuid4(),
+            agent_id=agent.id,
+            context_id=context_id,
+            can_read=True,
+            write_policy="deny",
+            is_default=False,
+            allowed_memory_types=["note"],
+            allowed_source_types=None,
+            created_by="test_user",
+        )
+    )
+    await db_session.flush()
+    set_agent_scope(
+        AgentScope(agent_id=agent.id, enforcement_mode="enforce", workspace_id=workspace_id)
+    )
+    return agent
+
+
+async def _cluster_with_members(
+    db_session,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+    pricing,
+    allowed: int,
+    denied: int,
+):
+    """Run + one cluster with ``allowed`` note-memories and ``denied``
+    decision-memories assigned; cluster.count stores the raw total."""
+    run = await _make_run(
+        db_session, workspace_id=workspace_id, context_id=context_id, pricing=pricing
+    )
+    mems = []
+    for _ in range(allowed):
+        mems.append(
+            await _make_typed_memory(
+                db_session, workspace_id=workspace_id, context_id=context_id, mem_type="note"
+            )
+        )
+    denied_mems = []
+    for _ in range(denied):
+        denied_mems.append(
+            await _make_typed_memory(
+                db_session, workspace_id=workspace_id, context_id=context_id, mem_type="decision"
+            )
+        )
+    cluster = await _make_cluster(
+        db_session,
+        run=run,
+        cluster_index=0,
+        label="alpha",
+        rep_ids=[mems[0].id, denied_mems[0].id] if mems and denied_mems else [],
+    )
+    cluster.count = allowed + denied
+    cluster.property_stats = {
+        "types": {"note": allowed, "decision": denied},
+        "tags": {"t1": allowed + denied},
+    }
+    for mem in mems + denied_mems:
+        db_session.add(
+            MemoryAnalysisAssignment(
+                analysis_id=run.id,
+                memory_id=mem.id,
+                cluster_id=cluster.id,
+                x=1.0,
+                y=2.0,
+            )
+        )
+    await db_session.flush()
+    return run, cluster, mems, denied_mems
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_next_cursor_never_names_a_denied_row(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1357 AC2: walking every page, no next_cursor value is ever a
+    binding-denied row's UUID (existence oracle, CWE-639)."""
+    from auth.agent_scope import set_agent_scope
+
+    run, _cluster, mems, denied_mems = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=3,
+        denied=4,
+    )
+    denied_ids = {str(m.id) for m in denied_mems}
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        seen: list[str] = []
+        cursor = None
+        for _ in range(10):
+            page = await query_service.get_cluster(
+                db_session,
+                workspace_id=fixture_workspace_id,
+                run_id=run.id,
+                cluster_index=0,
+                limit=2,
+                cursor=cursor,
+            )
+            assert page is not None
+            seen.extend(m["memory_id"] for m in page["memories"])
+            cursor = page["next_cursor"]
+            if cursor is None:
+                break
+            assert cursor not in denied_ids
+        assert cursor is None
+        assert set(seen) == {str(m.id) for m in mems}
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_list_clusters_subtracts_denied_rows_for_enforce_agent(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1357 AC1: REST /clusters matches MCP get_cluster subtraction —
+    count/types recomputed over permitted rows, other facets fail-closed,
+    denied representative ids dropped."""
+    from auth.agent_scope import set_agent_scope
+
+    run, cluster, mems, denied_mems = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=3,
+    )
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        rows = await query_service.list_clusters(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert rows is not None and len(rows) == 1
+        row = rows[0]
+        count = row["count"] if isinstance(row, dict) else row.count
+        stats = row["property_stats"] if isinstance(row, dict) else row.property_stats
+        rep_ids = (
+            row["representative_memory_ids"]
+            if isinstance(row, dict)
+            else row.representative_memory_ids
+        )
+        assert count == 2
+        assert stats.get("types") == {"note": 2}
+        assert "tags" not in stats  # fail-closed facet drop on subtraction
+        assert [str(r) for r in rep_ids] == [str(mems[0].id)]
+
+        # Parity with the MCP drill-down for the same cluster.
+        detail = await query_service.get_cluster(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            run_id=run.id,
+            cluster_index=0,
+        )
+        assert detail is not None and detail["count"] == count
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_list_positions_subtracts_denied_rows_for_enforce_agent(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1357 AC1: REST /positions never returns a denied row's memory_id."""
+    from auth.agent_scope import set_agent_scope
+
+    run, _cluster, mems, denied_mems = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=2,
+    )
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        positions = await query_service.list_positions(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert positions is not None
+        got = {p["memory_id"] for p in positions}
+        assert got == {str(m.id) for m in mems}
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_clusters_and_positions_unchanged_without_agent_scope(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """Non-agent credentials (human UI sessions) keep the full view."""
+    run, cluster, mems, denied_mems = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=2,
+    )
+    rows = await query_service.list_clusters(
+        db_session, workspace_id=fixture_workspace_id, run_id=run.id
+    )
+    assert rows is not None and len(rows) == 1
+    row = rows[0]
+    count = row["count"] if isinstance(row, dict) else row.count
+    stats = row["property_stats"] if isinstance(row, dict) else row.property_stats
+    assert count == 4
+    assert stats["types"] == {"note": 2, "decision": 2}
+    assert "tags" in stats
+    positions = await query_service.list_positions(
+        db_session, workspace_id=fixture_workspace_id, run_id=run.id
+    )
+    assert positions is not None and len(positions) == 4

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -1120,9 +1120,7 @@ async def test_shadow_scope_keeps_full_view(
         db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
     )
     set_agent_scope(
-        AgentScope(
-            agent_id=agent.id, enforcement_mode="shadow", workspace_id=fixture_workspace_id
-        )
+        AgentScope(agent_id=agent.id, enforcement_mode="shadow", workspace_id=fixture_workspace_id)
     )
     try:
         rows = await query_service.list_clusters(


### PR DESCRIPTION
Closes #1357

## Summary
#1301 binding filter の残余面 2 件。

- **get_cluster next_cursor oracle (CWE-639)**: enforce-mode binding predicate をページクエリの WHERE に組み込み。`next_cursor` が拒否行 UUID を名指しすることがなくなり、拒否行を fetch せずにページングが前進する。post-fetch row filter は shadow スコープの観測用に残置。
- **REST GET /analyses/{run_id}/clusters**: enforce agent には count/types を許可行で再計算(run 全体で 1 GROUP BY)、減算発生時は残り facet を fail-closed で drop、拒否行の representative_memory_ids を減算 — MCP get_cluster と同一規則(single-lever)。ORM 行は変異させず dict コピーを返す。
- **REST GET /analyses/{run_id}/positions**: WHERE に predicate 追加 — 拒否行の memory_id/座標が service を出ない。

## AC
- [x] enforce agent で REST clusters の count が MCP get_cluster と一致(pin)
- [x] 全ページ walk で next_cursor に拒否行 UUID が現れない(pin)
- [x] 非 agent(人間 UI セッション)はフルビュー維持(pin)
- [x] shadow scope は predicate None で無変化

## Tests
新規 4 本 + 既存 274 passed(analyses routes / binding gate / binding service / analysis services)。lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)