### PR TITLE
feat(mcp): make supersedes first-class — docs, telemetry, detection (#1403)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -98,6 +98,15 @@ Supports 3-layer architecture:
 - context_summary: Why this matters and how to use it
 - details: Complete data, code, or structured information
 
+UPDATING A FACT (supersedes) — the primary way to keep memory current:
+When you store the NEWER version of something you previously remembered, pass
+supersedes=<old_memory_id>. The old memory is SHADOWED out of default recall
+(not deleted — it stays restorable and reachable via recall(include_superseded=true)
+and explore()). Prefer this over storing a near-duplicate: a duplicate leaves the
+stale and fresh facts competing in recall, whereas a declared supersession makes
+the update authoritative. This is the strongest lever for update-correctness, so
+reach for it whenever a memory replaces an earlier one.
+
 CHUNKING BEST PRACTICES for long documents:
 • Optimal summary length: 100-250 characters (max: 500)
 • For long documents (>2000 chars): Create multiple semantic memories

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1578,6 +1578,19 @@ class MemoryService:
                         return_fresh_edge=False,
                     )
                     created += 1
+                    # #1403: count declared-supersedes adoption. The supersedes
+                    # edge is the dominant stale-suppression lever (F3 factorial:
+                    # +0.78, update_success@10 0.76 -> 1.00) and the one mechanism
+                    # users must explicitly invoke — emit a dedicated event so its
+                    # adoption is visible in telemetry, not buried in the generic
+                    # declared_links_created count.
+                    logger.info(
+                        "declared_supersedes_created",
+                        user_id=user_id,
+                        memory_id=str(memory_id),
+                        superseded_memory_id=str(supersedes_target),
+                        context_id=context_id,
+                    )
                 else:
                     logger.warning(
                         "supersedes_target_not_found",
@@ -4116,6 +4129,18 @@ class MemoryService:
         return hints
 
 
+# #1403: near-duplicate threshold above which the nearest k-NN neighbor of a
+# freshly-embedded memory is surfaced as a supersede candidate — the user is
+# likely storing an updated version of an existing fact. Deliberately high (well
+# above the calibrated per-model seed threshold) so the signal fires only on
+# true near-duplicates, not merely related memories. Unlike the seed threshold
+# (D4 calibration/operator-override chain), this is a fixed first-pass heuristic;
+# graduate it to a per-model calibrated / config-driven value if the adoption
+# telemetry shows it mis-fires across embedding models with different score
+# distributions.
+_SUPERSEDE_SUGGEST_THRESHOLD = 0.92
+
+
 async def _create_knn_seed_edges(
     db: AsyncSession,
     memory: Memory,
@@ -4256,6 +4281,23 @@ async def _create_knn_seed_edges(
                 threshold=threshold,
             )
             return
+
+        # #1403: supersede-suggestion signal. When the nearest neighbor is a
+        # near-duplicate (well above the calibrated seed threshold), this new
+        # memory is likely an updated version of an existing fact — a supersede
+        # candidate the user may prefer over storing a second copy. Seeding runs
+        # async (decoupled from the remember response), so the candidate is
+        # emitted as telemetry here; a synchronous client-facing prompt is a
+        # follow-up gated on the async-embedding hot-path trade-off.
+        top_neighbor = seed_neighbors[0]
+        top_score = float(top_neighbor["score"])
+        if top_score >= _SUPERSEDE_SUGGEST_THRESHOLD:
+            logger.info(
+                "supersede_candidate_detected",
+                memory_id=memory_id_str,
+                candidate_memory_id=str(top_neighbor["id"]),
+                similarity=round(top_score, 4),
+            )
 
         edges_created = 0
         similarities: list[float] = []

--- a/backend/tests/services/test_knn_seeding.py
+++ b/backend/tests/services/test_knn_seeding.py
@@ -180,6 +180,88 @@ class TestKnnSeeding:
             assert call.kwargs["dst_id"] != memory.id
 
     @pytest.mark.asyncio
+    async def test_supersede_candidate_detected_on_near_duplicate(self):
+        """#1403: when the nearest neighbor is a near-duplicate (score >= the
+        supersede-suggest threshold), a supersede_candidate_detected telemetry
+        event names it — the signal a client can turn into a 'does this
+        supersede X?' prompt (seeding is async, so the response can't carry it)."""
+        memory = _make_memory()
+        db = _make_db()
+        mock_repo = _make_edge_repo()
+        dup_id = str(uuid4())
+        candidates = [
+            {"id": dup_id, "score": 0.95, "payload": {}, "embedding": []},
+            {"id": str(uuid4()), "score": 0.70, "payload": {}, "embedding": []},
+        ]
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=_make_config(min_similarity=0.6)),
+            ),
+            patch(
+                "db.qdrant.search_memories_qdrant",
+                new=AsyncMock(return_value=candidates),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch("services.memory_service.logger") as mock_logger,
+        ):
+            await _create_knn_seed_edges(
+                db=db,
+                memory=memory,
+                vector=[0.1] * 512,
+                collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
+            )
+
+        events = {c.args[0]: c.kwargs for c in mock_logger.info.call_args_list if c.args}
+        assert "supersede_candidate_detected" in events
+        assert events["supersede_candidate_detected"]["candidate_memory_id"] == dup_id
+        assert events["supersede_candidate_detected"]["similarity"] == 0.95
+
+    @pytest.mark.asyncio
+    async def test_no_supersede_candidate_below_threshold(self):
+        """#1403: a merely-related nearest neighbor (score below the supersede-
+        suggest threshold) must NOT emit a supersede candidate — the signal
+        fires only on true near-duplicates, not on ordinary seed neighbors."""
+        memory = _make_memory()
+        db = _make_db()
+        mock_repo = _make_edge_repo()
+        candidates = [
+            {"id": str(uuid4()), "score": 0.85, "payload": {}, "embedding": []},
+            {"id": str(uuid4()), "score": 0.70, "payload": {}, "embedding": []},
+        ]
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=_make_config(min_similarity=0.6)),
+            ),
+            patch(
+                "db.qdrant.search_memories_qdrant",
+                new=AsyncMock(return_value=candidates),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch("services.memory_service.logger") as mock_logger,
+        ):
+            await _create_knn_seed_edges(
+                db=db,
+                memory=memory,
+                vector=[0.1] * 512,
+                collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
+            )
+
+        emitted = [c.args[0] for c in mock_logger.info.call_args_list if c.args]
+        assert "supersede_candidate_detected" not in emitted
+
+    @pytest.mark.asyncio
     async def test_threshold_filter_excludes_low_similarity(self):
         """Neighbors with score < min_similarity are excluded."""
         memory = _make_memory()

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -660,6 +660,91 @@ class TestDeclaredLinks:
         # The empty requested_ids list means no DB query at all
         service.db.execute.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_supersedes_emits_declared_supersedes_telemetry(self, service):
