### PR TITLE
fix(api): conform connector locale to the worker Locale contract (#1377)

### DIFF
--- a/backend/alembic/versions/e73_1377_locale_backfill.py
+++ b/backend/alembic/versions/e73_1377_locale_backfill.py
@@ -4,17 +4,21 @@ The bridge's WorkerConfigResponse.locale is ``Literal["en", "ja"]``; a
 non-conforming stored value fails bridge-side validation of the WHOLE
 config body and the tenant fails closed (``config_unavailable``). The
 write boundary now normalizes/rejects at create+update time; this
-migration repairs rows written before the fix:
+migration repairs rows written before the fix.
 
-* primary subtag ``en``/``ja`` (any case, BCP-47 suffix, ``_`` or ``-``
-  separator) → the bare contract value
-* anything else (including blank strings) → NULL, which the worker
-  treats as "use the worker default locale" — fail-open, matching the
-  vend-side normalization added with this change
+Normalization runs row-wise in Python (not SQL) so its whitespace
+semantics are byte-identical to the runtime normalizer — PostgreSQL's
+``btrim`` trims only ASCII spaces while Python's ``str.strip()`` also
+trims tabs and U+3000 (full-width space, common in Japanese input); an
+SQL implementation would silently downgrade a would-be ``ja`` row to
+NULL. The mapping is fail-open like the vend boundary: primary subtag
+``en``/``ja`` → the bare contract value, anything else → NULL (worker
+default).
 
-``config_version`` is intentionally NOT bumped: the vended value for a
-normalized row is identical to what the vend-side normalizer already
-produces, so no worker refetch is needed.
+``config_version`` is bumped for every rewritten row: a bridge may have
+cached the vend ETag for a body it then rejected, and without a version
+bump the corrected locale would keep 304ing forever (review finding).
+Rows already storing ``en``/``ja``/NULL are untouched.
 
 Downgrade is a no-op: normalization is lossy (the original raw strings
 are not preserved) and the normalized values remain valid for the old
@@ -36,23 +40,34 @@ branch_labels = None
 depends_on = None
 
 
+def _normalize(value: str) -> str | None:
+    """Frozen copy of models.worker_runtime.normalize_worker_locale semantics
+    at e73 time (migrations must not import drifting app code), except the
+    non-conforming case degrades to None here instead of raising — the
+    backfill is a read-boundary repair, not an admin write."""
+    primary = value.strip().replace("_", "-").split("-", 1)[0].lower()
+    if primary in ("en", "ja"):
+        return primary
+    return None
+
+
 def upgrade() -> None:
-    op.execute(
+    bind = op.get_bind()
+    rows = bind.execute(
         sa.text(
-            """
-            UPDATE workspace_connectors
-            SET locale = CASE
-                WHEN split_part(replace(lower(btrim(locale)), '_', '-'), '-', 1) = 'en'
-                    THEN 'en'
-                WHEN split_part(replace(lower(btrim(locale)), '_', '-'), '-', 1) = 'ja'
-                    THEN 'ja'
-                ELSE NULL
-            END
-            WHERE locale IS NOT NULL
-              AND locale NOT IN ('en', 'ja')
-            """
+            "SELECT id, locale FROM workspace_connectors "
+            "WHERE locale IS NOT NULL AND locale NOT IN ('en', 'ja')"
         )
-    )
+    ).fetchall()
+    for row in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE workspace_connectors "
+                "SET locale = :locale, config_version = config_version + 1 "
+                "WHERE id = :id"
+            ),
+            {"locale": _normalize(row.locale), "id": row.id},
+        )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/e73_1377_locale_backfill.py
+++ b/backend/alembic/versions/e73_1377_locale_backfill.py
@@ -1,0 +1,61 @@
+"""#1377: backfill workspace_connectors.locale to the worker Locale contract.
+
+The bridge's WorkerConfigResponse.locale is ``Literal["en", "ja"]``; a
+non-conforming stored value fails bridge-side validation of the WHOLE
+config body and the tenant fails closed (``config_unavailable``). The
+write boundary now normalizes/rejects at create+update time; this
+migration repairs rows written before the fix:
+
+* primary subtag ``en``/``ja`` (any case, BCP-47 suffix, ``_`` or ``-``
+  separator) → the bare contract value
+* anything else (including blank strings) → NULL, which the worker
+  treats as "use the worker default locale" — fail-open, matching the
+  vend-side normalization added with this change
+
+``config_version`` is intentionally NOT bumped: the vended value for a
+normalized row is identical to what the vend-side normalizer already
+produces, so no worker refetch is needed.
+
+Downgrade is a no-op: normalization is lossy (the original raw strings
+are not preserved) and the normalized values remain valid for the old
+code paths.
+
+Revision ID: e73_1377_locale_backfill
+Revises: e72_1365_secret_log_carveout
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e73_1377_locale_backfill"
+down_revision = "e72_1365_secret_log_carveout"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            UPDATE workspace_connectors
+            SET locale = CASE
+                WHEN split_part(replace(lower(btrim(locale)), '_', '-'), '-', 1) = 'en'
+                    THEN 'en'
+                WHEN split_part(replace(lower(btrim(locale)), '_', '-'), '-', 1) = 'ja'
+                    THEN 'ja'
+                ELSE NULL
+            END
+            WHERE locale IS NOT NULL
+              AND locale NOT IN ('en', 'ja')
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Lossy normalization cannot be reversed; normalized values are valid
+    # under the pre-#1377 schema too.
+    pass

--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from config.settings import get_settings
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
-from models.worker_runtime import WorkerRuntimeConfig
+from models.worker_runtime import WorkerLocale, WorkerRuntimeConfig, normalize_worker_locale
 from services.connector_provisioning import ConnectorProvisioningService
 from services.worker_app_identity import (
     WorkerAppIdentityService,
@@ -81,7 +81,10 @@ class WorkerConnectorConfig(TZAwareBaseModel):
     platform: str
     app_key: str
     config_revision: str
-    locale: str | None = None
+    # #1377: typed to the worker Locale contract so the OpenAPI schema carries
+    # the enum and the two repos cannot drift silently. The vend site
+    # normalizes legacy stored values before construction.
+    locale: WorkerLocale | None = None
     slack: dict[str, Any]
     kmc: dict[str, Any]
     # #895: resource-ingest credentials for worker #91 Option A. NULL on legacy
@@ -130,6 +133,29 @@ class WorkerAppBootstrapResponse(BaseModel):
 
 def _etag(revision: str) -> str:
     return f'"{revision}"'
+
+
+def _vend_locale(connector: Any) -> WorkerLocale | None:
+    """Best-effort normalization of the stored locale to the worker contract.
+
+    #1377 rolling compat: rows written before the write-boundary validation may
+    hold BCP-47 or arbitrary values. A non-conforming vended locale fails the
+    bridge's pydantic validation of the WHOLE config body (tenant fails closed
+    on a non-secret cosmetic field), so the read boundary degrades to ``None``
+    (worker default) instead — same fail-open principle as
+    ``WorkerRuntimeConfig.from_stored``.
+    """
+    try:
+        normalized = normalize_worker_locale(connector.locale)
+    except ValueError:
+        logger.warning(
+            "worker_config_locale_nonconforming",
+            connector_id=str(connector.id),
+            locale=str(connector.locale)[:32],
+        )
+        return None
+    # normalize_worker_locale returns a WORKER_LOCALES member or None here.
+    return normalized  # type: ignore[return-value]
 
 
 @router.get("/apps", response_model=WorkerAppBootstrapResponse)
@@ -318,7 +344,7 @@ async def get_worker_config(
         platform=connector.connector_type,
         app_key=selected_app_key,
         config_revision=config_revision,
-        locale=connector.locale,
+        locale=_vend_locale(connector),
         slack=slack,
         kmc={"mcp_url": get_settings().kmc_mcp_url, "api_key": kmc_api_key},
         resource=resource_block,

--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -136,17 +136,15 @@ def _etag(revision: str) -> str:
 
 
 def _vend_locale(connector: Any) -> WorkerLocale | None:
-    """Best-effort normalization of the stored locale to the worker contract.
+    """Best-effort normalization of a stored locale to ``WORKER_LOCALES``.
 
-    #1377 rolling compat: rows written before the write-boundary validation may
-    hold BCP-47 or arbitrary values. A non-conforming vended locale fails the
-    bridge's pydantic validation of the WHOLE config body (tenant fails closed
-    on a non-secret cosmetic field), so the read boundary degrades to ``None``
-    (worker default) instead — same fail-open principle as
+    #1377 rolling compat for pre-fix rows: the read boundary degrades a
+    non-conforming value to ``None`` (worker default) instead of failing the
+    tenant closed — same fail-open principle as
     ``WorkerRuntimeConfig.from_stored``.
     """
     try:
