### PR TITLE
feat(mcp): supersede-candidate read exposure + acceptance (#1403)

### DIFF
--- a/backend/alembic/versions/e75_1403_supersede_candidate.py
+++ b/backend/alembic/versions/e75_1403_supersede_candidate.py
@@ -1,0 +1,44 @@
+"""Add memories.supersede_candidate (server-only supersede suggestion).
+
+Issue #1403 (option B): the k-NN cold-start seeding detects, at ingest, when a
+new memory's top-1 neighbor is a near-duplicate (cosine >= the supersede-suggest
+threshold) — i.e. the new memory likely supersedes an existing fact. That
+suggestion is stored here and surfaced, liveness-guarded, on recall()/reference()
+so a client can offer a confirm -> create_edge(edge_type="supersedes") action
+(never auto-created — the #1208 over-supersede prevention stays intact).
+
+A DEDICATED column rather than a key inside the client-writable ``details`` JSON:
+storing it in ``details`` would let a client forge the ``memory_id`` (leaking
+another memory's summary through the read-path enrichment, bypassing the
+per-memory access check) or silently drop it on a ``details`` replace. This column
+is written only by the server (the async k-NN seeding) and cleared only when the
+suggested supersedes edge is created.
+
+Additive + nullable: existing rows read as NULL (no suggestion), no backfill.
+
+Revision ID: e75_1403_supersede_candidate
+Revises: e74_1401_mae_explore
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e75_1403_supersede_candidate"
+down_revision = "e74_1401_mae_explore"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add the nullable supersede_candidate JSON column to memories."""
+    op.add_column(
+        "memories",
+        sa.Column("supersede_candidate", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop the supersede_candidate column."""
+    op.drop_column("memories", "supersede_candidate")

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -9,6 +9,8 @@ from typing import Any
 from uuid import UUID
 
 from mcp.types import TextContent
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from mcp_server.tools._helpers import (
     _check_viewer_permission,
@@ -32,7 +34,11 @@ from models.memory import (
     EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
     EDGE_TYPE_SUPERSEDES,
+    Memory,
 )
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 # Issue #461 / #741 / #782: full set of edge_types accepted by the DB CHECK
 # constraint (`models/memory.py::valid_edge_type`). Sourced from `EDGE_TYPE_*`
@@ -146,6 +152,41 @@ def _parse_float(
             "validation_error", f"{name} must be between {min_val} and {max_val}."
         )
     return f, None
+
+
+async def _accept_supersede_candidate_if_matching(
+    db: AsyncSession, *, src_id: UUID, dst_id: UUID
+) -> None:
+    """#1403: record acceptance of a suggested supersession and self-heal.
+
+    When a ``supersedes`` edge ``src → dst`` confirms a previously-suggested
+    candidate (``src.supersede_candidate.memory_id == dst``), emit the
+    ``supersede_suggestion_accepted`` telemetry (the accept side of the
+    detected/accepted adoption funnel) and clear the stored suggestion so it
+    stops surfacing on recall()/reference(). The mutation is committed by the
+    caller's ``db.commit()`` in the same transaction as the edge.
+
+    Best-effort: any failure is swallowed — telemetry/self-heal must never fail
+    the edge creation itself.
+    """
+    try:
+        result = await db.execute(select(Memory).where(Memory.id == src_id))
+        memory = result.scalar_one_or_none()
+        if memory is None or not isinstance(memory.supersede_candidate, dict):
+            return
+        cand = memory.supersede_candidate
+        if cand.get("memory_id") != str(dst_id):
+            return
+        # Clear the accepted suggestion (server-only column; None = no suggestion).
+        memory.supersede_candidate = None
+        logger.info(
+            "supersede_suggestion_accepted",
+            memory_id=str(src_id),
+            superseded_memory_id=str(dst_id),
+            similarity=cand.get("similarity"),
+        )
+    except Exception as e:
+        logger.warning("supersede_accept_check_failed", error=str(e))
 
 
 async def handle_list_edges(
@@ -394,6 +435,13 @@ async def handle_create_edge(
                 ),
                 operation_name="create_edge",
             )
+
+            # #1403: if this supersedes edge confirms a stored suggestion, record
+            # the acceptance and clear it (self-heal), in the same transaction.
+            if edge_type == EDGE_TYPE_SUPERSEDES:
+                await _accept_supersede_candidate_if_matching(
+                    db, src_id=source_uuid, dst_id=target_uuid
+                )
 
             await _log_tool_usage(
                 db, user_id, "create_edge", start_time, 200, current_context_id, workspace_id

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -673,6 +673,13 @@ async def handle_recall(
                     # opposing memories (never hidden, both sides annotated).
                     "superseded_by": str(r.superseded_by) if r.superseded_by else None,
                     "contradicts": [str(c) for c in r.contradicts],
+                    # #1403: liveness-guarded near-duplicate this memory may
+                    # supersede — a client can offer confirm→create_edge.
+                    "supersede_candidate": (
+                        r.supersede_candidate.model_dump(mode="json")
+                        if r.supersede_candidate
+                        else None
+                    ),
                 }
                 for r in result.results
             ]
@@ -923,6 +930,13 @@ async def handle_reference(
                 "outgoing_has_more": result.outgoing_has_more,
                 "incoming_links": [ref.model_dump(mode="json") for ref in result.incoming_links],
                 "incoming_has_more": result.incoming_has_more,
+                # #1403: liveness-guarded supersede suggestion (from the
+                # server-only supersede_candidate column, not the details blob).
+                "supersede_candidate": (
+                    result.supersede_candidate.model_dump(mode="json")
+                    if result.supersede_candidate
+                    else None
+                ),
             }
 
             await _log_tool_usage(

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -250,6 +250,16 @@ class Memory(Base):
         server_default=SOURCE_TYPE_MANUAL,
     )
 
+    # #1403: server-only supersede suggestion — the top-1 near-duplicate found at
+    # ingest by the k-NN seeding (cosine >= _SUPERSEDE_SUGGEST_THRESHOLD), stored
+    # as {memory_id, similarity, detected_at}. A DEDICATED column, NOT a key inside
+    # the client-writable ``details`` blob: putting it in ``details`` would let a
+    # client forge the ``memory_id`` (leaking another memory's summary via the
+    # read-path enrichment, bypassing can_access_memory) or silently drop it on a
+    # ``details`` replace. Surfaced — liveness-guarded — on recall()/reference(),
+    # and cleared when the suggested supersedes edge is created. NULL = none.
+    supersede_candidate: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
     # Migration 061: Generated columns for efficient resource memory lookups
     # These columns are automatically computed from details JSONB field
     resource_id: Mapped[str | None] = mapped_column(

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -208,6 +208,26 @@ class RecallRequest(BaseModel):
     )
 
 
+class SupersedeCandidate(TZAwareBaseModel):
+    """#1403: a near-duplicate the memory likely supersedes (a suggestion — never
+    an auto-created edge).
+
+    Detected at ingest by the k-NN seeding (top-1 neighbor at cosine >=
+    _SUPERSEDE_SUGGEST_THRESHOLD) and stored on the new memory. Surfaced —
+    liveness-guarded — on recall()/reference() so a client can offer a
+    confirm→create_edge(edge_type="supersedes") action. It disappears on its own
+    once the target is deleted (self-healing) or the suggestion is accepted (the
+    stored key is cleared when the matching supersedes edge is created). The
+    #1208 over-supersede prevention is preserved: the edge is only ever created
+    on explicit user/agent confirmation, never by this suggestion.
+    """
+
+    memory_id: UUID
+    summary: str
+    similarity: float
+    detected_at: datetime | None = None
+
+
 class MemoryResponse(TZAwareBaseModel):
     """Response schema for single memory."""
 
@@ -239,6 +259,9 @@ class MemoryResponse(TZAwareBaseModel):
     # direction) — contradiction never hides, it annotates both sides.
     superseded_by: UUID | None = None
     contradicts: list[UUID] = Field(default_factory=list)
+    # #1403: liveness-guarded supersede suggestion (top-1 near-duplicate detected
+    # at ingest). None unless this memory has a still-actionable candidate.
+    supersede_candidate: SupersedeCandidate | None = None
 
     class Config:
         from_attributes = True
@@ -476,6 +499,9 @@ class ReferenceResponse(TZAwareBaseModel):
     outgoing_has_more: bool = False
     incoming_links: list[LinkedMemoryRef] = Field(default_factory=list)
     incoming_has_more: bool = False
+    # #1403: liveness-guarded supersede suggestion (from the server-only
+    # supersede_candidate column, never the client-writable details blob).
+    supersede_candidate: SupersedeCandidate | None = None
 
 
 class ExportedSearchConfig(BaseModel):

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1133,10 +1133,12 @@ class MemoryService:
 
         # #1403: surface the liveness-guarded suggestion here too. It lives in its
         # own column, so replacing `details` on this patch never drops it, and the
-        # client sees the current suggestion in the patch response.
+        # client sees the current suggestion in the patch response. operation="update"
+        # matches the PATCH surface's MAE vocabulary so a shadow-mode binding
+        # would_deny is attributed to the right operation (not "reference").
         supersede_candidate = (
             await self._resolve_supersede_candidates(
-                {memory.id: memory}, user_id=user_id, operation="reference"
+                {memory.id: memory}, user_id=user_id, operation="update"
             )
         ).get(memory.id)
 
@@ -4415,6 +4417,42 @@ async def _create_knn_seed_edges(
             collection_name=collection_name,
         )
 
+        # #1403 option B: supersede-suggestion signal — detected from the RAW top-1
+        # neighbor (excluding self), INDEPENDENT of the calibrated/operator seed-edge
+        # threshold. Coupling it to `seed_neighbors` would let an operator seed
+        # threshold (knn_seed_min_similarity) > _SUPERSEDE_SUGGEST_THRESHOLD silently
+        # suppress a valid suggestion (e.g. a 0.87 near-duplicate filtered out before
+        # the check). Seeding runs async (decoupled from the remember response), so
+        # rather than block remember() we PERSIST the candidate onto the new memory's
+        # dedicated server-only supersede_candidate column (never the client-writable
+        # details blob) and surface it — liveness-guarded — on the next
+        # recall()/reference(). Suggestion only: the edge is never auto-created (the
+        # #1208 over-supersede prevention keeps edge authorship with the user/agent,
+        # who confirms via create_edge).
+        non_self = [c for c in candidates if str(c["id"]) != memory_id_str]
+        if non_self:
+            raw_top = max(non_self, key=lambda c: float(c["score"]))
+            raw_top_score = float(raw_top["score"])
+            if raw_top_score >= _SUPERSEDE_SUGGEST_THRESHOLD:
+                candidate = {
+                    "memory_id": str(raw_top["id"]),
+                    "similarity": round(raw_top_score, 4),
+                    "detected_at": to_utc_iso(utcnow()),
+                }
+                # Reassign the dedicated column (JSON, not a MutableDict — a
+                # reassignment is what flags it dirty). Do NOT touch updated_at:
+                # detection is a system annotation, not a user edit (#1317). Commit
+                # is safe: the caller already committed the embedding_status update
+                # before invoking this function, so nothing else is pending here.
+                memory.supersede_candidate = candidate
+                await db.commit()
+                logger.info(
+                    "supersede_candidate_detected",
+                    memory_id=memory_id_str,
+                    candidate_memory_id=candidate["memory_id"],
+                    similarity=candidate["similarity"],
+                )
+
         # Filter: exclude self, apply resolved (calibrated) similarity threshold, cap at k
         seed_neighbors = [
             c for c in candidates if str(c["id"]) != memory_id_str and c["score"] >= threshold
@@ -4428,41 +4466,6 @@ async def _create_knn_seed_edges(
                 threshold=threshold,
             )
             return
-
-        # #1403 option B: supersede-suggestion signal. When the nearest neighbor
-        # is a near-duplicate (>= _SUPERSEDE_SUGGEST_THRESHOLD, well above the
-        # calibrated seed threshold), this new memory is likely an updated version
-        # of an existing fact — a supersede candidate the user may prefer over
-        # storing a second copy. Seeding runs async (decoupled from the remember
-        # response), so rather than block remember() we PERSIST the top-1 candidate
-        # onto the new memory's dedicated server-only supersede_candidate column
-        # (never the client-writable details blob) and surface it — liveness-
-        # guarded — on the next recall()/reference(). Suggestion only: the edge is never
-        # auto-created (the #1208 over-supersede prevention keeps edge authorship
-        # with the user/agent, who confirms via create_edge).
-        top_neighbor = seed_neighbors[0]
-        top_score = float(top_neighbor["score"])
-        if top_score >= _SUPERSEDE_SUGGEST_THRESHOLD:
-            candidate = {
-                "memory_id": str(top_neighbor["id"]),
-                "similarity": round(top_score, 4),
-                "detected_at": to_utc_iso(utcnow()),
-            }
-            # Assign the dedicated server-only column (JSON, not a MutableDict — a
-            # reassignment is what flags it dirty). Do NOT touch updated_at:
-            # candidate detection is a system annotation, not a user edit (#1317).
-            # The commit here is safe: the caller already committed the
-            # embedding_status update before invoking this function, so nothing
-            # else is pending in the session at this point; the per-edge SAVEPOINTs
-            # that follow open their own nested transactions.
-            memory.supersede_candidate = candidate
-            await db.commit()
-            logger.info(
-                "supersede_candidate_detected",
-                memory_id=memory_id_str,
-                candidate_memory_id=candidate["memory_id"],
-                similarity=candidate["similarity"],
-            )
 
         edges_created = 0
         similarities: list[float] = []

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -12,6 +12,7 @@ import functools
 import hashlib
 import math
 import statistics
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 from uuid import UUID, uuid4
@@ -56,6 +57,7 @@ from models.schemas import (
     RelatedTagItem,
     RememberRequest,
     RememberResponse,
+    SupersedeCandidate,
     UpdateMemoryRequest,
     UpdateMemoryResponse,
 )
@@ -1129,12 +1131,22 @@ class MemoryService:
             incoming_links = []
             incoming_has_more = False
 
+        # #1403: surface the liveness-guarded suggestion here too. It lives in its
+        # own column, so replacing `details` on this patch never drops it, and the
+        # client sees the current suggestion in the patch response.
+        supersede_candidate = (
+            await self._resolve_supersede_candidates(
+                {memory.id: memory}, user_id=user_id, operation="reference"
+            )
+        ).get(memory.id)
+
         return ReferenceResponse(
             memory_id=memory.id,
             summary=memory.summary,
             context_summary=memory.context_summary,
             content=memory.content,
             details=memory.details,
+            supersede_candidate=supersede_candidate,
             type=memory.type,
             scope=memory.scope,
             importance=memory.importance,
@@ -1304,12 +1316,24 @@ class MemoryService:
             context_id=memory.context_id,
         )
 
+        # #1403: resolve the (liveness-guarded, enriched) supersede suggestion for
+        # this single memory — the deliberate Layer-3 fetch is exactly where a
+        # client decides whether to confirm the supersession.
+        supersede_candidate = (
+            await self._resolve_supersede_candidates(
+                {memory.id: memory}, user_id=user_id, operation="reference"
+            )
+        ).get(memory.id)
+
         return ReferenceResponse(
             memory_id=memory.id,
             summary=memory.summary,
             context_summary=memory.context_summary,
             content=memory.content,
             details=memory.details,
+            # #1403: liveness-guarded supersede suggestion (its own server-only
+            # column — never mixed into the client-writable details blob).
+            supersede_candidate=supersede_candidate,
             type=memory.type,
             scope=memory.scope,
             importance=memory.importance,
@@ -1972,6 +1996,105 @@ class MemoryService:
         except Exception as e:
             logger.warning("supersede_shadowing_failed", error=str(e))
             return {}, {}
+
+    async def _resolve_supersede_candidates(
+        self, memories: Mapping[Any, Memory], *, user_id: str, operation: str
+    ) -> dict[UUID, SupersedeCandidate]:
+        """#1403: liveness-guarded supersede suggestions for a page of memories.
+
+        For every memory carrying a stored ``supersede_candidate`` (a server-only
+        column — never client-writable), return an enriched, still-actionable
+        ``SupersedeCandidate`` keyed by the SOURCE memory id, but only when the
+        candidate target still exists, is not soft-deleted, is in the SAME
+        (workspace, context) as the source memory, AND survives the same
+        agent-binding row filter (#1299) every other recall lane applies.
+
+        The (workspace, context) match is defense-in-depth: the column is written
+        only from a context-scoped k-NN neighbour, so the target is same-context
+        by construction — the check guarantees the read-path enrichment can never
+        surface a memory's ``summary`` across a workspace/context the caller is
+        not already reading (the source memory). The binding filter closes the
+        narrower gap where an agent-scoped credential is restricted (by type /
+        source) to a subset of an otherwise-visible context. Mirrors
+        ``_apply_supersede_shadowing``'s self-healing liveness JOIN: a suggestion
+        whose target is gone silently stops surfacing (the stored value is cleared
+        on acceptance at edge-creation time).
+
+        Fail-open, per item: a malformed stored value (or a Pydantic coercion
+        error) drops only that one suggestion; any wider error returns ``{}`` — a
+        suggestion is a read-path enhancement and must never blank
+        recall()/reference().
+        """
+        from pydantic import ValidationError as PydanticValidationError
+
+        from services.agent_binding_service import filter_memory_rows_by_binding
+
+        try:
+            pending: dict[UUID, dict] = {}
+            for memory in memories.values():
+                cand = memory.supersede_candidate
+                if not isinstance(cand, dict):
+                    continue
+                raw_target = cand.get("memory_id")
+                sim = cand.get("similarity")
+                if not raw_target or not isinstance(sim, (int, float)):
+                    continue
+                try:
+                    target_id = UUID(str(raw_target))
+                except (ValueError, TypeError):
+                    continue
+                pending[memory.id] = {"target_id": target_id, "candidate": cand, "source": memory}
+
+            if not pending:
+                return {}
+
+            target_ids = {p["target_id"] for p in pending.values()}
+            rows = await self.db.execute(
+                select(
+                    Memory.id,
+                    Memory.summary,
+                    Memory.workspace_id,
+                    Memory.context_id,
+                    Memory.type,
+                    Memory.source_type,
+                ).where(
+                    Memory.id.in_(target_ids),
+                    Memory.deleted_at.is_(None),
+                )
+            )
+            # Same agent-binding row filter every other recall lane enforces
+            # (#1299): a binding-restricted target must not leak its summary
+            # through the suggestion. Non-agent credentials → structural no-op.
+            kept_rows, _denied = await filter_memory_rows_by_binding(
+                self.db, list(rows.all()), operation=operation, user_id=user_id
+            )
+            live = {row.id: row for row in kept_rows}
+
+            resolved: dict[UUID, SupersedeCandidate] = {}
+            for source_id, p in pending.items():
+                target = live.get(p["target_id"])
+                if target is None:
+                    continue  # self-healing: target gone → drop the suggestion
+                source = p["source"]
+                if (target.workspace_id, target.context_id) != (
+                    source.workspace_id,
+                    source.context_id,
+                ):
+                    continue  # never enrich across a context the caller isn't reading
+                cand = p["candidate"]
+                try:
+                    resolved[source_id] = SupersedeCandidate(
+                        memory_id=target.id,
+                        summary=target.summary,
+                        similarity=float(cand["similarity"]),
+                        detected_at=cand.get("detected_at"),
+                    )
+                except (PydanticValidationError, ValueError, TypeError):
+                    continue  # malformed stored value → drop just this suggestion
+            return resolved
+        except Exception as e:
+            logger.warning("supersede_candidate_resolve_failed", error=str(e))
+            return {}
 
     async def _resolve_search_mode(
         self,
@@ -2876,6 +2999,18 @@ class MemoryService:
             # to consume ``search_results[:k]``; reorder only, never synthesize.
             search_results[:] = selected_results + unselected_results
 
+        # #1403: resolve liveness-guarded supersede suggestions for exactly the
+        # page that ships — one batched query, run AFTER the top-k slice + rerank
+        # so discarded candidates cost nothing (empty/fast when none carry one).
+        page_memories = {
+            sr["id"]: memories[sr["id"]]
+            for sr in search_results[: request.k]
+            if sr["id"] in memories
+        }
+        supersede_candidates = await self._resolve_supersede_candidates(
+            page_memories, user_id=user_id, operation="recall"
+        )
+
         responses = []
         for search_result in search_results[: request.k]:
             memory_id = search_result["id"]
@@ -2921,6 +3056,8 @@ class MemoryService:
                     # filtered shadowed memories out of search_results above).
                     superseded_by=shadow_map.get(memory.id),
                     contradicts=contradiction_map.get(memory.id, []),
+                    # #1403: near-duplicate this memory may supersede (or None).
+                    supersede_candidate=supersede_candidates.get(memory.id),
                 )
             )
 
@@ -4131,14 +4268,24 @@ class MemoryService:
 
 # #1403: near-duplicate threshold above which the nearest k-NN neighbor of a
 # freshly-embedded memory is surfaced as a supersede candidate — the user is
-# likely storing an updated version of an existing fact. Deliberately high (well
-# above the calibrated per-model seed threshold) so the signal fires only on
-# true near-duplicates, not merely related memories. Unlike the seed threshold
-# (D4 calibration/operator-override chain), this is a fixed first-pass heuristic;
-# graduate it to a per-model calibrated / config-driven value if the adoption
-# telemetry shows it mis-fires across embedding models with different score
-# distributions.
-_SUPERSEDE_SUGGEST_THRESHOLD = 0.92
+# likely storing an updated version of an existing fact. Well above the
+# calibrated per-model seed threshold so the signal fires only on true
+# near-duplicates, not merely related memories.
+#
+# Operating point 0.85 (option-B de-risk, 2026-07-20): on the frozen
+# update_slice_v2 corpus (100 ground-truth v1→v2 supersede pairs, measured with
+# the same embedder the k-NN seeding uses), the "top-1 neighbor >= tau" detector
+# holds precision == recall == 1.000 across the whole band tau = 0.60–0.88
+# (true v1 is the top-1 neighbor for 100/100 v2 memories; mean margin 0.249).
+# 0.85 is chosen conservatively within that band — not the precision×recall-
+# optimal midpoint — to preserve precision when real-world distractors sit
+# closer than the minimal-edit corpus pairs, trading a little recall for trust.
+# Unlike the seed threshold (D4 calibration/operator-override chain), this is a
+# fixed first-pass heuristic; graduate it to a per-model calibrated /
+# config-driven value if the adoption telemetry (supersede_candidate_detected
+# vs supersede_suggestion_accepted) shows it mis-fires across embedding models
+# with different score distributions.
+_SUPERSEDE_SUGGEST_THRESHOLD = 0.85
 
 
 async def _create_knn_seed_edges(
@@ -4282,21 +4429,39 @@ async def _create_knn_seed_edges(
             )
             return
 
-        # #1403: supersede-suggestion signal. When the nearest neighbor is a
-        # near-duplicate (well above the calibrated seed threshold), this new
-        # memory is likely an updated version of an existing fact — a supersede
-        # candidate the user may prefer over storing a second copy. Seeding runs
-        # async (decoupled from the remember response), so the candidate is
-        # emitted as telemetry here; a synchronous client-facing prompt is a
-        # follow-up gated on the async-embedding hot-path trade-off.
+        # #1403 option B: supersede-suggestion signal. When the nearest neighbor
+        # is a near-duplicate (>= _SUPERSEDE_SUGGEST_THRESHOLD, well above the
+        # calibrated seed threshold), this new memory is likely an updated version
+        # of an existing fact — a supersede candidate the user may prefer over
+        # storing a second copy. Seeding runs async (decoupled from the remember
+        # response), so rather than block remember() we PERSIST the top-1 candidate
+        # onto the new memory's dedicated server-only supersede_candidate column
+        # (never the client-writable details blob) and surface it — liveness-
+        # guarded — on the next recall()/reference(). Suggestion only: the edge is never
+        # auto-created (the #1208 over-supersede prevention keeps edge authorship
+        # with the user/agent, who confirms via create_edge).
         top_neighbor = seed_neighbors[0]
         top_score = float(top_neighbor["score"])
         if top_score >= _SUPERSEDE_SUGGEST_THRESHOLD:
+            candidate = {
+                "memory_id": str(top_neighbor["id"]),
+                "similarity": round(top_score, 4),
+                "detected_at": to_utc_iso(utcnow()),
+            }
+            # Assign the dedicated server-only column (JSON, not a MutableDict — a
+            # reassignment is what flags it dirty). Do NOT touch updated_at:
+            # candidate detection is a system annotation, not a user edit (#1317).
+            # The commit here is safe: the caller already committed the
+            # embedding_status update before invoking this function, so nothing
+            # else is pending in the session at this point; the per-edge SAVEPOINTs
+            # that follow open their own nested transactions.
+            memory.supersede_candidate = candidate
+            await db.commit()
             logger.info(
                 "supersede_candidate_detected",
                 memory_id=memory_id_str,
-                candidate_memory_id=str(top_neighbor["id"]),
-                similarity=round(top_score, 4),
+                candidate_memory_id=candidate["memory_id"],
+                similarity=candidate["similarity"],
             )
 
         edges_created = 0

--- a/backend/tests/mcp_server/test_context_last_used_touch.py
+++ b/backend/tests/mcp_server/test_context_last_used_touch.py
@@ -380,6 +380,7 @@ async def test_reference_bumps_context_but_not_on_memory_miss():
         outgoing_has_more=False,
         incoming_links=[],
         incoming_has_more=False,
+        supersede_candidate=None,  # #1403
     )
     service = MagicMock()
     service.reference = AsyncMock(return_value=reference_result)

--- a/backend/tests/mcp_server/test_edge_tools.py
+++ b/backend/tests/mcp_server/test_edge_tools.py
@@ -22,7 +22,11 @@ from uuid import uuid4
 import pytest
 
 from mcp_server.tools._definitions import get_tool_definitions
-from mcp_server.tools.edge import handle_create_edge, handle_update_edge
+from mcp_server.tools.edge import (
+    _accept_supersede_candidate_if_matching,
+    handle_create_edge,
+    handle_update_edge,
+)
 from models.memory import EDGE_ORIGIN_DECLARED
 
 
@@ -695,3 +699,68 @@ class TestCreateEdgeDuplicateSemantics:
         assert overwrite_schema["type"] == "boolean"
         assert overwrite_schema["default"] is False
         assert "operation" in create_edge["description"]
+
+
+class TestSupersedeAcceptanceTelemetry:
+    """#1403 option B: creating a supersedes edge that confirms a stored
+    suggestion records the acceptance and self-heals (clears the suggestion)."""
+
+    @staticmethod
+    def _db_returning(memory):
+        db = MagicMock()
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=memory)
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    @pytest.mark.asyncio
+    async def test_matching_candidate_accepted_and_cleared(self):
+        """When src.supersede_candidate.memory_id == dst, the acceptance event
+        fires and the stored candidate column is cleared to None."""
+        src_id, dst_id = uuid4(), uuid4()
+        memory = MagicMock()
+        memory.supersede_candidate = {"memory_id": str(dst_id), "similarity": 0.9}
+        db = self._db_returning(memory)
+
+        with patch("mcp_server.tools.edge.logger") as mock_logger:
+            await _accept_supersede_candidate_if_matching(db, src_id=src_id, dst_id=dst_id)
+
+        # Self-heal: the accepted suggestion is cleared.
+        assert memory.supersede_candidate is None
+        events = {c.args[0]: c.kwargs for c in mock_logger.info.call_args_list if c.args}
+        assert "supersede_suggestion_accepted" in events
+        assert events["supersede_suggestion_accepted"]["superseded_memory_id"] == str(dst_id)
+        assert events["supersede_suggestion_accepted"]["memory_id"] == str(src_id)
+
+    @pytest.mark.asyncio
+    async def test_non_matching_candidate_untouched(self):
+        """A supersedes edge to a DIFFERENT target than the stored candidate is
+        not an acceptance — nothing is cleared and no event fires."""
+        src_id, dst_id = uuid4(), uuid4()
+        other = uuid4()
+        memory = MagicMock()
+        candidate = {"memory_id": str(other), "similarity": 0.9}
+        memory.supersede_candidate = candidate
+        db = self._db_returning(memory)
+
+        with patch("mcp_server.tools.edge.logger") as mock_logger:
+            await _accept_supersede_candidate_if_matching(db, src_id=src_id, dst_id=dst_id)
+
+        assert memory.supersede_candidate == candidate  # untouched
+        emitted = [c.args[0] for c in mock_logger.info.call_args_list if c.args]
+        assert "supersede_suggestion_accepted" not in emitted
+
+    @pytest.mark.asyncio
+    async def test_no_stored_candidate_is_noop(self):
+        """No stored candidate → no acceptance event, no mutation."""
+        src_id, dst_id = uuid4(), uuid4()
+        memory = MagicMock()
+        memory.supersede_candidate = None
+        db = self._db_returning(memory)
+
+        with patch("mcp_server.tools.edge.logger") as mock_logger:
+            await _accept_supersede_candidate_if_matching(db, src_id=src_id, dst_id=dst_id)
+
+        assert memory.supersede_candidate is None
+        emitted = [c.args[0] for c in mock_logger.info.call_args_list if c.args]
+        assert "supersede_suggestion_accepted" not in emitted

--- a/backend/tests/services/test_knn_seeding.py
+++ b/backend/tests/services/test_knn_seeding.py
@@ -20,6 +20,9 @@ def _make_memory(workspace_id=None, context_id=None, user_id="user1"):
     memory.user_id = user_id
     memory.workspace_id = workspace_id or uuid4()
     memory.context_id = context_id or uuid4()
+    # #1403: real (non-mock) starting value for the server-only supersede
+    # suggestion column the storage path assigns to.
+    memory.supersede_candidate = None
     return memory
 
 
@@ -222,16 +225,27 @@ class TestKnnSeeding:
         assert events["supersede_candidate_detected"]["candidate_memory_id"] == dup_id
         assert events["supersede_candidate_detected"]["similarity"] == 0.95
 
+        # #1403 option B: the candidate is PERSISTED onto the server-only
+        # supersede_candidate column so recall()/reference() can surface it without
+        # re-running k-NN on the read path, committed independently of edge creation.
+        stored = memory.supersede_candidate
+        assert stored is not None
+        assert stored["memory_id"] == dup_id
+        assert stored["similarity"] == 0.95
+        assert "detected_at" in stored
+        db.commit.assert_awaited()
+
     @pytest.mark.asyncio
     async def test_no_supersede_candidate_below_threshold(self):
         """#1403: a merely-related nearest neighbor (score below the supersede-
-        suggest threshold) must NOT emit a supersede candidate — the signal
-        fires only on true near-duplicates, not on ordinary seed neighbors."""
+        suggest threshold 0.85) must NOT emit a supersede candidate nor store one
+        — the signal fires only on true near-duplicates, not on ordinary seed
+        neighbors."""
         memory = _make_memory()
         db = _make_db()
         mock_repo = _make_edge_repo()
         candidates = [
-            {"id": str(uuid4()), "score": 0.85, "payload": {}, "embedding": []},
+            {"id": str(uuid4()), "score": 0.80, "payload": {}, "embedding": []},
             {"id": str(uuid4()), "score": 0.70, "payload": {}, "embedding": []},
         ]
 
@@ -260,6 +274,8 @@ class TestKnnSeeding:
 
         emitted = [c.args[0] for c in mock_logger.info.call_args_list if c.args]
         assert "supersede_candidate_detected" not in emitted
+        # No candidate stored either — the column stays None.
+        assert memory.supersede_candidate is None
 
     @pytest.mark.asyncio
     async def test_threshold_filter_excludes_low_similarity(self):
@@ -470,8 +486,10 @@ class TestKnnSeeding:
             side_effect=[MagicMock(), RuntimeError("DB error"), MagicMock()]
         )
 
+        # Top score < 0.85 supersede threshold: keeps this test isolated to edge
+        # logic (no extra candidate-storage commit, #1403).
         candidates = [
-            {"id": str(uuid4()), "score": 0.9, "payload": {}, "embedding": []},
+            {"id": str(uuid4()), "score": 0.84, "payload": {}, "embedding": []},
             {"id": str(uuid4()), "score": 0.8, "payload": {}, "embedding": []},
             {"id": str(uuid4()), "score": 0.7, "payload": {}, "embedding": []},
         ]
@@ -538,8 +556,10 @@ class TestKnnSeeding:
         # Simulate all 2 candidates already having edges (existing Hebbian edges)
         mock_repo.create_edge_if_absent = AsyncMock(return_value=None)
 
+        # Top score < 0.85 supersede threshold: no candidate-storage commit, so
+        # this test still asserts "no commit when nothing inserted" (#1403).
         candidates = [
-            {"id": str(uuid4()), "score": 0.9, "payload": {}, "embedding": []},
+            {"id": str(uuid4()), "score": 0.84, "payload": {}, "embedding": []},
             {"id": str(uuid4()), "score": 0.8, "payload": {}, "embedding": []},
         ]
 

--- a/backend/tests/services/test_knn_seeding.py
+++ b/backend/tests/services/test_knn_seeding.py
@@ -278,6 +278,59 @@ class TestKnnSeeding:
         assert memory.supersede_candidate is None
 
     @pytest.mark.asyncio
+    async def test_supersede_candidate_independent_of_seed_threshold(self):
+        """#1403 (PR #1415 review): supersede detection uses the RAW top-1 neighbor,
+        not the seed-threshold-filtered list. A resolved/operator seed threshold
+        ABOVE the supersede threshold (0.90 > 0.85) must NOT suppress a valid
+        suggestion — and the below-seed-threshold neighbor still gets no seed edge."""
+        memory = _make_memory()
+        db = _make_db()
+        mock_repo = _make_edge_repo()
+        dup_id = str(uuid4())
+        # 0.87 is a valid supersede candidate (>= 0.85) but BELOW the resolved seed
+        # threshold 0.90 → filtered out of seed_neighbors (no edge), yet must still
+        # be detected + persisted from the raw k-NN results.
+        candidates = [
+            {"id": dup_id, "score": 0.87, "payload": {}, "embedding": []},
+            {"id": str(uuid4()), "score": 0.70, "payload": {}, "embedding": []},
+        ]
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=_make_config()),
+            ),
+            patch(
+                "neural.calibration.resolve_knn_threshold",
+                new=AsyncMock(return_value=0.90),
+            ),
+            patch(
+                "db.qdrant.search_memories_qdrant",
+                new=AsyncMock(return_value=candidates),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch("services.memory_service.logger") as mock_logger,
+        ):
+            await _create_knn_seed_edges(
+                db=db,
+                memory=memory,
+                vector=[0.1] * 512,
+                collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
+            )
+
+        events = {c.args[0]: c.kwargs for c in mock_logger.info.call_args_list if c.args}
+        assert "supersede_candidate_detected" in events
+        assert events["supersede_candidate_detected"]["candidate_memory_id"] == dup_id
+        assert memory.supersede_candidate is not None
+        assert memory.supersede_candidate["memory_id"] == dup_id
+        # 0.87 < 0.90 resolved seed threshold → no seed edge created.
+        mock_repo.create_edge_if_absent.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_threshold_filter_excludes_low_similarity(self):
         """Neighbors with score < min_similarity are excluded."""
         memory = _make_memory()

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1,6 +1,7 @@
 """Tests for MemoryService."""
 
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -744,6 +745,156 @@ class TestDeclaredLinks:
         mock_repo.create_or_update_edge.assert_not_awaited()
         emitted = [c.args[0] for c in mock_logger.info.call_args_list if c.args]
         assert "declared_supersedes_created" not in emitted
