### PR TITLE
docs(design): connector + entitlement design notes (#1390-#1394)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,11 @@
 - [`get_agent_bootstrap` Contract](design/agent-bootstrap-contract.md) — Implemented composed session-start bundle and fail-soft component contract
 - [Agent Correlation Design](design/agent-otel-correlation.md) — Implemented W3C session/run/trace mapping and verified identity precedence (v0.49.0 preview)
 - [`memory_access_events` Design](design/memory-access-events.md) — Implemented append-only agent audit schema/writer and current emission coverage
+- [Multi-Platform Connectors](design/multi-platform-connectors.md) — Design note (#1390): how the connectors UI/contracts generalize for a 2nd chat provider
+- [Slack Channel Picker](design/slack-channel-picker.md) — Design note (#1391): server-proxied channel listing for connector settings
+- [Platform-Borne Connector LLM](design/platform-borne-connector-llm.md) — Design note (#1392): SaaS-default LLM lane with BYOK as override
+- [Add-On Entitlements](design/addon-entitlements.md) — Design note (#1393): grant ledger upstream of the existing addon bonus columns
+- [Admin-Definable Plan Tiers](design/admin-definable-plan-tiers.md) — Design note (#1394): DB-backed tiers beyond hardcoded S/M/L
 
 ## Guides
 

--- a/docs/design/addon-entitlements.md
+++ b/docs/design/addon-entitlements.md
@@ -1,0 +1,99 @@
+# Add-On Entitlement Lane Alongside Base Plan Tiers
+
+> **Status: design note (#1393) — not implemented.** Some capabilities are
+> orthogonal to the base tier — connector seats and platform-borne connector
+> LLM usage ([#1392](platform-borne-connector-llm.md)) being the immediate
+> drivers — and should be grantable as **add-ons** stacked on a base plan
+> instead of forcing a tier upgrade.
+
+## What already exists (ground truth, not greenfield)
+
+The *effect* side of an add-on lane already ships:
+
+- `Workspace` carries denormalized bonus columns (Migration 048, #238;
+  extended by #15/#485/#494/#560 and the 2026-06-02 connector-seat spec):
+  `addon_memory_bonus`,
+  `addon_mcp_quota_bonus`, `addon_rest_quota_bonus`,
+  `addon_public_quota_bonus`, `addon_member_bonus`, `addon_context_bonus`,
+  `addon_analysis_bonus`, `addon_storage_bonus_mb`,
+  `addon_sleep_contexts_bonus`, `addon_connector_bonus`.
+- Every quota choke point reads `effective_*` properties which stack
+  `_zero_floor(plan_tier.<base>, addon_<bonus>)` — a plan base of 0 keeps the
+  feature off regardless of add-ons (paid-boundary rule).
+
+What is **missing** is the *grant* side: the bonus columns are bare integers
+with no provenance — no who/when/why, no source, no expiry, no audit trail,
+and no contract an external billing service can drive.
+
+## Design: a grant ledger upstream of the existing columns
+
+```
+workspace_addons
+  id             UUID PK
+  workspace_id   FK → workspaces
+  addon_key      str        -- e.g. "connector_seats", "context_slots",
+                            --      "llm_usage_topup_usd"
+  quantity       int        -- units of the addon_key's unit
+  source         str        -- "system_admin" | "billing"
+  granted_by     str | null -- admin user id for system_admin grants
+  external_ref   str | null -- billing service's opaque grant reference
+  granted_at     tz-aware timestamp
+  expires_at     tz-aware timestamp | null
+  revoked_at     tz-aware timestamp | null
+```
+
+- **The ledger is the source of truth; the existing `addon_*_bonus` columns
+  become a projection.** On grant/revoke/expiry, the service recomputes
+  `Σ quantity` per addon key and writes the matching bonus column. The 10+
+  `effective_*` call sites and `_zero_floor` stay byte-identical — the hot
+  path never joins the ledger.
+- Expiry is enforced at projection time (a periodic sweep + on-write
+  recompute), not per-request.
+- Grant/revoke are admin- or billing-driven service calls, never direct
+  column writes; the ledger row is the audit record.
+
+## Grant sources — deployment-mode two-sidedness
+
+- **`system_admin`**: manual ops grants. Self-hosted admins can grant freely
+  (their server, their rules) — same two-sidedness as env-based plan
+  overrides.
+- **`billing`**: the external billing service calls a grant contract
+  (`POST /api/v1/admin/workspaces/{id}/addons` or equivalent) with an
+  `external_ref` for reconciliation. memory-cloud remains the **entitlement
+  source of truth**; the billing service holds purchase state.
+
+## Metered add-ons (the #1392 driver)
+
+Static-capacity add-ons (seats, slots) are fully served by the ledger →
+projection model. **Metered** add-ons (platform LLM usage top-ups) also need
+per-addon *usage* accounting:
+
+- Model on the managed-embeddings **check + record** pattern (#709/#1030/
+  #1033): check remaining budget before the metered action, record actual
+  usage after.
+- The add-on contributes budget (`quantity` in the addon key's unit, e.g.
+  USD-cents of LLM usage); usage records deduct against
+  plan-cap + Σ active top-ups.
+
+## Boundary (deliberate)
+
+Purchase, checkout, and payment-provider mechanics live in the **private
+payment service**. This repo exposes only the grant contract and entitlement
+state. **No pricing appears in this repo** — `addon_key` + `quantity` are the
+whole vocabulary; what a grant costs is not memory-cloud's concern.
+
+## Admin UI
+
+The admin plans page gains a per-workspace add-on panel: active grants
+(key, quantity, source, granted_at, expires_at), grant/revoke actions
+(system-admin only), and the projected effective totals next to the base-tier
+values it already shows.
+
+## Interaction with admin-definable tiers
+
+The base tier defines defaults; the add-on lane stacks on top. The resolution
+order (base → Σ add-ons → zero-floor) is defined **once** at the projection/
+`effective_*` layer — the [admin-definable plan tiers](admin-definable-plan-tiers.md)
+design keeps that single definition point when tiers become data.
+
+Refs: #1392, #1394, #238, #857.

--- a/docs/design/admin-definable-plan-tiers.md
+++ b/docs/design/admin-definable-plan-tiers.md
@@ -1,0 +1,97 @@
+# Admin-Definable Plan Tiers (Beyond Hardcoded S/M/L)
+
+> **Status: design note (#1394) — not implemented.** Plan tiers are hardcoded
+> to three frozen dataclasses (`PLAN_FREE` / `PLAN_BASIC` / `PLAN_PRO` in
+> `backend/src/config/plan_tiers.py`, display names "S" / "M" / "L") with
+> env-var limit overrides applied at import time
+> (`_apply_settings_overrides()`), and frontend display names resolved from
+> `NEXT_PUBLIC_PLAN_*` env indirection (`frontend/src/lib/utils/planLabel`).
+> Adding a tier requires a code change. This note makes tiers **data**.
+
+## DB-backed plan definitions
+
+```
+plan_definitions
+  key           str PK     -- stable identifier: "free" | "basic" | "pro" | new keys
+  display_name  str        -- human label ("S", "M", "L", ...)
+  limits        JSONB      -- the PlanTier field set (max_contexts_per_workspace,
+                           -- memory_limit, mcp_calls_per_day, max_connectors,
+                           -- storage_limit_bytes, caps, features, ...)
+  archived_at   timestamp | null
+  created_at / updated_at
+```
+
+- **Seed `free`/`basic`/`pro`** from today's dataclass values (display names
+  S/M/L) for full backward compatibility — existing `workspaces.plan_tier`
+  values keep resolving.
+- `PlanTier` (the frozen dataclass) stays as the in-process shape;
+  `get_plan_tier()` becomes a cached DB read that materializes a `PlanTier`
+  from the row. Every quota consumer (`effective_*`, quota services) is
+  untouched — they already go through `get_plan_tier()` / `_plan_tier`.
+- Unknown-key fallback: a workspace pointing at a missing/archived key
+  resolves to its seeded equivalent if one exists, else fails loud (a
+  misconfigured tier must not silently become "free").
+
+## Admin CRUD (system admin only)
+
+- Create / edit / **archive** — never delete while any workspace references
+  the key. Archive hides the tier from assignment lists; existing workspaces
+  keep their limits until migrated.
+- Limit edits take effect on the next cache refresh (short TTL, e.g. 60s) —
+  no restart.
+- The admin plans page renders the dynamic list (it already renders per-tier
+  values; the source becomes the API instead of build-time constants).
+
+## Env override interplay (`PLAN_*`) — decision
+
+Self-hosted operators rely on `plan_basic_max_contexts`-style settings today.
+Options considered:
+
+1. Env stays a **final override layer** on top of DB rows (status quo
+   semantics, two sources of truth forever).
+2. Env becomes **bootstrap-seed-only**: values apply once when seeding an
+   empty `plan_definitions` table; after that, the DB is authoritative and
+   env changes are ignored (with a startup log line when an env var differs
+   from the DB row, so drift is visible, never silent).
+
+**Recommendation: (2) seed-only, with the drift warning.** A final-override
+layer would make the admin CRUD lie (edits silently masked by env), which is
+worse than a one-time migration story. Self-hosted operators keep their
+current workflow at first boot and gain the UI afterwards. The transition
+release notes must state this explicitly (the "don't break silently"
+requirement).
+
+## Frontend display
+
+Plan names and limits are served by the API (extend the existing plans/usage
+endpoints with `display_name` + limits from the definition). The
+`NEXT_PUBLIC_PLAN_DISPLAY_NAMES` / `NEXT_PUBLIC_PLAN_*_DISPLAY_NAME`
+indirection is dropped once all consumers read the API — build-time env for
+runtime-editable data is the wrong binding.
+
+## External contract: keys are the stable identifiers
+
+- The private payment service maps prices onto **plan keys**. Keys are
+  immutable once created (rename = new key + migration); `display_name` is
+  freely editable.
+- Key vocabulary is the whole cross-service contract — **no pricing data in
+  this repo** (same boundary as the [add-on lane](addon-entitlements.md)).
+- Workspace migration between tiers is an explicit admin/billing action
+  (`workspaces.plan_tier` update), never implicit via key edits.
+
+## Interaction with add-ons
+
+Base tier defines defaults; the [add-on lane](addon-entitlements.md) stacks
+on top via the existing `effective_* = _zero_floor(base, Σ addons)` layer.
+That resolution order stays defined in exactly one place — tiers becoming
+data must not introduce a second stacking site.
+
+## Non-goals
+
+- No per-workspace bespoke limits outside the tier + add-on system (that's
+  what add-on grants are for).
+- No self-serve tier switching in this repo (billing-service concern).
+- No feature-flag redesign — `features: frozenset[str]` rides along in
+  `limits` JSONB as a string list.
+
+Refs: #1393, #238, #485, #709, #850.

--- a/docs/design/admin-definable-plan-tiers.md
+++ b/docs/design/admin-definable-plan-tiers.md
@@ -22,8 +22,11 @@ plan_definitions
 ```
 
 - **Seed `free`/`basic`/`pro`** from today's dataclass values (display names
-  S/M/L) for full backward compatibility — existing `workspaces.plan_tier`
-  values keep resolving.
+  S/M/L) for full backward compatibility — existing `workspaces.plan_name`
+  values keep resolving. Note: `plan_name` today carries
+  `CheckConstraint("plan_name IN ('free','basic','pro')")` — the migration
+  that introduces `plan_definitions` must replace that constraint with an FK
+  to `plan_definitions.key`, or dynamic tiers can never be assigned.
 - `PlanTier` (the frozen dataclass) stays as the in-process shape;
   `get_plan_tier()` becomes a cached DB read that materializes a `PlanTier`
   from the row. Every quota consumer (`effective_*`, quota services) is
@@ -77,7 +80,7 @@ runtime-editable data is the wrong binding.
 - Key vocabulary is the whole cross-service contract — **no pricing data in
   this repo** (same boundary as the [add-on lane](addon-entitlements.md)).
 - Workspace migration between tiers is an explicit admin/billing action
-  (`workspaces.plan_tier` update), never implicit via key edits.
+  (`workspaces.plan_name` update), never implicit via key edits.
 
 ## Interaction with add-ons
 

--- a/docs/design/multi-platform-connectors.md
+++ b/docs/design/multi-platform-connectors.md
@@ -1,0 +1,97 @@
+# Multi-Platform Connector Readiness
+
+> **Status: design note (#1390) — not implemented.** Discord / Teams connectors
+> are on the ai-worker roadmap. This note decides how the connectors UI and
+> contracts generalize so the second provider is an *addition*, not a rewrite —
+> while deliberately building nothing speculative. The second-provider PR
+> should be executable against this document.
+
+## Current state (v0.55.3)
+
+| Layer | Generalization status |
+|---|---|
+| Frontend connect CTA / rows | Driven by the `CONNECTOR_PROVIDERS` descriptor (`frontend/src/lib/connectors/providers.ts`, landed with #1389) — Slack enabled, Discord/Teams rendered as disabled "coming soon" |
+| Frontend settings dialog | Slack-vocabulary labels (`channelsLabel`, helpers reference Slack UI) |
+| Callback / error params | Slack-specific: `?slack_install=`, `?slack_error=`, `slackCancelled*` / `slackFailed*` / `slackExpired*` i18n keys |
+| Backend routing | `/api/v1/connectors/slack/*` (OAuth install, callback, pending-install) |
+| Backend data model | Already platform-shaped: `WorkspaceConnector.connector_type` ∈ `CONNECTOR_TYPES = {"slack", "discord", "teams"}` (`connector_provisioning.py`); worker-side data layer is platform-agnostic (`SourceIdentifier` + `Platform` enum), only the worker's connector glue (webhook/auth/slash) is Slack-only |
+
+## 1. Provider descriptor (frontend) — implemented skeleton
+
+`ConnectorProviderDescriptor` carries `key`, `name` (brand, untranslated),
+`icon`, `connectFlow` (`"oauth" | "manual"`), `enabled`, and `installUrl?`.
+Contract decisions worth keeping:
+
+- **Routing lives in the descriptor.** `installUrl` is present iff the
+  provider's connect flow is wired. Flipping `enabled: true` without wiring
+  `installUrl` yields a dead button — never another provider's OAuth consent
+  screen. The second-provider PR adds its own `installUrl` (and, if needed, a
+  provider-specific pending-install fetch).
+- The descriptor is UI-only. It must not grow backend knowledge (endpoint
+  shapes, scope lists); those stay server-side.
+
+Additions the second provider will need (add then, not now):
+
+- `capabilities` flags consumed by the settings dialog (see §2), e.g.
+  `{ channelSelection: "flat" | "guild-scoped", vision: boolean }`.
+- Per-provider pending-install handling (`?slack_install=` equivalent).
+
+## 2. Capability-driven settings vocabulary
+
+The "channels" concept differs per provider:
+
+| Provider | Ingest scope unit | ID shape |
+|---|---|---|
+| Slack | channels (flat) | `C…` channel IDs; team `T…` / Enterprise `E…` |
+| Discord | servers (guilds) → channels | numeric snowflakes, guild-scoped |
+| Teams | teams → channels | GUID-ish, tenant-scoped |
+
+Decision: the settings dialog's *labels, helper copy, and client-side ID
+validation* derive from provider capabilities; the *stored contract* stays a
+flat `channel_ids: list[str]` vended opaquely to the worker (the worker's
+`SourceIdentifier` already scopes IDs by platform). Guild/team hierarchy, if a
+provider requires it for selection UX, is a picker-time concern (cf. the
+[Slack channel picker design](slack-channel-picker.md)) — not a storage-shape
+change.
+
+## 3. Generalization policy — deliberately deferred until the 2nd provider lands
+
+Renaming working Slack-specific surfaces now is churn with no user value.
+These renames are **batched into the second-provider PR**, which is the first
+change that can actually test them:
+
+1. `?slack_error=<reason>` → `?connector_error=<reason>&provider=<p>` — same
+   allowlisted-reason contract (`cancelled | failed | expired`, unknown
+   collapses to `failed`); `provider` joins the allowlist discipline. Keep
+   accepting `slack_error` for one release as a compatibility read.
+2. `slackCancelled*` / `slackFailed*` / `slackExpired*` i18n keys →
+   provider-interpolated generic keys ("{provider} 連携に失敗しました").
+3. Backend routing `/connectors/slack/*` → per-provider routers under
+   `/connectors/{provider}/*`, sharing the browser-facing redirect helpers
+   (allowlist + non-reflection, #1375/#1381 pattern) — the helper is already
+   provider-parameterized in spirit; make it so in signature.
+
+## 4. Non-goals
+
+- **No speculative backend abstraction.** The same altitude judgment as the
+  #1381 review: `auth.py` and `connectors_slack.py` keep sibling helpers with
+  different threat models; a shared "generic connector OAuth" layer is only
+  justified once a second concrete implementation exists.
+- **PII defaults and the vend contract stay per-provider decisions.** Discord
+  content norms ≠ Slack workspace norms; do not inherit Slack's defaults
+  implicitly.
+- Worker-side connector glue generalization is owned by the ai-worker repo
+  (its data layer is ready; glue refactoring waits for the Discord spec —
+  YAGNI).
+
+## Second-provider PR checklist
+
+1. Descriptor entry: `enabled: true`, `installUrl`, `capabilities`.
+2. Backend: `/connectors/{provider}/*` router + shared redirect helpers;
+   `connector_error`/`provider` params (§3.1) with `slack_error` compat read.
+3. i18n: generic provider-interpolated keys (§3.2); retire `slack*` keys.
+4. Settings dialog: capability-driven labels/validation (§2).
+5. Row/readiness: no change needed — `connectorReadiness` /
+   `connectorDisplayName` are already provider-neutral.
+
+Refs: #1376, #1389, #1390.

--- a/docs/design/platform-borne-connector-llm.md
+++ b/docs/design/platform-borne-connector-llm.md
@@ -1,0 +1,84 @@
+# Platform-Borne Connector LLM on SaaS Deployments
+
+> **Status: design note (#1392) — not implemented.** Today the worker-config
+> vend requires a per-connector BYO `llm_config` bundle, so every deployment —
+> including SaaS — forces the admin to bring their own LLM key. Product
+> intent: on SaaS the connector LLM is **platform-borne**; BYOK is an
+> override, not a prerequisite.
+
+## Resolution order at vend time
+
+When the worker fetches a connector's config (`GET /api/v1/workers/config`),
+the `llm` block resolves in this order:
+
+1. **Connector BYOK bundle** (`llm_config`, Fernet-encrypted) — explicit
+   per-connector override, unchanged from today.
+2. **Workspace LiteLLM virtual key** (`litellm_virtual_key_id`) — the SaaS
+   lane. The column exists and is admin-editable (#1376) but is currently
+   stored-not-vended; this design is where it becomes real.
+3. **Platform default** (SaaS) / **server-configured default** (self-hosted:
+   env-based `Settings` defaults are an intended feature on self-host — the
+   deployment-mode two-sidedness lesson from the Memory Analysis review).
+4. Nothing available → `llm: null` (readiness semantics below).
+
+## Mechanism: the LiteLLM virtual-key lane
+
+- The platform runs a LiteLLM proxy; each connector (or workspace) gets a
+  **virtual key** so usage is metered per tenant. `litellm_virtual_key_id`
+  identifies that key; the vend hands the worker a proxy base URL + the
+  virtual key instead of a raw provider credential.
+- Must align with the kagura-bridge dedicated-LLM-credential vend design
+  ([kagura-bridge#179](https://github.com/kagura-ai/kagura-bridge/issues/179))
+  — reference only; no cross-repo scope in this note. The convergence
+  requirement: one vend shape both consumers can read
+  (`{mode: "byok" | "virtual-key" | "platform", ...}` rather than an opaque
+  dict whose meaning depends on who filled it).
+
+## Cost control
+
+Platform-borne usage is metered within plan / connector-seat limits using the
+**check + record** pattern proven by managed embeddings (#709/#1030/#1033,
+`embedding_daily_cap_usd` / `embedding_monthly_cap_usd` on `PlanTier`):
+
+- Per-plan daily/monthly USD caps for connector LLM usage (new `PlanTier`
+  fields, env-overridable like the embedding caps).
+- Check before vend-window activation; record from LiteLLM usage callbacks.
+- Cap exhaustion degrades the connector to "paused (quota)" — a vend-visible
+  state, not a silent failure; the UI surfaces it via the readiness lane.
+- Metered add-on top-ups stack via the add-on lane (see
+  [add-on entitlements](addon-entitlements.md)).
+
+## Vend contract: readiness semantics change
+
+Today `llm: null` means "un-vendable" and the UI's `connectorReadiness`
+(`frontend/src/lib/api/workspace-connectors.ts`) encodes exactly that:
+`missingLlm = !llm_config_present` (the virtual key deliberately does NOT
+count — #1388/#1389). When a platform lane exists:
+
+- `missingLlm` becomes `!(llm_config_present || platformLlmAvailable)` where
+  `platformLlmAvailable` is a deployment capability, not per-connector state.
+- The flip is a **one-line change in one helper** by design — both the dialog
+  summary and the row badges already route through `connectorReadiness`.
+
+## Deployment-mode awareness (UI)
+
+- Mode signal: a feature flag on `GET /api/v1/system/info` (intentionally
+  public, non-sensitive deployment flags the web UI reads pre-auth — the
+  existing pattern per `.claude/rules/security.md`), e.g.
+  `connector_llm: "platform" | "self-hosted-default" | "byok-required"`.
+- SaaS: LLM section defaults to "Kagura 提供の LLM を使用(追加設定不要)"
+  with the BYOK fields in a fold (flips the default presentation delivered by
+  #1388 — that issue explicitly labeled its copy "for the current behavior").
+- Self-hosted: "サーバー既定を使用" + per-connector override fields.
+
+## Non-goals / boundaries
+
+- No pricing or billing mechanics in this repo — metering counts and caps are
+  entitlement facts; purchase flows live in the external billing service
+  (see [add-on entitlements](addon-entitlements.md) for the boundary rule).
+- No change to the BYOK contract (`provider` + `model` required, `api_key`
+  provider-dependent — `_validate_llm_config`).
+- Sleep/analysis LLM provider selection is a separate lane (BYOK-scoped
+  today) and out of scope.
+
+Refs: #1376, #1380, #1388, #1389, #1393, kagura-bridge#179.

--- a/docs/design/slack-channel-picker.md
+++ b/docs/design/slack-channel-picker.md
@@ -1,0 +1,84 @@
+# Slack Channel Picker for Connector Settings
+
+> **Status: design note (#1391) — not implemented.** Raw channel-ID entry is
+> the deepest remaining UX debt in the connector settings dialog (#1388): the
+> admin must leave the app, find a Slack channel ID, and paste it. This note
+> designs a channel picker backed by the connector's stored bot token.
+
+## Backend endpoint
+
+```
+GET /api/v1/workspace-connectors/{connector_id}/channels?cursor=<c>&q=<query>
+```
+
+- **Auth**: workspace admin (same `WorkspaceAdmin` dependency as the other
+  `/workspace-connectors` routes); the connector must belong to the current
+  workspace (workspace-predicated lookup, 404 on cross-workspace IDs — same
+  contract as the settings PATCH).
+- **Mechanism**: server-side proxy of Slack `conversations.list` using the
+  connector's Fernet-decrypted bot token (`get_oauth_tokens()["bot_token"]`).
+  The token **never reaches the browser** — this endpoint exists precisely so
+  it doesn't have to.
+- **Response**: `{ channels: [{id, name, is_private}], next_cursor }` — id and
+  name only (plus the private flag for display); no member counts, topics, or
+  other metadata (data minimization).
+- **Pagination**: pass through Slack's cursor (`limit=200` per page);
+  `q` filters server-side on the fetched page (Slack's API has no name filter;
+  the UI filters client-side within loaded pages, `q` is optional sugar).
+
+## Scope requirement and legacy installs
+
+`conversations.list` for public channels requires the **`channels:read`**
+scope, which IS in the default install scopes
+(`settings.slack_oauth_scopes` = `channels:history,channels:read,groups:history,chat:write,team:read,users:read`).
+Private channels additionally need `groups:read`, which is **not** currently
+requested — so the v1 picker lists public channels only, and private channels
+remain manual-ID entry (document this in the dialog copy).
+
+Behavior when the token lacks the scope (legacy installs, manual binds of
+older apps): Slack returns `missing_scope`. The endpoint maps this to a
+structured `409 {error_code: "CONNECTOR-SCOPE"}`; the frontend degrades to the
+manual-ID input with a notice ("再インストールで一覧選択が使えます"). Never a
+raw 5xx.
+
+## Rate limits and caching
+
+`conversations.list` is Slack rate-limit **Tier 2** (~20 req/min per token).
+A workspace admin repeatedly opening the dialog must not burn the budget the
+worker may also need:
+
+- Short server-side cache per connector: Redis key
+  `slack_channels:{connector_id}:{cursor}` with ~60s TTL.
+- On Slack `rate_limited`, surface `429` with `Retry-After` passthrough; the
+  frontend shows the manual-entry fallback rather than spinning.
+
+## Frontend
+
+- The settings dialog's ingest-scope section gains a searchable multi-select
+  (combobox) seeded with the current `channel_ids`; selection writes the same
+  `channel_ids` PATCH as today (order-insensitive compare unchanged).
+- **Manual-ID entry stays as a fallback lane** (private channels, scope-less
+  legacy installs, Enterprise edge cases) — a toggle between "一覧から選択"
+  and "ID を直接入力".
+- Channel IDs already selected but not present in the fetched list (e.g. a
+  private channel) render as opaque ID chips — never silently dropped by a
+  save.
+
+## Security summary
+
+- Bot token: server-side only, decrypt-per-request, never logged.
+- Response carries channel id/name only; no message content.
+- Workspace-admin RBAC + workspace-predicated connector lookup (no
+  cross-tenant channel enumeration).
+- The endpoint is read-only and cache-bounded; it cannot mutate connector
+  state.
+
+## Non-goals
+
+- No `groups:read` scope expansion in v1 (private-channel listing is a
+  follow-up decision — scope creep on installed apps forces re-consent).
+- No provider-generic picker abstraction yet — Discord/Teams pickers have
+  different hierarchy shapes and arrive with their providers (see
+  [multi-platform readiness](multi-platform-connectors.md)).
+
+Refs: #1376, #1388, #1391.


### PR DESCRIPTION
Closes #1390
Closes #1391
Closes #1392
Closes #1393
Closes #1394

## Summary
Five design-only notes under `docs/design/` that the follow-up implementation PRs can execute against (all five issues are design-only by scope; the note is the deliverable):

- **multi-platform-connectors** (#1390) — provider-descriptor contract (routing lives in the descriptor: `installUrl` present iff enabled), capability-driven settings vocabulary, and the deliberately deferred rename batch (`connector_error` param, provider-interpolated i18n keys, per-provider routers) packaged as a 2nd-provider PR checklist.
- **slack-channel-picker** (#1391) — server-proxied `conversations.list` with the stored bot token (never the browser), `channels:read` confirmed in default install scopes (`groups:read` is not → public channels only in v1, manual entry stays the fallback lane), Tier-2 rate-limit caching, structured scope-missing degradation.
- **platform-borne-connector-llm** (#1392) — vend resolution order (connector BYOK > workspace LiteLLM virtual key > platform/server default), the virtual-key lane aligned with kagura-bridge#179 (reference only), managed-embeddings-style check+record cost caps, and the readiness flip that is a one-line change because #1388/#1389 centralized the rule.
- **addon-entitlements** (#1393) — grounded in the EXISTING `addon_*_bonus` columns (Migration 048): a grant ledger (provenance / source / expiry / external_ref) becomes the source of truth upstream of those columns as a projection, so every `effective_*` choke point stays byte-identical. Purchase/checkout stay in the external billing service; no pricing in this repo.
- **admin-definable-plan-tiers** (#1394) — DB-backed `plan_definitions` seeded from today's S/M/L, archive-not-delete, env overrides become seed-only with a drift warning (decision recorded with rationale), plan keys as the stable external contract, and the `workspaces.plan_name` CheckConstraint → FK migration requirement.

## Review notes
- A fact-check pass verified every code reference in the notes against the tree; one error found and fixed (`workspaces.plan_tier` → `plan_name`, surfacing the CheckConstraint migration requirement).
- docs/README.md links the five notes as explicit "Design note" entries so they aren't mistaken for implemented designs.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (batch coherence review)
- review provider: code-review (fact-check pass)

🤖 Generated via /gh-issue-driven:ship