-        normalized = normalize_worker_locale(connector.locale)
+        return normalize_worker_locale(connector.locale)
     except ValueError:
         logger.warning(
             "worker_config_locale_nonconforming",
@@ -154,8 +152,6 @@ def _vend_locale(connector: Any) -> WorkerLocale | None:
             locale=str(connector.locale)[:32],
         )
         return None
-    # normalize_worker_locale returns a WORKER_LOCALES member or None here.
-    return normalized  # type: ignore[return-value]
 
 
 @router.get("/apps", response_model=WorkerAppBootstrapResponse)

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -63,7 +63,15 @@ class WorkspaceConnectorCreateRequest(BaseModel):
     )
     llm_config: dict[str, Any] | None = Field(None, description="BYO LLM bundle; Fernet-encrypted")
     channel_ids: list[Any] | None = Field(None, description="Ingest channel selection")
-    locale: str | None = Field(None, max_length=10)
+    locale: str | None = Field(
+        None,
+        max_length=10,
+        description=(
+            "Worker pre-compile locale. Must map to the worker Locale "
+            "contract ('en' | 'ja'); common BCP-47 forms are normalized "
+            "(ja-JP → ja). See models.worker_runtime.WORKER_LOCALES (#1377)."
+        ),
+    )
     external_team_id: str | None = Field(
         None, max_length=255, description="Platform team id (worker dispatch key)"
     )

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1557,7 +1557,12 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
                     },
                     "locale": {
                         "type": "string",
-                        "description": "Connector locale (max 10 chars).",
+                        "description": (
+                            "Worker pre-compile locale. Must map to the worker "
+                            "Locale contract ('en' | 'ja'); common BCP-47 forms "
+                            "are normalized (ja-JP -> ja), anything else is "
+                            "rejected (#1377)."
+                        ),
                     },
                     "external_team_id": {
                         "type": "string",

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -503,8 +503,10 @@ class WorkspaceConnector(Base):
         ForeignKey("contexts.id", ondelete="SET NULL"),
         nullable=True,
     )