+        """#1403: creating a declared supersedes edge emits a dedicated
+        declared_supersedes_created event so adoption of the dominant stale-
+        suppression lever is visible in telemetry (not buried in the generic
+        declared_links_created count)."""
+        memory_id = uuid4()
+        target_id = uuid4()
+        request = RememberRequest(
+            summary="Updated version of a previously stored fact",
+            content="fresh content",
+            type="note",
+            supersedes=target_id,
+        )
+        # The target-existence validation query returns the predecessor row.
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=target_id)
+        service.db.execute = AsyncMock(return_value=mock_result)
+        service.db.commit = AsyncMock()
+
+        mock_repo = MagicMock()
+        mock_repo.create_or_update_edge = AsyncMock()
+
+        with (
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch("services.memory_service.logger") as mock_logger,
+        ):
+            await service._create_declared_links(
+                memory_id=memory_id,
+                request=request,
+                user_id="test_user",
+                workspace_id=str(uuid4()),
+                context_id=str(uuid4()),
+            )
+
+        # The supersedes edge was created…
+        mock_repo.create_or_update_edge.assert_awaited_once()
+        # …and its adoption telemetry fired, naming the superseded predecessor.
+        events = {c.args[0]: c.kwargs for c in mock_logger.info.call_args_list if c.args}
+        assert "declared_supersedes_created" in events
+        assert events["declared_supersedes_created"]["superseded_memory_id"] == str(target_id)
+        assert events["declared_supersedes_created"]["memory_id"] == str(memory_id)
+
+    @pytest.mark.asyncio
+    async def test_supersedes_missing_target_emits_no_telemetry(self, service):
+        """#1403: when the supersedes target does not exist (validation query
+        returns None), no edge is created and the declared_supersedes_created
+        adoption event must NOT fire — it counts only real supersessions."""
+        request = RememberRequest(
+            summary="Update pointing at a non-existent predecessor",
+            content="fresh content",
+            type="note",
+            supersedes=uuid4(),
+        )
+        # Target-existence validation returns None (predecessor absent).
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none = MagicMock(return_value=None)
+        service.db.execute = AsyncMock(return_value=mock_result)
+        service.db.commit = AsyncMock()
+
+        mock_repo = MagicMock()
+        mock_repo.create_or_update_edge = AsyncMock()
+
+        with (
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch("services.memory_service.logger") as mock_logger,
+        ):
+            await service._create_declared_links(
+                memory_id=uuid4(),
+                request=request,
+                user_id="test_user",
+                workspace_id=str(uuid4()),
+                context_id=str(uuid4()),
+            )
+
+        mock_repo.create_or_update_edge.assert_not_awaited()
+        emitted = [c.args[0] for c in mock_logger.info.call_args_list if c.args]
+        assert "declared_supersedes_created" not in emitted
+
 
 class TestTagCooccurrenceSeeding:
     """Unit tests for _create_tag_cooccurrence_seed_edges (Issue #223).


### PR DESCRIPTION
## Summary

Makes declared **supersedes** first-class — the prereg-v2 F3 factorial attributes v0.53 update-correctness mostly to it (**+0.78** stale-suppression; update_success@10 0.76 → 1.00), yet it's the one mechanism users must explicitly invoke.

- **Docs**: promote `supersedes` in the remember tool description as *the* way to keep a fact current (shadow, don't duplicate).
- **Telemetry**: a dedicated `declared_supersedes_created` event at edge creation → adoption is measurable.
- **Detection**: when ingest-time k-NN seeding finds a near-duplicate nearest neighbor (score ≥ 0.92), emit `supersede_candidate_detected` naming the candidate.

## Deferred (why `Partially addresses`, not `Closes`)

The issue's headline ask is a **synchronous** "does this supersede X?" prompt *in* the remember response. But `remember()` fires `process_pending_embedding` as a fire-and-forget task and returns **before** the embedding + Qdrant round-trip — so the k-NN neighbor isn't knowable at response time. Surfacing it synchronously needs either synchronous embedding on the hot write path or a redundant lexical pre-check — a latency trade-off that warrants its own decision. This PR ships the **detection foundation** as telemetry; the client-facing prompt stays tracked by #1403.

## Tests
5 new/negative tests (detect fire + below-threshold no-fire; telemetry fire + missing-target no-fire), tool-schema policy green, ruff clean. Additive change (structured logs + doc + constant) — no control-flow change.

## Review
Reviewed via the `code-reviewer` agent (`/code-review`): confirmed the async-architecture reasoning (seeding genuinely can't feed the sync response), no code defects; its warnings (partial-scope `Closes`, threshold-calibration note, negative telemetry test) all applied here.

Partially addresses #1403

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5oDPkF6n5KiX9DKRFBogp