+
+
+class TestSupersedeCandidateExposure:
+    """#1403 option B: read-time exposure of the stored supersede candidate
+    (server-only column) on recall()/reference(), with the self-healing liveness
+    guard and the (workspace, context) scoping."""
+
+    WS = uuid4()
+    CTX = uuid4()
+
+    @pytest.fixture
+    def service(self):
+        return MemoryService(MagicMock())
+
+    @classmethod
+    def _mem(cls, candidate, *, workspace_id=None, context_id=None):
+        m = MagicMock()
+        m.id = uuid4()
+        m.supersede_candidate = candidate
+        m.workspace_id = workspace_id or cls.WS
+        m.context_id = context_id or cls.CTX
+        return m
+
+    @staticmethod
+    def _candidate(target_id, similarity=0.93, detected_at="2026-07-20T00:00:00Z"):
+        return {
+            "memory_id": str(target_id),
+            "similarity": similarity,
+            "detected_at": detected_at,
+        }
+
+    @classmethod
+    def _target_row(
+        cls, target_id, summary="the older fact", *, workspace_id=None, context_id=None
+    ):
+        return SimpleNamespace(
+            id=target_id,
+            summary=summary,
+            workspace_id=workspace_id or cls.WS,
+            context_id=context_id or cls.CTX,
+        )
+
+    def _mock_rows(self, service, rows):
+        result = MagicMock()
+        result.all = MagicMock(return_value=rows)
+        service.db.execute = AsyncMock(return_value=result)
+
+    @pytest.mark.asyncio
+    async def test_resolve_enriches_live_candidate(self, service):
+        """A stored candidate whose target is live and same-context is returned as
+        a SupersedeCandidate enriched with the target's summary."""
+        target_id = uuid4()
+        source = self._mem(self._candidate(target_id, similarity=0.91))
+        self._mock_rows(service, [self._target_row(target_id)])
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(source.id): source}, user_id="u1", operation="recall"
+        )
+
+        assert source.id in resolved
+        cand = resolved[source.id]
+        assert cand.memory_id == target_id
+        assert cand.summary == "the older fact"
+        assert cand.similarity == 0.91
+        assert cand.detected_at is not None
+
+    @pytest.mark.asyncio
+    async def test_resolve_drops_dead_target(self, service):
+        """Self-healing: a candidate pointing at a deleted/missing memory (not in
+        the live set) is dropped — the suggestion silently stops surfacing."""
+        target_id = uuid4()
+        source = self._mem(self._candidate(target_id))
+        self._mock_rows(service, [])  # target not live
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(source.id): source}, user_id="u1", operation="recall"
+        )
+
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_resolve_drops_cross_context_target(self, service):
+        """Security: even a live target is dropped when it is in a DIFFERENT
+        (workspace, context) than the source — the enrichment must never surface a
+        memory's summary across a context the caller isn't already reading."""
+        target_id = uuid4()
+        source = self._mem(self._candidate(target_id))
+        # Same workspace, different context → refused.
+        self._mock_rows(service, [self._target_row(target_id, context_id=uuid4())])
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(source.id): source}, user_id="u1", operation="recall"
+        )
+
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_resolve_no_candidates_runs_no_query(self, service):
+        """When no memory in the page carries a candidate, no liveness query runs
+        (the read path stays free)."""
+        plain = self._mem(None)
+        service.db.execute = AsyncMock()
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(plain.id): plain}, user_id="u1", operation="recall"
+        )
+
+        assert resolved == {}
+        service.db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolve_ignores_malformed_candidate(self, service):
+        """A stored candidate missing similarity or memory_id is ignored (old /
+        malformed values must not blow up recall)."""
+        source = self._mem({"memory_id": str(uuid4())})  # no similarity
+        service.db.execute = AsyncMock()
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(source.id): source}, user_id="u1", operation="recall"
+        )
+
+        assert resolved == {}
+        service.db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resolve_drops_candidate_with_bad_detected_at(self, service):
+        """Per-item fail-open: a non-ISO detected_at raises inside SupersedeCandidate
+        coercion and drops ONLY that suggestion, never blanking the whole call."""
+        target_id = uuid4()
+        source = self._mem(self._candidate(target_id, detected_at="not-a-real-date"))
+        self._mock_rows(service, [self._target_row(target_id)])
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(source.id): source}, user_id="u1", operation="recall"
+        )
+
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_resolve_fails_open_on_db_error(self, service):
+        """Fail-open: a query error returns {} rather than blanking recall."""
+        target_id = uuid4()
+        source = self._mem(self._candidate(target_id))
+        service.db.execute = AsyncMock(side_effect=RuntimeError("boom"))
+
+        resolved = await service._resolve_supersede_candidates(
+            {str(source.id): source}, user_id="u1", operation="recall"
+        )
+
+        assert resolved == {}
 
 
 class TestTagCooccurrenceSeeding:


