### PR TITLE
fix: close aggregate count oracles for enforce agents (#1366)

### DIFF
--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -202,13 +202,33 @@ class AnalysisRow(TZAwareBaseModel):
     triggered_by: str
     started_at: datetime
     finished_at: datetime | None
-    input_count: int
+    # #1366: nullable ONLY for enforce-mode agent credentials, where the
+    # run aggregates (input_count includes binding-denied rows; cost
+    # scales with total volume) act as an existence oracle and are
+    # withheld. Non-agent callers always receive an int.
+    input_count: int | None
     cost_estimated_cents: int | None
     cost_actual_cents: int | None
     error: str | None
     cancellation_reason: str | None
 
     model_config = {"populate_by_name": True, "from_attributes": True}
+
+    def redacted_for_agent_scope(self) -> AnalysisRow:
+        """Withhold aggregate fields for enforce-mode agents (#1366).
+
+        Mirrors ``_serialize_run_row`` in ``mcp_server/tools/analysis.py``
+        so REST and MCP consumers see the same redaction. No-op (returns
+        self) for non-agent and shadow scopes.
+        """
+        from services.agent_binding_service import (
+            REDACTED_RUN_AGGREGATE_FIELDS,
+            agent_scope_is_enforce,
+        )
+
+        if not agent_scope_is_enforce():
+            return self
+        return self.model_copy(update=dict.fromkeys(REDACTED_RUN_AGGREGATE_FIELDS))
 
 
 class AnalysisListResponse(BaseModel):
@@ -371,6 +391,9 @@ async def preview_analysis(
     # 200ms — the actual run will apply filters. The user-facing modal
     # text in #497 says "estimate based on full context size; actual
     # cost may be lower if filters apply".
+    from services.agent_binding_service import agent_scope_is_enforce
+
+    is_enforce = agent_scope_is_enforce()
     memory_count = await query_service.count_context_memories(
         db,
         workspace_id=workspace_id,
@@ -378,7 +401,15 @@ async def preview_analysis(
     )
     # #1244: run-size cap — surface the rejection at preview time so the
     # user is not shown a price for a run that start would refuse.
-    assert_run_size_within_cap(memory_count)
+    # #1366: cap decision on the TRUE count; the 422 omits the count for
+    # enforce agents (aggregate oracle).
+    assert_run_size_within_cap(memory_count, redact_count=is_enforce)
+    # #1366: the count an enforce agent sees (and its derived estimate)
+    # is binding-subtracted; non-agent/shadow callers skip the recount.
+    if is_enforce:
+        memory_count = await query_service.count_context_memories_binding_visible(
+            db, workspace_id=workspace_id, context_id=context_id
+        )
     # v1 only supports the default model in the cost estimator;
     # body.model_id is forward-compat scaffolding (preview.py:73-77).
     estimate = estimate_cost(memory_count, model_id=DEFAULT_MODEL_ID)
@@ -432,12 +463,15 @@ async def start_analysis(
     # the limit and the context's count). Same full-context count
     # semantics as /preview; vector_pull re-checks the filtered set as
     # defense in depth.
+    from services.agent_binding_service import agent_scope_is_enforce
+
     memory_count = await query_service.count_context_memories(
         db,
         workspace_id=workspace_id,
         context_id=context_id,
     )
-    assert_run_size_within_cap(memory_count)
+    # #1366: same true-count cap / redacted-message split as /preview.
+    assert_run_size_within_cap(memory_count, redact_count=agent_scope_is_enforce())
 
     params = _params_from_body(body)
     orchestrator = AnalysisOrchestrator(db)
@@ -506,7 +540,7 @@ async def list_runs(
         cursor=cursor,
     )
     return AnalysisListResponse(
-        items=[AnalysisRow.model_validate(row) for row in rows],
+        items=[AnalysisRow.model_validate(row).redacted_for_agent_scope() for row in rows],
         next_cursor=next_cursor,
     )
 
@@ -540,7 +574,7 @@ async def get_active(
             status_code=404,
             detail=f"No succeeded analysis run found for context {context_id}",
         )
-    return AnalysisRow.model_validate(row)
+    return AnalysisRow.model_validate(row).redacted_for_agent_scope()
 
 
 # ============================================================================
@@ -568,7 +602,7 @@ async def get_run(
     # context's runs even if the workspace gate passed.
     if row is None or row.context_id != context_id:
         raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
-    return AnalysisRow.model_validate(row)
+    return AnalysisRow.model_validate(row).redacted_for_agent_scope()
 
 
 # ============================================================================

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -213,9 +213,13 @@ def _serialize_run_row(row: Any) -> dict[str, Any]:
     consumers see the same fields. Datetimes are emitted with explicit
     UTC ``Z`` suffix via ``to_utc_iso`` (#489 wire-format guarantee).
     """
+    from services.agent_binding_service import (
+        REDACTED_RUN_AGGREGATE_FIELDS,
+        agent_scope_is_enforce,
+    )
     from utils.datetime import to_utc_iso
 
-    return {
+    out = {
         "run_id": str(row.id),
         "workspace_id": str(row.workspace_id),
         "context_id": str(row.context_id),
@@ -233,6 +237,20 @@ def _serialize_run_row(row: Any) -> dict[str, Any]:
         "error": row.error,
         "cancellation_reason": row.cancellation_reason,
     }
+    # #1366: run-level aggregates are an existence/volume oracle for
+    # enforce-mode agents — ``input_count`` includes binding-denied (and
+    # soft-deleted) rows, and cost scales with total token volume, so
+    # both would let a type/source-restricted agent recover the denied
+    # row volume by differencing against per-cluster recomputed counts.
+    # Withhold (null) rather than recompute: a binding-scoped recount
+    # would misrepresent what the run actually billed. Shadow mode is
+    # untouched (enforcement ramp invariant). The field set is shared
+    # with REST ``AnalysisRow.redacted_for_agent_scope`` so the lanes
+    # cannot drift.
+    if agent_scope_is_enforce():
+        for field in REDACTED_RUN_AGGREGATE_FIELDS:
+            out[field] = None
+    return out
 
 
 # ============================================================================
@@ -286,6 +304,7 @@ async def handle_analyze_context(
             if dry_run:
                 # Preview path — same memory count semantics as REST /preview
                 # (delegates to ``query_service.count_context_memories``).
+                from services.agent_binding_service import agent_scope_is_enforce
                 from services.analysis import query_service
                 from services.analysis.preview import (
                     DEFAULT_MODEL_ID,
@@ -293,15 +312,26 @@ async def handle_analyze_context(
                     estimate_cost,
                 )
 
+                is_enforce = agent_scope_is_enforce()
                 memory_count = await query_service.count_context_memories(
                     db, workspace_id=workspace_id, context_id=context_id
                 )
                 # #1244: run-size cap — same rejection the real start
                 # returns, so dry_run callers see it before confirming.
+                # #1366: the cap decision uses the TRUE count, but the
+                # 422 must not name it for enforce agents (oracle).
                 try:
-                    assert_run_size_within_cap(memory_count)
+                    assert_run_size_within_cap(memory_count, redact_count=is_enforce)
                 except ValidationError as cap_exc:
                     return _gate_error_response(cap_exc)
+                # #1366: the count an enforce agent SEES (and the
+                # estimate derived from it) is binding-subtracted so
+                # neither reports denied-row volume. Non-agent/shadow
+                # callers skip the second COUNT entirely.
+                if is_enforce:
+                    memory_count = await query_service.count_context_memories_binding_visible(
+                        db, workspace_id=workspace_id, context_id=context_id
+                    )
                 estimate = estimate_cost(memory_count, model_id=DEFAULT_MODEL_ID)
                 await _log_tool_usage(
                     db,
@@ -336,8 +366,12 @@ async def handle_analyze_context(
             memory_count = await query_service.count_context_memories(
                 db, workspace_id=workspace_id, context_id=context_id
             )
+            # #1366: same true-count cap / redacted-message split as the
+            # dry_run path above.
+            from services.agent_binding_service import agent_scope_is_enforce
+
             try:
-                assert_run_size_within_cap(memory_count)
+                assert_run_size_within_cap(memory_count, redact_count=agent_scope_is_enforce())
             except ValidationError as cap_exc:
                 return _gate_error_response(cap_exc)
 

--- a/backend/src/services/agent_binding_service.py
+++ b/backend/src/services/agent_binding_service.py
@@ -305,6 +305,35 @@ async def binding_memory_sql_predicate(db: AsyncSession) -> Any | None:
     return and_(membership_gate, not_(or_(*denied_clauses)))
 
 
+# #1366: the run-level aggregate fields withheld from enforce-mode agents.
+# Single source of truth shared by BOTH serialization lanes (REST
+# ``AnalysisRow.redacted_for_agent_scope`` and MCP ``_serialize_run_row``)
+# so a future aggregate added to one lane's redaction cannot silently stay
+# exposed on the other.
+REDACTED_RUN_AGGREGATE_FIELDS: tuple[str, ...] = (
+    "input_count",
+    "cost_estimated_cents",
+    "cost_actual_cents",
+)
+
+
+def agent_scope_is_enforce() -> bool:
+    """True iff the current request's credential is an ENFORCE-mode agent (#1366).
+
+    The cheap (no-DB, contextvar-only) companion to
+    :func:`binding_memory_sql_predicate`, sharing its exact activation
+    condition: non-agent credentials and shadow-mode scopes return False
+    (the enforcement ramp must observe no behavioral change in shadow).
+    Serializer-level redaction of aggregate fields (run ``input_count``
+    / cost columns) keys off this so the decision cannot drift from the
+    SQL lane's.
+    """
+    from auth.agent_scope import get_agent_scope
+
+    scope = get_agent_scope()
+    return scope is not None and scope.enforcement_mode != AGENT_ENFORCEMENT_SHADOW
+
+
 async def filter_memory_rows_by_binding(
     db: AsyncSession,
     rows: list[Any],

--- a/backend/src/services/analysis/preview.py
+++ b/backend/src/services/analysis/preview.py
@@ -107,7 +107,7 @@ def assert_run_size_within_cap(memory_count: int, *, redact_count: bool = False)
 
     Raises:
         ValidationError: 422 naming both the limit and the actual
-            count so the client can render a actionable message
+            count so the client can render an actionable message
             (count omitted when ``redact_count``).
     """
     from config.settings import get_settings
@@ -118,8 +118,8 @@ def assert_run_size_within_cap(memory_count: int, *, redact_count: bool = False)
         if redact_count:
             raise ValidationError(
                 f"This analysis run would exceed the per-run analysis "
-                f"cap of {cap}. Narrow the scope (filters, split the "
-                f"context, or archive old memories).",
+                f"cap of {cap} memories. Narrow the scope (filters, split "
+                f"the context, or archive old memories).",
                 field="memory_count",
                 limit=cap,
             )

--- a/backend/src/services/analysis/preview.py
+++ b/backend/src/services/analysis/preview.py
@@ -79,7 +79,7 @@ class CostEstimate:
     breakdown: dict[str, int]
 
 
-def assert_run_size_within_cap(memory_count: int) -> None:
+def assert_run_size_within_cap(memory_count: int, *, redact_count: bool = False) -> None:
     """Reject a run that would exceed ``ANALYSIS_MAX_MEMORY_COUNT`` (#1244).
 
     The pipeline materializes every matching vector into one in-RAM
@@ -98,15 +98,31 @@ def assert_run_size_within_cap(memory_count: int) -> None:
     rejected conservatively. Filter-aware counting is a v1.5
     follow-up.
 
+    ``redact_count=True`` (#1366) keeps the cap decision on the TRUE
+    count but omits the actual count from the 422 message and details —
+    for enforce-mode agents the exact total is precisely the aggregate
+    oracle the binding-scoped response counts exist to close, and the
+    cap error must not reopen it. The cap value itself stays named (it
+    is deployment config, not tenant data).
+
     Raises:
         ValidationError: 422 naming both the limit and the actual
-            count so the client can render a actionable message.
+            count so the client can render a actionable message
+            (count omitted when ``redact_count``).
     """
     from config.settings import get_settings
     from utils.exceptions import ValidationError
 
     cap = int(get_settings().analysis_max_memory_count)
     if memory_count > cap:
+        if redact_count:
+            raise ValidationError(
+                f"This analysis run would exceed the per-run analysis "
+                f"cap of {cap}. Narrow the scope (filters, split the "
+                f"context, or archive old memories).",
+                field="memory_count",
+                limit=cap,
+            )
         # Copilot review: phrased as the RUN's memory count, not "the
         # context has" — the vector_pull defense-in-depth re-check calls
         # this with the FILTERED match count, where context-sized wording

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -179,15 +179,50 @@ async def count_context_memories(
     so the count semantics (filters ignored in v1, soft-delete excluded)
     are defined in one place.
     """
-    from models.memory import Memory
-
     stmt = select(func.count(Memory.id)).where(
-        and_(
-            Memory.workspace_id == workspace_id,
-            Memory.context_id == context_id,
-            Memory.deleted_at.is_(None),
-        )
+        and_(*_live_context_count_conditions(workspace_id=workspace_id, context_id=context_id))
     )
+    return int((await db.execute(stmt)).scalar() or 0)
+
+
+def _live_context_count_conditions(*, workspace_id: UUID, context_id: UUID) -> list[Any]:
+    """Base WHERE set shared by BOTH count lanes (#1366).
+
+    The cap-lane count and the agent-visible count must differ ONLY by
+    the binding predicate — defining the live-row membership here keeps
+    that guaranteed when the base semantics evolve.
+    """
+    return [
+        Memory.workspace_id == workspace_id,
+        Memory.context_id == context_id,
+        Memory.deleted_at.is_(None),
+    ]
+
+
+async def count_context_memories_binding_visible(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+) -> int:
+    """Binding-subtracted count for agent-facing response payloads (#1366).
+
+    ``count_context_memories`` deliberately stays the TRUE full-context
+    total: the #1244 run-size cap must bound the run the pipeline would
+    actually execute, and a binding-scoped cap count would let an
+    enforce agent start an over-cap run. This variant applies the #1301
+    SQL predicate on top of the same conditions, so the count an enforce
+    agent *sees* (dry_run/preview ``memory_count`` and the estimate
+    derived from it) never acts as an existence oracle over denied rows.
+    Non-agent and shadow scopes get the true count (predicate is None).
+    """
+    from services.agent_binding_service import binding_memory_sql_predicate
+
+    predicate = await binding_memory_sql_predicate(db)
+    conditions = _live_context_count_conditions(workspace_id=workspace_id, context_id=context_id)
+    if predicate is not None:
+        conditions.append(predicate)
+    stmt = select(func.count(Memory.id)).where(and_(*conditions))
     return int((await db.execute(stmt)).scalar() or 0)
 
 

--- a/backend/src/services/analysis/vector_pull.py
+++ b/backend/src/services/analysis/vector_pull.py
@@ -234,7 +234,16 @@ async def pull_memories_with_vectors(
         ).scalar()
         or 0
     )
-    assert_run_size_within_cap(matched_count)
+    # #1366: ALWAYS redact the count here. This message is persisted
+    # verbatim into ``memory_analyses.error`` by the orchestrator's
+    # ``_mark_failed`` and later served to arbitrary principals —
+    # including enforce-mode agents whose aggregate counts are withheld
+    # at serialization. ``error`` is not (and should not be) scrubbed
+    # per-reader, so the count must never enter the stored message. The
+    # pre-flight 422 on the API paths keeps naming the count for
+    # non-agent callers; this rare defense-in-depth failure names only
+    # the cap.
+    assert_run_size_within_cap(matched_count, redact_count=True)
 
     memory_rows = list((await db.execute(stmt)).all())
 

--- a/backend/tests/api/test_analysis_row_redaction.py
+++ b/backend/tests/api/test_analysis_row_redaction.py
@@ -1,0 +1,62 @@
+"""#1366 — REST ``AnalysisRow`` aggregate redaction for enforce agents (unit).
+
+Mirrors ``tests/mcp_server/test_run_row_redaction.py`` on the REST
+serialization surface: ``AnalysisRow.redacted_for_agent_scope`` must
+withhold ``input_count`` / cost fields under an enforce-mode agent
+scope and be a strict no-op for non-agent and shadow scopes.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import uuid4
+
+from api.routes.analyses import AnalysisRow
+from auth.agent_scope import AgentScope, set_agent_scope
+
+
+def _row_model() -> AnalysisRow:
+    return AnalysisRow(
+        run_id=uuid4(),
+        workspace_id=uuid4(),
+        context_id=uuid4(),
+        status="succeeded",
+        triggered_by="user-1",
+        started_at=datetime(2026, 7, 19, 0, 0, 0),
+        finished_at=None,
+        input_count=120,
+        cost_estimated_cents=42,
+        cost_actual_cents=40,
+        error=None,
+        cancellation_reason=None,
+    )
+
+
+class TestAnalysisRowRedaction:
+    def teardown_method(self) -> None:
+        set_agent_scope(None)
+
+    def test_enforce_scope_withholds_aggregates(self):
+        set_agent_scope(
+            AgentScope(agent_id=uuid4(), enforcement_mode="enforce", workspace_id=uuid4())
+        )
+        out = _row_model().redacted_for_agent_scope()
+        assert out.input_count is None
+        assert out.cost_estimated_cents is None
+        assert out.cost_actual_cents is None
+        assert out.status == "succeeded"
+
+    def test_no_scope_is_noop(self):
+        set_agent_scope(None)
+        row = _row_model()
+        out = row.redacted_for_agent_scope()
+        assert out is row
+        assert out.input_count == 120
+
+    def test_shadow_scope_is_noop(self):
+        set_agent_scope(
+            AgentScope(agent_id=uuid4(), enforcement_mode="shadow", workspace_id=uuid4())
+        )
+        out = _row_model().redacted_for_agent_scope()
+        assert out.input_count == 120
+        assert out.cost_actual_cents == 40

--- a/backend/tests/mcp_server/test_run_row_redaction.py
+++ b/backend/tests/mcp_server/test_run_row_redaction.py
@@ -1,0 +1,101 @@
+"""#1366 — run-row aggregate redaction + cap-message redaction (unit).
+
+``_serialize_run_row`` (MCP) and ``assert_run_size_within_cap`` are pure
+with respect to the DB: the former reads only the row object and the
+agent-scope contextvar, the latter only settings. Both redactions are
+exercised here without a database.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from auth.agent_scope import AgentScope, set_agent_scope
+from mcp_server.tools.analysis import _serialize_run_row
+from services.analysis.preview import assert_run_size_within_cap
+from utils.exceptions import ValidationError
+
+
+def _row() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        workspace_id=uuid4(),
+        context_id=uuid4(),
+        status="succeeded",
+        triggered_by="user-1",
+        started_at=datetime(2026, 7, 19, 0, 0, 0),
+        finished_at=None,
+        input_count=120,
+        cost_estimated_cents=42,
+        cost_actual_cents=40,
+        error=None,
+        cancellation_reason=None,
+    )
+
+
+def _enforce_scope() -> None:
+    set_agent_scope(AgentScope(agent_id=uuid4(), enforcement_mode="enforce", workspace_id=uuid4()))
+
+
+class TestSerializeRunRowRedaction:
+    def teardown_method(self) -> None:
+        set_agent_scope(None)
+
+    def test_enforce_scope_withholds_aggregates(self):
+        _enforce_scope()
+        out = _serialize_run_row(_row())
+        assert out["input_count"] is None
+        assert out["cost_estimated_cents"] is None
+        assert out["cost_actual_cents"] is None
+        # Non-aggregate fields stay intact.
+        assert out["status"] == "succeeded"
+
+    def test_no_scope_keeps_aggregates(self):
+        set_agent_scope(None)
+        out = _serialize_run_row(_row())
+        assert out["input_count"] == 120
+        assert out["cost_estimated_cents"] == 42
+        assert out["cost_actual_cents"] == 40
+
+    def test_shadow_scope_keeps_aggregates(self):
+        """Enforcement ramp invariant: shadow observes no change."""
+        set_agent_scope(
+            AgentScope(agent_id=uuid4(), enforcement_mode="shadow", workspace_id=uuid4())
+        )
+        out = _serialize_run_row(_row())
+        assert out["input_count"] == 120
+        assert out["cost_actual_cents"] == 40
+
+
+class TestCapMessageRedaction:
+    def test_redacted_cap_error_omits_true_count(self, monkeypatch):
+        import config.settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod,
+            "get_settings",
+            lambda: SimpleNamespace(analysis_max_memory_count=10),
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            assert_run_size_within_cap(987654, redact_count=True)
+        msg = str(exc_info.value)
+        assert "987654" not in msg
+        assert "10" in msg  # the cap itself stays named (deployment config)
+        details = getattr(exc_info.value, "details", {}) or {}
+        assert details.get("memory_count") is None
+
+    def test_default_cap_error_names_count(self, monkeypatch):
+        import config.settings as settings_mod
+
+        monkeypatch.setattr(
+            settings_mod,
+            "get_settings",
+            lambda: SimpleNamespace(analysis_max_memory_count=10),
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            assert_run_size_within_cap(987654)
+        assert "987654" in str(exc_info.value)

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -1304,3 +1304,116 @@ async def test_soft_delete_emptied_cluster_stays_listed_for_enforce_agent(
         assert (row["count"] if isinstance(row, dict) else row.count) == 0
     finally:
         set_agent_scope(None)
+
+
+# ===========================================================================
+# #1366 — binding-visible count for agent-facing response payloads
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_count_binding_visible_subtracts_denied_for_enforce_agent(
+    db_session, fixture_workspace_id, fixture_context_id
+):
+    """Enforce agent (only ``note`` readable) sees 2, not the true 5 —
+    while the cap-lane count keeps reporting the true total."""
+    from auth.agent_scope import set_agent_scope
+
+    for _ in range(2):
+        await _make_typed_memory(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            mem_type="note",
+        )
+    for _ in range(3):
+        await _make_typed_memory(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            mem_type="decision",
+        )
+    await _enforce_scope(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    try:
+        visible = await query_service.count_context_memories_binding_visible(
+            db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+        )
+        true_count = await query_service.count_context_memories(
+            db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+        )
+        assert visible == 2
+        assert true_count == 5
+    finally:
+        set_agent_scope(None)
+
+
+@pytest.mark.asyncio
+async def test_count_binding_visible_equals_true_count_without_scope(
+    db_session, fixture_workspace_id, fixture_context_id
+):
+    for _ in range(3):
+        await _make_typed_memory(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            mem_type="decision",
+        )
+    visible = await query_service.count_context_memories_binding_visible(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    assert visible == 3
+
+
+@pytest.mark.asyncio
+async def test_count_binding_visible_shadow_scope_keeps_true_count(
+    db_session, fixture_workspace_id, fixture_context_id
+):
+    """Shadow mode must observe no change (enforcement ramp invariant)."""
+    from uuid import uuid4 as _uuid4
+
+    from auth.agent_scope import AgentScope, set_agent_scope
+    from models.agent import Agent, AgentContextBinding
+
+    for _ in range(3):
+        await _make_typed_memory(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            mem_type="decision",
+        )
+    agent = Agent(
+        id=_uuid4(),
+        workspace_id=fixture_workspace_id,
+        name=f"shadow-bot-{_uuid4().hex[:8]}",
+        owner_user_id="test_user",
+        status="active",
+        enforcement_mode="shadow",
+    )
+    db_session.add(agent)
+    await db_session.flush()
+    db_session.add(
+        AgentContextBinding(
+            id=_uuid4(),
+            agent_id=agent.id,
+            context_id=fixture_context_id,
+            can_read=True,
+            write_policy="deny",
+            is_default=False,
+            allowed_memory_types=["note"],
+            allowed_source_types=None,
+            created_by="test_user",
+        )
+    )
+    await db_session.flush()
+    set_agent_scope(
+        AgentScope(agent_id=agent.id, enforcement_mode="shadow", workspace_id=fixture_workspace_id)
+    )
+    try:
+        visible = await query_service.count_context_memories_binding_visible(
+            db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+        )
+        assert visible == 3
+    finally:
+        set_agent_scope(None)


### PR DESCRIPTION
Closes #1366

## Summary
- Close the two aggregate-count oracles the #1357 finder sweep left open for enforce-mode agents:
  - `analyze_context(dry_run)` / REST `/preview` now report a **binding-subtracted** `memory_count` (and derived estimate) via the #1301 SQL predicate, while the #1244 run-size cap keeps deciding on the TRUE count (a binding-scoped cap would let an enforce agent start an over-cap run)
  - Run-row aggregates (`input_count` / `cost_estimated_cents` / `cost_actual_cents`) are withheld (null) for enforce agents on both the MCP (`_serialize_run_row`) and REST (`AnalysisRow`) lanes
- Found during review and also closed: the cap 422 named the exact true count (same oracle through another door) — redacted for enforce agents; and `vector_pull`'s defense-in-depth cap message is now always count-free because it persists into `memory_analyses.error`, which is served unredacted to any principal

## Implementation notes
- `count_context_memories_binding_visible` shares its base WHERE set with the cap-lane count via `_live_context_count_conditions` — the two lanes can differ only by the binding predicate
- `REDACTED_RUN_AGGREGATE_FIELDS` (agent_binding_service) is the single source of truth consumed by both serialization lanes, so a future aggregate cannot silently stay exposed on one of REST/MCP
- `agent_scope_is_enforce()` shares `binding_memory_sql_predicate`'s activation condition (shadow ⇒ no-op) so serializer redaction cannot drift from the SQL lane; shadow mode observes zero change (enforcement ramp invariant), non-agent callers are byte-identical
- REST `input_count` is now `int | None` — nullable ONLY for enforce-agent credentials; web sessions always receive an int (frontend TS type intentionally unchanged)
- Accepted trade-off (per issue): an enforce agent's preview estimate reflects its visible subset, not the full-context volume the run actually bills — oracle closure wins over estimate accuracy

## Tests
- 3 DB tests: binding-visible count subtracts denied types / equals true count without scope / shadow keeps true count
- 8 unit tests: MCP serializer + REST AnalysisRow redaction (enforce / none / shadow), cap-message redaction
- Full analysis suite: 211 passed

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO)
- /code-review (medium, 5 finders + verify): 6 findings — 4 fixed in-branch, 1 documented trade-off, 1 no-change-needed
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1366-fix-fix-api-auth-remaining-aggregate-count-oracles.gate2.md

🤖 Generated via /gh-issue-driven:ship
