### PR TITLE
docs: update stale Python SDK description (#1387)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,7 @@
 
 <p align="center">
   Claude、ChatGPT、Gemini、その他あらゆる MCP 互換クライアントで動作。<br>
-  <a href="https://github.com/kagura-ai/kagura-memory-python-sdk"><strong>Python SDK (KaguraClient / KaguraAgent)</strong></a>
+  <a href="https://github.com/kagura-ai/kagura-memory-python-sdk"><strong>Python SDK（KaguraClient・REST クライアント・FileIngestor）</strong></a>
 </p>
 
 <p align="center">
@@ -319,7 +319,7 @@ MCP ツールに加えてフル REST API を提供:
 - [Deployment](docs/deployment.md) — Caddy リバースプロキシを用いた production 配備
 - [Contributing](CONTRIBUTING.md) — 開発セットアップ、コードスタイル、PR ワークフロー
 - [Security](SECURITY.md) — 脆弱性報告、セキュリティ設計
-- [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` と `KaguraAgent`
+- [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient`（MCP）に加え、リソース・ファイル・シークレット・ワークスペース・エージェント bootstrap の REST クライアントと、ドキュメント取り込みの `FileIngestor`
 - **プロジェクトサイト**: [www.kagura-ai.com/ja](https://www.kagura-ai.com/ja/) — 概要、ユースケース、スタート手順
 
 ## コントリビューション

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 <p align="center">
   Works with Claude, ChatGPT, Gemini, and any MCP-compatible client.<br>
-  <a href="https://github.com/kagura-ai/kagura-memory-python-sdk"><strong>Python SDK (KaguraClient / KaguraAgent)</strong></a>
+  <a href="https://github.com/kagura-ai/kagura-memory-python-sdk"><strong>Python SDK (KaguraClient, REST clients & FileIngestor)</strong></a>
 </p>
 
 <p align="center">
@@ -308,7 +308,7 @@ This project is designed to be developed **with** Claude Code and Kagura Memory 
 - [Deployment](docs/deployment.md) — Production deployment with Caddy reverse proxy
 - [Contributing](CONTRIBUTING.md) — Development setup, code style, PR workflow
 - [Security](SECURITY.md) — Vulnerability reporting, security design
-- [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` and `KaguraAgent` for Python
+- [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` (MCP) plus REST clients for resources, files, secrets, workspaces, and agent bootstrap, and a document `FileIngestor`
 - **Project site**: [www.kagura-ai.com](https://www.kagura-ai.com) — overview, use cases, getting started paths
 
 ## Contributing

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1282,7 +1282,7 @@ All errors follow this format:
 
 ## SDKs and Examples
 
-- **Python SDK**: [`kagura-memory-python-sdk`](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` (sync HTTP client) and `KaguraAgent` (LLM agent integration). Supports OAuth2 device flow via `kagura auth login` against the pre-seeded `kagura-cli` public client.
+- **Python SDK**: [`kagura-memory-python-sdk`](https://github.com/kagura-ai/kagura-memory-python-sdk) — `KaguraClient` (MCP JSON-RPC) plus REST clients (`ResourceClient`, `FilesClient`, `SecretClient`, `WorkspaceClient`, `AgentsClient`) and a document `FileIngestor`. Supports OAuth2 device flow via `kagura auth login` against the pre-seeded `kagura-cli` public client.
 - **JavaScript SDK**: Planned
 - **Example Code**: [README Quick Start](../README.md#quick-start) and the [Python SDK](https://github.com/kagura-ai/kagura-memory-python-sdk)
 


### PR DESCRIPTION
Closes #1387

## Summary
- Replaces the stale "`KaguraClient` and `KaguraAgent`" SDK description in `README.md`, `README.ja.md`, and `docs/api-reference.md` — `KaguraAgent` was removed from the SDK (SDK #233).
- New one-line description per the post-#1383 slim policy: `KaguraClient` (MCP) plus REST clients for resources, files, secrets, workspaces, and agent bootstrap, and a document `FileIngestor`; the full client table stays in the SDK repo's README.
- Verified against the SDK README that the `kagura auth login` device-flow sentence in `docs/api-reference.md` is still accurate — kept.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (DX Lead lens)
- review provider: code-review (low — docs-only, no findings)

🤖 Generated via /gh-issue-driven:ship
