### PR TITLE
fix(db): redact asyncpg DETAIL row payloads from all log output (#1359)

### DIFF
--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -3,11 +3,51 @@
 Based on structlog for structured logging with color output in Docker.
 """
 
+import io
 import logging
 import os
+import re
 import sys
 
 import structlog
+
+# #1359: asyncpg composes CHECK/constraint-violation messages with a
+# server-side ``DETAIL:  Failing row contains (...)`` payload — the FULL
+# row, including memory content and details.location coordinates.
+# SQLAlchemy's ``hide_parameters`` only suppresses bind-parameter echoes;
+# it cannot touch this server-composed string. Redact from ``DETAIL:`` to
+# the end of the value (DOTALL: row content may itself contain newlines,
+# and anything after it — SQLAlchemy's ``[SQL: ...]`` suffix — is cheap
+# to lose and safe-side to over-scrub).
+_PG_DETAIL_RE = re.compile(r"DETAIL:.*", re.DOTALL)
+_REDACTED = "DETAIL: [redacted]"
+
+
+def redact_pg_detail(logger, method_name, event_dict):  # noqa: ANN001, ANN201
+    """structlog processor: scrub postgres DETAIL payloads (#1359).
+
+    Runs on every event so ANY logger that stringifies a DB error (the
+    global SQLAlchemyError handler's ``exc_info=True``, ad-hoc
+    ``error=str(exc)`` fields) hits one chokepoint. The constraint name
+    before DETAIL survives for diagnosability; the failing-row payload
+    never reaches log aggregation.
+    """
+    for key, value in event_dict.items():
+        if isinstance(value, str) and "DETAIL:" in value:
+            event_dict[key] = _PG_DETAIL_RE.sub(_REDACTED, value)
+    return event_dict
+
+
+def _redacting_console_traceback(sio, exc_info) -> None:
+    """Console exception formatter that scrubs DETAIL from tracebacks.
+
+    The ConsoleRenderer renders exceptions itself (after all processors),
+    so the dev branch needs the scrub inside the formatter — the JSON
+    branch scrubs the ``format_exc_info``-rendered field instead.
+    """
+    buffer = io.StringIO()
+    structlog.dev.plain_traceback(buffer, exc_info)
+    sio.write(_PG_DETAIL_RE.sub(_REDACTED, buffer.getvalue()))
 
 
 def setup_logger(log_level: str = "INFO", enable_colors: bool = True) -> None:
@@ -40,11 +80,14 @@ def setup_logger(log_level: str = "INFO", enable_colors: bool = True) -> None:
     ]
 
     if use_colors:
-        # Color output for development
+        # Color output for development. The redaction processor scrubs
+        # string fields; the wrapped exception formatter scrubs the
+        # traceback the renderer produces itself (#1359).
+        processors.append(redact_pg_detail)
         processors.append(
             structlog.dev.ConsoleRenderer(
                 colors=True,
-                exception_formatter=structlog.dev.plain_traceback,
+                exception_formatter=_redacting_console_traceback,
             )
         )
     else:
@@ -56,6 +99,9 @@ def setup_logger(log_level: str = "INFO", enable_colors: bool = True) -> None:
         # renders exceptions itself and must NOT get this processor (structlog
         # docs: ConsoleRenderer + format_exc_info double-render).
         processors.append(structlog.processors.format_exc_info)
+        # #1359: AFTER format_exc_info (the rendered ``exception`` field
+        # must exist to be scrubbed), BEFORE the renderer.
+        processors.append(redact_pg_detail)
         processors.append(structlog.processors.JSONRenderer())
 
     structlog.configure(

--- a/backend/tests/utils/test_logger_redaction.py
+++ b/backend/tests/utils/test_logger_redaction.py
@@ -19,8 +19,12 @@ from utils.logger import redact_pg_detail, setup_logger
 
 @pytest.fixture
 def _structlog_reset():
+    # Snapshot + restore (NOT reset_defaults): the suite-wide conftest
+    # configures structlog for kwarg logging, and resetting to library
+    # defaults would make later tests order-dependent. Copilot review.
+    saved = structlog.get_config()
     yield
-    structlog.reset_defaults()
+    structlog.configure(**saved)
 
 
 def _fresh_logger():

--- a/backend/tests/utils/test_logger_redaction.py
+++ b/backend/tests/utils/test_logger_redaction.py
@@ -1,0 +1,102 @@
+"""Pin the postgres DETAIL redaction chokepoint (#1359).
+
+asyncpg puts the FULL failing row (content, details.location coordinates)
+into the server-side ``DETAIL:`` string of CHECK-violation errors.
+SQLAlchemy's ``hide_parameters`` only suppresses bind-parameter logging —
+it does nothing to the server-composed DETAIL text, so any
+``exc_info=True`` log call would ship precise coordinates to log
+aggregation. The redaction lives in the structlog pipeline (single
+chokepoint for every logger) on BOTH render branches.
+"""
+
+import uuid
+
+import pytest
+import structlog
+
+from utils.logger import redact_pg_detail, setup_logger
+
+
+@pytest.fixture
+def _structlog_reset():
+    yield
+    structlog.reset_defaults()
+
+
+def _fresh_logger():
+    # cache_logger_on_first_use caches per proxy — a unique name guarantees
+    # the logger picks up the configuration under test.
+    return structlog.get_logger(f"redaction-test-{uuid.uuid4().hex}")
+
+
+_ASYNCPG_STYLE_MESSAGE = (
+    'new row for relation "memories" violates check constraint '
+    '"valid_location_range"\n'
+    "DETAIL:  Failing row contains (mem-1, secret content, "
+    '{"location": {"lat": 35.6812, "lon": 139.7671}}).'
+)
+
+
+def test_redact_pg_detail_scrubs_string_values():
+    event_dict = {
+        "event": "database_error",
+        "error": _ASYNCPG_STYLE_MESSAGE,
+        "count": 3,
+    }
+    out = redact_pg_detail(None, "error", event_dict)
+    assert "35.6812" not in out["error"]
+    assert "secret content" not in out["error"]
+    assert "DETAIL: [redacted]" in out["error"]
+    assert "valid_location_range" in out["error"]  # constraint name survives
+    assert out["count"] == 3
+
+
+def test_redact_pg_detail_leaves_clean_values_alone():
+    event_dict = {"event": "ok", "message": "no detail here"}
+    assert redact_pg_detail(None, "info", event_dict) == event_dict
+
+
+def test_json_pipeline_scrubs_detail_from_rendered_exception(monkeypatch, capsys, _structlog_reset):
+    monkeypatch.setenv("LOG_COLORIZE", "false")
+    setup_logger(enable_colors=False)
+    logger = _fresh_logger()
+    try:
+        raise RuntimeError(_ASYNCPG_STYLE_MESSAGE)
+    except RuntimeError:
+        logger.error("database_error", exc_info=True)
+    out = capsys.readouterr().out
+    assert "35.6812" not in out
+    assert "secret content" not in out
+    assert "DETAIL: [redacted]" in out
+
+
+def test_console_pipeline_scrubs_detail_from_rendered_exception(
+    monkeypatch, capsys, _structlog_reset
+):
+    monkeypatch.setenv("LOG_COLORIZE", "true")
+    setup_logger(enable_colors=True)
+    logger = _fresh_logger()
+    try:
+        raise RuntimeError(_ASYNCPG_STYLE_MESSAGE)
+    except RuntimeError:
+        logger.error("database_error", exc_info=True)
+    out = capsys.readouterr().out
+    assert "35.6812" not in out
+    assert "secret content" not in out
+    assert "[redacted]" in out
+
+
+def test_json_path_orders_redaction_after_format_exc_info(monkeypatch):
+    """The rendered ``exception`` field only exists after format_exc_info —
+    redaction must run between it and the renderer."""
+    from unittest.mock import patch
+
+    monkeypatch.setenv("LOG_COLORIZE", "false")
+    with patch.object(structlog, "configure") as configure:
+        setup_logger(enable_colors=False)
+    processors = configure.call_args.kwargs["processors"]
+    assert redact_pg_detail in processors
+    assert processors.index(redact_pg_detail) > processors.index(
+        structlog.processors.format_exc_info
+    )
+    assert processors.index(redact_pg_detail) < len(processors) - 1


### PR DESCRIPTION
Closes #1359

## Summary
asyncpg は CHECK 制約違反時にサーバー側 `DETAIL:  Failing row contains (...)` へ**失敗行全体**(content、details.location の座標=精密位置情報)を載せる。SQLAlchemy の `hide_parameters` はバインドパラメータにしか効かない。

structlog パイプラインに `redact_pg_detail` processor を追加(全 logger の単一チョークポイント):
- **JSON(本番)branch**: `format_exc_info` の後段で rendered exception を含む全 string 値から `DETAIL:` 以降を `[redacted]` に置換(DOTALL — 行内容自体の改行と `[SQL: ...]` suffix も安全側で除去)
- **console(dev)branch**: processor + exception_formatter の wrap で renderer 内部のトレースバックも scrub
- 制約名(`valid_location_range` 等)は残す — 診断可能性維持

これで `exc_info=True` の global handler だけでなく `error=str(exc)` を渡す ad-hoc なログ(例: neural_config の IntegrityError ログ)も同じチョークポイントで守られる。

## AC
- [x] DETAIL + 座標入り例外を実際に raise してログ出力に座標/行内容が残らない(JSON/console 両 branch で pin)
- [x] response body: IntegrityError 経路は全て固定文言(contexts.py は constraint 名の substring 判定のみに str(e) を使用、body へは非搭載)、SQLAlchemyError handler は DatabaseConnectionError の固定 shape — DETAIL 非搭載を確認

## Tests
5 新規 + 既存 exc_info pin 2 本 = 7 passed。lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)