### PR TITLE
refactor(frontend): extract shared useConsumeSearchParams hook (#1382)

### DIFF
--- a/frontend/src/app/(authenticated)/profile/page.tsx
+++ b/frontend/src/app/(authenticated)/profile/page.tsx
@@ -8,9 +8,8 @@
  * Issue #223: i18n support
  */
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
-import { useRouter, useSearchParams } from "next/navigation";
 import {
   Card,
   CardContent,
@@ -32,6 +31,7 @@ import {
 import { useAuth } from "@/contexts/AuthContext";
 import { useLocale, type Locale } from "@/i18n";
 import { useToast } from "@/hooks/use-toast";
+import { useConsumeSearchParams } from "@/hooks/useConsumeSearchParams";
 import { User, Moon, Sun, Save, RefreshCw } from "lucide-react";
 import { COMMON_TIMEZONES } from "@/lib/utils/datetime";
 import { apiClient, ApiError } from "@/lib/api/base";
@@ -45,80 +45,73 @@ export default function ProfilePage() {
   const tCommon = useTranslations("common");
   const { user, refetchUser } = useAuth();
   const { toast } = useToast();
-  const router = useRouter();
-  const searchParams = useSearchParams();
   const [isEditMode, setIsEditMode] = useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Wait for useAuth() to finish its initial /auth/me fetch before
-  // surfacing the refreshed=1 / error=refresh_* toast. If the effect
-  // ran on the first render (where user is still null), the toast
-  // would say "Profile refreshed from IdP" instead of "from Google" /
-  // "from GitHub". The ref ensures the effect handles the params
-  // exactly once even though the deps now include `user`.
-  const refreshParamsHandled = useRef(false);
-  useEffect(() => {
-    if (refreshParamsHandled.current) return;
-    if (!user) return;
-    const refreshed = searchParams.get("refreshed");
-    const linked = searchParams.get("linked");
-    const errorCode = searchParams.get("error");
-    const isRefreshParam =
-      refreshed === "1" || !!errorCode?.startsWith("refresh_");
-    // Link outcomes from the link-mode callback (_maybe_link_redirect, #517).
-    const isLinkParam =
-      linked === "1" ||
-      errorCode === "link_failed" ||
-      errorCode === "provider_already_linked";
-    if (!isRefreshParam && !isLinkParam) return;
-    refreshParamsHandled.current = true;
+  // surfacing the refreshed=1 / error=refresh_* toast (enabled: !!user).
+  // If the consume ran on the first render (where user is still null), the
+  // toast would say "Profile refreshed from IdP" instead of "from Google" /
+  // "from GitHub". The hook handles the params exactly once and strips them
+  // via router.replace (#1382).
+  useConsumeSearchParams(
+    (params) => {
+      const refreshed = params.get("refreshed");
+      const linked = params.get("linked");
+      const errorCode = params.get("error");
+      const isRefreshParam =
+        refreshed === "1" || !!errorCode?.startsWith("refresh_");
+      // Link outcomes from the link-mode callback (_maybe_link_redirect, #517).
+      const isLinkParam =
+        linked === "1" ||
+        errorCode === "link_failed" ||
+        errorCode === "provider_already_linked";
+      if (!isRefreshParam && !isLinkParam) return false;
 
-    const provider =
-      getRefreshProviderName(user, t) ?? t("signInProviderFallback");
-    const cleanUrl = "/profile";
+      const provider =
+        getRefreshProviderName(user ?? {}, t) ?? t("signInProviderFallback");
 
-    if (refreshed === "1") {
-      toast({
-        title: t("refreshFromIdPSuccess", { provider }),
-        description: t("refreshFromIdPSuccessDesc"),
-      });
-      refetchUser();
-      router.replace(cleanUrl);
-    } else if (errorCode?.startsWith("refresh_")) {
-      // Wire-format contract with backend's _maybe_refresh_redirect:
-      // any code not in this map falls through to the generic message.
-      const errorMessageKey: Record<string, string> = {
-        refresh_user_mismatch: "refreshFromIdPErrorMismatch",
-        refresh_state_expired: "refreshFromIdPErrorExpired",
-      };
-      const messageKey =
-        errorMessageKey[errorCode] ?? "refreshFromIdPErrorGeneric";
-      toast({
-        title: tCommon("error"),
-        description: t(messageKey, { provider }),
-        variant: "destructive",
-      });
-      router.replace(cleanUrl);
-    } else if (linked === "1") {
-      toast({ title: t("linkSuccess") });
-      refetchUser();
-      router.replace(cleanUrl);
-    } else if (errorCode === "link_failed") {
-      toast({
-        title: tCommon("error"),
-        description: t("linkFailed"),
-        variant: "destructive",
-      });
-      router.replace(cleanUrl);
-    } else if (errorCode === "provider_already_linked") {
-      toast({
-        title: tCommon("error"),
-        description: t("linkAlreadyLinked"),
-        variant: "destructive",
-      });
-      router.replace(cleanUrl);
-    }
-  }, [user, searchParams, t, tCommon, toast, refetchUser, router]);
+      if (refreshed === "1") {
+        toast({
+          title: t("refreshFromIdPSuccess", { provider }),
+          description: t("refreshFromIdPSuccessDesc"),
+        });
+        refetchUser();
+      } else if (errorCode?.startsWith("refresh_")) {
+        // Wire-format contract with backend's _maybe_refresh_redirect:
+        // any code not in this map falls through to the generic message.
+        const errorMessageKey: Record<string, string> = {
+          refresh_user_mismatch: "refreshFromIdPErrorMismatch",
+          refresh_state_expired: "refreshFromIdPErrorExpired",
+        };
+        const messageKey =
+          errorMessageKey[errorCode] ?? "refreshFromIdPErrorGeneric";
+        toast({
+          title: tCommon("error"),
+          description: t(messageKey, { provider }),
+          variant: "destructive",
+        });
+      } else if (linked === "1") {
+        toast({ title: t("linkSuccess") });
+        refetchUser();
+      } else if (errorCode === "link_failed") {
+        toast({
+          title: tCommon("error"),
+          description: t("linkFailed"),
+          variant: "destructive",
+        });
+      } else {
+        // Group check above guarantees this is provider_already_linked.
+        toast({
+          title: tCommon("error"),
+          description: t("linkAlreadyLinked"),
+          variant: "destructive",
+        });
+      }
+      return true;
+    },
+    { enabled: !!user, cleanUrl: "/profile" },
+  );
 
   const handleRefreshFromIdP = async () => {
     const provider = getRefreshProviderName(user ?? {}, t);

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -44,6 +44,7 @@ import {
 } from "@/components/ui/dialog";
 import { useToast } from "@/hooks/use-toast";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
+import { useConsumeSearchParams } from "@/hooks/useConsumeSearchParams";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { API_BASE_URL } from "@/lib/api/base";
@@ -142,7 +143,6 @@ export default function ConnectorsPage() {
     [copyToTarget, toast, tCommon],
   );
   const installHandle = searchParams.get("slack_install");
-  const slackError = searchParams.get("slack_error");
 
   const [connectors, setConnectors] = useState<
     WorkspaceConnectorSummary[] | null
@@ -297,34 +297,37 @@ export default function ConnectorsPage() {
 
   // #1375/#1381: a cancelled/failed/expired Slack OAuth consent redirects
   // back with ?slack_error=cancelled|failed|expired (allowlisted by the
-  // backend). Surface a notice and strip the param so refresh/back doesn't
-  // re-trigger it. Cancel is a user choice (informational toast); expired is
-  // retryable (say so); anything else is destructive. Gated on `allowed`
-  // like the slack_install effect — only admins can run the install flow,
-  // so only they get the outcome notice.
-  useEffect(() => {
-    if (!slackError) return;
-    if (!allowed) return;
-    if (slackError === "cancelled") {
-      toast({
-        title: t("slackCancelledTitle"),
-        description: t("slackCancelledDesc"),
-      });
-    } else if (slackError === "expired") {
-      toast({
-        variant: "destructive",
-        title: t("slackExpiredTitle"),
-        description: t("slackExpiredDesc"),
-      });
-    } else {
-      toast({
-        variant: "destructive",
-        title: t("slackFailedTitle"),
-        description: t("slackFailedDesc"),
-      });
-    }
-    router.replace("/workspace/integrations/connectors");
-  }, [slackError, allowed, t, toast, router]);
+  // backend). Surface a notice, then the hook strips the param so
+  // refresh/back doesn't re-trigger it (#1382). Cancel is a user choice
+  // (informational toast); expired is retryable (say so); anything else is
+  // destructive. Gated on `allowed` like the slack_install effect — only
+  // admins can run the install flow, so only they get the outcome notice.
+  useConsumeSearchParams(
+    (params) => {
+      const slackError = params.get("slack_error");
+      if (!slackError) return false;
+      if (slackError === "cancelled") {
+        toast({
+          title: t("slackCancelledTitle"),
+          description: t("slackCancelledDesc"),
+        });
+      } else if (slackError === "expired") {
+        toast({
+          variant: "destructive",
+          title: t("slackExpiredTitle"),
+          description: t("slackExpiredDesc"),
+        });
+      } else {
+        toast({
+          variant: "destructive",
+          title: t("slackFailedTitle"),
+          description: t("slackFailedDesc"),
+        });
+      }
+      return true;
+    },
+    { enabled: allowed, cleanUrl: "/workspace/integrations/connectors" },
+  );
 
   const openSettings = useCallback((c: WorkspaceConnectorSummary) => {
     setSettingsFor(c);

--- a/frontend/src/hooks/useConsumeSearchParams.test.ts
+++ b/frontend/src/hooks/useConsumeSearchParams.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tests for useConsumeSearchParams (#1382).
+ *
+ * The hook centralizes the read-params → act → strip pattern shared by the
+ * profile and connectors pages: a `consume` callback inspects the current
+ * search params, acts (toast etc.) and returns true when it handled them;
+ * the hook then marks the group handled (exactly once, safe under React
+ * strict-mode double-invoked effects) and strips the params via
+ * `router.replace(cleanUrl)`.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useConsumeSearchParams } from "./useConsumeSearchParams";
+
+const { mockReplace, paramsHolder } = vi.hoisted(() => ({
+  mockReplace: vi.fn(),
+  paramsHolder: { current: new URLSearchParams() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => paramsHolder.current,
+  useRouter: () => ({ replace: mockReplace }),
+}));
+
+beforeEach(() => {
+  mockReplace.mockReset();
+  paramsHolder.current = new URLSearchParams();
+});
+
+describe("useConsumeSearchParams", () => {
+  it("calls consume with the params and strips via router.replace when consumed", () => {
+    paramsHolder.current = new URLSearchParams("slack_error=failed");
+    const consume = vi.fn().mockReturnValue(true);
+
+    renderHook(() =>
+      useConsumeSearchParams(consume, { cleanUrl: "/connectors" }),
+    );
+
+    expect(consume).toHaveBeenCalledTimes(1);
+    expect(consume.mock.calls[0][0].get("slack_error")).toBe("failed");
+    expect(mockReplace).toHaveBeenCalledWith("/connectors");
+  });
+
+  it("does not strip when consume returns false, and retries on params change", () => {
+    const consume = vi.fn().mockReturnValue(false);
+
+    const { rerender } = renderHook(() =>
+      useConsumeSearchParams(consume, { cleanUrl: "/x" }),
+    );
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    // New params arrive (e.g. client-side navigation) → consume runs again.
+    paramsHolder.current = new URLSearchParams("linked=1");
+    consume.mockReturnValue(true);
+    rerender();
+
+    expect(consume).toHaveBeenCalledTimes(2);
+    expect(mockReplace).toHaveBeenCalledWith("/x");
+  });
+
+  it("defers consumption until enabled becomes true", () => {
+    paramsHolder.current = new URLSearchParams("slack_error=expired");
+    const consume = vi.fn().mockReturnValue(true);
+
+    const { rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useConsumeSearchParams(consume, { enabled, cleanUrl: "/c" }),
+      { initialProps: { enabled: false } },
+    );
+    expect(consume).not.toHaveBeenCalled();
+    expect(mockReplace).not.toHaveBeenCalled();
+
+    rerender({ enabled: true });
+
+    expect(consume).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith("/c");
+  });
+
+  it("consumes exactly once — later rerenders and param changes are ignored", () => {
+    paramsHolder.current = new URLSearchParams("refreshed=1");
+    const consume = vi.fn().mockReturnValue(true);
+
+    const { rerender } = renderHook(() =>
+      useConsumeSearchParams(consume, { cleanUrl: "/profile" }),
+    );
+    expect(consume).toHaveBeenCalledTimes(1);
+
+    rerender();
+    paramsHolder.current = new URLSearchParams("refreshed=1&extra=x");
+    rerender();
+
+    expect(consume).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest consume closure (no stale captures)", () => {
+    const seen: string[] = [];
+    const { rerender } = renderHook(
+      ({ label }: { label: string }) =>
+        useConsumeSearchParams(
+          () => {
+            seen.push(label);
+            return label === "second";
+          },
+          { cleanUrl: "/y" },
+        ),
+      { initialProps: { label: "first" } },
+    );
+
+    paramsHolder.current = new URLSearchParams("a=1");
+    rerender({ label: "second" });
+
+    expect(seen).toEqual(["first", "second"]);
+    expect(mockReplace).toHaveBeenCalledWith("/y");
+  });
+});

--- a/frontend/src/hooks/useConsumeSearchParams.ts
+++ b/frontend/src/hooks/useConsumeSearchParams.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { ReadonlyURLSearchParams } from "next/navigation";
+
+export interface ConsumeSearchParamsOptions {
+  /**
+   * Gate: the consume attempt is deferred until this is true (default true).
+   * Keeps page-specific readiness (RBAC flags, loaded user) at the call site.
+   */
+  enabled?: boolean;
+  /** URL to `router.replace` to after a successful consume (strips the params). */
+  cleanUrl: string;
+}
+
+/**
+ * Consume one-shot search params: read → act → strip (#1382).
+ *
+ * The backend communicates OAuth/link outcomes by redirecting with query
+ * params (`?slack_error=…`, `?refreshed=1`, …). Pages surface a toast and
+ * must then strip the params so refresh/back doesn't re-trigger the notice.
+ * This hook owns the shared mechanics; the page keeps only its `consume`
+ * callback: inspect the params, act, and return `true` when handled.
+ *
+ * Semantics:
+ * - Exactly-once: after a successful consume the group is marked handled via
+ *   a ref, so React strict-mode double-invoked effects (and later param
+ *   changes) cannot re-fire the notice.
+ * - `consume` returning `false` leaves the params untouched and retries on
+ *   the next params change.
+ * - The latest `consume` closure is always used (ref-forwarded), so inline
+ *   callbacks capturing fresh state are safe without effect-dep churn.
+ *
+ * Deliberately NOT used by the login page: its `?error=` banner is
+ * URL-state-driven (never stripped, re-shows on refresh) — state, not a
+ * one-shot event.
+ */
+export function useConsumeSearchParams(
+  consume: (params: ReadonlyURLSearchParams) => boolean,
+  { enabled = true, cleanUrl }: ConsumeSearchParamsOptions,
+): void {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const handled = useRef(false);
+  const consumeRef = useRef(consume);
+  consumeRef.current = consume;
+
+  useEffect(() => {
+    if (handled.current) return;
+    if (!enabled) return;
+    if (!consumeRef.current(searchParams)) return;
+    handled.current = true;
+    router.replace(cleanUrl);
+  }, [searchParams, enabled, cleanUrl, router]);
+}


### PR DESCRIPTION
## Summary

The read-params → act → strip pattern was inlined on multiple pages (noted in PR #1378 / #1384). This extracts a shared `useConsumeSearchParams` hook so the mechanics cannot drift.

Closes #1382

## Changes

- **New `frontend/src/hooks/useConsumeSearchParams.ts`**: group-consume shape — the page passes a `consume(params) => boolean` callback; on `true` the hook marks the group handled (ref-guarded exactly-once, React strict-mode double-effect safe) and strips via `router.replace(cleanUrl)`. `enabled` keeps page-specific readiness gating (RBAC flag, loaded user) at the call site. The latest `consume` closure is ref-forwarded, so inline callbacks capturing fresh state need no effect-dep churn.
- **Migrated**: connectors `slack_error` toast effect (`enabled: allowed`) and the profile `refreshed`/`linked`/`error` group (`enabled: !!user`, replacing its local once-ref). Toast lanes, gating, and strip URLs unchanged.
- **Deliberately not migrated** (scope refined at gate1): the login `?error=` banner is URL-state-driven — never stripped, re-shows on refresh — i.e. state, not a one-shot event; forcing it in would need `once:false, strip:false` escape hatches. The connectors `slack_install` effect (async fetch, error-only strip) is likewise a different shape.

## Test plan

- New hook unit tests 5/5 (consume+strip, false→retry on params change, enabled deferral, exactly-once under rerenders/param changes, latest-closure).
- Existing page tests pass **unchanged** (59/59 across connectors / profile / login) — the behavior-preservation proof.
- tsc clean; /code-review low: no findings.
- Gate1 green (CTO) · Gate2 green ×3 (CSO / QA Lead / CTO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)