-    # Worker-facing pre-compile locale (e.g. cluster labelling). Defaults to the
-    # workspace locale at provision time; NULL falls back to worker default.
+    # Worker-facing pre-compile locale (e.g. cluster labelling). Client-supplied
+    # at provision time (no workspace-locale defaulting exists); normalized to
+    # the worker Locale contract (models.worker_runtime.WORKER_LOCALES, #1377).
+    # NULL falls back to the worker default.
     locale: Mapped[str | None] = mapped_column(String(10), nullable=True)
     # Stable platform app selector. Existing connectors are backfilled to the
     # compatibility identity ``default`` by migration e68 (#1315).

--- a/backend/src/models/worker_runtime.py
+++ b/backend/src/models/worker_runtime.py
@@ -3,22 +3,24 @@
 from __future__ import annotations
 
 import string
-from typing import Literal
+from typing import Literal, cast, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
-# #1377: the worker Locale contract. The bridge's WorkerConfigResponse.locale is
-# Literal["en", "ja"] and a non-conforming vended value fails bridge-side
-# validation of the WHOLE config body — the tenant fails closed with only a
-# generic config_unavailable in the logs. This tuple + normalizer are the
-# single source both the admin write boundary (strict: 422) and the vend read
-# boundary (lenient: degrade to None) share.
-WORKER_LOCALES: tuple[str, ...] = ("en", "ja")
-
+# #1377: the worker Locale contract, mirroring kagura-bridge's
+# WorkerConfigResponse.locale (Literal["en", "ja"]). A non-conforming vended
+# value fails bridge-side validation of the WHOLE config body — the tenant
+# fails closed with only a generic config_unavailable in the logs. This is the
+# single source shared by the admin write boundary (strict: 422), the vend
+# read boundary (lenient: degrade to None), and the OpenAPI schema. See
+# docs/connector-ingest-contract.md for the cross-repo contract.
 WorkerLocale = Literal["en", "ja"]
