### PR TITLE
fix: pseudonymize remaining raw-sub residuals after erasure (#1365)

### DIFF
--- a/backend/alembic/versions/e72_1365_secret_log_carveout.py
+++ b/backend/alembic/versions/e72_1365_secret_log_carveout.py
@@ -1,0 +1,83 @@
+"""#1365: erasure carve-out for secret_access_log's append-only trigger.
+
+Replaces ``secret_access_log_no_mutate`` (e50) so an UPDATE touching
+ONLY the identity columns ``(actor_user_id, recipient_identity)`` is
+permitted — the #1278 ``memory_access_events`` carve-out pattern.
+DELETE and TRUNCATE stay blocked; any UPDATE touching any other column
+stays blocked. The account-erasure sweep is the intended (and only)
+writer through this carve-out.
+
+Tamper-evidence trade-off (GDPR Art.17 / APPI 第22条 precedence): rows
+are HMAC hash-chained (``entry_hash = HMAC(key, prev_hash ||
+canonical(entry))``). Pseudonymizing the identity columns makes the
+stored ``entry_hash`` no longer recompute for EXACTLY the mutated rows;
+chain LINKAGE (``prev_hash`` pointers) is untouched, so every other
+row — and the chain topology itself — still verifies. Verifiers must
+treat entry-hash mismatches on pseudonymized rows as expected (see
+docs/ops/erasure-runbook.md §2.4).
+
+Revision ID: e72_1365_secret_log_carveout
+Revises: e71_1333_measurements
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e72_1365_secret_log_carveout"
+down_revision = "e71_1333_measurements"
+branch_labels = None
+depends_on = None
+
+# Columns the erasure sweep may UPDATE. Everything else stays immutable.
+_CARVE_OUT = "'actor_user_id', 'recipient_identity'"
+
+
+def upgrade() -> None:
+    # The e50 triggers already reference this function by name —
+    # CREATE OR REPLACE swaps the body without touching the triggers.
+    op.execute(
+        sa.text(
+            f"""
+            CREATE OR REPLACE FUNCTION secret_access_log_no_mutate()
+            RETURNS trigger AS $$
+            BEGIN
+                IF TG_OP = 'UPDATE' THEN
+                    IF (to_jsonb(OLD) - ARRAY[{_CARVE_OUT}])
+                       IS DISTINCT FROM
+                       (to_jsonb(NEW) - ARRAY[{_CARVE_OUT}]) THEN
+                        RAISE EXCEPTION
+                            'secret_access_log is append-only; only '
+                            '(actor_user_id, recipient_identity) may be '
+                            'updated (erasure carve-out)'
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+                    RETURN NEW;
+                END IF;
+                RAISE EXCEPTION
+                    'secret_access_log is append-only; % is not permitted', TG_OP
+                    USING ERRCODE = 'restrict_violation';
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Restore the e50 blanket version (no carve-out).
+    op.execute(
+        sa.text(
+            """
+            CREATE OR REPLACE FUNCTION secret_access_log_no_mutate()
+            RETURNS trigger AS $$
+            BEGIN
+                RAISE EXCEPTION
+                    'secret_access_log is append-only; % is not permitted', TG_OP
+                    USING ERRCODE = 'restrict_violation';
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+        )
+    )

--- a/backend/src/api/routes/secrets.py
+++ b/backend/src/api/routes/secrets.py
@@ -304,6 +304,10 @@ class AuditVerifyResponse(BaseModel):
     head: str | None = None
     broken_at: int | None = None
     reason: str | None = None
+    # #1365: row ids whose entry_hash mismatch is the EXPECTED erasure scar
+    # (identity columns pseudonymized through the e72 carve-out). Present
+    # (possibly empty) on valid=True results; None on tamper failures.
+    erasure_pseudonymized: list[int] | None = None
 
 
 @router.get("/audit/verify", response_model=AuditVerifyResponse)

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -1051,6 +1051,65 @@ class AccountErasureService:
             WorkerAppIdentity, WorkerAppIdentity.created_by, user_id
         ) + await self._pseudonymize_field(WorkerAppIdentity, WorkerAppIdentity.updated_by, user_id)
 
+        # #1365 (1): config_overrides are the same #1358 shape — GLOBAL
+        # control-plane rows with no workspace FK, so no cascade ever
+        # removes them and an erased admin's raw sub would persist in
+        # updated_by. Same legal-retention posture.
+        from models.config import ConfigOverride
+
+        counts["config_overrides_pseudonymized"] = await self._pseudonymize_field(
+            ConfigOverride, ConfigOverride.updated_by, user_id
+        )
+
+        # #1365 (3+4): workspace-scoped authorship columns on rows that
+        # OUTLIVE the erased subject (co-owned/transferred workspaces —
+        # the sole-owner cascade above already wiped the rest). Same
+        # posture as agent_context_bindings.created_by (#1275): row
+        # survives, personal link breaks. contexts.created_by closes the
+        # #1336 asymmetry (deleted_by was NULL-cleared there; created_by
+        # was the leftover).
+        from models.file_objects import FileObject
+        from models.resource import (
+            Resource,
+            ResourceToken,
+            WorkspaceAddon,
+            WorkspaceConnector,
+        )
+        from models.secrets import (
+            RecipientPubkey,
+            Secret,
+            SecretGrant,
+            SecretVersion,
+        )
+
+        authorship_sweeps: tuple[tuple[Any, Any], ...] = (
+            (WorkspaceConnector, WorkspaceConnector.created_by),
+            (Resource, Resource.created_by),
+            (ResourceToken, ResourceToken.created_by),
+            (WorkspaceAddon, WorkspaceAddon.created_by),
+            (FileObject, FileObject.created_by),
+            (Secret, Secret.created_by),
+            (SecretVersion, SecretVersion.created_by),
+            (RecipientPubkey, RecipientPubkey.created_by),
+            # attested_by: another user's sub lands here when they attest a
+            # pubkey — same surviving-row shape (code-review finder, #1365).
+            (RecipientPubkey, RecipientPubkey.attested_by),
+            (SecretGrant, SecretGrant.granted_by),
+            (Context, Context.created_by),
+            # updated_by on keys OWNED BY OTHERS survives the user_id delete
+            # above (code-review finder, #1365).
+            (ExternalAPIKey, ExternalAPIKey.updated_by),
+        )
+        authorship_total = 0
+        for model, column in authorship_sweeps:
+            authorship_total += await self._pseudonymize_field(model, column, user_id)
+        counts["authorship_columns_pseudonymized"] = authorship_total
+
+        # #1365 (2): secret_access_log — append-only, HMAC hash-chained
+        # audit rows that deliberately survive entity deletion. The e72
+        # trigger carve-out permits UPDATE of ONLY the identity columns.
+        counts["secret_access_log_pseudonymized"] = await self._erase_secret_access_log(user_id)
+
         # #1336 Gap 2: author memories that OUTLIVE the erased subject — rows
         # in co-owned/transferred workspaces (the sole-owner cascade above
         # already wiped the rest). Their Qdrant points were deleted in step 1
@@ -1076,6 +1135,15 @@ class AccountErasureService:
         counts["users"] = 1
 
         return counts
+
+    def _pseudonym(self, value: str) -> str:
+        """Salted-SHA256 pseudonym — the single derivation every sweep uses.
+
+        One definition so a future salt rotation / algorithm change cannot
+        produce inconsistent pseudonyms for the same subject across tables
+        (same-user cross-row correlation is the legal-retention contract).
+        """
+        return sha256_hex(value, salt=_audit_salt())
 
     async def _count_and_delete(self, model: Any, where_clause: Any) -> int:
         """Delete rows and return the affected count from the cursor.
@@ -1112,7 +1180,7 @@ class AccountErasureService:
         """
         from models.memory_access_event import MemoryAccessEvent
 
-        pseudonym = sha256_hex(user_id, salt=_audit_salt())
+        pseudonym = self._pseudonym(user_id)
         result = cast(
             CursorResult[Any],
             await self.db.execute(
@@ -1127,6 +1195,44 @@ class AccountErasureService:
             ),
         )
         return result.rowcount or 0
+
+    async def _erase_secret_access_log(self, user_id: str) -> int:
+        """Pseudonymize the erased subject in ``secret_access_log`` (#1365).
+
+        The e72 append-only carve-out permits UPDATE of ONLY
+        ``(actor_user_id, recipient_identity)`` — the #1278 pattern. Two
+        UPDATEs, one per identity column; a row where the subject is
+        both actor and recipient contributes 2 to the count (mirrors
+        worker_app_identities' per-column sum).
+
+        Tamper-evidence trade-off (runbook §2.4): rows are HMAC
+        hash-chained, so the stored ``entry_hash`` no longer recomputes
+        for exactly the mutated rows. Chain linkage (``prev_hash``
+        pointers) is untouched — every other row still verifies — and
+        GDPR/APPI erasure takes precedence over per-row content
+        authentication for the erased subject. Verifiers must treat
+        entry-hash mismatches on pseudonymized rows as expected.
+        """
+        from models.secrets import SecretAccessLog
+
+        pseudonym = self._pseudonym(user_id)
+        actor = cast(
+            CursorResult[Any],
+            await self.db.execute(
+                update(SecretAccessLog)
+                .where(SecretAccessLog.actor_user_id == user_id)
+                .values(actor_user_id=pseudonym)
+            ),
+        )
+        recipient = cast(
+            CursorResult[Any],
+            await self.db.execute(
+                update(SecretAccessLog)
+                .where(SecretAccessLog.recipient_identity == user_id)
+                .values(recipient_identity=pseudonym)
+            ),
+        )
+        return (actor.rowcount or 0) + (recipient.rowcount or 0)
 
     async def _scrub_surviving_memories(self, user_id: str) -> int:
         """Scrub author memories that outlive the erased subject (#1336).
@@ -1178,7 +1284,7 @@ class AccountErasureService:
         same UPDATE (#1336: memories.details) so the pseudonym convention
         stays single-sourced here.
         """
-        pseudonym = sha256_hex(user_id, salt=_audit_salt())
+        pseudonym = self._pseudonym(user_id)
         values: dict[Any, Any] = {column: pseudonym}
         if extra_values:
             values.update(extra_values)

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -213,16 +213,47 @@ class SecretStoreService:
             default=str,
         )
 
+    # An erasure pseudonym is a salted SHA256 hex digest (64 lowercase hex
+    # chars) — real actor/recipient identities are OAuth subs / emails and
+    # never take this shape on the append path.
+    _PSEUDONYM_RE = re.compile(r"^[0-9a-f]{64}$")
+
+    def _entry_mutation_is_erasure_shaped(self, e: SecretAccessLog) -> bool:
+        """True iff the row's mutable (e72 carve-out) columns look pseudonymized.
+
+        The account-erasure sweep (#1365) rewrites ``actor_user_id`` /
+        ``recipient_identity`` to a 64-hex salted-SHA256 pseudonym through the
+        append-only trigger's carve-out. That legitimately breaks the row's
+        stored ``entry_hash`` recomputation, so the verifier classifies such
+        rows instead of raising a tamper alarm. Residual risk (documented in
+        the runbook §2.4): an attacker with raw SQL access could disguise an
+        identity-column edit as a 64-hex string — but that attacker class
+        already defeats the trigger and could run the erasure path itself;
+        every NON-carve-out column remains fully tamper-evident.
+        """
+        return bool(
+            self._PSEUDONYM_RE.match(e.actor_user_id or "")
+            or self._PSEUDONYM_RE.match(e.recipient_identity or "")
+        )
+
     async def verify_audit_chain(self, *, workspace_id: UUID) -> dict[str, Any]:
         """Recompute and verify a workspace's tamper-evident audit chain.
 
         Walks entries id-ascending, recomputing ``entry_hash`` from the stored
         fields with the same payload construction as the append path, and checks
         the ``prev_hash`` linkage (genesis for the first). Returns
-        ``{valid, entries, head}`` on success, or ``{valid: False, broken_at,
-        reason}`` at the first entry that fails — catching any out-of-band field
-        edit that left ``entry_hash`` stale. This is the verifier that makes the
-        chain's tamper-evidence usable (not merely latent).
+        ``{valid, entries, head, erasure_pseudonymized}`` on success, or
+        ``{valid: False, broken_at, reason}`` at the first entry that fails —
+        catching any out-of-band field edit that left ``entry_hash`` stale.
+        This is the verifier that makes the chain's tamper-evidence usable
+        (not merely latent).
+
+        #1365: an ``entry_hash`` mismatch on a row whose carve-out identity
+        columns look erasure-pseudonymized (64-hex) is EXPECTED — the row id
+        is reported in ``erasure_pseudonymized`` and the walk continues
+        (chain linkage still uses the stored ``entry_hash``, which erasure
+        never touches, so all other rows keep verifying). Any other mismatch
+        remains a hard tamper alarm.
         """
         rows = await self.db.execute(
             select(SecretAccessLog)
@@ -232,6 +263,7 @@ class SecretStoreService:
         entries = list(rows.scalars().all())
         key = get_settings().audit_hmac_key
         expected_prev = AUDIT_GENESIS_HASH
+        erasure_pseudonymized: list[int] = []
         for e in entries:
             if e.prev_hash != expected_prev:
                 return {"valid": False, "broken_at": e.id, "reason": "prev_hash_mismatch"}
@@ -248,12 +280,19 @@ class SecretStoreService:
                 req_meta=e.req_meta,
             )
             if hmac_sha256_hex(payload, key) != e.entry_hash:
+                if self._entry_mutation_is_erasure_shaped(e):
+                    # Expected erasure scar (#1365) — record and keep walking;
+                    # linkage continues off the untouched stored entry_hash.
+                    erasure_pseudonymized.append(e.id)
+                    expected_prev = e.entry_hash
+                    continue
                 return {"valid": False, "broken_at": e.id, "reason": "entry_hash_mismatch"}
             expected_prev = e.entry_hash
         return {
             "valid": True,
             "entries": len(entries),
             "head": expected_prev if entries else AUDIT_GENESIS_HASH,
+            "erasure_pseudonymized": erasure_pseudonymized,
         }
 
     # -------------------------------------------------------------- pubkeys

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -56,7 +56,7 @@ from models.secrets import (
     SecretVersion,
 )
 from utils.datetime import utcnow
-from utils.hashing import hmac_sha256_hex, sha256_hex
+from utils.hashing import SHA256_HEX_PATTERN, hmac_sha256_hex, sha256_hex
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -213,10 +213,12 @@ class SecretStoreService:
             default=str,
         )
 
-    # An erasure pseudonym is a salted SHA256 hex digest (64 lowercase hex
-    # chars) — real actor/recipient identities are OAuth subs / emails and
-    # never take this shape on the append path.
-    _PSEUDONYM_RE = re.compile(r"^[0-9a-f]{64}$")
+    # An erasure pseudonym is a salted SHA256 hex digest — real
+    # actor/recipient identities are OAuth subs / emails and never take
+    # this shape on the append path. Uses the shared SHA256_HEX_PATTERN
+    # (case-insensitive) so the shape check cannot drift from the
+    # codebase-wide hex convention (Copilot review, PR #1374).
+    _PSEUDONYM_RE = re.compile(SHA256_HEX_PATTERN)
 
     def _entry_mutation_is_erasure_shaped(self, e: SecretAccessLog) -> bool:
         """True iff the row's mutable (e72 carve-out) columns look pseudonymized.

--- a/backend/tests/integration/test_secret_store_integration.py
+++ b/backend/tests/integration/test_secret_store_integration.py
@@ -397,13 +397,26 @@ async def test_audit_log_append_only_triggers(db_session, ws):
     then assert in-band mutation (UPDATE/DELETE) and a full-table TRUNCATE — which
     would silently reset the hash chain to genesis — are all rejected.
     """
-    # Install the same triggers the migration ships (row UPDATE/DELETE + TRUNCATE).
+    # Install the same triggers the migrations ship (e50 triggers + the
+    # e72 carve-out body: UPDATE limited to the erasure identity columns).
     await db_session.execute(
         text(
             """
             CREATE OR REPLACE FUNCTION secret_access_log_no_mutate()
             RETURNS trigger AS $$
             BEGIN
+                IF TG_OP = 'UPDATE' THEN
+                    IF (to_jsonb(OLD) - ARRAY['actor_user_id', 'recipient_identity'])
+                       IS DISTINCT FROM
+                       (to_jsonb(NEW) - ARRAY['actor_user_id', 'recipient_identity']) THEN
+                        RAISE EXCEPTION
+                            'secret_access_log is append-only; only '
+                            '(actor_user_id, recipient_identity) may be '
+                            'updated (erasure carve-out)'
+                            USING ERRCODE = 'restrict_violation';
+                    END IF;
+                    RETURN NEW;
+                END IF;
                 RAISE EXCEPTION
                     'secret_access_log is append-only; % is not permitted', TG_OP
                     USING ERRCODE = 'restrict_violation';
@@ -457,6 +470,19 @@ async def test_audit_log_append_only_triggers(db_session, ws):
 
         with pytest.raises(Exception, match="append-only"):
             await db_session.execute(text("TRUNCATE secret_access_log"))
+        await db_session.rollback()
+
+        # #1365: the erasure carve-out — an UPDATE touching ONLY the
+        # identity columns is permitted (pseudonymization path); the
+        # non-carve-out UPDATE above stays rejected.
+        result = await db_session.execute(
+            text(
+                "UPDATE secret_access_log SET actor_user_id = 'pseudonym-x', "
+                "recipient_identity = NULL WHERE workspace_id = :w"
+            ),
+            {"w": str(ws)},
+        )
+        assert result.rowcount >= 1
         await db_session.rollback()
     finally:
         # Drop the triggers so the fixture teardown can wipe rows.
@@ -616,6 +642,40 @@ async def test_verify_audit_chain_valid_then_detects_tampering(db_session, ws):
     bad = await svc.verify_audit_chain(workspace_id=ws)
     assert bad["valid"] is False
     assert bad["reason"] == "entry_hash_mismatch"
+
+
+async def test_verify_audit_chain_classifies_erasure_pseudonym(db_session, ws):
+    """#1365: an erasure-shaped mutation (64-hex pseudonym in a carve-out
+    identity column) is reported in ``erasure_pseudonymized`` — NOT a tamper
+    alarm — and the walk continues so all other rows still verify."""
+    svc = SecretStoreService(db_session)
+    await _register_and_approve(svc, ws, "alice", PUBKEY_A)
+    await db_session.commit()
+
+    ok = await svc.verify_audit_chain(workspace_id=ws)
+    assert ok["valid"] is True
+    assert ok["entries"] >= 2
+    assert ok["erasure_pseudonymized"] == []
+
+    # Simulate the erasure sweep on the FIRST row (identity columns only —
+    # exactly what _erase_secret_access_log writes through the e72 carve-out).
+    pseudonym = "ab" * 32  # 64 lowercase hex chars
+    await db_session.execute(
+        text(
+            "UPDATE secret_access_log SET actor_user_id = :p "
+            "WHERE id = (SELECT min(id) FROM secret_access_log WHERE workspace_id = :w)"
+        ),
+        {"p": pseudonym, "w": str(ws)},
+    )
+    await db_session.commit()
+
+    after = await svc.verify_audit_chain(workspace_id=ws)
+    assert after["valid"] is True
+    assert len(after["erasure_pseudonymized"]) == 1
+    # The scarred row did not stop the walk — every entry was visited and
+    # the head hash still reflects the full chain.
+    assert after["entries"] == ok["entries"]
+    assert after["head"] == ok["head"]
 
 
 async def test_put_multi_recipient_integrity(db_session, ws):

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -1051,3 +1051,124 @@ class TestMemoryAccessEventsErasure:
         assert params["user_id"] != target.user_id  # pseudonymized
         assert params["session_id"] is None
         assert params["run_id"] is None
+
+
+class TestErasureResiduals1365:
+    """#1365: the four raw-sub residual families left by #1358."""
+
+    @pytest.mark.asyncio
+    async def test_sweep_pseudonymizes_config_overrides_updated_by(self):
+        from models.config import ConfigOverride
+
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=0)
+        svc._pseudonymize_field = AsyncMock(return_value=0)
+        svc._erase_secret_access_log = AsyncMock(return_value=0)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        target = _user()
+
+        counts = await svc._delete_postgres(target)
+
+        assert "config_overrides_pseudonymized" in counts
+        calls = [c for c in svc._pseudonymize_field.await_args_list if c.args[0] is ConfigOverride]
+        assert len(calls) == 1
+        assert calls[0].args[1] is ConfigOverride.updated_by
+        assert calls[0].args[2] == target.user_id
+
+    @pytest.mark.asyncio
+    async def test_sweep_pseudonymizes_all_authorship_columns(self):
+        """All 10 surviving-row authorship columns are swept, and the
+        count is their sum (distinct per-column values pin the SUM)."""
+        from models.auth import Context, ExternalAPIKey
+        from models.file_objects import FileObject
+        from models.resource import (
+            Resource,
+            ResourceToken,
+            WorkspaceAddon,
+            WorkspaceConnector,
+        )
+        from models.secrets import (
+            RecipientPubkey,
+            Secret,
+            SecretGrant,
+            SecretVersion,
+        )
+
+        expected = {
+            (WorkspaceConnector, "created_by"): 1,
+            (Resource, "created_by"): 2,
+            (ResourceToken, "created_by"): 3,
+            (WorkspaceAddon, "created_by"): 4,
+            (FileObject, "created_by"): 5,
+            (Secret, "created_by"): 6,
+            (SecretVersion, "created_by"): 7,
+            (RecipientPubkey, "created_by"): 8,
+            (RecipientPubkey, "attested_by"): 9,
+            (SecretGrant, "granted_by"): 10,
+            (Context, "created_by"): 11,
+            (ExternalAPIKey, "updated_by"): 12,
+        }
+
+        async def _by_column(model, column, user_id, extra_values=None):
+            return expected.get((model, column.key), 0)
+
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=0)
+        svc._pseudonymize_field = AsyncMock(side_effect=_by_column)
+        svc._erase_secret_access_log = AsyncMock(return_value=0)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        target = _user()
+
+        counts = await svc._delete_postgres(target)
+
+        assert counts["authorship_columns_pseudonymized"] == sum(expected.values())
+        swept = {
+            (c.args[0], c.args[1].key)
+            for c in svc._pseudonymize_field.await_args_list
+            if (c.args[0], c.args[1].key) in expected
+        }
+        assert swept == set(expected)
+
+    @pytest.mark.asyncio
+    async def test_sweep_calls_secret_access_log_erasure(self):
+        svc = _service()
+        svc._count_and_delete = AsyncMock(return_value=0)
+        svc._pseudonymize_field = AsyncMock(return_value=0)
+        svc._erase_secret_access_log = AsyncMock(return_value=5)
+        svc.db.delete = AsyncMock()
+        svc.db.commit = AsyncMock()
+        target = _user()
+
+        counts = await svc._delete_postgres(target)
+
+        assert counts["secret_access_log_pseudonymized"] == 5
+        svc._erase_secret_access_log.assert_awaited_once_with(target.user_id)
+
+    @pytest.mark.asyncio
+    async def test_erase_secret_access_log_touches_only_carveout_columns(self):
+        """Two UPDATEs (actor / recipient), each touching ONLY its own
+        carve-out identity column — anything else would be rejected by
+        the e72 append-only trigger in production."""
+        svc = _service()
+        captured = []
+
+        async def _exec(stmt):
+            captured.append(stmt)
+            return SimpleNamespace(rowcount=2)
+
+        svc.db.execute = AsyncMock(side_effect=_exec)
+        target = _user()
+
+        count = await svc._erase_secret_access_log(target.user_id)
+
+        assert count == 4
+        assert len(captured) == 2
+        for stmt in captured:
+            compiled = str(stmt).lower()
+            assert "update secret_access_log" in compiled
+        actor_params = captured[0].compile().params
+        assert actor_params["actor_user_id"] != target.user_id  # pseudonymized
+        recipient_params = captured[1].compile().params
+        assert recipient_params["recipient_identity"] != target.user_id

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -1078,7 +1078,7 @@ class TestErasureResiduals1365:
 
     @pytest.mark.asyncio
     async def test_sweep_pseudonymizes_all_authorship_columns(self):
-        """All 10 surviving-row authorship columns are swept, and the
+        """All 12 surviving-row authorship columns are swept, and the
         count is their sum (distinct per-column values pin the SUM)."""
         from models.auth import Context, ExternalAPIKey
         from models.file_objects import FileObject

--- a/docs/ops/erasure-runbook.md
+++ b/docs/ops/erasure-runbook.md
@@ -72,6 +72,9 @@ FK の依存逆順で削除:
 | `workspaces` | `owner_user_id = :uid` | step 3 後の sole-owner のみ。cascade で contexts/memories/etc. |
 | `memories` (残存行) | `user_id` を SHA256 pseudonymize + `details = NULL` | #1336: 共有/移譲 workspace に残る本人著メモリの scrub。details の NULL 化で生成列 (location_lat/lon, trigger_from/until) も自動 NULL。tombstone 行も対象 |
 | `worker_app_identities.created_by` / `updated_by` | SHA256 pseudonymize | #1358: global 行 (workspace cascade なし)。legal retention 維持、operator sub のリンクのみ切断 |
+| `config_overrides.updated_by` | SHA256 pseudonymize | #1365: #1358 と同形の global 行。admin sub のリンク切断 |
+| authorship 列族 (残存 workspace 行) | SHA256 pseudonymize | #1365: `workspace_connectors` / `resources` / `resource_tokens` / `workspace_addons` / `file_objects` / `secrets` / `secret_versions` / `recipient_pubkeys` の `created_by` + `recipient_pubkeys.attested_by` + `secret_grants.granted_by` + `contexts.created_by` + `external_api_keys.updated_by`。counts キー = `authorship_columns_pseudonymized` (12 列の合計) |
+| `secret_access_log.actor_user_id` / `recipient_identity` | SHA256 pseudonymize (e72 trigger carve-out) | #1365: append-only + HMAC hash chain。**pseudonymize した行の per-row entry_hash 再計算は fail する (意図的・検出可能)**。chain リンク (prev_hash→entry_hash) は無傷で他行の検証は通る。GDPR/APPI 消去義務 > 当該行の content 認証、という受容トレードオフ。`verify_audit_chain` は 64-hex pseudonym 形の mismatch を `erasure_pseudonymized` として分類して walk を継続する (それ以外の mismatch は従来どおり tamper alarm)。残余リスク: raw SQL 権限を持つ攻撃者は identity 列改竄を 64-hex に偽装できるが、その攻撃者クラスは trigger も erasure コードも実行できるため chain の脅威モデル外。carve-out 外の全列は完全に tamper-evident のまま |
 | `users` | `user_id = :uid` | 最後 |
 
 ### 2.5 Audit logs (Step 5)


### PR DESCRIPTION
Closes #1365

## Summary
- Pseudonymize the four raw-OAuth-sub residual families the #1358 sweep left after erasure:
  1. `config_overrides.updated_by` (global control-plane row, no cascade)
  2. `secret_access_log.actor_user_id` / `recipient_identity` — via a new **e72 migration** that narrows the append-only trigger to the #1278 carve-out pattern (UPDATE permitted ONLY on the two identity columns; DELETE/TRUNCATE and all other UPDATEs stay blocked)
  3. Workspace-scoped authorship columns on surviving rows — `created_by` on workspace_connectors / resources / resource_tokens / workspace_addons / file_objects / secrets / secret_versions / recipient_pubkeys + `secret_grants.granted_by`
  4. `contexts.created_by` (closes the #1336 deleted_by/created_by asymmetry)
- Review findings folded in: two same-shape residuals the finder surfaced (`recipient_pubkeys.attested_by`, `external_api_keys.updated_by` on keys owned by others) are also swept — 12 authorship columns total

## Tamper-evidence trade-off (deliberate, documented)
`secret_access_log` is HMAC hash-chained. Pseudonymizing the identity columns makes the stored `entry_hash` no longer recompute for exactly the mutated rows; chain **linkage** (prev_hash pointers) is untouched. `verify_audit_chain` now classifies 64-hex erasure-shaped mismatches into a new `erasure_pseudonymized` list and continues the walk (all other rows keep verifying); any other mismatch remains a hard tamper alarm. Residual risk (attacker with raw SQL disguising an edit as a pseudonym) is documented in runbook §2.4 — that attacker class already defeats the trigger and the chain's threat model. GDPR Art.17 / APPI 第22条 erasure precedence.

## Implementation notes
- `_pseudonym()` helper unifies the salted-SHA256 derivation across all four sweep lanes (same-user cross-row correlation is the legal-retention contract)
- Counts keys: `config_overrides_pseudonymized`, `authorship_columns_pseudonymized` (12-column sum), `secret_access_log_pseudonymized` (per-column sum); runbook §2.4 updated
- e72 downgrade restores the exact e50 blanket trigger body
- Follow-up noted (not in this PR): a guard test enumerating every `*_by` identity column across models and asserting sweep coverage, so future models can't silently drift out of erasure scope

## Tests
- Unit: config_overrides / 12-column authorship sweep (distinct per-column values pin the SUM) / secret_access_log two-UPDATE carve-out shape — 42 passed
- Integration: e72 carve-out trigger DDL (identity-column UPDATE passes; result-column UPDATE, DELETE, TRUNCATE rejected), verify_audit_chain erasure-scar classification + walk continuation — 26 passed
- Full erasure + secret-store + routes suite: 87 passed; migration/trigger integration: 11 passed

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO)
- /code-review (medium, finder sweep + verify): 4 findings — 3 fixed in-branch (incl. the verify_audit_chain false-alarm), 1 deferred as follow-up
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
