### PR TITLE
docs(mcp): guide agents through the supersede accept loop (#1403)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -106,6 +106,10 @@ and explore()). Prefer this over storing a near-duplicate: a duplicate leaves th
 stale and fresh facts competing in recall, whereas a declared supersession makes
 the update authoritative. This is the strongest lever for update-correctness, so
 reach for it whenever a memory replaces an earlier one.
+If you did NOT set supersedes at store time but the new memory is in fact an
+update, you don't have to remember perfectly: the server auto-detects near-
+duplicates and surfaces a `supersede_candidate` on the next recall()/reference()
+of the memory — confirm it then via create_edge(edge_type="supersedes").
 
 CHUNKING BEST PRACTICES for long documents:
 • Optimal summary length: 100-250 characters (max: 500)
@@ -326,6 +330,7 @@ Returns summaries and context (Layers 1-2) optimized for quick understanding.
 Agent-facing signals in the response:
 • Each result carries `updated_at` — the last time that fact was changed (null if never edited since creation). Use it to self-assess staleness without extra calls; an old `updated_at` means the fact may be out of date.
 • The response carries a top-level `confidence` object — a cheap TRIAGE hint for "is anything relevant here, or should I go external?", NOT a correctness verdict. `level` (high/moderate/low/none) is driven by `top_score` (best hit's absolute semantic cosine) and `prominence` ((top_score − mean background cosine) / mean background cosine; a ratio → robust to a model's cosine scale, not a global cutoff). How to act on it: `none`/`low` → likely nothing relevant, prefer an external source over forcing an answer from these results (this signal is reliable even without a reranker). `high`/`moderate` → relevant memory is likely present, so READ the returned summaries and judge from their content — `level` measures topical match strength, so a closely-related "near-miss" (an adjacent topic) can also read `high`; it does NOT guarantee the exact fact you asked for is stored. Treat the returned content as the source of truth and `level` only as the hint for whether to bother reading; to actually separate a near-miss from an exact match, pass `use_rerank=true` (cross-encoder), since plain cosine cannot. (`relative_margin` is kept for transparency but inflates on off-topic queries — do NOT use it to decide relevance.) Example: `confidence: {"level": "high", "top_score": 0.92, "prominence": 0.55, "result_count": 20}`; an empty pool returns `{"level": "none", "top_score": null, "result_count": 0}`.
+• A result may carry `supersede_candidate` — a near-duplicate this memory likely SUPERSEDES. At ingest the server detected that this memory's nearest neighbour is a near-identical earlier fact, i.e. this memory reads like the updated version of it. Shape: `{memory_id, summary, similarity, detected_at}` (the candidate is the OLDER fact). It is a SUGGESTION, never an auto-applied edge. If this memory really is the update, ACCEPT it: `create_edge(source_id=<this result's memory_id>, target_id=<supersede_candidate.memory_id>, edge_type="supersedes", context_id=...)` — that shadows the stale candidate out of default recall (the strongest update-correctness lever). If it is only similar, not a replacement, ignore it; the suggestion self-heals (it disappears once you accept it, or once the candidate is deleted). It is liveness-guarded — you only ever see a candidate you can already read.
 
 IMPORTANT: Always specify context_id to ensure you're searching the intended context. Use list_contexts() to discover available context IDs.
 
@@ -334,7 +339,7 @@ Search modes: Use search_mode to control the search strategy.
 • semantic: Vector similarity only — best when you know the exact concept but not the exact words.
 • keyword: BM25 only — best for hiragana queries, exact term matching, or when semantic search returns noise. Particularly effective for Japanese hiragana-only queries where embedding models struggle.
 
-Returns: {status, results: [{memory_id, summary, context_summary, type, importance, scope, score, tags, created_at, updated_at}], count, related_tags, context_id, context_name, context_display_name, context_is_private, context_is_locked, confidence (see above), explore_hints (only when include_explore_hints=true)}. results carry Layers 1-2 only — call reference(memory_id) for full Layer-3 content.""",
+Returns: {status, results: [{memory_id, summary, context_summary, type, importance, scope, score, tags, created_at, updated_at, superseded_by, contradicts, supersede_candidate (see Agent-facing signals above; null unless a still-actionable near-duplicate suggestion exists)}], count, related_tags, context_id, context_name, context_display_name, context_is_private, context_is_locked, confidence (see above), explore_hints (only when include_explore_hints=true)}. results carry Layers 1-2 only — call reference(memory_id) for full Layer-3 content.""",
             "inputSchema": {
                 "type": "object",
                 # ``query`` is the only unconditional requirement. The handler
@@ -409,7 +414,7 @@ Returns all 3 layers: summary, context_summary, and complete details/content.
 
 IMPORTANT: Always specify context_id to ensure you're retrieving from the intended context. Use list_contexts() to discover available context IDs.
 
-Returns: {status, memory: {memory_id, summary, context_summary, content, details, type, scope, importance, tags, context, created_at, updated_at, client, source_uri, source_type, outgoing_links: [{memory_id, summary, type, importance, weight, created_at}], outgoing_has_more, incoming_links: [...], incoming_has_more}} — all three layers plus declared-link references and provenance. updated_at is a staleness cue (an old value means the fact may be out of date).""",
+Returns: {status, memory: {memory_id, summary, context_summary, content, details, type, scope, importance, tags, context, created_at, updated_at, client, source_uri, source_type, outgoing_links: [{memory_id, summary, type, importance, weight, created_at}], outgoing_has_more, incoming_links: [...], incoming_has_more, supersede_candidate}} — all three layers plus declared-link references and provenance. updated_at is a staleness cue (an old value means the fact may be out of date). supersede_candidate, when present, is a near-duplicate this memory likely supersedes — {memory_id, summary, similarity, detected_at} of the OLDER fact; a suggestion only. To accept it, call create_edge(source_id=<this memory_id>, target_id=<supersede_candidate.memory_id>, edge_type="supersedes"). It is liveness-guarded and self-heals (disappears once accepted or once the candidate is deleted); null when there is none.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["memory_id", "context_id"],
@@ -764,7 +769,7 @@ Returns: {status, operation: "created"|"updated"|"unchanged", edge: {source_id, 
                             "supersedes",
                             "contradicts",
                         ],
-                        "description": "Type of relationship (default: 'related_to'). #1208: 'supersedes' (src = newer memory, dst = the outdated one it replaces — dst is shadowed out of default recall while src lives) and 'contradicts' (both sides stay visible, annotated — contradiction never hides).",
+                        "description": "Type of relationship (default: 'related_to'). #1208: 'supersedes' (src = newer memory, dst = the outdated one it replaces — dst is shadowed out of default recall while src lives) and 'contradicts' (both sides stay visible, annotated — contradiction never hides). Creating a 'supersedes' edge is also how you ACCEPT a `supersede_candidate` suggestion surfaced by recall()/reference() — source_id = the memory carrying the suggestion, target_id = its supersede_candidate.memory_id (the server clears the suggestion once the edge exists).",
                         "default": "related_to",
                     },
                     "weight": {

--- a/backend/tests/mcp_server/test_supersede_tool_guidance.py
+++ b/backend/tests/mcp_server/test_supersede_tool_guidance.py
@@ -1,0 +1,65 @@
+"""#1403: the MCP tool descriptions must guide an agent through the supersede
+auto-suggest loop — recall()/reference() surface a `supersede_candidate`, and the
+agent accepts it by creating a `supersedes` edge. These are contract tests: the
+guidance is the ONLY thing that turns the (already-forwarded) response field into
+an actionable client loop for an agent, so it must not silently disappear.
+"""
+
+from mcp_server.tools._definitions import get_tool_definitions
+
+
+def _all_text(name: str) -> str:
+    """All agent-facing text for a tool: top-level description + every parameter
+    description (the create_edge supersede guidance lives on the edge_type param)."""
+    tool = next(t for t in get_tool_definitions() if t["name"] == name)
+    parts = [tool.get("description", "")]
+    props = tool.get("inputSchema", {}).get("properties", {})
+    for prop in props.values():
+        if isinstance(prop, dict) and isinstance(prop.get("description"), str):
+            parts.append(prop["description"])
+    return "\n".join(parts)
+
+
+def test_recall_documents_supersede_candidate_and_accept_flow():
+    d = _all_text("recall")
+    assert "supersede_candidate" in d
+    # The accept action must be spelled out (confirm -> create_edge supersedes).
+    assert "create_edge" in d
+    assert "supersedes" in d
+    # And the "suggestion only" contract (never auto-applied) must be stated.
+    assert "SUGGESTION" in d or "suggestion" in d
+
+
+def test_reference_documents_supersede_candidate_and_accept_flow():
+    d = _all_text("reference")
+    assert "supersede_candidate" in d
+    assert "create_edge" in d
+    assert 'edge_type="supersedes"' in d
+
+
+def test_create_edge_documents_accepting_a_supersede_candidate():
+    d = _all_text("create_edge")
+    # create_edge is the acceptance entry point for a supersede_candidate.
+    assert "supersede_candidate" in d
+    assert "supersedes" in d
+
+
+def test_remember_points_to_the_auto_suggest_fallback():
+    d = _all_text("remember")
+    # remember() should tell the agent that a missed supersedes is auto-detected
+    # and surfaced later as a supersede_candidate.
+    assert "supersede_candidate" in d
+
+
+def test_supersede_guidance_carries_no_bare_issue_ids():
+    """Agent-facing description text must not carry bare issue-tracker IDs an
+    agent cannot resolve — provenance belongs in the commit/PR, not the tool
+    contract. Guards the #1403 additions (lines that mention supersede_candidate).
+    Pre-existing unrelated ids (e.g. #1208 on the supersedes edge-type line) are
+    out of scope and intentionally not asserted against."""
+    for name in ("recall", "reference", "create_edge", "remember"):
+        for line in _all_text(name).splitlines():
+            if "supersede_candidate" in line:
+                assert "#1403" not in line and "#1299" not in line, (
+                    f"{name}: bare issue id in agent-facing supersede guidance: {line!r}"
+                )


### PR DESCRIPTION
Closes #1403

## Summary
Completes the #1403 client loop for the **agent** consumer. As of v0.57.0, `recall()`/`reference()` return a `supersede_candidate` suggestion; this PR documents, in the MCP tool descriptions, how an agent acts on it — turning the (already-forwarded) response field into an actionable loop.

- **recall / reference**: describe `supersede_candidate` (`{memory_id, summary, similarity, detected_at}` of the OLDER fact) and the accept action.
- **create_edge** (edge_type param): creating a `supersedes` edge is how you ACCEPT a suggestion — `source_id` = the memory carrying it, `target_id` = its `supersede_candidate.memory_id`; the server clears the suggestion once the edge exists.
- **remember**: notes that a missed `supersedes` is auto-detected and surfaced later as a `supersede_candidate`.

No code-path / behavior change — description strings + a contract test only.

## Notes
- **Agent-facing text carries no bare issue ids** — an agent can't resolve `#1403`, so provenance stays in the commit/PR, not the tool contract. (The pre-existing `#1208` on the supersedes/contradicts line is left as-is.) A contract test (`test_supersede_guidance_carries_no_bare_issue_ids`) guards this.
- Guidance accuracy (accept direction, shape, self-heal, liveness) verified against the implementation via code-review.

## Split out
The **web-UI** surface (a confirm button in the memory-detail dialog) needs a new public REST edge-create endpoint — edge creation is MCP-only today (`graph.py` is read-only) — so it is tracked separately in #1416.

## Verification
`tests/mcp_server/test_supersede_tool_guidance.py` (5 contract tests) + `test_edge_tools.py` pass; ruff + format clean. No backend behavior change (no migration, no schema change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
