### PR TITLE
fix(mcp): explore read-gate + audit-thread explore & bootstrap (#1400)

### DIFF
--- a/backend/alembic/versions/e74_1401_mae_explore.py
+++ b/backend/alembic/versions/e74_1401_mae_explore.py
@@ -1,0 +1,51 @@
+"""Add 'explore' to memory_access_events.valid_mae_operation CHECK.
+
+Issue #1401: explore was outside the MAE operation vocabulary, so no
+memory_access_events row could ever be written for it (allows and denies
+were equally invisible to the append-only audit trail). #1400 additionally
+routes explore's context resolution through the read-path helper with
+operation="explore", so an enforce-mode binding deny now emits an audit
+row — which requires 'explore' to be a permitted operation value.
+
+The CHECK literal is kept byte-identical to the ordered ``MAE_OPERATIONS``
+tuple in ``models/memory_access_event.py`` (the house drift-pin convention,
+pinned by ``tests/test_memory_access_event_constants.py``). New values are
+APPENDED, never reordered.
+
+Revision ID: e74_1401_mae_explore
+Revises: e73_1377_locale_backfill
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e74_1401_mae_explore"
+down_revision = "e73_1377_locale_backfill"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add 'explore' to the valid_mae_operation CHECK constraint."""
+    op.drop_constraint("valid_mae_operation", "memory_access_events", type_="check")
+    op.create_check_constraint(
+        "valid_mae_operation",
+        "memory_access_events",
+        "operation IN ('recall', 'reference', 'remember', 'update', 'forget', "
+        "'load_pinned', 'bootstrap', 'feedback', 'explore')",
+    )
+
+
+def downgrade() -> None:
+    """Remove 'explore' from the valid_mae_operation CHECK constraint.
+
+    Note: fails if any rows with operation='explore' exist. Delete them first:
+        DELETE FROM memory_access_events WHERE operation = 'explore';
+    """
+    op.drop_constraint("valid_mae_operation", "memory_access_events", type_="check")
+    op.create_check_constraint(
+        "valid_mae_operation",
+        "memory_access_events",
+        "operation IN ('recall', 'reference', 'remember', 'update', 'forget', "
+        "'load_pinned', 'bootstrap', 'feedback')",
+    )

--- a/backend/src/mcp_server/tools/explore.py
+++ b/backend/src/mcp_server/tools/explore.py
@@ -15,7 +15,7 @@ from mcp_server.tools._helpers import (
     _ContextNotFoundError,
     _error_response,
     _log_tool_usage,
-    _resolve_context,
+    _resolve_context_for_read,
     _resolve_context_id,
     _validate_memory_id,
     execute_with_timeout,
@@ -48,7 +48,14 @@ async def handle_explore(
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
-            await _resolve_context(db, user_id, current_context_id)
+            # #1400/#1401: explore is a READ surface. Resolve via the read-path
+            # helper (ACCESS_READ) so a read-only bound agent (can_read=true,
+            # write_policy=deny) is allowed on its own bound context — mirroring
+            # recall/reference/load_pinned — instead of being denied by the
+            # WRITE gate. operation="explore" threads MAE audit identity so an
+            # enforce-mode binding deny at this pre-gate persists its audit row
+            # (explore was previously outside the MAE vocabulary → invisible).
+            await _resolve_context_for_read(db, user_id, current_context_id, operation="explore")
 
             service = MemoryService(db)
             result = await execute_with_timeout(

--- a/backend/src/models/memory_access_event.py
+++ b/backend/src/models/memory_access_event.py
@@ -1,8 +1,8 @@
 """memory_access_events — append-only agent memory-access audit (RFC-0002 P0-5, #1278).
 
-The append-only audit row for the eight memory operations performed under
+The append-only audit row for the nine memory operations performed under
 **verified agent identity**: recall / reference / remember / update / forget /
-load_pinned / bootstrap / feedback (design F3,
+load_pinned / bootstrap / feedback / explore (design F3,
 ``docs/design/memory-access-events.md``). Rows store identifiers, outcome,
 latency, policy decision, and keyed (HMAC) hashes — NEVER raw prompts,
 retrieved content, secrets, or PII.
@@ -57,6 +57,9 @@ MAE_OPERATIONS: tuple[str, ...] = (
     "load_pinned",
     "bootstrap",
     "feedback",
+    # #1401: explore is a read surface; appended (never reordered) so its
+    # context-resolution deny rows are auditable. CHECK altered in e74_1401.
+    "explore",
 )
 MAE_OUTCOMES: tuple[str, ...] = ("success", "denied", "error", "partial")
 MAE_SURFACES: tuple[str, ...] = ("mcp", "rest")

--- a/backend/src/services/agent_bootstrap_service.py
+++ b/backend/src/services/agent_bootstrap_service.py
@@ -293,14 +293,36 @@ class AgentBootstrapService:
         # first (with #963 key-workspace forwarding + allowed_context_ids), and
         # the AgentContextBinding intersection is applied inside it because the
         # per-request agent scope is set — it MAY narrow, MUST NOT widen.
+        decision_holder: list[str] = []
         try:
             context = await PermissionService(self.db).resolve_context_for_workspace_read(
                 user_id=principal.user_id,
                 context_id=context_id,
                 key_workspace_id=principal.key_workspace_id,
+                # #1402: thread the MAE operation so an enforce-mode agent-binding
+                # deny at this pre-gate persists a binding_denied row (in shadow
+                # mode, a would_deny row). Without it bootstrap — the surface that
+                # rehydrates an agent's whole cognitive state — was the one audited
+                # operation whose binding denials were silent.
+                operation="bootstrap",
+                # #1402: capture the evaluated decision so the success audit row
+                # reflects the REAL decision (allowed vs shadow would_deny), not a
+                # flat "allowed" that would contradict the paired would_deny row
+                # emitted inside evaluate_context_access on the shadow ramp.
+                binding_decision_out=decision_holder,
             )
         except NotFoundException as exc:
             raise BootstrapError("context_not_found", "Context not found.") from exc
+
+        # #1402: stamp the evaluated binding decision on the (later) bootstrap
+        # success audit row (written in mcp_server/tools/agent_bootstrap.py from
+        # principal.metadata["policy_decision"]). A hard binding_denied raised
+        # above; on the allow / shadow-would-deny path evaluate_context_access
+        # emits no success row itself, so the success row must carry the decision.
+        # decision_holder is populated only for agent-bound requests — non-agent
+        # principals leave policy_decision NULL (binding evaluation not applicable).
+        if decision_holder:
+            principal.metadata["policy_decision"] = decision_holder[0]
 
         return context, {"context_id": str(context_id), "is_default": is_default}
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -3644,14 +3644,19 @@ class MemoryService:
         from services.permission_service import CallerId, MemoryAuthorId, PermissionService
 
         perm_service = PermissionService(self.db)
-        # #1286 (P0-5): no operation threaded — "explore" is outside the
-        # MAE_OPERATIONS vocabulary; its denies stay log-only until the
-        # vocabulary grows (CHECK widening = a migration, out of scope here).
+        # #1401: "explore" is now in the MAE_OPERATIONS vocabulary (e74_1401),
+        # so thread it (with the requested memory_id) here too. This seed gate
+        # authorizes the seed's OWN stored context — a second deny surface
+        # distinct from the declared-context pre-gate in handle_explore — so an
+        # enforce-mode binding / #1299 row-filter deny here must persist its
+        # audit row, exactly like the reference / forget-by-id siblings.
         can_access = await perm_service.can_access_memory(
             user_id=CallerId(user_id),
             memory_user_id=MemoryAuthorId(seed_memory.user_id),
             workspace_id=seed_memory.workspace_id,
             context_id=seed_memory.context_id,
+            operation="explore",
+            memory_id=request.memory_id,
             memory_type=seed_memory.type,  # #1299: per-memory type/source filter
             memory_source_type=seed_memory.source_type,
         )

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -246,6 +246,7 @@ class PermissionService:
         required_role: WorkspaceRole | str = WorkspaceRole.VIEWER,
         key_workspace_id: UUID | None = None,
         operation: str | None = None,
+        binding_decision_out: list[str] | None = None,
     ) -> Context:
         """Resolve a ``context_id`` to a Context the caller can read, with uniform 404.
 
@@ -409,15 +410,21 @@ class PermissionService:
         # writers pass admin/owner. WorkspaceRole is a StrEnum, so the
         # comparison holds for both str and enum callers.
         access = "read" if required_role == WorkspaceRole.VIEWER else "write"
-        await self._apply_agent_binding_filter(
+        decision = await self._apply_agent_binding_filter(
             context_id, access=access, user_id=user_id, operation=operation
         )
+        # #1402: surface the evaluated binding decision (``allowed`` /
+        # ``would_deny``) to callers that stamp it on their OWN success audit
+        # row (agent bootstrap), without changing the return shape for the
+        # other read callers. ``None`` when no agent scope applies.
+        if binding_decision_out is not None and decision is not None:
+            binding_decision_out.append(decision)
 
         return context
 
     async def _apply_agent_binding_filter(
         self, context_id: UUID, *, access: str, user_id: str, operation: str | None = None
-    ) -> None:
+    ) -> str | None:
         """Deny with the uniform 404 when the agent binding subtracts access.
 
         Reads the per-request agent scope (#1275, set at API-key verify for
@@ -434,12 +441,19 @@ class PermissionService:
         the MCP face (the #1291/#1292 parity class). ``None`` (callers
         outside the MAE vocabulary — context CRUD/metadata reads) keeps the
         log-only behavior.
+
+        Returns the evaluated binding decision (``allowed`` or ``would_deny``)
+        when an agent scope applies and the request is permitted (or shadow-
+        proceeds), or ``None`` when no agent scope applies. A hard deny raises
+        ``NotFoundException`` instead of returning. Callers that stamp the
+        decision on their own audit row (#1402, agent bootstrap) read it; the
+        others ignore it (byte-compat).
         """
         from auth.agent_scope import get_agent_scope
 
         scope = get_agent_scope()
         if scope is None:
-            return
+            return None
 
         from services.agent_binding_service import AgentBindingService
 
@@ -457,6 +471,7 @@ class PermissionService:
                 user_id=user_id,
             )
             raise NotFoundException("Context", str(context_id))
+        return decision
 
     async def check_workspace_owner(self, user_id: str, workspace_id: UUID) -> WorkspaceMember:
         """Check if user is workspace owner.

--- a/backend/tests/mcp_server/test_deny_capture_threading.py
+++ b/backend/tests/mcp_server/test_deny_capture_threading.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 
 import pytest
 
+from mcp_server.tools import explore as explore_tools
 from mcp_server.tools import feedback as feedback_tools
 from mcp_server.tools import memory as memory_tools
 from mcp_server.tools._helpers import _ContextNotFoundError
@@ -78,6 +79,18 @@ CASES = [
         {"context_id": _CTX, "memory_id": _MID, "helpful": True},
         "_resolve_context_for_read",
         "feedback",
+    ),
+    (
+        # #1400/#1401: explore is a READ surface — it must resolve via the
+        # read-path helper (ACCESS_READ) AND thread operation="explore" so an
+        # enforce-mode binding deny persists an audit row (explore was
+        # previously on the WRITE resolver with operation=None → both wrongly
+        # denied read-only agents and left zero audit evidence).
+        explore_tools,
+        "handle_explore",
+        {"memory_id": _MID, "context_id": _CTX},
+        "_resolve_context_for_read",
+        "explore",
     ),
     (
         memory_tools,

--- a/backend/tests/services/test_agent_bootstrap_service.py
+++ b/backend/tests/services/test_agent_bootstrap_service.py
@@ -284,6 +284,122 @@ class TestContextResolution:
                 )
         assert e.value.code == "context_not_found"
 
+    @staticmethod
+    def _resolver_capturing(decision):
+        """A resolve_context_for_workspace_read double honoring the #1402
+        decision-out contract: append the evaluated decision to the caller's
+        ``binding_decision_out`` holder (as the real resolver does for agent-
+        bound requests), then return a context. ``decision=None`` models a
+        non-agent request that captures nothing."""
+
+        async def _side(*_args, **kwargs):
+            holder = kwargs.get("binding_decision_out")
+            if holder is not None and decision is not None:
+                holder.append(decision)
+            return _context()
+
+        return _side
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_threads_bootstrap_operation(self):
+        """#1402: bootstrap must thread operation='bootstrap' into the read
+        resolver so an enforce-mode binding deny at that pre-gate persists a
+        binding_denied audit row (previously un-threaded → silent)."""
+        svc = AgentBootstrapService(MagicMock())
+        resolver = AsyncMock(return_value=_context())
+        with (
+            patch(
+                "services.agent_binding_service.AgentBindingService.get_binding_for_context",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                new=resolver,
+            ),
+        ):
+            await svc.resolve_context(
+                agent=_agent(),
+                params=BootstrapParams(agent_id=AGENT_ID, context_id=CONTEXT_ID),
+                principal=self._principal(),
+            )
+        assert resolver.await_args.kwargs.get("operation") == "bootstrap"
+        # The decision-out holder must be threaded so the success row can carry
+        # the real decision (#1402 code-review).
+        assert isinstance(resolver.await_args.kwargs.get("binding_decision_out"), list)
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_stamps_allowed_decision(self):
+        """#1402: on an enforce-mode allow, the principal carries
+        policy_decision='allowed' so the bootstrap success MAE row is no longer
+        NULL (the surface that rehydrates cognitive state was the one audited op
+        whose rows never carried a binding decision)."""
+        svc = AgentBootstrapService(MagicMock())
+        principal = self._principal()
+        with (
+            patch(
+                "services.agent_binding_service.AgentBindingService.get_binding_for_context",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                new=self._resolver_capturing("allowed"),
+            ),
+        ):
+            await svc.resolve_context(
+                agent=_agent(),
+                params=BootstrapParams(agent_id=AGENT_ID, context_id=CONTEXT_ID),
+                principal=principal,
+            )
+        assert principal.metadata.get("policy_decision") == "allowed"
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_stamps_real_would_deny_decision(self):
+        """#1402 (code-review): a shadow would-deny that PROCEEDS must stamp the
+        REAL decision on the success row, not a flat 'allowed' — otherwise the
+        canonical bootstrap row contradicts the paired would_deny ramp row that
+        evaluate_context_access emits on the shadow path."""
+        svc = AgentBootstrapService(MagicMock())
+        principal = self._principal()
+        with (
+            patch(
+                "services.agent_binding_service.AgentBindingService.get_binding_for_context",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                new=self._resolver_capturing("would_deny"),
+            ),
+        ):
+            await svc.resolve_context(
+                agent=_agent(),
+                params=BootstrapParams(agent_id=AGENT_ID, context_id=CONTEXT_ID),
+                principal=principal,
+            )
+        assert principal.metadata.get("policy_decision") == "would_deny"
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_no_policy_decision_without_binding(self):
+        """#1402: a non-agent principal (resolver captures no decision) leaves
+        policy_decision NULL — binding evaluation is not applicable."""
+        svc = AgentBootstrapService(MagicMock())
+        principal = self._principal()
+        with (
+            patch(
+                "services.agent_binding_service.AgentBindingService.get_binding_for_context",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "services.permission_service.PermissionService.resolve_context_for_workspace_read",
+                new=self._resolver_capturing(None),
+            ),
+        ):
+            await svc.resolve_context(
+                agent=_agent(),
+                params=BootstrapParams(agent_id=AGENT_ID, context_id=CONTEXT_ID),
+                principal=principal,
+            )
+        assert principal.metadata.get("policy_decision") is None
+
 
 class TestAuditOnBehalfOf:
     """#1276 code-review: operator (owner/admin) bootstraps MUST persist an

--- a/backend/tests/services/test_permission_agent_binding.py
+++ b/backend/tests/services/test_permission_agent_binding.py
@@ -494,6 +494,12 @@ class TestReadLaneRowFilterThreading:
         with self._deny_can_access() as can_access, pytest.raises(NotFoundException):
             await MemoryService.explore(svc, ExploreRequest(memory_id=mem.id), "u")
         kw = can_access.await_args.kwargs
+        # #1401: explore's seed gate threads its audit identity like the
+        # reference / forget siblings ('explore' entered the MAE vocabulary in
+        # e74_1401), so an enforce-mode deny here persists a row instead of
+        # staying log-only.
+        assert kw["operation"] == "explore"
+        assert kw["memory_id"] == mem.id
         assert kw["memory_type"] == "code"
         assert kw["memory_source_type"] == "file"
 
@@ -596,8 +602,8 @@ class TestCanAccessMemoryDenyCapture:
 
     @pytest.mark.asyncio
     async def test_no_operation_rbac_deny_emits_nothing(self):
-        # Un-threaded callers (explore — not in the MAE vocabulary yet) keep
-        # the pre-#1286 shape: deny without a row.
+        # Un-threaded callers (internal maintenance paths outside the MAE
+        # operation vocabulary) keep the pre-#1286 shape: deny without a row.
         set_agent_scope(
             AgentScope(agent_id=AGENT_ID, enforcement_mode="enforce", workspace_id=uuid.uuid4())
         )

--- a/backend/tests/test_memory_access_event_constants.py
+++ b/backend/tests/test_memory_access_event_constants.py
@@ -22,7 +22,7 @@ def _check(name: str) -> str:
     return c.sqltext.text
 
 
-def test_operation_tuple_is_the_eight_audited_ops():
+def test_operation_tuple_is_the_audited_ops():
     assert MAE_OPERATIONS == (
         "recall",
         "reference",
@@ -32,13 +32,14 @@ def test_operation_tuple_is_the_eight_audited_ops():
         "load_pinned",
         "bootstrap",
         "feedback",
+        "explore",  # #1401 (appended, never reordered)
     )
 
 
 def test_check_literals_byte_identical_to_migration():
     assert _check("valid_mae_operation") == (
         "operation IN ('recall', 'reference', 'remember', 'update', 'forget', "
-        "'load_pinned', 'bootstrap', 'feedback')"
+        "'load_pinned', 'bootstrap', 'feedback', 'explore')"
     )
     assert _check("valid_mae_outcome") == "outcome IN ('success', 'denied', 'error', 'partial')"
     assert _check("valid_mae_surface") == "surface IN ('mcp', 'rest')"

--- a/docs/design/memory-access-events.md
+++ b/docs/design/memory-access-events.md
@@ -15,17 +15,18 @@
   [#1277](https://github.com/kagura-ai/memory-cloud/issues/1277)) for the semantics of the
   correlation columns this table stores
 
-`MemoryAccessEvent` (`memory_access_events`) is the append-only audit row for the eight
+`MemoryAccessEvent` (`memory_access_events`) is the append-only audit row for the nine
 memory operations performed under verified agent identity: **recall / reference / remember /
-update / forget / load_pinned / bootstrap / feedback**. Rows store identifiers, outcome,
+update / forget / load_pinned / bootstrap / feedback / explore** (`explore` appended in
+#1401, migration `e74_1401`). Rows store identifiers, outcome,
 latency, policy decision, and keyed (HMAC) hashes — **never** raw prompts, retrieved
 content, secrets, or PII. This document restates every RFC-0002 decision the schema depends
 on (D20–D25, D29, D34) so it is self-contained, records the CSO review of the deny-logging
 layer, and settles the one question RFC-0002 deferred to F3 (the deny-capture layer).
 
 The v0.49.0 implementation emits bootstrap, load-pinned, feedback, recall, reference, and
-remember events. The schema already reserves all eight operations; `update`/`forget`
-emission plus denied/`would_deny` persistence remain in #1286.
+remember events. The schema reserves all nine operations (`explore` added in #1401);
+`update`/`forget` emission plus denied/`would_deny` persistence remain in #1286.
 
 ## Scope and non-goals
 
@@ -139,7 +140,7 @@ CREATE TABLE memory_access_events (
                                                      -- raw query NEVER stored
     event_metadata     JSONB NULL,
     CONSTRAINT valid_mae_operation CHECK (operation IN
-        ('recall','reference','remember','update','forget','load_pinned','bootstrap','feedback')),
+        ('recall','reference','remember','update','forget','load_pinned','bootstrap','feedback','explore')),
     CONSTRAINT valid_mae_outcome   CHECK (outcome IN ('success','denied','error','partial')),
     CONSTRAINT valid_mae_surface   CHECK (surface IN ('mcp','rest')),
     CONSTRAINT valid_mae_principal CHECK (principal_type IN ('api_key','oauth','session')),


### PR DESCRIPTION
## Summary

Agent-plane **audit-correctness cluster** (found by the prereg-v2 F6 conformance suite, verified at v0.53.0). Closes #1400, #1401, #1402.

### #1400 — explore denied read-only bound agents on their own context
`handle_explore` resolved its declared context via the WRITE-path helper (`_resolve_context`, `ACCESS_WRITE`), so a read-only binding (`can_read=true, write_policy=deny`) was denied `explore` — while `recall`/`reference`/`load_pinned` correctly allowed. Routed through `_resolve_context_for_read` (`ACCESS_READ`). The **seed-memory** gate (`MemoryService.explore` → `can_access_memory`) is a second, distinct deny surface — it now threads `operation="explore"` / `memory_id` like its `reference`/`forget` siblings (this second gate was flagged in review; the first version only fixed the pre-gate).

### #1401 — explore was outside the MAE audit vocabulary
`explore` was absent from `MAE_OPERATIONS`, so **no** `memory_access_events` row could be written for it — allows and denies equally invisible. Appended `"explore"` (append-only) + migration `e74_1401` drops/recreates the `valid_mae_operation` CHECK (mirrors the `a94` pattern; single head, chains from `e73_1377`). Both explore gates now thread `operation="explore"`, so enforce-mode binding denies persist audit rows.

### #1402 — bootstrap binding denials were silent; success rows had NULL policy_decision
`agent_bootstrap_service.resolve_context` called the binding evaluation with no `operation=`, so `_emit_decision` no-op'd (enforce deny → no `binding_denied` row) and the success row carried `policy_decision=NULL`. Now threads `operation="bootstrap"`, and **surfaces the evaluated decision** via a new opt-in `binding_decision_out` out-param on `resolve_context_for_workspace_read` (byte-compat for the other 8 callers) so the success row stamps the **real** decision — `allowed` on a clean allow, `would_deny` on the shadow ramp — instead of a flat `"allowed"` that would contradict the paired `would_deny` row. Non-agent principals leave it NULL.

## Tests

- `test_deny_capture_threading.py`: added the `explore` case pinning `operation="explore"` + read-path threading.
- `test_agent_bootstrap_service.py`: `operation="bootstrap"` + `binding_decision_out` threaded; `policy_decision` stamped as `allowed` / **`would_deny`** (shadow) / NULL (non-agent).
- `test_permission_agent_binding.py`: `test_explore_seed_threads_row` now asserts `operation="explore"` + `memory_id`; corrected the stale "explore not in vocabulary" comment.
- Constants drift-pin test + design doc (`docs/design/memory-access-events.md`) updated to nine ops.
- 170 affected-suite tests pass locally; ruff clean. Full fresh-DB migration apply runs in CI `backend-integration`.

## Review

Reviewed via the `code-reviewer` agent (the `/code-review` skill's agent form). Both `[W]` findings from the first pass — the un-threaded explore **seed** gate and the shadow-would-deny `policy_decision` flattening — are fixed in this PR, plus the `[I]` stale docstring.

Closes #1400. Closes #1401. Closes #1402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5oDPkF6n5KiX9DKRFBogp
