### PR TITLE
fix(db): let incoming 'declared' origin win on edge upsert (#1406)

### DIFF
--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -174,9 +174,12 @@ class NeuralEdgeRepository:
                 discard the return value (Hebbian via GraphService.add_edge,
                 Sleep edge_discovery) pass False to skip the extra SELECT.
             origin: Edge origin (``EDGE_ORIGIN_HEBBIAN`` default). On upsert,
-                non-hebbian origins are preserved — only ``hebbian`` rows can
-                be overwritten. Sleep/declared writers should pass the explicit
-                enum value.
+                an existing non-hebbian origin is preserved against a
+                non-``declared`` incoming origin — only ``hebbian`` rows can be
+                overwritten by hebbian/semantic writers. An incoming
+                ``declared`` origin always wins, regardless of the existing
+                origin (#1406: user assertion outranks machine provenance).
+                Sleep/declared writers should pass the explicit enum value.
 
         Returns:
             Created or updated edge. When ``return_fresh_edge=False`` the
@@ -238,7 +241,19 @@ class NeuralEdgeRepository:
         # symmetric arm of the protect_declared_link CASE above — when the
         # existing row has origin='declared', its origin is preserved
         # alongside its edge_type, keeping the two columns co-managed.
+        #
+        # Issue #1406: an INCOMING user-asserted 'declared' origin outranks any
+        # existing machine provenance — user assertion beats machine guess. When
+        # ingest-time k-NN seeding has already linked a near-duplicate pair with
+        # origin='semantic', a later remember(supersedes=...) declaration must
+        # land the edge as origin='declared', otherwise the sticky-origin arm
+        # below would preserve 'semantic' and leave the declared supersede
+        # outside the #457/#741 protect_declared_link shield. The existing
+        # hebbian-cannot-overwrite guarantee is unchanged: a hebbian incoming
+        # origin never matches this arm and still falls through to the sticky
+        # arm (existing non-hebbian preserved).
         origin_set = case(
+            (stmt.excluded.origin == EDGE_ORIGIN_DECLARED, stmt.excluded.origin),
             (NeuralMemoryEdge.origin != EDGE_ORIGIN_HEBBIAN, NeuralMemoryEdge.origin),
             else_=stmt.excluded.origin,
         )

--- a/backend/tests/repositories/test_neural_edge_origin.py
+++ b/backend/tests/repositories/test_neural_edge_origin.py
@@ -13,6 +13,7 @@ Verifies:
 import pytest
 
 from models.memory import (
+    EDGE_ORIGIN_DECLARED,
     EDGE_ORIGIN_HEBBIAN,
     EDGE_ORIGIN_SEMANTIC,
 )
@@ -195,6 +196,145 @@ async def test_upsert_promotes_hebbian_to_semantic(db_session, sample_memory_pai
     edge = await repo.get_edge(src.user_id, src.id, dst.id)
     assert edge is not None
     assert edge.origin == EDGE_ORIGIN_SEMANTIC  # promoted
+
+
+@pytest.mark.asyncio
+async def test_upsert_declared_wins_over_existing_semantic(db_session, sample_memory_pair):
+    """#1406: a user-asserted ``declared`` upsert MUST overwrite an existing
+    ``semantic`` seed origin.
+
+    When ingest-time k-NN cold-start seeding has already linked a
+    near-duplicate pair (``origin='semantic'``) and the user then declares a
+    supersession over it (``remember(supersedes=...)`` -> the
+    ``origin=EDGE_ORIGIN_DECLARED`` write path), the upsert must land the
+    edge as ``origin='declared'``. The old sticky-origin rule preserved any
+    existing non-hebbian origin, silently keeping ``semantic`` and leaving the
+    declared supersede outside the #457/#741 ``protect_declared_link`` shield.
+    """
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    # Existing seed edge: k-NN cold-start seeding wrote origin='semantic'.
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.5,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+
+    # User declares a supersession over the same pair.
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="supersedes",
+        weight=1.0,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_DECLARED,
+    )
+
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.edge_type == "supersedes"
+    assert edge.origin == EDGE_ORIGIN_DECLARED  # user assertion wins over seed
+
+
+@pytest.mark.asyncio
+async def test_upsert_declared_survives_later_semantic_reseed(db_session, sample_memory_pair):
+    """#1406 guard: an existing ``declared`` origin is NOT downgraded by a
+    subsequent ``semantic`` upsert — the incoming-declared arm must not
+    weaken the existing sticky protection for machine-origin writes.
+    """
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    # Existing user-declared supersede edge.
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="supersedes",
+        weight=1.0,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_DECLARED,
+    )
+
+    # A later machine reseed with semantic origin must not overwrite it.
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.6,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.origin == EDGE_ORIGIN_DECLARED  # declared preserved, not demoted
+
+
+@pytest.mark.asyncio
+async def test_upsert_declared_wins_under_protect_link_flips_both_columns(
+    db_session, sample_memory_pair
+):
+    """#1406 co-management: with ``protect_declared_link=True`` an incoming
+    ``declared`` origin landing over an existing ``semantic`` seed must flip
+    ``edge_type`` AND ``origin`` together.
+
+    This is the property the issue calls out — a declared supersede must not
+    land with ``origin='semantic'`` (outside the #457/#741 shield) while its
+    ``edge_type`` becomes ``supersedes``. The ``edge_type_set`` arm keys on the
+    EXISTING origin ('semantic', not 'declared') so it takes the incoming
+    edge_type, and the ``origin_set`` arm keys on the INCOMING origin
+    ('declared') so it takes 'declared' — both columns move as one.
+    """
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    # Existing semantic seed edge.
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.5,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+
+    # Incoming declared supersede via a protect_declared_link writer.
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="supersedes",
+        weight=1.0,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_DECLARED,
+        protect_declared_link=True,
+    )
+
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.edge_type == "supersedes"  # edge_type flipped to incoming
+    assert edge.origin == EDGE_ORIGIN_DECLARED  # origin flipped together
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #1406. `NeuralEdgeRepository.create_or_update_edge`'s sticky-origin `origin_set` CASE preserved **any** existing non-hebbian origin on upsert. So when ingest-time k-NN seeding had already linked a near-duplicate pair with `origin='semantic'`, a later user-declared supersession (`remember(supersedes=...)` → the `origin=EDGE_ORIGIN_DECLARED` write path) retyped the edge to `supersedes` but read back `origin='semantic'` — leaving the declared edge **outside** the #457/#741 `protect_declared_link` shield (a later hebbian upsert with `protect_declared_link=True` could then retype it and silently break the shadowing the user asked for).