+# Derived from the Literal so the runtime normalizer and the type/OpenAPI
+# contract can never disagree.
+WORKER_LOCALES: tuple[str, ...] = get_args(WorkerLocale)
 
 
-def normalize_worker_locale(value: str | None) -> str | None:
+def normalize_worker_locale(value: str | None) -> WorkerLocale | None:
     """Normalize a connector locale to the worker Locale contract.
 
     Maps common BCP-47 forms to their primary subtag (``ja-JP`` → ``ja``,
@@ -38,7 +40,7 @@ def normalize_worker_locale(value: str | None) -> str | None:
             f"locale must map to one of {list(WORKER_LOCALES)} "
             f"(the worker Locale contract); got {value!r}"
         )
-    return primary
+    return cast(WorkerLocale, primary)
 
 
 # Upper bounds on tenant-writable knobs (#1350 review). These controls tune a

--- a/backend/src/models/worker_runtime.py
+++ b/backend/src/models/worker_runtime.py
@@ -7,6 +7,40 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
+# #1377: the worker Locale contract. The bridge's WorkerConfigResponse.locale is
+# Literal["en", "ja"] and a non-conforming vended value fails bridge-side
+# validation of the WHOLE config body — the tenant fails closed with only a
+# generic config_unavailable in the logs. This tuple + normalizer are the
+# single source both the admin write boundary (strict: 422) and the vend read
+# boundary (lenient: degrade to None) share.
+WORKER_LOCALES: tuple[str, ...] = ("en", "ja")
+
+WorkerLocale = Literal["en", "ja"]
+
+
+def normalize_worker_locale(value: str | None) -> str | None:
+    """Normalize a connector locale to the worker Locale contract.
+
+    Maps common BCP-47 forms to their primary subtag (``ja-JP`` → ``ja``,
+    ``en_GB`` → ``en``, case-insensitive). Blank/None normalizes to ``None``
+    (worker default).
+
+    Raises:
+        ValueError: when the primary subtag is not in ``WORKER_LOCALES``.
+    """
+    if value is None:
+        return None
+    primary = value.strip().replace("_", "-").split("-", 1)[0].lower()
+    if not primary:
+        return None
+    if primary not in WORKER_LOCALES:
+        raise ValueError(
+            f"locale must map to one of {list(WORKER_LOCALES)} "
+            f"(the worker Locale contract); got {value!r}"
+        )
+    return primary
+
+
 # Upper bounds on tenant-writable knobs (#1350 review). These controls tune a
 # SHARED worker process (its Redis, its supervisor loop, its shutdown budget),
 # so an unbounded value is a cross-tenant resource lever: max_len/volume caps

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -163,9 +163,8 @@ class ConnectorProvisioningService:
         """
         self._validate_inputs(connector_type, resource_id, quota_events_per_hour)
 
