### PR TITLE
docs: slim down README, move deep-dive sections into docs/ (#1383)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,3 +225,60 @@ This project includes pre-configured Claude Code tooling in `.claude/`. See the 
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).
+
+## Development with Claude Code
+
+This project is designed to be developed **with** Claude Code and Kagura Memory Cloud itself.
+
+### Getting Started with Claude Code
+
+1. [Install Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+2. Clone the repo and start services (see [README Quick Start](README.md#quick-start))
+3. Create an API key in the Web UI (`http://localhost:3000`)
+4. Create `.mcp.json` in the project root (see [MCP Client Setup](docs/mcp-clients.md))
+
+   > `.mcp.json` is in `.gitignore` — never commit it (contains API keys)
+
+5. Verify in Claude Code:
+   ```
+   > list_contexts()
+   > create_context(name="my-project")
+   ```
+6. Pre-configured tooling loads automatically from `.claude/`:
+
+### Slash Commands
+
+Project-specific local commands (`.claude/commands/`):
+
+| Command | Description |
+|---------|-------------|
+| `/setup` | Set up dev environment from scratch (detects WSL/macOS/Linux) |
+| `/remember <text>` | Save patterns, decisions, or learnings to memory |
+| `/recall <query>` | Search past knowledge for relevant patterns |
+| `/guide` | Show Kagura Memory Cloud usage guide |
+| `/test` | Run full test suite (backend pytest + frontend build) |
+| `/quality` | Run all quality checks (ruff, pyright, frontend build) |
+| `/self-maint` | Audit `.claude/` config against current codebase state |
+| `/api-docs-audit` | Audit OpenAPI tags and endpoint documentation |
+
+The issue→PR workflow lives in the [`kagura-plugins`](https://github.com/kagura-ai/kagura-plugins) marketplace: `/gh-issue-driven:start` (branch + gate1 + recall), `/kagura-code-reviewer` (memory-grounded review), `/gh-issue-driven:ship` (gate2 + PR), `/gh-issue-driven:review` (post-PR loop).
+
+### Hooks (Automatic Safety Guards)
+
+- **Auto-format**: Python (ruff) / TypeScript (prettier) on every file save
+- **Secret detection**: Blocks commits containing hardcoded API keys or passwords
+- **SQL injection prevention**: Blocks f-string SQL queries (enforces SQLAlchemy)
+- **.env protection**: Prevents accidental modification of .env files
+- **Migration protection**: Prevents modification of lock files
+- **Memory sync**: Auto-syncs Claude Code memory files to Kagura Memory Cloud ([details](docs/mcp-clients.md#claude-code-recommended))
+
+### Agents
+
+- **code-reviewer**: Read-only code review against project standards (runs on Sonnet)
+- **test-runner**: Test execution, failure diagnosis, and auto-fix (runs on Sonnet)
+
+### Rules (Auto-loaded Context)
+
+- `rules/backend.md`: FastAPI/Python patterns, async requirements, testing conventions
+- `rules/frontend.md`: Next.js/TypeScript patterns, Tailwind, SWR conventions
+- `rules/security.md`: Auth requirements, RBAC, SQL safety, CORS policy

--- a/README.ja.md
+++ b/README.ja.md
@@ -205,238 +205,29 @@ docker compose up -d
 
 ## MCP クライアント設定
 
-### Claude Code (推奨)
+Claude Code / Claude Desktop / Claude Chat / ChatGPT / Gemini CLI ほか、Streamable HTTP 対応の任意の MCP クライアントから接続できます。
 
-Claude Code + Kagura Memory Cloud で、**セッション / マシン / プロジェクト横断の永続・検索可能・チーム共有メモリ** を AI アシスタントに与えます。
+**Claude Code(3 ステップ):**
 
-**Claude Code の組込みメモリで足りないのはなぜ？**
-
-| | Claude Code メモリ | Kagura Memory Cloud |
-|---|---|---|
-| 保存場所 | ローカルファイル (`~/.claude/`) | クラウド (PostgreSQL + Qdrant) |
-| 検索 | ファイル名のみ | Hybrid Search (semantic + 全文) |
-| 共有 | 単一マシン | RBAC 付き team workspace |
-| 構造 | フラット markdown | 3 層 + Neural Memory graph |
-| プロジェクト横断 | プロジェクトごと | MCP で任意プロジェクト |
-
-**セットアップ (3 ステップ):**
-
-1. サービス起動後 `http://localhost:3000/workspace/integrations/api-keys` で API キー作成
-2. `.mcp.json.example` を `.mcp.json` にコピーし workspace ID と API キーを設定:
+1. サービスを起動し `http://localhost:3000/workspace/integrations/api-keys` で API キーを作成
+2. `.mcp.json.example` を `.mcp.json` にコピーし、workspace ID と API キーを設定:
 
 ```bash
 cp .mcp.json.example .mcp.json
 # .mcp.json を編集 — URL の workspace_id と API キーを入れる
 ```
 
-3. Claude Code を再起動して確認:
-```
-あなた: "メモリの context 一覧を教えて"
-→ AI が list_contexts() を呼ぶ
+3. Claude Code を再起動して動作確認(`recall` / `remember` が呼べれば OK)
 
-あなた: "覚えておいて: API は JWT 1h expiry + refresh token rotation"
-→ AI が remember() で恒久保存
+> `.mcp.json` は `.gitignore` 済み — API キーを含むためコミット禁止。
 
-あなた: "認証について何を知ってる？"
-→ AI が recall() で即検索、数ヶ月後でも発見
-```
-
-> `.mcp.json` は `.gitignore` 済み — 絶対に commit しない (API キーが入るため)。
-> プロジェクトごとはプロジェクトルート、全体設定は `~/.claude/.mcp.json` に配置。
-
-### Claude Desktop / Claude Chat (Web)
-
-**Claude Desktop**: `.mcp.json` の形式は Claude Code と同一。プロジェクトルートまたは `~/.claude/.mcp.json` に置く。
-
-**Claude Chat (claude.ai)**: Settings > Integrations でリモート MCP サーバを追加:
-1. "Add Integration" → "Custom MCP Server"
-2. MCP エンドポイント URL: `https://your-domain.com/mcp/w/{workspace_id}`
-3. `Authorization: Bearer kagura_{your_api_key}` ヘッダを追加
-
-> Claude Chat は `localhost` 不可、公開 URL が必須。production 配備または tunnel (ngrok、Cloudflare Tunnel 等) を使う。
-
-### ChatGPT Desktop
-
-ChatGPT デスクトップ版は MCP サーバ対応。Settings > MCP Servers から追加:
-1. サーバ URL: `https://your-domain.com/mcp/w/{workspace_id}`
-2. 認証: Bearer トークン `kagura_{your_api_key}`
-
-> Claude Chat と同様に公開 URL が必要。ローカル開発では tunnel または REST API 直接使用を推奨。
-
-### Gemini CLI
-
-`.gemini/settings.json` (プロジェクトルートまたは `~/.gemini/settings.json`) に追加:
-
-```json
-{
-  "mcpServers": {
-    "kagura-memory": {
-      "url": "http://localhost:8080/mcp/w/{workspace_id}",
-      "headers": {
-        "Authorization": "Bearer kagura_{your_api_key}"
-      }
-    }
-  }
-}
-```
-
-### その他の MCP クライアント / REST API
-
-MCP 互換クライアントなら Streamable HTTP 経由で接続可。MCP 非対応クライアントは REST API を直接利用:
-
-```bash
-# メモリ検索
-curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "your search", "context_id": "..."}' \
-  http://localhost:8080/api/v1/memories/search
-```
+各クライアントの詳細設定・メモリ同期フック・`.claude/` テンプレート・WSL2 ネットワーク注意点は **[MCP Client Setup](docs/mcp-clients.md)**(英語)を参照してください。
 
 ## MCP ツール
 
-13 カテゴリ・全 63 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
+**13 カテゴリ 63 ツール**: Memory(`remember` / `recall` / `explore` …)、Agent Substrate、Agent Control Plane(preview)、Neural Edges、Contexts、Tags、Files (R2)、Analyses(メモリー分析)、Resources、Secrets(ゼロ知識)、Sleep Maintenance、Usage、API-Key Bindings — 各ツールにロール別アクセス制御。
 
-### Memory (7)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `remember` | 新規メモリ保存 (summary + content + type、任意で `delivery_mode`) | Member+ |
-| `recall` | Hybrid Search でメモリ検索 (`trust_tier` フィルタ対応) | Viewer+ |
-| `recall_nearby` | 決定論の WHERE 軸クエリ — `details.location` を持つメモリを指定地点から `radius_m` 以内・近い順に返す | Viewer+ |
-| `reference` | メモリの 3 層詳細取得 | Viewer+ |
-| `update_memory` | メモリ更新 / 外部 ID で upsert | Member+ |
-| `forget` | ソフト削除 (30 日保持) | Member+ |
-| `explore` | Neural Memory graph で関連メモリ発見 | Viewer+ |
-
-### Agent Substrate (7)
-
-自律エージェントのループに必要なプリミティブ群 — 詳細は [Concepts › Agent Memory Substrate](docs/concepts.md#agent-memory-substrate)。
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `load_pinned` | always-load メモリ (`delivery_mode="always"`) を決定的にロード — Goal / Guardrail / ポリシー用 | Viewer+ |
-| `recall_upcoming` | 近日の Time Memory (`type="time"`、`delivery_mode="on_trigger"`) を列挙 | Viewer+ |
-| `set_state` | エージェントの scratch state を upsert (key→value、任意 TTL、recall から除外) | Editor+ |
-| `get_state` | state を 1 件取得、または context の全 live state を列挙 | Viewer+ |
-| `record_measurement` | metric の系列に数値観測を 1 件 append (HOW-MUCH レーン、recall から除外・Sleep 対象外) | Editor+ |
-| `recall_series` | metric の系列を day/week/month でバケット集計 (avg/min/max/sum/count/last) | Viewer+ |
-| `feedback` | recall したメモリが有用だったかを記録 (append-only シグナル) | Viewer+ |
-
-### Agent Control Plane (10、preview)
-
-v0.49.0 の control plane は既存の workspace RBAC を土台にする。Agent は principal ではなく registry resource であり、context binding は agent-bound member key の権限を減らすことしかできない。Registry、binding、composed bootstrap、W3C Trace Context / baggage correlation、append-only audit 基盤は実装済み。
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `register_agent` | workspace スコープの agent を登録 | Owner/Admin |
-| `list_agents` | 登録 agent と lifecycle/enforcement status を列挙 | Owner/Admin |
-| `get_agent` | agent を 1 件取得 | Owner/Admin |
-| `update_agent` | metadata、`status`、`enforcement_mode` を更新 | Owner/Admin |
-| `delete_agent` | agent と bound key を恒久削除。運用上は `status="retired"` を推奨 | Owner/Admin |
-| `bind_agent_context` | 減算的な context binding を追加 | Owner/Admin |
-| `list_agent_bindings` | agent の context binding 一覧 | Owner/Admin |
-| `update_agent_binding` | read/write/default binding policy を更新 | Owner/Admin |
-| `unbind_agent_context` | binding を削除 (enforce mode では default-deny) | Owner/Admin |
-| `get_agent_bootstrap` | session start 用に context guide + pinned + 任意の trusted recall + upcoming + state を合成 | Agent-bound key または Owner/Admin |
-
-> **Preview 境界:** memory type/source 単位の filter は enforce モードの agent に対し、メモリ読取レーン (recall、recall_nearby、reference、forget、explore、load_pinned、upcoming) で [#1299](https://github.com/kagura-ai/memory-cloud/issues/1299)、列挙/集計面 (list、stats、access-patterns、get_cluster) で [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301) から強制される — `null` = 全 type 許可、`[]` = deny-all。shadow モードはフィルタせず `would_deny` を記録する。`traceparent` と W3C baggage による `agent_id` / `session_id` / `run_id` correlation は実装済みだが、server-side span export は P0 の対象外。`memory_access_events` は bootstrap、load-pinned、feedback、recall、reference、remember、update、forget で稼働し、binding deny / `would_deny` を永続化する。
-
-### Neural Edges (4)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `list_edges` | メモリに接続された edge 一覧 | Viewer+ |
-| `create_edge` | 2 メモリ間に edge 作成 | Member+ |
-| `update_edge` | edge の weight / type 更新 | Member+ |
-| `delete_edge` | 2 メモリ間の edge 削除 | Member+ |
-
-### Contexts (7)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `get_context_info` | context メタデータとガイドライン取得 | Viewer+ |
-| `list_contexts` | workspace 内の context 一覧 | Viewer+ |
-| `create_context` | context 新規作成 | Owner/Admin |
-| `update_context` | context 設定更新 (summary、usage guide、resource_id、is_public) | Editor+ |
-| `delete_context` | context とその全メモリを削除 | Owner/Admin |
-| `merge_contexts` | source context から target context へメモリを統合 | Owner/Admin |
-| `update_search_config` | context 単位で hybrid search 重み、reranker、query-intent routing (`routing_mode`) を調整 | Editor+ |
-
-### Tags (1)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `list_tags` | context 内の tag 語彙一覧 (remember/recall 前に呼んで揃える用途) | Viewer+ |
-
-### Files / R2 添付ファイル (5)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `init_file_upload` | quota 予約 + presigned PUT URL 発行 (R2、≤100 MiB) | Member+ |
-| `complete_file_upload` | R2 PUT 後にアップロード確定、sha256 検証、status=uploaded に遷移 | Member+ |
-| `list_files` | workspace 内のアップロード済み (非削除) ファイル一覧 (新しい順) | Viewer+ |
-| `get_file_download_url` | ファイルへの presigned GET URL 発行 | Viewer+ |
-| `delete_file` | ファイルオブジェクトのソフト削除 | Member+ |
-
-### Analyses — メモリー分析 (5)
-
-メモリを UMAP + KMeans + LLM ラベリング (kouchou-ai 方式) で大規模クラスタリング。質的分析用途。
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `analyze_context` | 分析 run 開始 (`dry_run=true` でコスト試算のみ可) | Owner + Pro プラン + BYOK + quota |
-| `list_analyses` | context の過去分析 run 一覧 | Owner |
-| `get_analysis` | 完了済み分析 (クラスタ、ラベル、統計) 取得 | Owner |
-| `get_active_analysis` | 実行中分析の取得 (あれば) | Owner |
-| `get_cluster` | 単一クラスタの所属メモリを drilldown | Owner |
-
-分析 run は `ANALYSIS_MAX_MEMORY_COUNT` (既定 10,000、preview/start の両方で超過を拒否) で上限を持つ。v0.47.0 以降、cancel は all-or-nothing、削除済み context の run は REST/MCP の双方で不可視、strict BYOK labeling は platform key へ fallback せず、labeling 対象 cluster の過半数が失敗した run は `failed` になる。
-
-### Resources — 外部データ取り込み (6)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `setup_resource` | public context 作成 + resource token 発行 | Owner/Admin + Pro プラン |
-| `setup_connector` | ai-worker チャットコネクタを provision (resource + connector 行 + token) | Owner/Admin + connector seats |
-| `list_resource_tokens` | workspace の有効 resource token 一覧 | Owner/Admin |
-| `ingest_events` | resource に batch upsert/delete events (最大 100 events、session-auth MCP 経路) | Member+ |
-| `get_resource_impact` | resource 統計 (token 数、memory 数、schema version) | Viewer+ |
-| `get_resource_schema` | resource のフィールド定義取得 | Viewer+ |
-
-### Secrets (5)
-
-ゼロ知識シークレットストア: サーバーは `age` 公開受信者キーと不透明な ciphertext のみを保持し、**復号は一切行わない**。暗号化・復号はすべてクライアント側 (`kagura secret` CLI / SDK)。`list` はメタデータのみを返し、平文値を返すエンドポイントは存在しない。
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `secret_register_pubkey` | 自分の `age` 受信者公開鍵を登録 (pending で開始、owner 承認後に grant 受領可) | Member+ |
-| `secret_put` | age 暗号化 ciphertext を保存 + 承認済み受信者へ grant (`recipients_snapshot` は `grant_pubkey_ids` と完全一致必須) | Owner/Admin |
-| `secret_get` | 有効な grant を持つ ciphertext を取得 (ローカルで復号、全 fetch は改竄検知監査ログに記録) | Member+ |
-| `secret_list` | secret 名 + メタデータ (status、version、grant 数、rotation フラグ) を列挙 — 値は返さない | Owner/Admin |
-| `secret_revoke_grant` | 受信者の grant を revoke し secret を `rotation_needed` にフラグ (遡及不可 — 上流を rotate) | Owner/Admin |
-
-### Sleep Maintenance (3)
-
-バックグラウンドでメモリ統合 (decay、edge pruning、テーマ要約) を実行。
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `get_sleep_history` | 過去 sleep run 一覧 | Viewer+ |
-| `get_sleep_report` | sleep run の詳細レポート (全 action 込み) | Viewer+ |
-| `rollback_sleep_run` | 完了済み sleep run の全 action をロールバック | Member+ (report 作成者のみ) |
-
-### Usage (1)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `get_usage` | workspace の現在使用量 (memory / context / member / MCP 呼出/日) | Viewer+ |
-
-### API-Key Bindings (2)
-
-| ツール | 説明 | 必要ロール |
-|--------|------|------------|
-| `list_my_bindings` | public-bound API キー一覧 (read-only、owner スコープ) | Viewer+ |
-| `describe_binding` | `key_id` か `context_id` の一方で binding を 1 件記述 (read-only、owner スコープ) | Viewer+ |
+ツールごとの詳細と必要ロール: **[MCP Tools Reference](docs/mcp-tools.md)**(英語)
 
 ## REST API
 
@@ -458,39 +249,14 @@ MCP ツールに加えてフル REST API を提供:
 
 2 つの OAuth2 プロバイダをサポート:
 
-- **Google OAuth2** — 必須。`GOOGLE_CLIENT_ID` と `GOOGLE_CLIENT_SECRET` を設定
+- **Google OAuth2** — 任意。`GOOGLE_CLIENT_ID` と `GOOGLE_CLIENT_SECRET` を設定
 - **GitHub OAuth2** — 任意。`GITHUB_CLIENT_ID` と `GITHUB_CLIENT_SECRET` を設定
 
-プロバイダ間で同じメールアドレスのユーザは単一アカウントを共有。
+プロバイダ間で同じメールアドレスのユーザは単一アカウントを共有。OAuth プロバイダなしでもパスワード + MFA ログインが利用できます。
 
 ## プランティア カスタマイズ
 
-プランは workspace ごとのリソース上限を制御。既定:
-
-| プラン | Contexts | Memories | MCP 呼出/日 |
-|--------|----------|----------|------------|
-| S (Free) | 1 | 1,000 | 1,000 |
-| M (Basic) | 3 | 10,000 | 10,000 |
-| L (Pro) | 20 | 100,000 | 50,000 |
-
-環境変数でオーバーライド:
-
-```bash
-PLAN_FREE_MAX_CONTEXTS=5
-PLAN_FREE_MEMORY_LIMIT=5000
-PLAN_BASIC_MAX_CONTEXTS=10
-PLAN_PRO_MAX_CONTEXTS=50
-```
-
-セルフホストの個人利用では自分の workspace に L (Pro) を割当て。プラン変更は既定で admin のみ。SaaS で self-service billing を使う場合は Stripe を有効化:
-
-```bash
-BILLING_ENABLED=true
-STRIPE_SECRET_KEY=sk_...
-STRIPE_WEBHOOK_SECRET=whsec_...
-STRIPE_PRICE_BASIC=price_xxx
-STRIPE_PRICE_PRO=price_yyy
-```
+プランは workspace ごとのリソース上限(contexts / memories / MCP 呼出/日)を制御します。セルフホストの単独利用では自分の workspace に L (Pro) プランを割り当ててください。既定値・環境変数での上書き・Stripe 課金の有効化: **[Deployment → Plan Tiers](docs/deployment.md#plan-tiers)**(英語)
 
 ## Claude Code プラグイン
 
@@ -538,6 +304,9 @@ STRIPE_PRICE_PRO=price_yyy
 - **エンドポイント (ライブ)**: `http://localhost:8080/redoc` — FastAPI から自動生成、稼働バックエンドと常に同期
 
 **コンセプトとガイド:**
+
+- [MCP Client Setup](docs/mcp-clients.md) — 各クライアントの接続設定(英語)
+- [MCP Tools Reference](docs/mcp-tools.md) — 全 63 ツールと必要ロール(英語)
 
 - [Core Concepts](docs/concepts.md) — Workspace、Context、Memory、Neural Memory、MCP ツール
 - [Architecture](docs/architecture.md) — システム設計とデータフロー

--- a/README.md
+++ b/README.md
@@ -219,23 +219,11 @@ docker compose up -d
 
 </details>
 
-## MCP Client Setup
+## Connect an MCP Client
 
-### Claude Code (Recommended)
+Works with Claude Code, Claude Desktop, Claude Chat, ChatGPT, Gemini CLI, and any Streamable-HTTP MCP client.
 
-Claude Code + Kagura Memory Cloud gives your AI assistant **persistent, searchable, team-shareable memory** that works across sessions, machines, and projects.
-
-**Why not just use Claude Code's built-in memory?**
-
-| | Claude Code Memory | Kagura Memory Cloud |
-|---|---|---|
-| Storage | Local files (`~/.claude/`) | Cloud (PostgreSQL + Qdrant) |
-| Search | File name only | Hybrid Search (semantic + full-text) |
-| Sharing | Single machine | Team workspace with RBAC |
-| Structure | Flat markdown | 3-layer architecture + Neural Memory graph |
-| Cross-project | Per-project only | Any project via MCP |
-
-**Setup (3 steps):**
+**Claude Code (3 steps):**
 
 1. Start services and open `http://localhost:3000/workspace/integrations/api-keys` to create an API key
 2. Copy `.mcp.json.example` to `.mcp.json` and fill in your workspace ID and API key:
@@ -246,10 +234,8 @@ cp .mcp.json.example .mcp.json
 ```
 
 3. Restart Claude Code and verify:
-```
-You: "List my memory contexts"
-→ AI calls list_contexts()
 
+```
 You: "Remember: our API uses JWT with 1h expiry and refresh token rotation"
 → AI calls remember() — stored permanently
 
@@ -258,310 +244,14 @@ You: "What do we know about auth?"
 ```
 
 > `.mcp.json` is in `.gitignore` — never commit it (contains API keys).
-> Place in project root for per-project config, or `~/.claude/.mcp.json` for global access.
 
-<details>
-<summary>Auto-sync Claude Code memory to Kagura (optional)</summary>
-
-Kagura Memory Cloud includes a hook that **automatically syncs** Claude Code's local memory files to the cloud whenever they're updated. This means your local `~/.claude/` memories are also searchable via Hybrid Search and shared with your team.
-
-Add these environment variables to `.env.local`:
-
-```bash
-KAGURA_MCP_URL=http://localhost:8080/mcp/w/{workspace_id}
-KAGURA_MCP_TOKEN=kagura_{your_api_key}
-KAGURA_CONTEXT_ID={context_id}  # optional — auto-detected from project name if omitted
-```
-
-The sync hook is pre-configured in `.claude/settings.json` and runs automatically on every memory file write.
-
-</details>
-
-<details>
-<summary>Claude Code integration templates (copy to your project)</summary>
-
-This repo's `.claude/` directory is a **ready-to-use template** for integrating Kagura Memory Cloud into any project. Copy what you need:
-
-**Slash commands** — drop into your project's `.claude/commands/`:
-```
-/recall <query>   → Search past knowledge via MCP
-/remember <text>  → Save decisions, patterns, learnings via MCP
-/guide            → Show setup and usage guide
-```
-
-**Hooks** (`.claude/settings.json`) — auto-configured safety guards:
-```
-Auto-format    → ruff (Python) / prettier (TypeScript) on every save
-Secret detect  → Blocks hardcoded API keys or passwords
-SQL injection  → Blocks f-string SQL (enforces parameterized queries)
-Memory sync    → Auto-syncs Claude Code memory files to Kagura Cloud
-```
-
-**Agents** (`.claude/agents/`) — specialized sub-agents:
-```
-code-reviewer  → Read-only code review against project standards
-test-runner    → Run tests, diagnose failures, auto-fix
-```
-
-**Rules** (`.claude/rules/`) — auto-loaded project conventions:
-```
-backend.md     → FastAPI/Python patterns, async, testing
-frontend.md    → Next.js/TypeScript, Tailwind, SWR
-security.md    → Auth, RBAC, SQL safety, CORS
-```
-
-All of these are designed to work together with Kagura Memory Cloud MCP tools. Adapt them for your own project by editing the prompts and context IDs.
-
-</details>
-
-<details>
-<summary>Claude Code Plugin (use Kagura in any project)</summary>
-
-The **kagura-memory** plugin adds session management and memory workflow skills to Claude Code. Install it once and use it across all your projects.
-
-**Install:**
-
-```bash
-# From marketplace
-/plugin marketplace add kagura-ai/memory-cloud
-/plugin install kagura-memory@kagura-memory-cloud
-```
-
-**Available skills:**
-
-| Skill | Description |
-|-------|-------------|
-| `/kagura-memory:session-start` | Restore previous session context on start |
-| `/kagura-memory:session-summary` | Save session knowledge before ending |
-| `/kagura-memory:recall` | Search past knowledge |
-| `/kagura-memory:remember` | Save new knowledge |
-| `/kagura-memory:guide` | Usage guide, connection status, and setup help |
-| `/kagura-memory:smoke-test` | Verify all MCP tools work |
-
-**Recommended workflow:**
-
-```
-/kagura-memory:session-start       # ← Start here: restore context from last session
-  ... work normally ...
-/kagura-memory:recall              # Search past decisions, patterns, fixes
-/kagura-memory:remember            # Save important learnings as you go
-  ... finish work ...
-/kagura-memory:session-summary     # ← End here: save session knowledge for next time
-```
-
-Skills wrap the raw MCP tools (`recall`, `remember`, etc.) with workflow logic — context selection, git state analysis, and structured prompts. Use skills for session management and guided workflows; use MCP tools directly for fine-grained operations.
-
-Run `/kagura-memory:guide` for setup help and an optional SessionStart hook you can add to your project.
-
-> **Prerequisite:** MCP connection must be configured (`.mcp.json` with API key). Run `/kagura-memory:guide` in your project to set it up.
-
-</details>
-
-### WSL2 + Claude Code (NAT networking note)
-
-If you run Claude Code **inside WSL2** and use the **OAuth** flow (not the API-key setup above), the browser callback can fail silently: WSL2's default `nat` mode isolates `localhost` between Windows and WSL, so the Windows browser's redirect to `localhost:<port>` never reaches Claude Code's listener inside WSL. **This is a WSL networking issue, not a Kagura server bug** — the resolved server-side cousin was [#689 / PR #692](https://github.com/kagura-ai/memory-cloud/pull/692).
-
-Quick fixes:
-
-- **Enable mirrored networking** — set `networkingMode=mirrored` in `C:\Users\<YourName>\.wslconfig`, then `wsl --shutdown` (requires WSL 2.0.0+ on Windows 11 22H2+).
-- **Use API key (Bearer) auth** — the `.mcp.json` setup above skips the OAuth callback entirely.
-- **Use the device flow** ([#635 / PR #636](https://github.com/kagura-ai/memory-cloud/pull/636), RFC 8628) if your client supports it.
-
-See [Troubleshooting → WSL2 + Claude Code](docs/troubleshooting.md#wsl2--claude-code--mcp-oauth-callback-fails-default-nat-networking) for the full symptom → diagnosis → fix walkthrough.
-
-### Claude Desktop / Claude Chat (Web)
-
-**Claude Desktop**: Same `.mcp.json` format as Claude Code — place in your project root or `~/.claude/.mcp.json`.
-
-**Claude Chat (claude.ai)**: Add as a remote MCP server in Settings > Integrations:
-1. Click "Add Integration" → "Custom MCP Server"
-2. Enter the MCP endpoint URL: `https://your-domain.com/mcp/w/{workspace_id}`
-3. Add the `Authorization: Bearer kagura_{your_api_key}` header
-
-> Claude Chat requires a publicly accessible URL (not `localhost`). Use a production deployment or tunnel (e.g., ngrok, Cloudflare Tunnel).
-
-### ChatGPT Desktop
-
-ChatGPT desktop app supports MCP servers. Add via Settings > MCP Servers:
-1. Server URL: `https://your-domain.com/mcp/w/{workspace_id}`
-2. Authentication: Bearer token `kagura_{your_api_key}`
-
-> Like Claude Chat, ChatGPT requires a public URL. For local development, use a tunnel or the REST API directly.
-
-### Gemini CLI
-
-Add to `.gemini/settings.json` (project root or `~/.gemini/settings.json`):
-
-```json
-{
-  "mcpServers": {
-    "kagura-memory": {
-      "url": "http://localhost:8080/mcp/w/{workspace_id}",
-      "headers": {
-        "Authorization": "Bearer kagura_{your_api_key}"
-      }
-    }
-  }
-}
-```
-
-### Other MCP Clients / REST API
-
-Any MCP-compatible client can connect via Streamable HTTP. For clients without MCP support, use the REST API directly:
-
-```bash
-# Search memories
-curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "your search", "context_id": "..."}' \
-  http://localhost:8080/api/v1/memories/search
-```
+Full setup guide — every client, the memory-sync hook, the ready-to-use `.claude/` templates, the **kagura-memory** Claude Code plugin, and the WSL2 networking note: **[MCP Client Setup](docs/mcp-clients.md)**
 
 ## MCP Tools
 
-63 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+**63 tools across 13 categories**: Memory (`remember` / `recall` / `explore` …), Agent Substrate (pinned + time-triggered delivery, state, measurements, feedback), Agent Control Plane (preview), Neural Edges, Contexts, Tags, Files (R2), Analyses (Memory Analysis), Resources, Secrets (zero-knowledge), Sleep Maintenance, Usage, and API-Key Bindings — each with per-role access control.
 
-### Memory (7)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `remember` | Store a new memory (summary + content + type; optional `delivery_mode`) | Member+ |
-| `recall` | Search memories with Hybrid Search (supports `trust_tier` filter) | Viewer+ |
-| `recall_nearby` | Deterministic WHERE-axis query — memories with `details.location` within `radius_m` of a point, nearest first | Viewer+ |
-| `reference` | Get full 3-layer details of a memory | Viewer+ |
-| `update_memory` | Update an existing memory in-place or upsert by external ID | Member+ |
-| `forget` | Soft-delete a memory (30-day retention) | Member+ |
-| `explore` | Discover related memories via Neural Memory graph | Viewer+ |
-
-### Agent Substrate (7)
-
-The primitives an autonomous agent loop needs beyond a knowledge store — see [Concepts › Agent Memory Substrate](docs/concepts.md#agent-memory-substrate).
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `load_pinned` | Deterministically load always-load memories (`delivery_mode="always"`) — Goal / Guardrail / policy | Viewer+ |
-| `recall_upcoming` | List upcoming Time Memories (`type="time"`, `delivery_mode="on_trigger"`) | Viewer+ |
-| `set_state` | Upsert agent scratch state (key→value, optional TTL; excluded from recall) | Editor+ |
-| `get_state` | Read one state key, or list all live state for a context | Viewer+ |
-| `record_measurement` | Append one numeric observation to a metric's series (HOW-MUCH lane; excluded from recall, untouched by Sleep) | Editor+ |
-| `recall_series` | Read a metric's series bucketed by day/week/month with avg/min/max/sum/count/last | Viewer+ |
-| `feedback` | Record whether a recalled memory was helpful (append-only signal) | Viewer+ |
-
-### Agent Control Plane (10, preview)
-
-The v0.49.0 control plane builds on existing workspace RBAC: agents are registry resources, not principals, and context bindings can only remove access from an agent-bound member key. Registry, bindings, composed bootstrap, W3C Trace Context/baggage correlation, and the append-only audit foundation are implemented.
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `register_agent` | Register a workspace-scoped agent | Owner/Admin |
-| `list_agents` | List registered agents and lifecycle/enforcement status | Owner/Admin |
-| `get_agent` | Get one registered agent | Owner/Admin |
-| `update_agent` | Update metadata, `status`, or `enforcement_mode` | Owner/Admin |
-| `delete_agent` | Permanently delete an agent and its bound keys; prefer `status="retired"` operationally | Owner/Admin |
-| `bind_agent_context` | Add a purely subtractive context binding | Owner/Admin |
-| `list_agent_bindings` | List an agent's context bindings | Owner/Admin |
-| `update_agent_binding` | Update read/write/default binding policy | Owner/Admin |
-| `unbind_agent_context` | Remove a binding (default-deny in enforce mode) | Owner/Admin |
-| `get_agent_bootstrap` | Compose context guide + pinned + optional trusted recall + upcoming + state for session start | Agent-bound key or Owner/Admin |
-
-> **Preview boundary:** per-memory type/source filters are enforced on the memory-read lanes (recall, recall_nearby, reference, forget, explore, load_pinned, upcoming) for enforce-mode agents as of [#1299](https://github.com/kagura-ai/memory-cloud/issues/1299) — and on the enumeration/aggregate surfaces (list, stats, access-patterns, get_cluster) as of [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301) — `null` = all types, `[]` = deny-all; shadow mode records `would_deny` without filtering. `traceparent` plus W3C baggage correlation for `agent_id` / `session_id` / `run_id` is implemented, but server-side span export remains out of scope for P0. `memory_access_events` is live for bootstrap, load-pinned, feedback, recall, reference, remember, update, and forget with binding deny / `would_deny` persistence.
-
-### Neural Edges (4)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `list_edges` | List edges connected to a memory | Viewer+ |
-| `create_edge` | Create an edge between two memories | Member+ |
-| `update_edge` | Update edge weight or type | Member+ |
-| `delete_edge` | Delete an edge between two memories | Member+ |
-
-### Contexts (7)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `get_context_info` | Get context metadata and guidelines | Viewer+ |
-| `list_contexts` | List available contexts in workspace | Viewer+ |
-| `create_context` | Create a new context | Owner/Admin |
-| `update_context` | Update context settings (summary, usage guide, resource_id, is_public) | Editor+ |
-| `delete_context` | Delete a context and all its memories | Owner/Admin |
-| `merge_contexts` | Merge memories from source context into target context | Owner/Admin |
-| `update_search_config` | Tune hybrid search weights, reranker settings, and query-intent routing (`routing_mode`) per context | Editor+ |
-
-### Tags (1)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `list_tags` | List tag vocabulary in a context (call before remember/recall to align tagging) | Viewer+ |
-
-### Files / R2 Attachments (5)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `init_file_upload` | Reserve quota + return presigned PUT URL (R2, ≤100 MiB) | Member+ |
-| `complete_file_upload` | Finalize upload after R2 PUT, verify sha256, mark as uploaded | Member+ |
-| `list_files` | List uploaded, non-deleted files in the workspace (newest first) | Viewer+ |
-| `get_file_download_url` | Issue presigned GET URL for a file | Viewer+ |
-| `delete_file` | Soft-delete a file object | Member+ |
-
-### Analyses — Memory Analysis (5)
-
-Cluster memories into themes (kouchou-ai-style UMAP + KMeans + LLM labeling) for large-scale qualitative analysis.
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `analyze_context` | Start an analysis run (or preview cost with `dry_run=true`) | Owner + Pro plan + BYOK + quota |
-| `list_analyses` | List past analysis runs for a context | Owner |
-| `get_analysis` | Get a completed analysis (clusters, labels, stats) | Owner |
-| `get_active_analysis` | Get the in-flight analysis for a context (if any) | Owner |
-| `get_cluster` | Drill into a single cluster's member memories | Owner |
-
-Analysis runs are capped by `ANALYSIS_MAX_MEMORY_COUNT` (default 10,000; preview and start reject larger contexts). Since v0.47.0, cancellation is all-or-nothing, deleted-context runs are invisible on both REST and MCP, strict BYOK labeling never falls back to the platform key, and runs fail when more than half of labelable clusters fail labeling.
-
-### Resources — External Data Ingestion (6)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `setup_resource` | Create public context + issue resource token | Owner/Admin + Pro plan |
-| `setup_connector` | Provision an ai-worker chat connector (resource + connector row + token) | Owner/Admin + connector seats |
-| `list_resource_tokens` | List active resource tokens for your workspace | Owner/Admin |
-| `ingest_events` | Batch upsert/delete events into a resource (max 100 events; session-auth MCP variant) | Member+ |
-| `get_resource_impact` | Resource stats (tokens, memories, schema version) | Viewer+ |
-| `get_resource_schema` | Field definitions for a resource | Viewer+ |
-
-### Secrets (5)
-
-Zero-knowledge secret store: the server holds only `age` public recipient keys and opaque ciphertext, and **never decrypts**. Encryption/decryption happen client-side (the `kagura secret` CLI / SDK). `list` returns metadata only — there is no endpoint that returns a plaintext value.
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `secret_register_pubkey` | Register your own `age` recipient public key (starts pending; an owner approves it before it can receive grants) | Member+ |
-| `secret_put` | Store age-encrypted ciphertext + grant approved recipients (`recipients_snapshot` must match `grant_pubkey_ids`) | Owner/Admin |
-| `secret_get` | Fetch ciphertext you hold an active grant for (decrypt locally; every fetch is recorded in a tamper-evident audit log) | Member+ |
-| `secret_list` | List secret names + metadata (status, version, grant count, rotation flag) — never values | Owner/Admin |
-| `secret_revoke_grant` | Revoke a recipient's grant and flag the secret `rotation_needed` (not retroactive — rotate upstream) | Owner/Admin |
-
-### Sleep Maintenance (3)
-
-Background consolidation of memories (decay, edge pruning, theme summarization).
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `get_sleep_history` | List past sleep runs | Viewer+ |
-| `get_sleep_report` | Detailed sleep report with all actions | Viewer+ |
-| `rollback_sleep_run` | Rollback all actions from a completed sleep run | Member+ (report owner only) |
-
-### Usage (1)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `get_usage` | Get current workspace usage (memories, contexts, members, MCP calls/day) | Viewer+ |
-
-### API-Key Bindings (2)
-
-| Tool | Description | Required Role |
-|------|------------|---------------|
-| `list_my_bindings` | List your public-bound API keys (read-only; owner-scoped) | Viewer+ |
-| `describe_binding` | Describe one binding by `key_id` XOR `context_id` (read-only; owner-scoped) | Viewer+ |
+Tool-by-tool reference with required roles: **[MCP Tools Reference](docs/mcp-tools.md)**
 
 ## REST API
 
@@ -583,96 +273,18 @@ Full API documentation: `http://localhost:8080/redoc`
 
 Two OAuth2 providers are supported:
 
-- **Google OAuth2** — Required. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+- **Google OAuth2** — Optional. Set `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
 - **GitHub OAuth2** — Optional. Set `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`
 
-Users with the same email address across providers share a single account.
+Users with the same email address across providers share a single account. Password + MFA login is available without any OAuth provider (see [Quick Start](#quick-start)).
 
 ## Plan Tier Customization
 
-Plans control resource limits per workspace. Defaults:
-
-| Plan | Contexts | Memories | MCP calls/day |
-|------|----------|----------|---------------|
-| S (Free) | 1 | 1,000 | 1,000 |
-| M (Basic) | 3 | 10,000 | 10,000 |
-| L (Pro) | 20 | 100,000 | 50,000 |
-
-Override via environment variables:
-
-```bash
-PLAN_FREE_MAX_CONTEXTS=5
-PLAN_FREE_MEMORY_LIMIT=5000
-PLAN_BASIC_MAX_CONTEXTS=10
-PLAN_PRO_MAX_CONTEXTS=50
-```
-
-For self-hosted single-user setups, assign the L (Pro) plan to your workspace. Plan changes are **admin-only** by default. For SaaS deployments with self-service billing, enable Stripe:
-
-```bash
-BILLING_ENABLED=true
-STRIPE_SECRET_KEY=sk_...
-STRIPE_WEBHOOK_SECRET=whsec_...
-STRIPE_PRICE_BASIC=price_xxx
-STRIPE_PRICE_PRO=price_yyy
-```
+Plans control per-workspace resource limits (contexts / memories / MCP calls per day). For self-hosted single-user setups, assign the L (Pro) plan to your workspace. Defaults, environment-variable overrides, and optional Stripe self-service billing: **[Deployment → Plan Tiers](docs/deployment.md#plan-tiers)**
 
 ## Development with Claude Code
 
-This project is designed to be developed **with** Claude Code and Kagura Memory Cloud itself.
-
-### Getting Started with Claude Code
-
-1. [Install Claude Code](https://docs.anthropic.com/en/docs/claude-code)
-2. Clone the repo and start services (see [Quick Start](#quick-start))
-3. Create an API key in the Web UI (`http://localhost:3000`)
-4. Create `.mcp.json` in the project root (see [Claude Code setup](#claude-code--claude-desktop))
-
-   > `.mcp.json` is in `.gitignore` — never commit it (contains API keys)
-
-5. Verify in Claude Code:
-   ```
-   > list_contexts()
-   > create_context(name="my-project")
-   ```
-6. Pre-configured tooling loads automatically from `.claude/`:
-
-### Slash Commands
-
-Project-specific local commands (`.claude/commands/`):
-
-| Command | Description |
-|---------|-------------|
-| `/setup` | Set up dev environment from scratch (detects WSL/macOS/Linux) |
-| `/remember <text>` | Save patterns, decisions, or learnings to memory |
-| `/recall <query>` | Search past knowledge for relevant patterns |
-| `/guide` | Show Kagura Memory Cloud usage guide |
-| `/test` | Run full test suite (backend pytest + frontend build) |
-| `/quality` | Run all quality checks (ruff, pyright, frontend build) |
-| `/self-maint` | Audit `.claude/` config against current codebase state |
-| `/api-docs-audit` | Audit OpenAPI tags and endpoint documentation |
-
-The issue→PR workflow lives in the [`kagura-plugins`](https://github.com/kagura-ai/kagura-plugins) marketplace: `/gh-issue-driven:start` (branch + gate1 + recall), `/kagura-code-reviewer` (memory-grounded review), `/gh-issue-driven:ship` (gate2 + PR), `/gh-issue-driven:review` (post-PR loop).
-
-### Hooks (Automatic Safety Guards)
-
-- **Auto-format**: Python (ruff) / TypeScript (prettier) on every file save
-- **Secret detection**: Blocks commits containing hardcoded API keys or passwords
-- **SQL injection prevention**: Blocks f-string SQL queries (enforces SQLAlchemy)
-- **.env protection**: Prevents accidental modification of .env files
-- **Migration protection**: Prevents modification of lock files
-- **Memory sync**: Auto-syncs Claude Code memory files to Kagura Memory Cloud ([details](#claude-code-recommended))
-
-### Agents
-
-- **code-reviewer**: Read-only code review against project standards (runs on Sonnet)
-- **test-runner**: Test execution, failure diagnosis, and auto-fix (runs on Sonnet)
-
-### Rules (Auto-loaded Context)
-
-- `rules/backend.md`: FastAPI/Python patterns, async requirements, testing conventions
-- `rules/frontend.md`: Next.js/TypeScript patterns, Tailwind, SWR conventions
-- `rules/security.md`: Auth requirements, RBAC, SQL safety, CORS policy
+This project is designed to be developed **with** Claude Code and Kagura Memory Cloud itself — pre-configured slash commands, safety hooks, sub-agents, and rules load automatically from `.claude/`. Setup and the full tooling reference: **[Contributing → Development with Claude Code](CONTRIBUTING.md#development-with-claude-code)**
 
 ## Documentation
 
@@ -684,6 +296,8 @@ The issue→PR workflow lives in the [`kagura-plugins`](https://github.com/kagur
 **Concepts & guides:**
 
 - [Core Concepts](docs/concepts.md) — Workspace, Context, Memory, Neural Memory, MCP Tools
+- [MCP Client Setup](docs/mcp-clients.md) — Claude Code / Desktop / Chat, ChatGPT, Gemini CLI, plugin & templates
+- [MCP Tools Reference](docs/mcp-tools.md) — All 63 tools with required roles
 - [Architecture](docs/architecture.md) — System design and data flow
 - [Getting Started](docs/getting-started.md) — Detailed setup guide
 - [Chunking Guide](docs/chunking-guide.md) — Best practices for memory storage
@@ -696,47 +310,6 @@ The issue→PR workflow lives in the [`kagura-plugins`](https://github.com/kagur
 - [Security](SECURITY.md) — Vulnerability reporting, security design
 - [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` and `KaguraAgent` for Python
 - **Project site**: [www.kagura-ai.com](https://www.kagura-ai.com) — overview, use cases, getting started paths
-
-## 🇯🇵 日本語ガイド / Japanese Guide
-
-<details>
-<summary>Claude Code プラグインの使い方</summary>
-
-### インストール
-
-```bash
-# マーケットプレイスから追加
-/plugin marketplace add kagura-ai/memory-cloud
-/plugin install kagura-memory@kagura-memory-cloud
-```
-
-### 利用可能なスキル
-
-| スキル | 説明 |
-|--------|------|
-| `/kagura-memory:session-start` | 前回のセッションコンテキストを復元 |
-| `/kagura-memory:session-summary` | セッション終了前に知識を保存 |
-| `/kagura-memory:recall` | 過去の知識を検索 |
-| `/kagura-memory:remember` | 新しい知識を保存 |
-| `/kagura-memory:guide` | 使い方ガイド・接続確認・セットアップ |
-| `/kagura-memory:smoke-test` | 全MCPツールの動作確認 |
-
-### 推奨ワークフロー
-
-```
-/kagura-memory:session-start       # ← ここから：前回のコンテキストを復元
-  ... 通常の作業 ...
-/kagura-memory:recall              # 過去の設計判断・パターン・修正を検索
-/kagura-memory:remember            # 重要な学びを都度保存
-  ... 作業完了 ...
-/kagura-memory:session-summary     # ← ここで終了：次回のためにセッション知識を保存
-```
-
-スキルは MCP ツール（`recall`, `remember` など）をワークフローロジックで包んだものです。コンテキスト選択、git 状態の分析、構造化プロンプトが組み込まれています。セッション管理やガイド付きワークフローにはスキルを、細かい操作には MCP ツールを直接使ってください。
-
-> **前提条件:** MCP接続の設定が必要です（`.mcp.json` に API キーを設定）。プロジェクトで `/kagura-memory:guide` を実行してセットアップしてください。
-
-</details>
 
 ## Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@
 
 - [Getting Started](getting-started.md) — Installation, setup, and first steps
 - [Core Concepts](concepts.md) — Workspace, Context, Memory, Neural Memory, MCP Tools
+- [MCP Client Setup](mcp-clients.md) — Claude Code / Desktop / Chat, ChatGPT, Gemini CLI, plugin & templates, WSL2 note
+- [MCP Tools Reference](mcp-tools.md) — All 63 tools with required roles
 
 ## Architecture & API
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -353,3 +353,34 @@ pre-tokenized FTS text. Semantic + BM25 hybrid fusion is unchanged.
 
 Configuration: `KAGURA_VECTOR_BACKEND` (`qdrant` | `lance`, default `qdrant`)
 and `KAGURA_LANCE_DB_PATH`. Implementation: `backend/src/db/lance_store.py`.
+
+## Plan Tiers
+
+Plans control resource limits per workspace. Defaults:
+
+| Plan | Contexts | Memories | MCP calls/day |
+|------|----------|----------|---------------|
+| S (Free) | 1 | 1,000 | 1,000 |
+| M (Basic) | 3 | 10,000 | 10,000 |
+| L (Pro) | 20 | 100,000 | 50,000 |
+
+Override via environment variables:
+
+```bash
+PLAN_FREE_MAX_CONTEXTS=5
+PLAN_FREE_MEMORY_LIMIT=5000
+PLAN_BASIC_MAX_CONTEXTS=10
+PLAN_PRO_MAX_CONTEXTS=50
+```
+
+For self-hosted single-user setups, assign the L (Pro) plan to your workspace. Plan changes are **admin-only** by default. For SaaS deployments with self-service billing, enable Stripe:
+
+```bash
+BILLING_ENABLED=true
+STRIPE_SECRET_KEY=sk_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_BASIC=price_xxx
+STRIPE_PRICE_PRO=price_yyy
+```
+
+Plan display names in the web UI can be customized via `NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME` / `BASIC` / `PRO` (see [Frontend Environment Variables](#frontend-environment-variables)).

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -1,0 +1,200 @@
+# MCP Client Setup
+
+How to connect MCP clients (Claude Code, Claude Desktop/Chat, ChatGPT, Gemini CLI, and any Streamable-HTTP client) to a self-hosted Kagura Memory Cloud. Start from the [README Quick Start](../README.md#quick-start) if your server isn't running yet; the full tool list is in the [MCP Tools Reference](mcp-tools.md).
+
+
+## Claude Code (Recommended)
+
+Claude Code + Kagura Memory Cloud gives your AI assistant **persistent, searchable, team-shareable memory** that works across sessions, machines, and projects.
+
+**Why not just use Claude Code's built-in memory?**
+
+| | Claude Code Memory | Kagura Memory Cloud |
+|---|---|---|
+| Storage | Local files (`~/.claude/`) | Cloud (PostgreSQL + Qdrant) |
+| Search | File name only | Hybrid Search (semantic + full-text) |
+| Sharing | Single machine | Team workspace with RBAC |
+| Structure | Flat markdown | 3-layer architecture + Neural Memory graph |
+| Cross-project | Per-project only | Any project via MCP |
+
+**Setup (3 steps):**
+
+1. Start services and open `http://localhost:3000/workspace/integrations/api-keys` to create an API key
+2. Copy `.mcp.json.example` to `.mcp.json` and fill in your workspace ID and API key:
+
+```bash
+cp .mcp.json.example .mcp.json
+# Edit .mcp.json — set workspace_id (from URL bar) and API key
+```
+
+3. Restart Claude Code and verify:
+```
+You: "List my memory contexts"
+→ AI calls list_contexts()
+
+You: "Remember: our API uses JWT with 1h expiry and refresh token rotation"
+→ AI calls remember() — stored permanently
+
+You: "What do we know about auth?"
+→ AI calls recall() — finds it instantly, even months later
+```
+
+> `.mcp.json` is in `.gitignore` — never commit it (contains API keys).
+> Place in project root for per-project config, or `~/.claude/.mcp.json` for global access.
+
+<details>
+<summary>Auto-sync Claude Code memory to Kagura (optional)</summary>
+
+Kagura Memory Cloud includes a hook that **automatically syncs** Claude Code's local memory files to the cloud whenever they're updated. This means your local `~/.claude/` memories are also searchable via Hybrid Search and shared with your team.
+
+Add these environment variables to `.env.local`:
+
+```bash
+KAGURA_MCP_URL=http://localhost:8080/mcp/w/{workspace_id}
+KAGURA_MCP_TOKEN=kagura_{your_api_key}
+KAGURA_CONTEXT_ID={context_id}  # optional — auto-detected from project name if omitted
+```
+
+The sync hook is pre-configured in `.claude/settings.json` and runs automatically on every memory file write.
+
+</details>
+
+<details>
+<summary>Claude Code integration templates (copy to your project)</summary>
+
+This repo's `.claude/` directory is a **ready-to-use template** for integrating Kagura Memory Cloud into any project. Copy what you need:
+
+**Slash commands** — drop into your project's `.claude/commands/`:
+```
+/recall <query>   → Search past knowledge via MCP
+/remember <text>  → Save decisions, patterns, learnings via MCP
+/guide            → Show setup and usage guide
+```
+
+**Hooks** (`.claude/settings.json`) — auto-configured safety guards:
+```
+Auto-format    → ruff (Python) / prettier (TypeScript) on every save
+Secret detect  → Blocks hardcoded API keys or passwords
+SQL injection  → Blocks f-string SQL (enforces parameterized queries)
+Memory sync    → Auto-syncs Claude Code memory files to Kagura Cloud
+```
+
+**Agents** (`.claude/agents/`) — specialized sub-agents:
+```
+code-reviewer  → Read-only code review against project standards
+test-runner    → Run tests, diagnose failures, auto-fix
+```
+
+**Rules** (`.claude/rules/`) — auto-loaded project conventions:
+```
+backend.md     → FastAPI/Python patterns, async, testing
+frontend.md    → Next.js/TypeScript, Tailwind, SWR
+security.md    → Auth, RBAC, SQL safety, CORS
+```
+
+All of these are designed to work together with Kagura Memory Cloud MCP tools. Adapt them for your own project by editing the prompts and context IDs.
+
+</details>
+
+<details>
+<summary>Claude Code Plugin (use Kagura in any project)</summary>
+
+The **kagura-memory** plugin adds session management and memory workflow skills to Claude Code. Install it once and use it across all your projects.
+
+**Install:**
+
+```bash
+# From marketplace
+/plugin marketplace add kagura-ai/memory-cloud
+/plugin install kagura-memory@kagura-memory-cloud
+```
+
+**Available skills:**
+
+| Skill | Description |
+|-------|-------------|
+| `/kagura-memory:session-start` | Restore previous session context on start |
+| `/kagura-memory:session-summary` | Save session knowledge before ending |
+| `/kagura-memory:recall` | Search past knowledge |
+| `/kagura-memory:remember` | Save new knowledge |
+| `/kagura-memory:guide` | Usage guide, connection status, and setup help |
+| `/kagura-memory:smoke-test` | Verify all MCP tools work |
+
+**Recommended workflow:**
+
+```
+/kagura-memory:session-start       # ← Start here: restore context from last session
+  ... work normally ...
+/kagura-memory:recall              # Search past decisions, patterns, fixes
+/kagura-memory:remember            # Save important learnings as you go
+  ... finish work ...
+/kagura-memory:session-summary     # ← End here: save session knowledge for next time
+```
+
+Skills wrap the raw MCP tools (`recall`, `remember`, etc.) with workflow logic — context selection, git state analysis, and structured prompts. Use skills for session management and guided workflows; use MCP tools directly for fine-grained operations.
+
+Run `/kagura-memory:guide` for setup help and an optional SessionStart hook you can add to your project.
+
+> **Prerequisite:** MCP connection must be configured (`.mcp.json` with API key). Run `/kagura-memory:guide` in your project to set it up.
+
+</details>
+
+## WSL2 + Claude Code (NAT networking note)
+
+If you run Claude Code **inside WSL2** and use the **OAuth** flow (not the API-key setup above), the browser callback can fail silently: WSL2's default `nat` mode isolates `localhost` between Windows and WSL, so the Windows browser's redirect to `localhost:<port>` never reaches Claude Code's listener inside WSL. **This is a WSL networking issue, not a Kagura server bug** — the resolved server-side cousin was [#689 / PR #692](https://github.com/kagura-ai/memory-cloud/pull/692).
+
+Quick fixes:
+
+- **Enable mirrored networking** — set `networkingMode=mirrored` in `C:\Users\<YourName>\.wslconfig`, then `wsl --shutdown` (requires WSL 2.0.0+ on Windows 11 22H2+).
+- **Use API key (Bearer) auth** — the `.mcp.json` setup above skips the OAuth callback entirely.
+- **Use the device flow** ([#635 / PR #636](https://github.com/kagura-ai/memory-cloud/pull/636), RFC 8628) if your client supports it.
+
+See [Troubleshooting → WSL2 + Claude Code](troubleshooting.md#wsl2--claude-code--mcp-oauth-callback-fails-default-nat-networking) for the full symptom → diagnosis → fix walkthrough.
+
+## Claude Desktop / Claude Chat (Web)
+
+**Claude Desktop**: Same `.mcp.json` format as Claude Code — place in your project root or `~/.claude/.mcp.json`.
+
+**Claude Chat (claude.ai)**: Add as a remote MCP server in Settings > Integrations:
+1. Click "Add Integration" → "Custom MCP Server"
+2. Enter the MCP endpoint URL: `https://your-domain.com/mcp/w/{workspace_id}`
+3. Add the `Authorization: Bearer kagura_{your_api_key}` header
+
+> Claude Chat requires a publicly accessible URL (not `localhost`). Use a production deployment or tunnel (e.g., ngrok, Cloudflare Tunnel).
+
+## ChatGPT Desktop
+
+ChatGPT desktop app supports MCP servers. Add via Settings > MCP Servers:
+1. Server URL: `https://your-domain.com/mcp/w/{workspace_id}`
+2. Authentication: Bearer token `kagura_{your_api_key}`
+
+> Like Claude Chat, ChatGPT requires a public URL. For local development, use a tunnel or the REST API directly.
+
+## Gemini CLI
+
+Add to `.gemini/settings.json` (project root or `~/.gemini/settings.json`):
+
+```json
+{
+  "mcpServers": {
+    "kagura-memory": {
+      "url": "http://localhost:8080/mcp/w/{workspace_id}",
+      "headers": {
+        "Authorization": "Bearer kagura_{your_api_key}"
+      }
+    }
+  }
+}
+```
+
+## Other MCP Clients / REST API
+
+Any MCP-compatible client can connect via Streamable HTTP. For clients without MCP support, use the REST API directly:
+
+```bash
+# Search memories
+curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "your search", "context_id": "..."}' \
+  http://localhost:8080/api/v1/memories/search
+```

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,0 +1,147 @@
+# MCP Tools Reference
+
+See [MCP Client Setup](mcp-clients.md) for connecting a client, and [Core Concepts](concepts.md) for the memory model behind these tools.
+
+63 tools across 13 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+
+## Memory (7)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `remember` | Store a new memory (summary + content + type; optional `delivery_mode`) | Member+ |
+| `recall` | Search memories with Hybrid Search (supports `trust_tier` filter) | Viewer+ |
+| `recall_nearby` | Deterministic WHERE-axis query — memories with `details.location` within `radius_m` of a point, nearest first | Viewer+ |
+| `reference` | Get full 3-layer details of a memory | Viewer+ |
+| `update_memory` | Update an existing memory in-place or upsert by external ID | Member+ |
+| `forget` | Soft-delete a memory (30-day retention) | Member+ |
+| `explore` | Discover related memories via Neural Memory graph | Viewer+ |
+
+## Agent Substrate (7)
+
+The primitives an autonomous agent loop needs beyond a knowledge store — see [Concepts › Agent Memory Substrate](concepts.md#agent-memory-substrate).
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `load_pinned` | Deterministically load always-load memories (`delivery_mode="always"`) — Goal / Guardrail / policy | Viewer+ |
+| `recall_upcoming` | List upcoming Time Memories (`type="time"`, `delivery_mode="on_trigger"`) | Viewer+ |
+| `set_state` | Upsert agent scratch state (key→value, optional TTL; excluded from recall) | Editor+ |
+| `get_state` | Read one state key, or list all live state for a context | Viewer+ |
+| `record_measurement` | Append one numeric observation to a metric's series (HOW-MUCH lane; excluded from recall, untouched by Sleep) | Editor+ |
+| `recall_series` | Read a metric's series bucketed by day/week/month with avg/min/max/sum/count/last | Viewer+ |
+| `feedback` | Record whether a recalled memory was helpful (append-only signal) | Viewer+ |
+
+## Agent Control Plane (10, preview)
+
+The v0.49.0 control plane builds on existing workspace RBAC: agents are registry resources, not principals, and context bindings can only remove access from an agent-bound member key. Registry, bindings, composed bootstrap, W3C Trace Context/baggage correlation, and the append-only audit foundation are implemented.
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `register_agent` | Register a workspace-scoped agent | Owner/Admin |
+| `list_agents` | List registered agents and lifecycle/enforcement status | Owner/Admin |
+| `get_agent` | Get one registered agent | Owner/Admin |
+| `update_agent` | Update metadata, `status`, or `enforcement_mode` | Owner/Admin |
+| `delete_agent` | Permanently delete an agent and its bound keys; prefer `status="retired"` operationally | Owner/Admin |
+| `bind_agent_context` | Add a purely subtractive context binding | Owner/Admin |
+| `list_agent_bindings` | List an agent's context bindings | Owner/Admin |
+| `update_agent_binding` | Update read/write/default binding policy | Owner/Admin |
+| `unbind_agent_context` | Remove a binding (default-deny in enforce mode) | Owner/Admin |
+| `get_agent_bootstrap` | Compose context guide + pinned + optional trusted recall + upcoming + state for session start | Agent-bound key or Owner/Admin |
+
+> **Preview boundary:** per-memory type/source filters are enforced on the memory-read lanes (recall, recall_nearby, reference, forget, explore, load_pinned, upcoming) for enforce-mode agents as of [#1299](https://github.com/kagura-ai/memory-cloud/issues/1299) — and on the enumeration/aggregate surfaces (list, stats, access-patterns, get_cluster) as of [#1301](https://github.com/kagura-ai/memory-cloud/issues/1301) — `null` = all types, `[]` = deny-all; shadow mode records `would_deny` without filtering. `traceparent` plus W3C baggage correlation for `agent_id` / `session_id` / `run_id` is implemented, but server-side span export remains out of scope for P0. `memory_access_events` is live for bootstrap, load-pinned, feedback, recall, reference, remember, update, and forget with binding deny / `would_deny` persistence.
+
+## Neural Edges (4)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `list_edges` | List edges connected to a memory | Viewer+ |
+| `create_edge` | Create an edge between two memories | Member+ |
+| `update_edge` | Update edge weight or type | Member+ |
+| `delete_edge` | Delete an edge between two memories | Member+ |
+
+## Contexts (7)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `get_context_info` | Get context metadata and guidelines | Viewer+ |
+| `list_contexts` | List available contexts in workspace | Viewer+ |
+| `create_context` | Create a new context | Owner/Admin |
+| `update_context` | Update context settings (summary, usage guide, resource_id, is_public) | Editor+ |
+| `delete_context` | Delete a context and all its memories | Owner/Admin |
+| `merge_contexts` | Merge memories from source context into target context | Owner/Admin |
+| `update_search_config` | Tune hybrid search weights, reranker settings, and query-intent routing (`routing_mode`) per context | Editor+ |
+
+## Tags (1)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `list_tags` | List tag vocabulary in a context (call before remember/recall to align tagging) | Viewer+ |
+
+## Files / R2 Attachments (5)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `init_file_upload` | Reserve quota + return presigned PUT URL (R2, ≤100 MiB) | Member+ |
+| `complete_file_upload` | Finalize upload after R2 PUT, verify sha256, mark as uploaded | Member+ |
+| `list_files` | List uploaded, non-deleted files in the workspace (newest first) | Viewer+ |
+| `get_file_download_url` | Issue presigned GET URL for a file | Viewer+ |
+| `delete_file` | Soft-delete a file object | Member+ |
+
+## Analyses — Memory Analysis (5)
+
+Cluster memories into themes (kouchou-ai-style UMAP + KMeans + LLM labeling) for large-scale qualitative analysis.
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `analyze_context` | Start an analysis run (or preview cost with `dry_run=true`) | Owner + Pro plan + BYOK + quota |
+| `list_analyses` | List past analysis runs for a context | Owner |
+| `get_analysis` | Get a completed analysis (clusters, labels, stats) | Owner |
+| `get_active_analysis` | Get the in-flight analysis for a context (if any) | Owner |
+| `get_cluster` | Drill into a single cluster's member memories | Owner |
+
+Analysis runs are capped by `ANALYSIS_MAX_MEMORY_COUNT` (default 10,000; preview and start reject larger contexts). Since v0.47.0, cancellation is all-or-nothing, deleted-context runs are invisible on both REST and MCP, strict BYOK labeling never falls back to the platform key, and runs fail when more than half of labelable clusters fail labeling.
+
+## Resources — External Data Ingestion (6)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `setup_resource` | Create public context + issue resource token | Owner/Admin + Pro plan |
+| `setup_connector` | Provision an ai-worker chat connector (resource + connector row + token) | Owner/Admin + connector seats |
+| `list_resource_tokens` | List active resource tokens for your workspace | Owner/Admin |
+| `ingest_events` | Batch upsert/delete events into a resource (max 100 events; session-auth MCP variant) | Member+ |
+| `get_resource_impact` | Resource stats (tokens, memories, schema version) | Viewer+ |
+| `get_resource_schema` | Field definitions for a resource | Viewer+ |
+
+## Secrets (5)
+
+Zero-knowledge secret store: the server holds only `age` public recipient keys and opaque ciphertext, and **never decrypts**. Encryption/decryption happen client-side (the `kagura secret` CLI / SDK). `list` returns metadata only — there is no endpoint that returns a plaintext value.
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `secret_register_pubkey` | Register your own `age` recipient public key (starts pending; an owner approves it before it can receive grants) | Member+ |
+| `secret_put` | Store age-encrypted ciphertext + grant approved recipients (`recipients_snapshot` must match `grant_pubkey_ids`) | Owner/Admin |
+| `secret_get` | Fetch ciphertext you hold an active grant for (decrypt locally; every fetch is recorded in a tamper-evident audit log) | Member+ |
+| `secret_list` | List secret names + metadata (status, version, grant count, rotation flag) — never values | Owner/Admin |
+| `secret_revoke_grant` | Revoke a recipient's grant and flag the secret `rotation_needed` (not retroactive — rotate upstream) | Owner/Admin |
+
+## Sleep Maintenance (3)
+
+Background consolidation of memories (decay, edge pruning, theme summarization).
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `get_sleep_history` | List past sleep runs | Viewer+ |
+| `get_sleep_report` | Detailed sleep report with all actions | Viewer+ |
+| `rollback_sleep_run` | Rollback all actions from a completed sleep run | Member+ (report owner only) |
+
+## Usage (1)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `get_usage` | Get current workspace usage (memories, contexts, members, MCP calls/day) | Viewer+ |
+
+## API-Key Bindings (2)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `list_my_bindings` | List your public-bound API keys (read-only; owner-scoped) | Viewer+ |
+| `describe_binding` | Describe one binding by `key_id` XOR `context_id` (read-only; owner-scoped) | Viewer+ |


### PR DESCRIPTION
## Summary

`README.md` had grown to ~750 lines, absorbing per-feature reference material. This slims it to a landing page (Why / Architecture / Quick Start / 3-step MCP hookup / pointers) and moves the deep dives into `docs/` where they can grow without bloating the front door. `README.ja.md` is mirror-slimmed in the same pass so the maintenance burden doesn't survive in the Japanese mirror.

Closes #1383

## Moves (content preserved verbatim; headings re-leveled, relative links rewired)

| From README section | To |
|---|---|
| MCP Client Setup (~200 lines: per-client matrix, memory-sync hook, `.claude/` templates, kagura-memory plugin, WSL2 note) | **new `docs/mcp-clients.md`** |
| MCP Tools (~145 lines, tool-by-tool with roles) | **new `docs/mcp-tools.md`** |
| Plan Tier Customization | `docs/deployment.md#plan-tiers` |
| Development with Claude Code (slash commands / hooks / agents / rules) | `CONTRIBUTING.md#development-with-claude-code` |
| Inlined 🇯🇵 Japanese plugin guide | dropped — `README.ja.md` is linked at the top and keeps its own plugin section |

README: 748 → 320 lines · README.ja.md: 562 → ~330 lines.

## Two content fixes (beyond pure moves — flagged for review)

- The `#claude-code--claude-desktop` anchor never existed (dead link in the old Development section) — now points at `docs/mcp-clients.md`.
- Authentication said "Google OAuth2 — **Required**", contradicting Quick Start ("optional — password + MFA login available without OAuth"). Fixed in both languages.

## No-orphan / integrity checks

- Both new pages are linked from the README Documentation section, `README.ja.md`, and the `docs/README.md` index.
- Relative-link check across all 7 touched files: 0 broken targets.
- Repo-wide grep for the removed sections' anchors: no stale references.
- Public-repo positioning unchanged: self-hosted only, no hosted-URL additions.
- Gate1 green (DX Lead) · Gate2 green ×3 (CSO / QA Lead / CTO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)