## Change

Add an incoming-`declared`-wins arm to the `origin_set` CASE — user assertion outranks machine provenance, while the hebbian-cannot-overwrite guarantee is unchanged (an incoming `hebbian` origin never matches the new arm):

```python
origin_set = case(
    (stmt.excluded.origin == EDGE_ORIGIN_DECLARED, stmt.excluded.origin),
    (NeuralMemoryEdge.origin != EDGE_ORIGIN_HEBBIAN, NeuralMemoryEdge.origin),
    else_=stmt.excluded.origin,
)
```

Pure application-layer CASE logic — **no schema/migration change**.

## Tests (12/12 origin tests green; adjacent declared-link/shadowing suites green; ruff clean)

- `test_upsert_declared_wins_over_existing_semantic` — the fix: existing `semantic` + incoming `declared` → `declared`.
- `test_upsert_declared_survives_later_semantic_reseed` — guard: existing `declared` not demoted by a later `semantic` upsert.
- `test_upsert_declared_wins_under_protect_link_flips_both_columns` — co-management: under `protect_declared_link=True`, `edge_type` and `origin` flip together (the exact property #1406 calls out).

## Review

Reviewed via the `code-reviewer` agent (the `/code-review` skill's agent form): traced the full 3×3 existing×incoming origin cross-product and every `create_or_update_edge` caller. No critical/warning findings; both info-level polish items (stale `origin` docstring, missing co-management test) applied in this PR.

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5oDPkF6n5KiX9DKRFBogp