-        # #1377: normalize to the worker Locale contract (en|ja) at the write
-        # boundary so a connector can never be born un-vendable — a bad locale
-        # fails the bridge's validation of the WHOLE config body downstream.
+        # #1377: strict write boundary for the worker Locale contract (see
+        # WORKER_LOCALES) — a connector must never be born un-vendable.
         from models.worker_runtime import normalize_worker_locale
 
         try:

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -163,6 +163,16 @@ class ConnectorProvisioningService:
         """
         self._validate_inputs(connector_type, resource_id, quota_events_per_hour)
 
+        # #1377: normalize to the worker Locale contract (en|ja) at the write
+        # boundary so a connector can never be born un-vendable — a bad locale
+        # fails the bridge's validation of the WHOLE config body downstream.
+        from models.worker_runtime import normalize_worker_locale
+
+        try:
+            locale = normalize_worker_locale(locale)
+        except ValueError as ve:
+            raise ValidationError(str(ve), field="locale") from ve
+
         normalized_runtime_config = None
         if runtime_config is not None:
             from models.worker_runtime import WorkerRuntimeConfig

--- a/backend/tests/api/test_workers.py
+++ b/backend/tests/api/test_workers.py
@@ -128,6 +128,62 @@ async def test_get_worker_config_returns_secrets_for_ready_connector():
     assert result.resource is None
 
 
+def _minimal_ready_conn(locale):
+    """MagicMock connector with just enough state for a config vend (#1377)."""
+    conn = MagicMock()
+    conn.id = uuid4()
+    conn.workspace_id = uuid4()
+    conn.context_id = uuid4()
+    conn.connector_type = "slack"
+    conn.locale = locale
+    conn.external_team_id = "T01"
+    conn.config_version = 1
+    conn.channel_ids = ["C01"]
+    conn.pii_guardrail_config = None
+    conn.runtime_config = None
+    conn.get_oauth_tokens.return_value = {"bot_token": "xoxb-x"}
+    conn.get_kmc_api_key.return_value = "kagura_writekey"
+    conn.kmc_api_key_expires_at = None
+    conn.get_resource_token.return_value = None
+    conn.get_llm_config.return_value = None
+    return conn
+
+
+async def _vend_config_for(conn):
+    with (
+        patch("api.routes.workers.get_settings", return_value=_settings()),
+        patch("api.routes.workers.ConnectorProvisioningService") as svc,
+        patch("api.routes.workers.WorkerAppIdentityService") as app_svc,
+    ):
+        app_svc.return_value.get_identity = AsyncMock(return_value=None)
+        svc.return_value.get_connector_for_dispatch = AsyncMock(return_value=conn)
+        return await get_worker_config(
+            response=Response(),
+            platform="slack",
+            team_id="T01",
+            app_key=None,
+            if_none_match=None,
+            _=None,
+            db=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_normalizes_legacy_bcp47_locale():
+    """#1377: a pre-fix row storing ja-JP is vended as the contract value ja."""
+    result = await _vend_config_for(_minimal_ready_conn("ja-JP"))
+    assert result.locale == "ja"
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_nonconforming_locale_vends_none():
+    """#1377: a non-conforming legacy locale must not fail the tenant closed —
+    it degrades to None (worker default) instead of failing bridge-side
+    validation of the whole config body."""
+    result = await _vend_config_for(_minimal_ready_conn("zz-XX"))
+    assert result.locale is None
+
+
 @pytest.mark.asyncio
 async def test_get_worker_config_revision_changes_when_runtime_revision_changes():
     db = MagicMock()

--- a/backend/tests/integration/test_e73_1377_locale_backfill_migration.py
+++ b/backend/tests/integration/test_e73_1377_locale_backfill_migration.py
@@ -1,0 +1,108 @@
+"""DB contract for the locale backfill migration e73 (#1377)."""
+
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from alembic import command
+from tests.integration.test_alembic_migrations import (
+    _alembic_at_test_db,
+    _get_alembic_config,
+    _reset_alembic_state,
+    _sync_engine,
+)
+
+PRE_E73_REV = "e72_1365_secret_log_carveout"
+E73_REV = "e73_1377_locale_backfill"
+
+
+def _seed_connector(conn: Connection, locale: str | None) -> str:
+    suffix = uuid.uuid4().hex[:12]
+    user_id = f"u-{suffix}"
+    workspace_id = str(uuid.uuid4())
+    resource_pk = str(uuid.uuid4())
+    connector_id = str(uuid.uuid4())
+    conn.execute(
+        text(
+            "INSERT INTO users "
+            "(email, user_id, role, timezone, locale, is_initial_admin) "
+            "VALUES (:email, :uid, 'user', 'UTC', 'en', false)"
+        ),
+        {"email": f"{user_id}@test.example", "uid": user_id},
+    )
+    conn.execute(
+        text("INSERT INTO workspaces (id, name, owner_user_id) VALUES (:id, :name, :owner)"),
+        {"id": workspace_id, "name": f"ws-{suffix}", "owner": user_id},
+    )
+    conn.execute(
+        text("INSERT INTO resources (id, workspace_id, resource_id) VALUES (:id, :ws, :slug)"),
+        {"id": resource_pk, "ws": workspace_id, "slug": f"r-{suffix}"},
+    )
+    conn.execute(
+        text(
+            "INSERT INTO workspace_connectors "
+            "(id, resource_pk, workspace_id, connector_type, locale) "
+            "VALUES (:id, :resource, :workspace, 'slack', :locale)"
+        ),
+        {
+            "id": connector_id,
+            "resource": resource_pk,
+            "workspace": workspace_id,
+            "locale": locale,
+        },
+    )
+    return connector_id
+
+
+def _leave_db_at_head() -> None:
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), "head")
+
+
+class TestE73LocaleBackfillMigration:
+    def test_backfill_normalizes_variants_and_bumps_only_rewritten_rows(self) -> None:
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), PRE_E73_REV)
+            engine = _sync_engine()
+            # (stored locale, expected post-migration locale, expect version bump)
+            cases = [
+                ("ja-JP", "ja", True),
+                ("EN_us", "en", True),
+                # U+3000 full-width space — the btrim-vs-strip divergence the
+                # Python row-wise implementation exists for (review finding):
+                # an SQL btrim would have downgraded this row to NULL.
+                ("　ja", "ja", True),
+                ("fr", None, True),
+                ("ja", "ja", False),  # already conforming — untouched, no bump
+                (None, None, False),
+            ]
+            with engine.begin() as conn:
+                seeded = [
+                    (_seed_connector(conn, stored), stored, expected, bumped)
+                    for stored, expected, bumped in cases
+                ]
+
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), E73_REV)
+
+            with engine.begin() as conn:
+                for connector_id, stored, expected, bumped in seeded:
+                    row = conn.execute(
+                        text(
+                            "SELECT locale, config_version FROM workspace_connectors WHERE id = :id"
+                        ),
+                        {"id": connector_id},
+                    ).one()
+                    assert row.locale == expected, (
+                        f"stored {stored!r}: expected {expected!r}, got {row.locale!r}"
+                    )
+                    # Seed default config_version is 1; a rewritten row must
+                    # bump to 2 so a bridge holding the old ETag refetches.
+                    assert row.config_version == (2 if bumped else 1), (
+                        f"stored {stored!r}: config_version {row.config_version}"
+                    )
+        finally:
+            _leave_db_at_head()

