### PR TITLE
chore(frontend): opt-in allowedDevOrigins dev knob for WSL2

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -9,6 +9,14 @@ import type { NextConfig } from "next";
 // standalone bundle for Docker.
 const nextConfig: NextConfig = {
   ...(process.env.NODE_ENV === "production" ? { output: "standalone" } : {}),
+  // WSL2 dev trap: when a Windows browser reaches the dev server via the
+  // WSL IP (localhost forwarding broken in NAT mode), Next blocks the
+  // cross-origin /_next asset requests from the unlisted origin and the
+  // page silently never hydrates (no buttons, no API calls). Opt in per
+  // environment with a comma-separated hostname list; dev-only knob.
+  ...(process.env.NEXT_DEV_ALLOWED_ORIGINS
+    ? { allowedDevOrigins: process.env.NEXT_DEV_ALLOWED_ORIGINS.split(",") }
+    : {}),
   reactStrictMode: true,
 };
 


### PR DESCRIPTION
## What

Adds a **dev-only, env-gated** opt-in for Next's `allowedDevOrigins` in `frontend/next.config.ts` (8 lines added, no other changes).

## Why

WSL2 dev trap: when a Windows browser reaches the dev server via the WSL IP (localhost forwarding broken in NAT mode), Next blocks the cross-origin `/_next` asset requests from the unlisted origin and the page silently never hydrates (no buttons, no API calls). This is the recurring WSL2 dev issue captured in past troubleshooting notes.

## Behavior

- When `NEXT_DEV_ALLOWED_ORIGINS` is set → its comma-separated list is injected into `allowedDevOrigins`.
- When unset → spreads `{}`, so the config is behavior-identical to before (no-op).
- `allowedDevOrigins` is a `next dev`-only option; it has zero effect on `next build` / `next start` (production) or CI/Docker (which never set the env var).

## Impact

No effect on other developers, CI, Docker, or production unless a developer explicitly opts in by exporting `NEXT_DEV_ALLOWED_ORIGINS`. Behavior-preserving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)