### PR DESCRIPTION
Partially addresses #1403

## Summary
- Completes the backend + read-time exposure for the #1403 supersede auto-suggest mechanism (the #1413 foundation only logged detection telemetry).
- Stores the top-1 near-duplicate detected at k-NN ingest in a dedicated server-only column `memories.supersede_candidate` (migration `e75`); lowers the detection threshold 0.92 → 0.85 (de-risked operating point: precision==recall==1.0 across τ 0.60–0.88).
- Surfaces it, liveness-guarded, on `recall()` / `reference()` / `patch_memory()` via a new `SupersedeCandidate` schema field so a client can offer a confirm → `create_edge(supersedes)` action — never auto-created (#1208 over-supersede prevention intact).
- `create_edge(supersedes)` matching a stored suggestion emits `supersede_suggestion_accepted` and clears the column (self-heal), in the same transaction as the edge.

## Implementation notes
- **Dedicated column, not the client-writable `details` blob**: a security review found that storing it in `details` enabled an IDOR (a client could forge the target `memory_id` and leak another memory's `summary` via the read-path enrichment, bypassing `can_access_memory`), a fail-open break (poison `detected_at` → `ValidationError` blanks recall), and data-loss on a `details` replace. The column has exactly two server-only writers.
- `_resolve_supersede_candidates`: one batched query per recall page (after the top-k slice), with three guards before exposing a target's `summary` — liveness / not-deleted (self-healing, mirrors `#1208`), same `(workspace, context)` as the source, and the `#1299` agent-binding row filter (the same boundary every other recall lane enforces). Fail-open per item and overall.
- `expire_on_commit=False` verified for the mid-task commit in `_create_knn_seed_edges`.
- Migration is additive + nullable (no backfill); single alembic head (`e75`).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- review provider: code-review (post-PR loop via /gh-issue-driven:review)

Also reviewed twice by the code-reviewer agent (2 Critical + 2 Warning fixed: client-write leak, fail-open ValidationError, patch drop, agent-binding bypass). Full gate2 review saved in the plugin cache.

## Verification
- 205 targeted unit tests pass (k-NN storage/threshold, resolver liveness/cross-context/binding/malformed/fail-open, acceptance/self-heal). ruff + format clean; zero new pyright errors.
- api/integration tests require Docker (Redis/Postgres) — CI is the authoritative gate.

## Remaining (not in this PR)
- Client-side confirm → `create_edge` loop (agent/UX consumer).
- Follow-up tests: agent-binding drop (with an agent scope set), exactly-0.85 boundary, live-DB recall wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
