### PR TITLE
chore(api,frontend): v0.53.0 final-inspection quality bundle (#1360)

### DIFF
--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -629,6 +629,20 @@ async def get_cluster(
         count = permitted_count
         if permitted_count != live_count:
             property_stats = {"types": permitted_types}
+            # Deny-observability parity with the row-filter lever (#1360
+            # review): the SQL predicate subtracts silently — emit the
+            # aggregate operators previously got from
+            # agent_binding_row_filter_denied. Ids/counts only.
+            from auth.agent_scope import get_agent_scope
+
+            scope = get_agent_scope()
+            logger.warning(
+                "agent_binding_sql_subtraction",
+                surface="get_cluster",
+                run_id=str(run_id),
+                denied_count=live_count - permitted_count,
+                agent_id=str(scope.agent_id) if scope else None,
+            )
         elif "types" in property_stats:
             property_stats = {**property_stats, "types": permitted_types}
 
@@ -759,16 +773,22 @@ async def list_clusters(
         permitted_rep_ids = {row[0] for row in rep_id_rows}
 
     subtracted: list[dict[str, Any]] = []
+    denied_total = 0
     for c in clusters:
         types = permitted_types.get(c.id, {})
         filtered_count = sum(types.values())
-        if filtered_count == 0:
-            # Fail-closed on the ENUMERATION surface: a cluster with zero
-            # permitted rows would still volunteer its LLM label /
-            # description — content synthesized from the denied members —
-            # and the count-0-with-label shape confirms denied rows exist.
-            # Direct drill-down (get_cluster by index) keeps the #1301
-            # contract; the list simply does not advertise it.
+        cluster_live = live_counts.get(c.id, 0)
+        denied_total += cluster_live - filtered_count
+        if filtered_count == 0 and cluster_live > 0:
+            # Fail-closed on the ENUMERATION surface: a cluster whose
+            # every LIVE row the binding denies would still volunteer its
+            # LLM label / description — content synthesized from the
+            # denied members — and the count-0-with-label shape confirms
+            # denied rows exist. A cluster emptied purely by post-analysis
+            # soft-deletes (live == 0, nothing denied) stays listed with
+            # count 0, matching the human view and the get_cluster
+            # drill-down. Direct drill-down keeps the #1301 contract; the
+            # list simply does not advertise denied-only clusters.
             continue
         stats = dict(c.property_stats or {})
         count = filtered_count
@@ -792,6 +812,21 @@ async def list_clusters(
                 "property_stats": stats,
                 "label_confidence": float(c.label_confidence),
             }
+        )
+    if denied_total > 0:
+        # Deny-observability parity with the row-filter lever (#1360
+        # review): the SQL predicate subtracts silently, so emit the
+        # aggregate the operators previously got from
+        # agent_binding_row_filter_denied. Ids/counts only.
+        from auth.agent_scope import get_agent_scope
+
+        scope = get_agent_scope()
+        logger.warning(
+            "agent_binding_sql_subtraction",
+            surface="list_clusters",
+            run_id=str(run_id),
+            denied_count=denied_total,
+            agent_id=str(scope.agent_id) if scope else None,
         )
     return subtracted
 

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -496,13 +496,16 @@ async def get_cluster(
         next_cursor = str(rows[-1].id)
 
     # #1301: enforce-mode subtraction now happens in the page WHERE above
-    # (#1357) — for enforce agents this row filter finds nothing to drop.
-    # It stays for SHADOW scopes (predicate is None there): rows are kept
+    # (#1357) — running the row filter too would only re-fetch the bindings
+    # to drop nothing, so it is skipped for enforce (#1360 item 7). It
+    # stays for SHADOW scopes (predicate is None there): rows are kept
     # unchanged and the would-deny volume is logged (outside the MAE
-    # vocabulary, so shadow is log-only).
+    # vocabulary, so shadow is log-only); non-agent calls are a no-query
+    # no-op inside the filter.
     from services.agent_binding_service import filter_memory_rows_by_binding
 
-    rows, _ = await filter_memory_rows_by_binding(db, rows, operation=None, user_id=None)
+    if binding_predicate is None:
+        rows, _ = await filter_memory_rows_by_binding(db, rows, operation=None, user_id=None)
 
     memories_out = [
         {
@@ -547,9 +550,12 @@ async def get_cluster(
                 ).where(and_(*rep_conditions))
             )
         ).all()
-        rep_rows, _ = await filter_memory_rows_by_binding(
-            db, list(rep_rows), operation=None, user_id=None
-        )
+        # Same enforce-skip as the page rows (#1360 item 7): the SQL
+        # predicate above already subtracted for enforce agents.
+        if binding_predicate is None:
+            rep_rows, _ = await filter_memory_rows_by_binding(
+                db, list(rep_rows), operation=None, user_id=None
+            )
         # Preserve the order from ``representative_memory_ids`` so the UI
         # gets stable "top-k" semantics across repeated calls.
         rep_by_id = {r.id: r for r in rep_rows}
@@ -589,9 +595,19 @@ async def get_cluster(
     count = int(cluster.count)
     property_stats = cluster.property_stats or {}
     if binding_predicate is not None:
+        # #1360 item 12: one grouped query yields BOTH the live count and
+        # the binding-permitted count per type (FILTER clause), so a
+        # stored-count mismatch caused purely by post-analysis
+        # soft-deletes is no longer mistaken for a binding subtraction —
+        # facets drop fail-closed ONLY when the binding actually
+        # subtracted a live row.
         type_rows = (
             await db.execute(
-                select(Memory.type, func.count(Memory.id))
+                select(
+                    Memory.type,
+                    func.count(Memory.id),
+                    func.count(Memory.id).filter(binding_predicate),
+                )
                 .join(
                     MemoryAnalysisAssignment,
                     MemoryAnalysisAssignment.memory_id == Memory.id,
@@ -602,19 +618,19 @@ async def get_cluster(
                         MemoryAnalysisAssignment.cluster_id == cluster.id,
                         Memory.deleted_at.is_(None),
                         Memory.workspace_id == workspace_id,
-                        binding_predicate,
                     )
                 )
                 .group_by(Memory.type)
             )
         ).all()
-        filtered_types = {row[0]: int(row[1]) for row in type_rows}
-        filtered_count = sum(filtered_types.values())
-        if filtered_count != count:
-            count = filtered_count
-            property_stats = {"types": filtered_types}
+        live_count = sum(int(row[1]) for row in type_rows)
+        permitted_types = {row[0]: int(row[2]) for row in type_rows if int(row[2])}
+        permitted_count = sum(permitted_types.values())
+        count = permitted_count
+        if permitted_count != live_count:
+            property_stats = {"types": permitted_types}
         elif "types" in property_stats:
-            property_stats = {**property_stats, "types": filtered_types}
+            property_stats = {**property_stats, "types": permitted_types}
 
     return {
         "run_id": str(run_id),
@@ -696,12 +712,16 @@ async def list_clusters(
     if binding_predicate is None or not clusters:
         return clusters
 
+    # #1360 item 12: live + permitted counts in ONE grouped query (FILTER
+    # clause) so post-analysis soft-delete drift is not mistaken for a
+    # binding subtraction — same rule as get_cluster.
     type_rows = (
         await db.execute(
             select(
                 MemoryAnalysisAssignment.cluster_id,
                 Memory.type,
                 func.count(Memory.id),
+                func.count(Memory.id).filter(binding_predicate),
             )
             .join(Memory, Memory.id == MemoryAnalysisAssignment.memory_id)
             .where(
@@ -709,15 +729,17 @@ async def list_clusters(
                     MemoryAnalysisAssignment.analysis_id == run_id,
                     Memory.deleted_at.is_(None),
                     Memory.workspace_id == workspace_id,
-                    binding_predicate,
                 )
             )
             .group_by(MemoryAnalysisAssignment.cluster_id, Memory.type)
         )
     ).all()
     permitted_types: dict[UUID, dict[str, int]] = {}
-    for cluster_id, mem_type, cnt in type_rows:
-        permitted_types.setdefault(cluster_id, {})[mem_type] = int(cnt)
+    live_counts: dict[UUID, int] = {}
+    for cluster_id, mem_type, live_cnt, permitted_cnt in type_rows:
+        live_counts[cluster_id] = live_counts.get(cluster_id, 0) + int(live_cnt)
+        if int(permitted_cnt):
+            permitted_types.setdefault(cluster_id, {})[mem_type] = int(permitted_cnt)
 
     all_rep_ids = {rid for c in clusters for rid in (c.representative_memory_ids or [])}
     permitted_rep_ids: set[UUID] = set()
@@ -748,10 +770,12 @@ async def list_clusters(
             # Direct drill-down (get_cluster by index) keeps the #1301
             # contract; the list simply does not advertise it.
             continue
-        count = int(c.count)
         stats = dict(c.property_stats or {})
-        if filtered_count != count:
-            count = filtered_count
+        count = filtered_count
+        # Facets drop fail-closed ONLY on a real binding subtraction —
+        # a live-vs-stored mismatch from post-analysis soft-deletes keeps
+        # the stored facets (types still refreshed to permitted values).
+        if filtered_count != live_counts.get(c.id, 0):
             stats = {"types": types}
         elif "types" in stats:
             stats = {**stats, "types": types}

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -204,15 +204,12 @@ class ConnectorProvisioningService:
         # a malformed OAuth response. Do NOT include the conflicting connector_id —
         # it may belong to a different workspace (cross-tenant UUID disclosure).
         if external_team_id:
-            existing_team = await self.get_connector_for_dispatch(
+            await self._assert_team_unclaimed(
+                workspace_id=workspace_id,
                 connector_type=connector_type,
-                external_team_id=external_team_id,
                 app_key=app_key,
+                external_team_id=external_team_id,
             )
-            if existing_team is not None:
-                raise ConflictError(
-                    f"A {connector_type} connector for team '{external_team_id}' already exists.",
-                )
 
         # ``auto_create_context_name`` goes through ContextService.create_context,
         # which COMMITS mid-flow — that would release the seat-cap advisory lock
@@ -622,6 +619,51 @@ class ConnectorProvisioningService:
             ConnectorListItem(connector=connector, resource_id=resource_id)
             for connector, resource_id in result.all()
         ]
+
+    async def _assert_team_unclaimed(
+        self,
+        *,
+        workspace_id: UUID,
+        connector_type: str,
+        app_key: str,
+        external_team_id: str,
+    ) -> None:
+        """Reject binding a platform team that is already claimed.
+
+        Two layers (#1360): the app-qualified exact match keeps one
+        connector per ``(type, app_key, team)`` anywhere, and the
+        cross-tenant guard blocks a team bound to ANOTHER workspace from
+        being pre-bound here under a *different* ``app_key`` — the #1315
+        app-qualification would otherwise let a second tenant route that
+        team's future events to a workspace its owner never authorized.
+        Same-workspace multi-app stays allowed (one tenant, several
+        platform apps). Both arms raise the same fixed message — no
+        cross-tenant existence disclosure beyond the conflict itself.
+        """
+        existing_team = await self.get_connector_for_dispatch(
+            connector_type=connector_type,
+            external_team_id=external_team_id,
+            app_key=app_key,
+        )
+        if existing_team is not None:
+            raise ConflictError(
+                f"A {connector_type} connector for team '{external_team_id}' already exists.",
+            )
+        other_tenant = (
+            await self.db.execute(
+                select(WorkspaceConnector.id)
+                .where(
+                    WorkspaceConnector.connector_type == connector_type,
+                    WorkspaceConnector.external_team_id == external_team_id,
+                    WorkspaceConnector.workspace_id != workspace_id,
+                )
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if other_tenant is not None:
+            raise ConflictError(
+                f"A {connector_type} connector for team '{external_team_id}' already exists.",
+            )
 
     async def get_connector_for_dispatch(
         self, connector_type: str, external_team_id: str, app_key: str = "default"

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -640,6 +640,19 @@ class ConnectorProvisioningService:
         platform apps). Both arms raise the same fixed message — no
         cross-tenant existence disclosure beyond the conflict itself.
         """
+        # Serialize concurrent claims on the same (type, team): the
+        # cross-tenant arm below is a read-then-write check with NO unique
+        # backstop (the index is app_key-qualified), so two workspaces
+        # racing under different app_keys would both pass the SELECT. The
+        # xact-scoped advisory lock holds until commit — same pattern as
+        # the seat-cap lock.
+        await self.db.execute(
+            select(
+                func.pg_advisory_xact_lock(
+                    func.hashtext(f"wct:{connector_type}:{external_team_id}")
+                )
+            )
+        )
         existing_team = await self.get_connector_for_dispatch(
             connector_type=connector_type,
             external_team_id=external_team_id,

--- a/backend/src/services/worker_app_identity.py
+++ b/backend/src/services/worker_app_identity.py
@@ -114,6 +114,7 @@ class WorkerAppIdentityService:
         status: str | None = None,
     ) -> WorkerAppIdentity:
         identity = await self._require_identity(platform, app_key)
+        config_changed = False
         if display_name is not None:
             identity.display_name = display_name
         if status is not None:
@@ -166,9 +167,18 @@ class WorkerAppIdentityService:
                         retiring_secret_revision=identity.retiring_secret_revision,
                     )
                 identity.clear_retiring_secret()
+            if status != identity.status:
+                config_changed = True
             identity.status = status
         identity.updated_by = actor_id
-        identity.config_version += 1
+        # #1360: display_name is admin-display-only — it is not part of the
+        # worker-facing config, so a rename must not bump config_version
+        # (the bump changes identity_collection_revision and makes EVERY
+        # worker refetch its config on the next bootstrap poll). Only a
+        # real status transition is config-relevant here; rotate_secret
+        # bumps on its own.
+        if config_changed:
+            identity.config_version += 1
         await self.db.flush()
         return identity
 

--- a/backend/src/utils/logger.py
+++ b/backend/src/utils/logger.py
@@ -23,18 +23,37 @@ _PG_DETAIL_RE = re.compile(r"DETAIL:.*", re.DOTALL)
 _REDACTED = "DETAIL: [redacted]"
 
 
+def _scrub_detail(value):  # noqa: ANN001, ANN202
+    """Recursively scrub DETAIL payloads from strings and containers.
+
+    Nested containers matter (#1360 review): a handler logging
+    ``results=[{"error": str(exc)}]`` would otherwise carry the failing
+    row straight past a top-level-only scrub — the JSON renderer
+    stringifies the structure AFTER the processors have run.
+    """
+    if isinstance(value, str):
+        if "DETAIL:" in value:
+            return _PG_DETAIL_RE.sub(_REDACTED, value)
+        return value
+    if isinstance(value, dict):
+        return {key: _scrub_detail(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return type(value)(_scrub_detail(item) for item in value)
+    return value
+
+
 def redact_pg_detail(logger, method_name, event_dict):  # noqa: ANN001, ANN201
     """structlog processor: scrub postgres DETAIL payloads (#1359).
 
     Runs on every event so ANY logger that stringifies a DB error (the
     global SQLAlchemyError handler's ``exc_info=True``, ad-hoc
-    ``error=str(exc)`` fields) hits one chokepoint. The constraint name
-    before DETAIL survives for diagnosability; the failing-row payload
-    never reaches log aggregation.
+    ``error=str(exc)`` fields, nested dict/list fields) hits one
+    chokepoint. The constraint name before DETAIL survives for
+    diagnosability; the failing-row payload never reaches log
+    aggregation.
     """
     for key, value in event_dict.items():
-        if isinstance(value, str) and "DETAIL:" in value:
-            event_dict[key] = _PG_DETAIL_RE.sub(_REDACTED, value)
+        event_dict[key] = _scrub_detail(value)
     return event_dict
 
 

--- a/backend/tests/api/test_worker_apps_http_gate.py
+++ b/backend/tests/api/test_worker_apps_http_gate.py
@@ -1,0 +1,89 @@
+"""HTTP-level admin gate pin for /admin/worker-apps (#1360 item 2).
+
+The existing tests in ``test_worker_apps.py`` call the route handlers
+directly, which bypasses FastAPI dependency injection — they prove the
+handler logic but not that ``require_admin`` actually guards the HTTP
+surface. This module exercises the real DI chain (real ``require_admin``,
+only ``get_current_user`` overridden) through a ``TestClient``, mirroring
+``test_admin_force_transfer_route.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.routes import worker_apps as worker_apps_mod
+from auth.dependencies import get_current_user
+from db.base import get_db
+from utils.exceptions import MemoryCloudException
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(worker_apps_mod.router)
+
+    async def _mc_handler(_request, exc: MemoryCloudException) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {"code": getattr(exc, "error_code", None), "message": str(exc)}},
+        )
+
+    app.add_exception_handler(MemoryCloudException, _mc_handler)
+    return app
+
+
+def _client(role: str = "admin") -> TestClient:
+    app = _build_app()
+
+    async def _user():
+        return {"user_id": "admin_user_1", "email": "admin@test.com", "role": role}
+
+    async def _db():
+        yield MagicMock()
+
+    app.dependency_overrides[get_current_user] = _user
+    app.dependency_overrides[get_db] = _db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+_NON_ADMIN_CALLS = [
+    ("GET", "/admin/worker-apps", None),
+    (
+        "POST",
+        "/admin/worker-apps",
+        {
+            "platform": "slack",
+            "app_key": "sales",
+            "display_name": "Sales",
+            "signing_secret": "s3cret",
+        },
+    ),
+    ("PATCH", "/admin/worker-apps/slack/sales", {"display_name": "Renamed"}),
+    (
+        "POST",
+        "/admin/worker-apps/slack/sales/rotate-secret",
+        {"signing_secret": "n3w", "retiring_for_seconds": 0},
+    ),
+]
+
+
+class TestWorkerAppsHttpGate:
+    @pytest.mark.parametrize(("method", "path", "body"), _NON_ADMIN_CALLS)
+    def test_non_admin_is_403_via_http(self, method, path, body):
+        resp = _client(role="user").request(method, path, json=body)
+        assert resp.status_code == 403
+
+    def test_admin_passes_gate_via_http(self):
+        """The gate admits role=admin — proves the 403s above come from
+        require_admin, not from a broken route wiring."""
+        svc = MagicMock()
+        svc.list_identities = AsyncMock(return_value=[])
+        with patch.object(worker_apps_mod, "WorkerAppIdentityService", return_value=svc):
+            resp = _client(role="admin").get("/admin/worker-apps")
+        assert resp.status_code == 200
+        assert resp.json() == []

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -1269,3 +1269,38 @@ async def test_enforce_mode_skips_redundant_row_filter(
         assert len(detail["memories"]) == 2
     finally:
         set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_emptied_cluster_stays_listed_for_enforce_agent(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1360 review F4: a cluster emptied purely by post-analysis
+    soft-deletes (nothing denied) must stay in the enforce-agent list
+    with count 0 — omission is reserved for denied-only clusters."""
+    from auth.agent_scope import set_agent_scope
+
+    run, cluster, mems, _denied = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=0,
+    )
+    for mem in mems:
+        mem.deleted_at = utcnow()
+    await db_session.flush()
+
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        rows = await query_service.list_clusters(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert rows is not None and len(rows) == 1
+        row = rows[0]
+        assert (row["count"] if isinstance(row, dict) else row.count) == 0
+    finally:
+        set_agent_scope(None)

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -1144,3 +1144,128 @@ async def test_shadow_scope_keeps_full_view(
         assert detail["count"] == 4
     finally:
         set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_soft_delete_drift_keeps_facets_for_enforce_agent(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1360 item 12: a stored-count mismatch caused purely by
+    post-analysis soft-deletes must NOT be treated as a binding
+    subtraction — facets survive, count reflects live permitted rows."""
+    from auth.agent_scope import set_agent_scope
+
+    run, cluster, mems, _denied = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=3,
+        denied=0,
+    )
+    # cluster.count stored 3; soft-delete one member AFTER the analysis.
+    mems[0].deleted_at = utcnow()
+    await db_session.flush()
+
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        detail = await query_service.get_cluster(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            run_id=run.id,
+            cluster_index=0,
+        )
+        assert detail is not None
+        assert detail["count"] == 2
+        # No binding subtraction happened → the tags facet survives.
+        assert "tags" in detail["property_stats"]
+        assert detail["property_stats"]["types"] == {"note": 2}
+
+        rows = await query_service.list_clusters(
+            db_session, workspace_id=fixture_workspace_id, run_id=run.id
+        )
+        assert rows is not None and len(rows) == 1
+        row = rows[0]
+        assert row["count"] == 2
+        assert "tags" in row["property_stats"]
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_real_subtraction_still_drops_facets_for_enforce_agent(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """Companion pin: an actual binding subtraction keeps the fail-closed
+    facet drop even when soft-delete drift is present too."""
+    from auth.agent_scope import set_agent_scope
+
+    run, _cluster, mems, denied_mems = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=1,
+    )
+    mems[0].deleted_at = utcnow()
+    await db_session.flush()
+
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        detail = await query_service.get_cluster(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            run_id=run.id,
+            cluster_index=0,
+        )
+        assert detail is not None
+        assert detail["count"] == 1
+        assert detail["property_stats"] == {"types": {"note": 1}}
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_enforce_mode_skips_redundant_row_filter(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """#1360 item 7: enforce mode subtracts in the page WHERE — the
+    post-fetch row filter (an extra binding SELECT per row set) must not
+    run at all."""
+    from unittest.mock import AsyncMock, patch
+
+    from auth.agent_scope import set_agent_scope
+
+    run, cluster, mems, _denied = await _cluster_with_members(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        allowed=2,
+        denied=1,
+    )
+    cluster.representative_memory_ids = [mems[0].id]
+    await db_session.flush()
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        with patch(
+            "services.agent_binding_service.filter_memory_rows_by_binding",
+            AsyncMock(side_effect=AssertionError("row filter must not run in enforce mode")),
+        ):
+            detail = await query_service.get_cluster(
+                db_session,
+                workspace_id=fixture_workspace_id,
+                run_id=run.id,
+                cluster_index=0,
+            )
+        assert detail is not None
+        assert len(detail["memories"]) == 2
+    finally:
+        set_agent_scope(None)

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -516,4 +516,8 @@ class TestTeamUniquenessGuard:
                 app_key="default",
                 external_team_id="T123",
             )
-        db.execute.assert_not_awaited()
+        # Only the (type, team) advisory lock ran — the cross-tenant probe
+        # never fires once the app-qualified duplicate rejects.
+        assert db.execute.await_count == 1
+        lock_sql = str(db.execute.await_args_list[0].args[0])
+        assert "pg_advisory_xact_lock" in lock_sql

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -463,3 +463,57 @@ async def test_update_runtime_config_survives_drifted_stored_document():
     )
     assert result.config_version == 2
     assert connector.runtime_config["vision_enabled"] is False
+
+
+class TestTeamUniquenessGuard:
+    """#1360: the #1315 app-qualified uniqueness must not re-open
+    cross-tenant pre-binding of an already-bound platform team."""
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_prebind_rejected_even_under_different_app_key(self):
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_result(one=uuid4()))  # other-tenant hit
+        svc = ConnectorProvisioningService(db)
+        svc.get_connector_for_dispatch = AsyncMock(return_value=None)  # app-qualified miss
+
+        with pytest.raises(ConflictError):
+            await svc._assert_team_unclaimed(
+                workspace_id=uuid4(),
+                connector_type="slack",
+                app_key="second-app",
+                external_team_id="T123",
+            )
+
+    @pytest.mark.asyncio
+    async def test_same_workspace_multi_app_allowed(self):
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=_result(one=None))  # no OTHER-workspace row
+        svc = ConnectorProvisioningService(db)
+        svc.get_connector_for_dispatch = AsyncMock(return_value=None)
+
+        await svc._assert_team_unclaimed(
+            workspace_id=uuid4(),
+            connector_type="slack",
+            app_key="second-app",
+            external_team_id="T123",
+        )
+
+        # The cross-tenant probe excludes the caller's own workspace.
+        sql = str(db.execute.await_args.args[0])
+        assert "workspace_id !=" in sql
+
+    @pytest.mark.asyncio
+    async def test_exact_app_qualified_duplicate_rejected_first(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        svc = ConnectorProvisioningService(db)
+        svc.get_connector_for_dispatch = AsyncMock(return_value=SimpleNamespace(id=uuid4()))
+
+        with pytest.raises(ConflictError):
+            await svc._assert_team_unclaimed(
+                workspace_id=uuid4(),
+                connector_type="slack",
+                app_key="default",
+                external_team_id="T123",
+            )
+        db.execute.assert_not_awaited()

--- a/backend/tests/services/test_worker_app_identity.py
+++ b/backend/tests/services/test_worker_app_identity.py
@@ -419,6 +419,69 @@ async def test_status_noop_update_keeps_retiring_window(_fernet_env):
     assert result.retiring_valid_until == valid_until
 
 
+@pytest.mark.asyncio
+async def test_rename_only_does_not_bump_config_version(_fernet_env):
+    """#1360: display_name is admin-display-only — a rename must not bump
+    config_version (the bump flips identity_collection_revision and makes
+    every worker refetch its config on the next bootstrap poll)."""
+    from services.worker_app_identity import identity_revision
+
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        id=uuid4(),
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="active",
+        active_secret_revision=2,
+        config_version=7,
+    )
+    identity.set_active_signing_secret("secret")
+    revision_before = identity_revision(identity)
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    result = await service.update_identity(
+        platform="slack",
+        app_key="sales",
+        actor_id="admin-1",
+        display_name="Sales EMEA",
+    )
+
+    assert result.display_name == "Sales EMEA"
+    assert result.config_version == 7
+    assert identity_revision(result) == revision_before
+    assert result.updated_by == "admin-1"
+
+
+@pytest.mark.asyncio
+async def test_status_transition_still_bumps_config_version(_fernet_env):
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="sales",
+        display_name="Sales",
+        status="active",
+        active_secret_revision=2,
+        config_version=7,
+    )
+    identity.set_active_signing_secret("secret")
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    result = await service.update_identity(
+        platform="slack",
+        app_key="sales",
+        actor_id="admin-1",
+        status="disabled",
+    )
+
+    assert result.status == "disabled"
+    assert result.config_version == 8
+
+
 def test_bootstrap_revision_changes_when_retiring_window_expires():
     identity = WorkerAppIdentity(
         id=uuid4(),

--- a/backend/tests/utils/test_logger_redaction.py
+++ b/backend/tests/utils/test_logger_redaction.py
@@ -104,3 +104,20 @@ def test_json_path_orders_redaction_after_format_exc_info(monkeypatch):
         structlog.processors.format_exc_info
     )
     assert processors.index(redact_pg_detail) < len(processors) - 1
+
+
+def test_redact_pg_detail_scrubs_nested_containers():
+    """#1360 review: DETAIL inside dict/list fields must be scrubbed too —
+    the JSON renderer stringifies nested structures after the processors."""
+    event_dict = {
+        "event": "batch_failed",
+        "results": [{"row": 3, "error": _ASYNCPG_STYLE_MESSAGE}],
+        "context": {"cause": _ASYNCPG_STYLE_MESSAGE, "n": 1},
+    }
+    out = redact_pg_detail(None, "error", event_dict)
+    assert "35.6812" not in str(out)
+    assert "secret content" not in str(out)
+    assert out["results"][0]["row"] == 3
+    assert "DETAIL: [redacted]" in out["results"][0]["error"]
+    assert "DETAIL: [redacted]" in out["context"]["cause"]
+    assert out["context"]["n"] == 1

--- a/frontend/src/app/(authenticated)/admin/worker-apps/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/worker-apps/page.test.tsx
@@ -24,6 +24,11 @@ vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
 }));
 
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
 beforeEach(() => {
   mockListWorkerApps.mockResolvedValue([]);
   mockCreateWorkerApp.mockResolvedValue({});
@@ -134,6 +139,81 @@ describe("WorkerAppsPage", () => {
         expect.objectContaining({ app_key: "sales", platform: "slack" }),
         { status: "disabled" },
       ),
+    );
+  });
+it("surfaces action failures as a destructive toast (#1360)", async () => {
+    const app = {
+      platform: "slack",
+      app_key: "sales",
+      display_name: "Sales Slack App",
+      status: "active",
+      revision: "opaque-revision",
+      has_active_secret: true,
+      active_secret_revision: 2,
+      retiring_secret_revision: null,
+      retiring_valid_until: null,
+      created_at: "2026-07-17T00:00:00Z",
+      updated_at: "2026-07-17T00:00:00Z",
+    };
+    mockUseAuth.mockReturnValue({ user: { role: "admin" }, isLoading: false });
+    mockListWorkerApps.mockResolvedValue([app]);
+    mockUpdateWorkerApp.mockRejectedValue(new Error("boom"));
+
+    render(<WorkerAppsPage />);
+    await screen.findByText("sales");
+
+    fireEvent.click(screen.getByRole("button", { name: "save" }));
+
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variant: "destructive",
+          title: "operationFailed",
+          description: "boom",
+        }),
+      ),
+    );
+    // No inline banner for an action failure (error-surface rule).
+    expect(screen.queryByText("boom")).not.toBeInTheDocument();
+  });
+
+  it("keeps another row's unsaved draft across a reload (#1360)", async () => {
+    const base = {
+      platform: "slack",
+      status: "active",
+      revision: "r",
+      has_active_secret: true,
+      active_secret_revision: 1,
+      retiring_secret_revision: null,
+      retiring_valid_until: null,
+      created_at: "2026-07-17T00:00:00Z",
+      updated_at: "2026-07-17T00:00:00Z",
+    };
+    const appA = { ...base, app_key: "alpha", display_name: "Alpha" };
+    const appB = { ...base, app_key: "beta", display_name: "Beta" };
+    mockUseAuth.mockReturnValue({ user: { role: "admin" }, isLoading: false });
+    mockListWorkerApps.mockResolvedValue([appA, appB]);
+
+    render(<WorkerAppsPage />);
+    await screen.findByText("alpha");
+
+    const inputs = screen.getAllByLabelText("displayNameFor");
+    // Draft an edit in row B, then save row A.
+    fireEvent.change(inputs[1], { target: { value: "Beta DRAFT" } });
+    fireEvent.click(screen.getAllByRole("button", { name: "save" })[0]);
+
+    await waitFor(() =>
+      expect(mockUpdateWorkerApp).toHaveBeenCalledWith(
+        expect.objectContaining({ app_key: "alpha" }),
+        { display_name: "Alpha" },
+      ),
+    );
+    // The reload after the save must NOT discard row B's draft.
+    await waitFor(() =>
+      expect(mockListWorkerApps).toHaveBeenCalledTimes(2),
+    );
+    expect(screen.getAllByLabelText("displayNameFor")[1]).toHaveValue(
+      "Beta DRAFT",
     );
   });
 });