--- a/backend/tests/models/test_worker_runtime.py
+++ b/backend/tests/models/test_worker_runtime.py
@@ -123,3 +123,35 @@ class TestReviewHardening:
         assert WorkerRuntimeConfig.from_stored({"buffer": {"max_len": 10**15}}) is None
         assert WorkerRuntimeConfig.from_stored("not-a-dict") is None
         assert WorkerRuntimeConfig.from_stored(None) is None
+
+
+class TestNormalizeWorkerLocale:
+    """#1377: connector locale must conform to the worker Locale contract (en|ja)."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("en", "en"),
+            ("ja", "ja"),
+            ("EN", "en"),
+            ("Ja", "ja"),
+            ("ja-JP", "ja"),
+            ("en-US", "en"),
+            ("en_GB", "en"),
+            (" ja ", "ja"),
+            (None, None),
+            ("", None),
+            ("   ", None),
+        ],
+    )
+    def test_normalizes_conforming_and_bcp47_values(self, raw, expected):
+        from models.worker_runtime import normalize_worker_locale
+
+        assert normalize_worker_locale(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["fr", "de-DE", "japanese", "j", "english", "jp"])
+    def test_rejects_non_contract_locales(self, raw):
+        from models.worker_runtime import normalize_worker_locale
+
+        with pytest.raises(ValueError):
+            normalize_worker_locale(raw)

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -465,6 +465,27 @@ async def test_update_runtime_config_survives_drifted_stored_document():
     assert connector.runtime_config["vision_enabled"] is False
 
 
+@pytest.mark.asyncio
+async def test_provision_connector_rejects_non_contract_locale():
+    """#1377: locale is validated at the service choke point BEFORE any DB work,
+    so a non-conforming value 422s instead of producing an un-vendable connector."""
+    db = MagicMock()
+    db.execute = AsyncMock()
+    svc = ConnectorProvisioningService(db)
+
+    with pytest.raises(ValidationError) as exc:
+        await svc.provision_connector(
+            workspace_id=uuid4(),
+            user_id="u1",
+            connector_type="slack",
+            resource_id="slack-x",
+            locale="fr",
+        )
+
+    assert "locale" in str(exc.value).lower()
+    db.execute.assert_not_awaited()
+
+
 class TestTeamUniquenessGuard:
     """#1360: the #1315 app-qualified uniqueness must not re-open
     cross-tenant pre-binding of an already-bound platform team."""

--- a/docs/connector-ingest-contract.md
+++ b/docs/connector-ingest-contract.md
@@ -143,6 +143,23 @@ worker (connector token)
 - **Slug, not UUID.** Address the resource by its slug in the URL; the server
   resolves it against the authenticated workspace.
 
+## Worker config vend: the Locale contract (#1377)
+
+The config vend (`GET /api/v1/workers/config`) types
+`WorkerConnectorConfig.locale` as `"en" | "ja" | null`, mirroring the bridge's
+`WorkerConfigResponse.locale` (`Literal["en", "ja"]` in kagura-bridge
+`models.py::Locale`). A vended value outside that enum fails the bridge's
+validation of the **whole** config body and the tenant fails closed
+(`config_unavailable`), so both sides of the contract are pinned:
+
+- **memory-cloud** — single source `models.worker_runtime.WORKER_LOCALES`
+  (write boundary rejects/normalizes at connector create/update; vend boundary
+  degrades non-conforming legacy rows to `null` = worker default).
+- **kagura-bridge** — `models.py::Locale`.
+
+Widening the enum (e.g. adding `ko`) requires a coordinated change to **both**
+repos: bridge `Locale` first (workers tolerate `null`), then `WORKER_LOCALES`.
+
 ## Related
 
 - Epic #755 (F6) — chat ingest reuses Resource Foundation


### PR DESCRIPTION
## Summary

A stored connector locale outside the bridge's `Literal["en", "ja"]` contract fails bridge-side validation of the whole vended config body, so the tenant fails closed with only a generic `config_unavailable` — a non-secret cosmetic field taking down the connector (found during the 2026-07-19 kagura-bridge multi-tenant canary).

Closes #1377

## Changes

- **Contract single source** (`models/worker_runtime.py`): `WorkerLocale = Literal["en", "ja"]` with `WORKER_LOCALES = get_args(WorkerLocale)` and `normalize_worker_locale()` — primary-subtag BCP-47 mapping (`ja-JP`/`ja_JP`/`JA` → `ja`), blank → `None`, anything else raises.
- **Strict write boundary**: `provision_connector` normalizes/422s before any DB work — the service choke point shared by REST and the MCP `setup_connector` path (and the upcoming #1376 PATCH).
- **Lenient read boundary**: the worker config vend normalizes legacy rows best-effort and degrades non-conforming values to `None` (worker default) with a warning — same fail-open principle as `WorkerRuntimeConfig.from_stored`. The response field is typed `Literal["en", "ja"] | None` so OpenAPI carries the enum.
- **e73 backfill**: row-wise **Python** with a frozen copy of the normalizer semantics — SQL `btrim` trims only ASCII spaces while `str.strip()` also trims U+3000 (full-width space, common in Japanese input); an SQL implementation silently downgraded a would-be `ja` row to NULL (caught in review, pinned by an integration test). `config_version` is bumped on every rewritten row so a bridge holding the ETag of a body it rejected refetches instead of 304ing forever.
- **Docs/contract**: cross-repo Locale contract + coordinated-widening procedure documented in `docs/connector-ingest-contract.md`; stale MCP `setup_connector` locale description and the inaccurate workspace-locale-defaulting model comment fixed.

## Test plan

- `tests/models/test_worker_runtime.py`: 17-case normalize matrix (BCP-47 variants, blanks, rejections).
- `tests/services/test_connector_provisioning.py`: non-contract locale 422s at the choke point before any DB work.
- `tests/api/test_workers.py`: vend normalizes legacy `ja-JP` → `ja`; non-conforming value degrades to `None` (fail-open).
- `tests/integration/test_e73_1377_locale_backfill_migration.py`: variant matrix incl. the U+3000 case; selective `config_version` bump (rewritten rows only).
- ruff / pyright / integration suite clean (pre-existing env-only failures identical on main).
- Gate1 green (CTO) · /code-review medium (8 finders: 8 findings — 7 fixed, 1 documented) · Gate2 green ×3 (CSO / QA Lead / CTO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)