### PR TITLE
chore(db): opt-in retention window for the measurements lane (#1355)

### DIFF
--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -262,6 +262,12 @@ class NeuralMemoryConfig:
     # phase hard-deletes user-forgotten rows (details incl. coordinates)
     # past the window; merge losers keep their own window above.
     sleep_forget_retention_days: int = 0
+    # #1355: measurement-series retention window in days. 0 = disabled =
+    # retain forever (the #1333 append-only default — series completeness
+    # is the lane's value). When > 0 the measurement_retention phase
+    # hard-deletes observations older than the window for the run's
+    # context. Opt-in growth control; no downsampling in v1.
+    sleep_measurement_retention_days: int = 0
     # #1208: shadow-mode dedup — merges record a supersedes edge and leave the
     # loser alive-but-shadowed instead of soft-deleting it. Default OFF =
     # update-by-removal (pre-#1208 behavior).
@@ -481,6 +487,11 @@ class NeuralMemoryConfig:
                 f"sleep_forget_retention_days must be >= 0 (0 = retain forever), "
                 f"got {self.sleep_forget_retention_days}"
             )
+        if self.sleep_measurement_retention_days < 0:
+            raise ValueError(
+                f"sleep_measurement_retention_days must be >= 0 (0 = retain forever), "
+                f"got {self.sleep_measurement_retention_days}"
+            )
         if not self.sleep_edge_discovery_sample_size > 0:
             raise ValueError(
                 f"sleep_edge_discovery_sample_size must be positive, "
@@ -618,6 +629,7 @@ class NeuralMemoryConfig:
             sleep_dedup_similarity_threshold=get_float("SLEEP_DEDUP_SIMILARITY_THRESHOLD", 0.92),
             sleep_merge_retention_days=get_int("SLEEP_MERGE_RETENTION_DAYS", 0),
             sleep_forget_retention_days=get_int("SLEEP_FORGET_RETENTION_DAYS", 0),
+            sleep_measurement_retention_days=get_int("SLEEP_MEASUREMENT_RETENTION_DAYS", 0),
             sleep_dedup_supersede_enabled=get_bool("SLEEP_DEDUP_SUPERSEDE_ENABLED", False),
             sleep_edge_discovery_enabled=get_bool("SLEEP_EDGE_DISCOVERY_ENABLED", True),
             sleep_edge_discovery_sample_size=get_int("SLEEP_EDGE_DISCOVERY_SAMPLE_SIZE", 30),
@@ -862,6 +874,10 @@ class NeuralMemoryConfig:
             sleep_forget_retention_days=configs.get(
                 "sleep_forget_retention_days",
                 base_config.sleep_forget_retention_days,
+            ),
+            sleep_measurement_retention_days=configs.get(
+                "sleep_measurement_retention_days",
+                base_config.sleep_measurement_retention_days,
             ),
             sleep_dedup_supersede_enabled=configs.get(
                 "sleep_dedup_supersede_enabled",

--- a/backend/src/services/measurement_service.py
+++ b/backend/src/services/measurement_service.py
@@ -8,6 +8,15 @@ untouchable by Sleep consolidation.
 ``record`` is a plain INSERT (no upsert — a series is history, not state).
 ``recall_series`` buckets with PostgreSQL ``date_trunc`` and aggregates with
 an allowlist-gated aggregate, capped to a bounded lookback window.
+
+Retention (#1355): **unbounded by default** — series completeness is the
+lane's value, so nothing expires unless the operator opts in. Growth
+control is ``SLEEP_MEASUREMENT_RETENTION_DAYS`` (0 = retain forever):
+when > 0, the sleep ``measurement_retention`` phase hard-deletes
+observations older than the window for the run's context. The workspace
+MCP rate limiter remains the only ingestion ceiling; ``recall_series``
+deliberately stays rate-limited (NOT in ``_RATE_LIMIT_EXEMPT_TOOLS`` —
+strict-side default, unlike the deterministic id-keyed siblings).
 """
 
 from __future__ import annotations

--- a/backend/src/services/sleep/measurement_retention.py
+++ b/backend/src/services/sleep/measurement_retention.py
@@ -21,7 +21,7 @@ Default is **0 = disabled = retain forever** (the #1333 contract).
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
 from sqlalchemy import delete
@@ -77,20 +77,26 @@ class MeasurementRetentionPhase:
             return result
 
         cutoff = utcnow() - timedelta(days=retention_days)
-        delete_result = cast_cursor(
+        delete_result = cast(
+            CursorResult,
             await self.db.execute(
                 delete(Measurement).where(
                     Measurement.context_id == UUID(context_id),
                     Measurement.measured_at < cutoff,
                 )
-            )
+            ),
         )
         purged = delete_result.rowcount or 0
 
         # Purged rows never consume the shared per-run budget (mirrors
         # merge/forget retention: a first-enable backlog purge must not
-        # starve the live-memory phases).
-        result.details = {"purged": purged, "retention_days": retention_days}
+        # starve the live-memory phases). ``cutoff`` mirrors the
+        # merge/forget details shape for report parity.
+        result.details = {
+            "purged": purged,
+            "retention_days": retention_days,
+            "cutoff": f"{cutoff:%Y-%m-%d %H:%M}",
+        }
 
         if purged and reporter is not None and report_id is not None:
             # One batch-summary action — ids/counts only, never metric
@@ -99,18 +105,15 @@ class MeasurementRetentionPhase:
                 report_id=report_id,
                 phase="measurement_retention",
                 action_type="purge",
-                details={"purged": purged, "retention_days": retention_days},
+                details=dict(result.details),
             )
-        if purged:
-            logger.info(
-                "measurement_retention_purged",
-                context_id=context_id,
-                purged=purged,
-                retention_days=retention_days,
-            )
+        # Unconditional: an ENABLED run that purged 0 must be
+        # distinguishable from a disabled/dead phase without a report
+        # column (like forget_retention, this phase has none).
+        logger.info(
+            "measurement_retention_ran",
+            context_id=context_id,
+            purged=purged,
+            retention_days=retention_days,
+        )
         return result
-
-
-def cast_cursor(result: object) -> CursorResult:
-    """Narrow the Any-typed execute() return for rowcount access."""
-    return result  # type: ignore[return-value]

--- a/backend/src/services/sleep/measurement_retention.py
+++ b/backend/src/services/sleep/measurement_retention.py
@@ -1,0 +1,116 @@
+"""Measurement-series retention purge (#1355) — growth control for the
+HOW-MUCH lane (#1333).
+
+The measurements table is append-only and unbounded by design (a series'
+value IS its completeness), but nothing manages growth: an agent loop
+recording at the workspace rate limit accrues hundreds of thousands of
+rows per context per year, all RAW_EXPORTABLE. When
+``sleep_measurement_retention_days > 0``, observations older than the
+window are hard-deleted for the run's context, audited as one
+batch-summary action — the ``forget_retention`` posture applied to a
+table with no tombstones, no Qdrant points, and no undo path.
+
+Scope discipline: the sweep runs ONLY for context-scoped sleep runs.
+``measurements`` carries no user/workspace column, so a broader run has
+no safe ownership predicate — skipping is fail-safe, not a limitation
+in practice (sleep runs are per-context).
+
+Default is **0 = disabled = retain forever** (the #1333 contract).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import delete
+from sqlalchemy.engine import CursorResult
+from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from neural.config import NeuralMemoryConfig
+    from services.sleep.reporter import SleepBudget, SleepReporter
+
+from models.measurement import Measurement
+from services.sleep.reporter import PhaseResult
+from utils.datetime import utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class MeasurementRetentionPhase:
+    """Hard-delete measurement observations past the declared window."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def execute(
+        self,
+        config: NeuralMemoryConfig,
+        user_id: str,
+        workspace_id: str | None,
+        context_id: str | None,
+        budget: SleepBudget,
+        *,
+        reporter: SleepReporter | None = None,
+        report_id: UUID | None = None,
+    ) -> PhaseResult:
+        """Purge observations older than ``sleep_measurement_retention_days``.
+
+        No-op (skipped) when the window is disabled (<= 0) or the run is
+        not context-scoped.
+        """
+        result = PhaseResult(phase_name="measurement_retention")
+
+        retention_days = int(getattr(config, "sleep_measurement_retention_days", 0) or 0)
+        if retention_days <= 0:
+            result.skipped = True
+            result.skip_reason = "retention_disabled"
+            return result
+        if not context_id:
+            # No ownership predicate exists on measurements beyond
+            # context_id — never sweep outside an explicit context scope.
+            result.skipped = True
+            result.skip_reason = "no_context_scope"
+            return result
+
+        cutoff = utcnow() - timedelta(days=retention_days)
+        delete_result = cast_cursor(
+            await self.db.execute(
+                delete(Measurement).where(
+                    Measurement.context_id == UUID(context_id),
+                    Measurement.measured_at < cutoff,
+                )
+            )
+        )
+        purged = delete_result.rowcount or 0
+
+        # Purged rows never consume the shared per-run budget (mirrors
+        # merge/forget retention: a first-enable backlog purge must not
+        # starve the live-memory phases).
+        result.details = {"purged": purged, "retention_days": retention_days}
+
+        if purged and reporter is not None and report_id is not None:
+            # One batch-summary action — ids/counts only, never metric
+            # names or values (they are user-authored free-form data).
+            await reporter.add_action(
+                report_id=report_id,
+                phase="measurement_retention",
+                action_type="purge",
+                details={"purged": purged, "retention_days": retention_days},
+            )
+        if purged:
+            logger.info(
+                "measurement_retention_purged",
+                context_id=context_id,
+                purged=purged,
+                retention_days=retention_days,
+            )
+        return result
+
+
+def cast_cursor(result: object) -> CursorResult:
+    """Narrow the Any-typed execute() return for rowcount access."""
+    return result  # type: ignore[return-value]

--- a/backend/src/services/sleep/orchestrator.py
+++ b/backend/src/services/sleep/orchestrator.py
@@ -28,6 +28,7 @@ from services.sleep.dedup_merge import DedupMergePhase
 from services.sleep.edge_discovery import EdgeDiscoveryPhase
 from services.sleep.forget_retention import ForgetRetentionPhase
 from services.sleep.importance_reeval import ImportanceReevalPhase
+from services.sleep.measurement_retention import MeasurementRetentionPhase
 from services.sleep.merge_retention import MergeRetentionPhase
 from services.sleep.reindex import ReindexPhase
 from services.sleep.reporter import PhaseResult, SleepBudget, SleepReporter
@@ -44,6 +45,7 @@ FULL_PHASES = {
     "dedup_merge",
     "merge_retention",
     "forget_retention",
+    "measurement_retention",
     "importance_reeval",
     "consolidation",
 }
@@ -130,6 +132,7 @@ class SleepOrchestrator:
             ("dedup_merge", lambda: DedupMergePhase(self.db, self.llm_service, em, cn)),
             ("merge_retention", lambda: MergeRetentionPhase(self.db)),
             ("forget_retention", lambda: ForgetRetentionPhase(self.db)),
+            ("measurement_retention", lambda: MeasurementRetentionPhase(self.db)),
             ("importance_reeval", lambda: ImportanceReevalPhase(self.db, self.llm_service, cn)),
             ("consolidation", lambda: ConsolidationPhase(self.db, self.llm_service, cn)),
         ]

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -483,6 +483,52 @@ class TestFromDbSleepLLMPrecedence:
         ]
 
 
+class TestMeasurementRetentionConfigPlumbing:
+    """#1355: same 3-point-set pin as forget_retention (#1336 lesson) — a
+    field missing from the from_db merged-kwargs list silently pins the
+    dataclass default and ships the phase as dead code."""
+
+    @pytest.fixture(autouse=True)
+    def _fresh_cache(self):
+        NeuralMemoryConfig.invalidate_cache()
+        yield
+        NeuralMemoryConfig.invalidate_cache()
+
+    @staticmethod
+    def _db(rows: dict):
+        class _Row:
+            def __init__(self, key, value):
+                self.key = key
+                self._value = value
+
+            def get_typed_value(self):
+                return self._value
+
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [_Row(k, v) for k, v in rows.items()]
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    async def test_env_value_survives_from_db_merge(self, monkeypatch):
+        monkeypatch.setenv("SLEEP_MEASUREMENT_RETENTION_DAYS", "90")
+        config = await NeuralMemoryConfig.from_db(self._db({}))
+        assert config.sleep_measurement_retention_days == 90
+
+    async def test_db_override_wins(self, monkeypatch):
+        monkeypatch.delenv("SLEEP_MEASUREMENT_RETENTION_DAYS", raising=False)
+        config = await NeuralMemoryConfig.from_db(
+            self._db({"sleep_measurement_retention_days": 30})
+        )
+        assert config.sleep_measurement_retention_days == 30
+
+    def test_negative_value_rejected(self):
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="sleep_measurement_retention_days"):
+            NeuralMemoryConfig(sleep_measurement_retention_days=-1)
+
+
 class TestForgetRetentionConfigPlumbing:
     """#1336 review: the config key must survive the from_db merge — a field
     missing from the merged-kwargs list silently pins the dataclass default

--- a/backend/tests/services/sleep/test_measurement_retention.py
+++ b/backend/tests/services/sleep/test_measurement_retention.py
@@ -1,0 +1,109 @@
+"""#1355: measurement-series retention purge phase.
+
+Pins (mirroring test_forget_retention.py):
+
+1. Default (``sleep_measurement_retention_days = 0``) is DISABLED — the
+   #1333 append-only contract (retain forever) is preserved unless the
+   operator declares a window.
+2. The sweep runs ONLY for context-scoped runs: measurements carry no
+   user/workspace column, so a broader run has no safe ownership
+   predicate and must skip.
+3. When enabled + context-scoped, old observations are hard-deleted and
+   audited as ONE batch-summary action with counts only — never metric
+   names or values (user-authored free-form data).
+4. Nothing purged → no audit action.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.sleep.measurement_retention import MeasurementRetentionPhase
+
+
+def _config(days: int) -> MagicMock:
+    cfg = MagicMock()
+    cfg.sleep_measurement_retention_days = days
+    return cfg
+
+
+def _budget() -> MagicMock:
+    budget = MagicMock()
+    budget.exhausted = False
+    return budget
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_skips() -> None:
+    db = AsyncMock()
+    phase = MeasurementRetentionPhase(db)
+    result = await phase.execute(_config(0), "user", None, str(uuid4()), _budget())
+    assert result.skipped is True
+    assert result.skip_reason == "retention_disabled"
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_non_context_scoped_run_skips() -> None:
+    db = AsyncMock()
+    phase = MeasurementRetentionPhase(db)
+    result = await phase.execute(_config(30), "user", str(uuid4()), None, _budget())
+    assert result.skipped is True
+    assert result.skip_reason == "no_context_scope"
+    db.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_purges_old_observations_and_audits_batch_summary() -> None:
+    db = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.rowcount = 5
+    db.execute.return_value = delete_result
+
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+    report_id = uuid4()
+    ctx = str(uuid4())
+
+    phase = MeasurementRetentionPhase(db)
+    result = await phase.execute(
+        _config(90), "user", None, ctx, _budget(), reporter=reporter, report_id=report_id
+    )
+
+    assert result.skipped is False
+    # Purged rows never consume the shared per-run budget.
+    assert result.memories_processed == 0
+    assert result.details["purged"] == 5
+    assert result.details["retention_days"] == 90
+
+    delete_sql = str(db.execute.await_args.args[0])
+    assert "measurements" in delete_sql
+    assert "measured_at" in delete_sql
+    assert "context_id" in delete_sql
+
+    reporter.add_action.assert_awaited_once()
+    kwargs = reporter.add_action.await_args.kwargs
+    assert kwargs["phase"] == "measurement_retention"
+    assert kwargs["action_type"] == "purge"
+    assert kwargs["details"] == {"purged": 5, "retention_days": 90}
+
+
+@pytest.mark.asyncio
+async def test_nothing_to_purge_records_no_action() -> None:
+    db = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.rowcount = 0
+    db.execute.return_value = delete_result
+
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+
+    phase = MeasurementRetentionPhase(db)
+    result = await phase.execute(
+        _config(7), "user", None, str(uuid4()), _budget(), reporter=reporter, report_id=uuid4()
+    )
+
+    assert result.skipped is False
+    assert result.details["purged"] == 0
+    reporter.add_action.assert_not_awaited()

--- a/backend/tests/services/sleep/test_measurement_retention.py
+++ b/backend/tests/services/sleep/test_measurement_retention.py
@@ -90,6 +90,29 @@ async def test_purges_old_observations_and_audits_batch_summary() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reads_real_config_field_and_is_wired_into_full_phases() -> None:
+    """#1336 dead-code lesson, closed both ways: the phase must read the
+    REAL NeuralMemoryConfig field (a getattr against a renamed field would
+    silently return 0 = disabled forever while MagicMock tests stay
+    green), and the orchestrator must actually schedule the phase."""
+    from neural.config import NeuralMemoryConfig
+    from services.sleep.orchestrator import FULL_PHASES
+
+    db = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.rowcount = 1
+    db.execute.return_value = delete_result
+
+    phase = MeasurementRetentionPhase(db)
+    real_config = NeuralMemoryConfig(sleep_measurement_retention_days=30)
+    result = await phase.execute(real_config, "user", None, str(uuid4()), _budget())
+
+    assert result.skipped is False
+    assert result.details["retention_days"] == 30
+    assert "measurement_retention" in FULL_PHASES
+
+
+@pytest.mark.asyncio
 async def test_nothing_to_purge_records_no_action() -> None:
     db = AsyncMock()
     delete_result = MagicMock()

--- a/backend/tests/services/sleep/test_measurement_retention.py
+++ b/backend/tests/services/sleep/test_measurement_retention.py
@@ -86,7 +86,9 @@ async def test_purges_old_observations_and_audits_batch_summary() -> None:
     kwargs = reporter.add_action.await_args.kwargs
     assert kwargs["phase"] == "measurement_retention"
     assert kwargs["action_type"] == "purge"
-    assert kwargs["details"] == {"purged": 5, "retention_days": 90}
+    assert kwargs["details"]["purged"] == 5
+    assert kwargs["details"]["retention_days"] == 90
+    assert "cutoff" in kwargs["details"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1355

## 設計判断
オプション 1 の縮小版を採用: **retention のみ、ダウンサンプリングなし**。
- デフォルト **0 = 無効 = 永久保持**(#1333 の append-only 契約を保存)— 系列の完全性がレーンの価値のため、破壊的挙動は operator の opt-in のみ
- 前例 1:1: `SLEEP_FORGET_RETENTION_DAYS`(#1336)と同じ env knob + sleep phase 形式
- option 2(上限+422)は agent loop を突然壊すため不採用、option 3(文書化のみ)は成長無管理のままのため不採用
- `recall_series` の rate-limit 免除は**見送り**(厳格側維持、service docstring に判断を記録)

## 実装
- `neural/config.py`: `sleep_measurement_retention_days`(dataclass + validation + from_env + **from_db merged kwargs** — #1336 の dead-code 教訓どおり 3 点セット + plumbing pin)
- `services/sleep/measurement_retention.py`: MeasurementRetentionPhase — **context-scoped run のみ**掃除(measurements に user/workspace 列がないため、context スコープ外は fail-safe skip)。1 DELETE、batch-summary audit(counts のみ — metric 名/値はユーザー自由記述のためログ非搭載)
- orchestrator FULL_PHASES に登録(forget_retention の直後)。report 列は追加しない(#1336 と同じ: SleepAction 行 + details のみ)
- migration 不要・frontend 変更なし(#1336 と同様 env-only)

## Tests
phase 4 pin(disabled skip / no-context skip / purge+audit / no-op)+ config plumbing 3 pin。430 passed(sleep + neural config + measurement suites)。lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)