### PR TITLE
fix(auth): erasure sweep covers worker_app_identities.created_by/updated_by (#1358)

### DIFF
--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -1039,6 +1039,18 @@ class AccountErasureService:
             AgentContextBinding, AgentContextBinding.created_by, user_id
         )
 
+        # #1358: worker app identities are GLOBAL control-plane rows — no
+        # workspace FK, so no cascade ever removes them and the operator's
+        # raw OAuth sub in created_by/updated_by would outlive erasure.
+        # Same legal-retention posture (row survives, personal link breaks).
+        # The count is per swept column: a row where the subject is both
+        # creator and last updater contributes 2.
+        from models.worker_app import WorkerAppIdentity
+
+        counts["worker_app_identities_pseudonymized"] = await self._pseudonymize_field(
+            WorkerAppIdentity, WorkerAppIdentity.created_by, user_id
+        ) + await self._pseudonymize_field(WorkerAppIdentity, WorkerAppIdentity.updated_by, user_id)
+
         # #1336 Gap 2: author memories that OUTLIVE the erased subject — rows
         # in co-owned/transferred workspaces (the sole-owner cascade above
         # already wiped the rest). Their Qdrant points were deleted in step 1

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -981,7 +981,6 @@ class TestDeletePostgresSweep:
         assert agent_call.args[1] is Agent.owner_user_id
         assert agent_call.args[2] == target.user_id
 
-
     @pytest.mark.asyncio
     async def test_sweep_pseudonymizes_worker_app_identity_actor_columns(self):
         """#1358: worker_app_identities are GLOBAL control-plane rows (no
@@ -1013,9 +1012,7 @@ class TestDeletePostgresSweep:
 
         assert counts["worker_app_identities_pseudonymized"] == 3
         calls = [
-            c
-            for c in svc._pseudonymize_field.await_args_list
-            if c.args[0] is WorkerAppIdentity
+            c for c in svc._pseudonymize_field.await_args_list if c.args[0] is WorkerAppIdentity
         ]
         assert len(calls) == 2
         assert any(c.args[1] is WorkerAppIdentity.created_by for c in calls)

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -993,14 +993,25 @@ class TestDeletePostgresSweep:
 
         svc = _service()
         svc._count_and_delete = AsyncMock(return_value=0)
-        svc._pseudonymize_field = AsyncMock(return_value=1)
+
+        # Distinct per-column values pin the SUM semantics exactly — a
+        # refactor that doubles one sweep (2 * created_by) would still
+        # produce 2 under a uniform return_value.
+        async def _by_column(model, column, user_id, extra_values=None):
+            if model is WorkerAppIdentity and column is WorkerAppIdentity.created_by:
+                return 1
+            if model is WorkerAppIdentity and column is WorkerAppIdentity.updated_by:
+                return 2
+            return 0
+
+        svc._pseudonymize_field = AsyncMock(side_effect=_by_column)
         svc.db.delete = AsyncMock()
         svc.db.commit = AsyncMock()
         target = _user()
 
         counts = await svc._delete_postgres(target)
 
-        assert counts["worker_app_identities_pseudonymized"] == 2
+        assert counts["worker_app_identities_pseudonymized"] == 3
         calls = [
             c
             for c in svc._pseudonymize_field.await_args_list

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -982,6 +982,36 @@ class TestDeletePostgresSweep:
         assert agent_call.args[2] == target.user_id
 
 
+    @pytest.mark.asyncio
+    async def test_sweep_pseudonymizes_worker_app_identity_actor_columns(self):
+        """#1358: worker_app_identities are GLOBAL control-plane rows (no
+        workspace FK, so no cascade ever removes them) — created_by /
+        updated_by hold the operator's raw OAuth sub and must be
+        pseudonymized on erasure (plan_changes/agents legal-retention
+        posture: row survives, personal link breaks)."""
+        from models.worker_app import WorkerAppIdentity
+
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=0)
+        svc._pseudonymize_field = AsyncMock(return_value=1)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        target = _user()
+
+        counts = await svc._delete_postgres(target)
+
+        assert counts["worker_app_identities_pseudonymized"] == 2
+        calls = [
+            c
+            for c in svc._pseudonymize_field.await_args_list
+            if c.args[0] is WorkerAppIdentity
+        ]
+        assert len(calls) == 2
+        assert any(c.args[1] is WorkerAppIdentity.created_by for c in calls)
+        assert any(c.args[1] is WorkerAppIdentity.updated_by for c in calls)
+        assert all(c.args[2] == target.user_id for c in calls)
+
+
 class TestMemoryAccessEventsErasure:
     """#1278: the erased subject's memory_access_events rows are pseudonymized
     + scrubbed in ONE carve-out UPDATE (user_id pseudonym, session_id/run_id

--- a/docs/ops/erasure-runbook.md
+++ b/docs/ops/erasure-runbook.md
@@ -71,6 +71,7 @@ FK の依存逆順で削除:
 | `plan_changes.changed_by` | SHA256 pseudonymize | legal retention 維持 |
 | `workspaces` | `owner_user_id = :uid` | step 3 後の sole-owner のみ。cascade で contexts/memories/etc. |
 | `memories` (残存行) | `user_id` を SHA256 pseudonymize + `details = NULL` | #1336: 共有/移譲 workspace に残る本人著メモリの scrub。details の NULL 化で生成列 (location_lat/lon, trigger_from/until) も自動 NULL。tombstone 行も対象 |
+| `worker_app_identities.created_by` / `updated_by` | SHA256 pseudonymize | #1358: global 行 (workspace cascade なし)。legal retention 維持、operator sub のリンクのみ切断 |
 | `users` | `user_id = :uid` | 最後 |
 
 ### 2.5 Audit logs (Step 5)


### PR DESCRIPTION
Closes #1358

## Summary
account-erasure の Postgres sweep に `worker_app_identities.created_by` / `updated_by` の SHA256 pseudonymize を追加。global 行(workspace FK なし)のため cascade では消えず、消去済みユーザーの生 OAuth sub が残存していた。plan_changes/agents と同じ legal-retention 姿勢(行は残し本人リンクのみ切断)。

## AC
- [x] erasure 後、worker_app_identities に生 sub が残らない(pin: 両カラム sweep をテストで固定)
- [x] counts に `worker_app_identities_pseudonymized` 追加(カラム単位カウント、両カラム該当行は 2)
- [x] runbook §2.4 に行追加

## Tests
37 passed(erasure suite)。lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)