--- a/frontend/src/app/(authenticated)/admin/worker-apps/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/worker-apps/page.tsx
@@ -66,11 +66,12 @@ export default function WorkerAppsPage() {
   }, [allowed, reload]);
 
   const run = useCallback(
-    async (key: string, action: () => Promise<unknown>) => {
+    async (key: string, action: () => Promise<unknown>): Promise<boolean> => {
       setBusyKey(key);
       try {
         await action();
         await reload();
+        return true;
       } catch (error) {
         // #1360: user-action failures go to a destructive toast (error
         // surface rule) — inline banners are for load failures only.
@@ -79,6 +80,7 @@ export default function WorkerAppsPage() {
           title: t("operationFailed"),
           description: error instanceof Error ? error.message : String(error),
         });
+        return false;
       } finally {
         setBusyKey(null);
       }
@@ -206,16 +208,22 @@ export default function WorkerAppsPage() {
                       variant="outline"
                       disabled={busy || busyKey !== null}
                       onClick={() =>
-                        void run(key, async () => {
-                          await updateWorkerApp(app, {
+                        void run(key, () =>
+                          updateWorkerApp(app, {
                             display_name: names[key] ?? app.display_name,
-                          });
-                          // Saved — drop this row's draft so the input
-                          // tracks the fresh server value again.
-                          setNames((current) => {
-                            const { [key]: _saved, ...rest } = current;
-                            return rest;
-                          });
+                          }),
+                        ).then((saved) => {
+                          // Drop this row's draft only AFTER the reload
+                          // inside run() delivered the fresh server value
+                          // — clearing earlier flashes the stale name
+                          // mid-refetch, and a failed save keeps the
+                          // draft for retry.
+                          if (saved) {
+                            setNames((current) => {
+                              const { [key]: _saved, ...rest } = current;
+                              return rest;
+                            });
+                          }
                         })
                       }
                     >

--- a/frontend/src/app/(authenticated)/admin/worker-apps/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/worker-apps/page.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/contexts/AuthContext";
+import { useToast } from "@/hooks/use-toast";
 import {
   createWorkerApp,
   listWorkerApps,
@@ -25,9 +26,9 @@ export default function WorkerAppsPage() {
   const t = useTranslations("workerApps");
   const { user, isLoading: authLoading } = useAuth();
   const allowed = user?.role === "admin";
+  const { toast } = useToast();
   const [apps, setApps] = useState<WorkerAppIdentity[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [operationError, setOperationError] = useState<string | null>(null);
   const [busyKey, setBusyKey] = useState<string | null>(null);
   const [appKey, setAppKey] = useState("");
   const [displayName, setDisplayName] = useState("");
@@ -42,14 +43,19 @@ export default function WorkerAppsPage() {
       setLoadError(null);
       const rows = await listWorkerApps();
       setApps(rows);
-      setNames(
-        Object.fromEntries(
-          rows.map((app) => [
-            `${app.platform}:${app.app_key}`,
-            app.display_name,
-          ]),
-        ),
-      );
+      // #1360: `names` holds only the user's unsaved drafts (the inputs
+      // fall back to app.display_name). Reload must NOT reseed it with
+      // server values — that silently discarded edits in other rows
+      // whenever any action completed. Only prune keys that no longer
+      // exist.
+      setNames((current) => {
+        const live = new Set(
+          rows.map((app) => `${app.platform}:${app.app_key}`),
+        );
+        return Object.fromEntries(
+          Object.entries(current).filter(([key]) => live.has(key)),
+        );
+      });
     } catch (error) {
       setLoadError(error instanceof Error ? error.message : String(error));
     }
@@ -62,17 +68,22 @@ export default function WorkerAppsPage() {
   const run = useCallback(
     async (key: string, action: () => Promise<unknown>) => {
       setBusyKey(key);
-      setOperationError(null);
       try {
         await action();
         await reload();
       } catch (error) {
-        setOperationError(error instanceof Error ? error.message : String(error));
+        // #1360: user-action failures go to a destructive toast (error
+        // surface rule) — inline banners are for load failures only.
+        toast({
+          variant: "destructive",
+          title: t("operationFailed"),
+          description: error instanceof Error ? error.message : String(error),
+        });
       } finally {
         setBusyKey(null);
       }
     },
-    [reload],
+    [reload, toast, t],
   );
 
   const handleCreate = async (event: FormEvent) => {
@@ -116,8 +127,6 @@ export default function WorkerAppsPage() {
         <AlertDescription>{t("secretNotice")}</AlertDescription>
       </Alert>
 
-      {operationError && <ErrorBanner error={operationError} />}
-
       <form
         onSubmit={handleCreate}
         className="mb-8 grid gap-3 rounded-md border p-4 md:grid-cols-4"
@@ -156,7 +165,11 @@ export default function WorkerAppsPage() {
       ) : apps === null ? (
         <TableLoadingState rows={3} />
       ) : apps.length === 0 ? (
-        <EmptyState icon={Puzzle} title={t("emptyTitle")} description={t("emptyDesc")} />
+        <EmptyState
+          icon={Puzzle}
+          title={t("emptyTitle")}
+          description={t("emptyDesc")}
+        />
       ) : (
         <ul className="space-y-4">
           {apps.map((app) => {
@@ -193,11 +206,17 @@ export default function WorkerAppsPage() {
                       variant="outline"
                       disabled={busy || busyKey !== null}
                       onClick={() =>
-                        void run(key, () =>
-                          updateWorkerApp(app, {
+                        void run(key, async () => {
+                          await updateWorkerApp(app, {
                             display_name: names[key] ?? app.display_name,
-                          }),
-                        )
+                          });
+                          // Saved — drop this row's draft so the input
+                          // tracks the fresh server value again.
+                          setNames((current) => {
+                            const { [key]: _saved, ...rest } = current;
+                            return rest;
+                          });
+                        })
                       }
                     >
                       {t("save")}
@@ -206,7 +225,9 @@ export default function WorkerAppsPage() {
 
                   <div className="flex gap-2">
                     <Input
-                      aria-label={t("newSigningSecretFor", { appKey: app.app_key })}
+                      aria-label={t("newSigningSecretFor", {
+                        appKey: app.app_key,
+                      })}
                       type="password"
                       autoComplete="new-password"
                       placeholder={t("newSigningSecret")}
@@ -257,12 +278,15 @@ export default function WorkerAppsPage() {
                   {(app.status !== "unconfigured" || app.has_active_secret) && (
                     <Button
                       type="button"
-                      variant={app.status === "active" ? "destructive" : "outline"}
+                      variant={
+                        app.status === "active" ? "destructive" : "outline"
+                      }
                       disabled={busy || busyKey !== null}
                       onClick={() =>
                         void run(key, () =>
                           updateWorkerApp(app, {
-                            status: app.status === "active" ? "disabled" : "active",
+                            status:
+                              app.status === "active" ? "disabled" : "active",
                           }),
                         )
                       }

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
@@ -223,4 +223,34 @@ describe("ConnectorsPage RBAC gate", () => {
       ),
     );
   });
+  it("keeps the connectors list when available-apps fails (#1360)", async () => {
+    setWorkspace("admin");
+    mockListConnectors.mockResolvedValue([
+      {
+        connector_id: "connector-1",
+        connector_type: "slack",
+        app_key: "default",
+        resource_id: "slack-t01",
+        context_id: "context-1",
+        config_version: 1,
+        created_at: "2026-07-18T00:00:00Z",
+        created_by: "user-1",
+        runtime: { vision_enabled: true },
+      },
+    ]);
+    mockListAvailableWorkerApps.mockRejectedValue(new Error("apps down"));
+
+    render(<ConnectorsPage />);
+
+    // Primary content still renders (the i18n mock drops params, so
+    // match the row's static bits rather than the resource id).
+    expect(await screen.findByText("slack")).toBeInTheDocument();
+    expect(
+      screen.getByRole("switch", { name: "visionEnabledFor" }),
+    ).toBeInTheDocument();
+    // ...the manual-bind form degrades away...
+    expect(screen.queryByText("manualBindTitle")).not.toBeInTheDocument();
+    // ...and the degradation is surfaced, not silent.
+    expect(screen.getByText("apps down")).toBeInTheDocument();
+  });
 });

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -179,18 +179,30 @@ export default function ConnectorsPage() {
   const reload = useCallback(async () => {
     try {
       setLoadError(null);
-      const [connectorRows, appRows] = await Promise.all([
+      // #1360: allSettled, not all — the connectors list is the page's
+      // primary content and must not be taken down by a failure of the
+      // auxiliary available-apps lookup (the app selector just degrades).
+      const [connectorResult, appResult] = await Promise.allSettled([
         listConnectors(),
         listAvailableWorkerApps(),
       ]);
-      const slackApps = appRows.filter((app) => app.platform === "slack");
-      setConnectors(connectorRows);
-      setAvailableApps(slackApps);
-      setManualAppKey((current) =>
-        slackApps.some((app) => app.app_key === current)
-          ? current
-          : (slackApps[0]?.app_key ?? ""),
-      );
+      if (connectorResult.status === "rejected") {
+        throw connectorResult.reason;
+      }
+      setConnectors(connectorResult.value);
+      if (appResult.status === "fulfilled") {
+        const slackApps = appResult.value.filter(
+          (app) => app.platform === "slack",
+        );
+        setAvailableApps(slackApps);
+        setManualAppKey((current) =>
+          slackApps.some((app) => app.app_key === current)
+            ? current
+            : (slackApps[0]?.app_key ?? ""),
+        );
+      } else {
+        setAvailableApps(null);
+      }
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : String(err));
     }
@@ -331,16 +343,17 @@ export default function ConnectorsPage() {
           },
           connector.config_version,
         );
-        setConnectors((current) =>
-          current?.map((item) =>
-            item.connector_id === connector.connector_id
-              ? {
-                  ...item,
-                  runtime: result.runtime,
-                  config_version: result.config_version,
-                }
-              : item,
-          ) ?? null,
+        setConnectors(
+          (current) =>
+            current?.map((item) =>
+              item.connector_id === connector.connector_id
+                ? {
+                    ...item,
+                    runtime: result.runtime,
+                    config_version: result.config_version,
+                  }
+                : item,
+            ) ?? null,
         );
         toast({ title: t("runtimeUpdated") });
       } catch (err) {
@@ -397,14 +410,8 @@ export default function ConnectorsPage() {
       } finally {
         setManualSubmitting(false);
       }
-    }, [
-      availableApps,
-      locale,
-      manualAppKey,
-      manualBotToken,
-      manualTeamId,
-      reload,
-    ],
+    },
+    [availableApps, locale, manualAppKey, manualBotToken, manualTeamId, reload],
   );
 
   // Resolve loading before role gating to avoid a flash of the admin UI
@@ -568,7 +575,9 @@ export default function ConnectorsPage() {
                   )}
                   <Switch
                     checked={c.runtime?.vision_enabled ?? true}
-                    disabled={c.runtime == null || runtimeSaving === c.connector_id}
+                    disabled={
+                      c.runtime == null || runtimeSaving === c.connector_id
+                    }
                     onCheckedChange={(enabled) =>
                       void handleVisionEnabledChange(c, enabled)
                     }

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -137,6 +137,9 @@ export default function ConnectorsPage() {
     WorkspaceConnectorSummary[] | null
   >(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  // #1360: available-apps panel failure is decoupled from the primary
+  // connectors list — its own banner, never a page takedown.
+  const [appsLoadError, setAppsLoadError] = useState<string | null>(null);
   const [availableApps, setAvailableApps] = useState<
     AvailableWorkerApp[] | null
   >(null);
@@ -191,6 +194,7 @@ export default function ConnectorsPage() {
       }
       setConnectors(connectorResult.value);
       if (appResult.status === "fulfilled") {
+        setAppsLoadError(null);
         const slackApps = appResult.value.filter(
           (app) => app.platform === "slack",
         );
@@ -201,7 +205,15 @@ export default function ConnectorsPage() {
             : (slackApps[0]?.app_key ?? ""),
         );
       } else {
-        setAvailableApps(null);
+        // Keep whatever list we already had (a transient refresh failure
+        // must not wipe a working selector mid-session) and surface the
+        // degradation via a panel-level banner instead of vanishing
+        // silently — null vs [] would otherwise be indistinguishable.
+        setAppsLoadError(
+          appResult.reason instanceof Error
+            ? appResult.reason.message
+            : String(appResult.reason),
+        );
       }
     } catch (err) {
       setLoadError(err instanceof Error ? err.message : String(err));
@@ -455,6 +467,8 @@ export default function ConnectorsPage() {
           {t("connectSlack")}
         </Button>
       </div>
+
+      {appsLoadError && !availableApps && <ErrorBanner error={appsLoadError} />}
 
       {availableApps && availableApps.length > 0 && (
         <form

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3932,7 +3932,8 @@
     "secretRevision": "Active secret revision: {revision}",
     "status_unconfigured": "Unconfigured",
     "status_active": "Active",
-    "status_disabled": "Disabled"
+    "status_disabled": "Disabled",
+    "operationFailed": "Operation failed"
   },
   "connectors": {
     "title": "Workspace Connectors",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3932,7 +3932,8 @@
     "secretRevision": "有効なシークレットリビジョン: {revision}",
     "status_unconfigured": "未設定",
     "status_active": "有効",
-    "status_disabled": "無効"
+    "status_disabled": "無効",
+    "operationFailed": "操作に失敗しました"
   },
   "connectors": {
     "title": "ワークスペースコネクタ",


### PR DESCRIPTION
Closes #1360

## 6 項目すべて対応

1. **get_cluster の binding SELECT 3 回 → 1 回**: enforce agent では SQL predicate が既に減算済みのため post-fetch row filter をスキップ(shadow の would-deny 観測は維持)
2. **require_admin の HTTP レベル pin**: 実 DI チェーン経由で 4 面(GET/POST/PATCH/rotate)の 403 + admin 通過を TestClient で固定(従来の直呼びテストは DI をバイパス)
3. **worker-apps page**: ① action 失敗を destructive toast へ(error surface 規約 — inline banner は load 失敗専用)② `names` state を draft 専用にし、reload() が他行の未保存 display_name を破棄しなくなった ③ rename のみの PATCH は config_version を bump しない(全 worker の config 再取得誘発を解消。service 側で status 遷移時のみ bump、pin 付き)
4. **connector 一意性**: cross-tenant guard 復元 — 他 workspace に bind 済みの team は app_key を変えても pre-bind 不可(#1315 の app-qualification が再開放していた穴)。同一 workspace の multi-app は許容。`_assert_team_unclaimed` helper に抽出しユニットテスト
5. **connectors page**: `Promise.allSettled` — available-apps 失敗時は app selector だけ degrade し connectors 一覧は表示継続
6. **recompute の drift 区別**: FILTER 句 1 クエリで live/permitted を同時集計 — 分析後 soft-delete による stored count 乖離では facet を保持し、真の binding 減算時のみ fail-closed drop(get_cluster / list_clusters 両面)

## Tests
28 passed(query_service)+ 14(worker identity)+ 18(provisioning)+ 5(HTTP gate)+ frontend 12 passed。lint clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)