### PR TITLE
feat(api): re-point connector write-target context via settings PATCH (#1428)

### DIFF
--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -505,9 +505,12 @@ async def update_workspace_connector_settings(
             **kwargs,
         )
         await db.commit()
-    except NotFoundException as exc:
+    except NotFoundException:
+        # Re-raise as-is so a bad context_id re-point (#1428) surfaces as
+        # "Context not found" rather than being masked as "Connector". Both
+        # ids are caller-supplied (URL / body), so this leaks nothing.
         await db.rollback()
-        raise NotFoundException("Connector") from exc
+        raise
     except (ConflictError, ValidationError):
         await db.rollback()
         raise

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -173,6 +173,11 @@ class WorkspaceConnectorSettingsUpdateRequest(BaseModel):
         "contract ('en' | 'ja'); common BCP-47 forms are normalized "
         "(ja-JP → ja). Null clears (#1377).",
     )
+    context_id: UUID | None = Field(
+        None,
+        description="Re-point the write-target context (#1428). Must be a live "
+        "context in this workspace; null clears the binding (no write target).",
+    )
     expected_config_version: int | None = Field(default=None, ge=0)
 
 
@@ -185,6 +190,7 @@ class WorkspaceConnectorSettingsUpdateResponse(BaseModel):
     llm_config_present: bool
     locale: str | None
     config_version: int
+    context_id: UUID | None
 
 
 class WorkspaceConnectorRuntimeUpdateRequest(BaseModel):
@@ -523,6 +529,7 @@ async def update_workspace_connector_settings(
         llm_config_present=settings_result.llm_config_present,
         locale=settings_result.locale,
         config_version=settings_result.config_version,
+        context_id=settings_result.context_id,
     )
 
 

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -133,6 +133,7 @@ class ConnectorSettingsUpdateResult:
     llm_config_present: bool
     locale: str | None
     config_version: int
+    context_id: UUID | None
 
 
 # Sentinel distinguishing "field not provided" from an explicit null (clear)
@@ -957,15 +958,23 @@ class ConnectorProvisioningService:
         litellm_virtual_key_id: str | None = _UNSET,
         llm_config: dict[str, Any] | None = _UNSET,
         locale: str | None = _UNSET,
+        context_id: UUID | None = _UNSET,
     ) -> ConnectorSettingsUpdateResult:
-        """PATCH-update connector vend settings (#1376).
+        """PATCH-update connector vend settings (#1376, #1428).
 
         Fields left at ``_UNSET`` are untouched; an explicit ``None`` clears.
         Repairs UI-created connectors born un-vendable (the create endpoint is
-        the only other writer of these columns). Shares the runtime PATCH's
+        the only other writer of these columns) and re-points the write-target
+        ``context_id`` in place (#1428) — the CREATE path was previously the
+        only writer of the binding, so changing where an already-registered
+        Slack team writes meant delete→recreate. Shares the runtime PATCH's
         contract: workspace-predicated ``SELECT FOR UPDATE``, optional
         ``expected_config_version`` optimistic lock (409 on staleness), and a
         ``config_version`` bump so the worker refetches.
+
+        A non-null ``context_id`` must name a live context in the SAME
+        workspace (soft-deleted contexts are rejected); an explicit ``None``
+        clears the binding back to the legacy no-context state.
 
         Raises:
             ValidationError: no field provided, malformed ``channel_ids``
@@ -974,7 +983,8 @@ class ConnectorProvisioningService:
                 the explicit null the vend already coalesces to ``[]``), an
                 un-vendable ``llm_config`` shape, or a locale outside the
                 worker contract.
-            NotFoundException: unknown or cross-workspace connector.
+            NotFoundException: unknown or cross-workspace connector, or a
+                ``context_id`` that is not a live context in this workspace.
             ConflictError: stale ``expected_config_version``.
         """
         provided_names = sorted(
@@ -984,12 +994,14 @@ class ConnectorProvisioningService:
                 ("litellm_virtual_key_id", litellm_virtual_key_id),
                 ("llm_config", llm_config),
                 ("locale", locale),
+                ("context_id", context_id),
             )
             if value is not _UNSET
         )
         if not provided_names:
             raise ValidationError(
-                "Provide at least one of channel_ids, litellm_virtual_key_id, llm_config, locale",
+                "Provide at least one of channel_ids, litellm_virtual_key_id, "
+                "llm_config, locale, context_id",
                 field="body",
             )
 
@@ -1007,6 +1019,25 @@ class ConnectorProvisioningService:
             except ValueError as ve:
                 raise ValidationError(str(ve), field="locale") from ve
 
+        # Re-point validation runs BEFORE the connector row lock so a bad
+        # target fails without holding SELECT FOR UPDATE. A cross-workspace or
+        # soft-deleted context surfaces as NotFound — no existence disclosure
+        # beyond "not a context you can bind here" (#1428).
+        if context_id is not _UNSET and context_id is not None:
+            from models.auth import Context
+
+            target = (
+                await self.db.execute(
+                    select(Context.id).where(
+                        Context.id == context_id,
+                        Context.workspace_id == workspace_id,
+                        Context.deleted_at.is_(None),
+                    )
+                )
+            ).scalar_one_or_none()
+            if target is None:
+                raise NotFoundException("Context", str(context_id))
+
         connector = await self._get_connector_for_update(
             workspace_id, connector_id, expected_config_version
         )
@@ -1019,6 +1050,8 @@ class ConnectorProvisioningService:
             connector.set_llm_config(llm_config)
         if locale is not _UNSET:
             connector.locale = locale
+        if context_id is not _UNSET:
+            connector.context_id = context_id
         connector.config_version += 1
         await self.db.flush()
 
@@ -1037,6 +1070,7 @@ class ConnectorProvisioningService:
             llm_config_present=bool(connector.llm_config_encrypted),
             locale=connector.locale,
             config_version=connector.config_version,
+            context_id=connector.context_id,
         )
 
     async def rotate_kmc_key(

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -1042,6 +1042,26 @@ class ConnectorProvisioningService:
             workspace_id, connector_id, expected_config_version
         )
 
+        # A connector created without a context never had its workspace-scoped
+        # KMC write key / resource token minted (CREATE only mints them when a
+        # write-target context is present). Re-pointing such a connector to a
+        # context would set context_id but leave it un-worker-usable — GET
+        # /workers/config requires BOTH context_id and the KMC key — so the
+        # PATCH would 200 yet silently do nothing. Reject and steer to recreate
+        # (#1428). Non-null → non-null re-point is fine: the key is
+        # workspace-scoped, not bound to the old context.
+        if (
+            context_id is not _UNSET
+            and context_id is not None
+            and not connector.kmc_api_key_encrypted
+        ):
+            raise ValidationError(
+                "This connector has no write credentials (it was created "
+                "without a context). Re-create it bound to the target context "
+                "instead of re-pointing.",
+                field="context_id",
+            )
+
         if channel_ids is not _UNSET:
             connector.channel_ids = channel_ids
         if litellm_virtual_key_id is not _UNSET:

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -521,6 +521,7 @@ async def test_update_settings_route_passes_only_provided_fields():
                 llm_config_present=False,
                 locale=None,
                 config_version=4,
+                context_id=None,
             )
         )
         response = await update_workspace_connector_settings(connector_id, request, admin, db)
@@ -563,6 +564,7 @@ async def test_update_settings_route_distinguishes_explicit_null_from_absent():
                 llm_config_present=False,
                 locale=None,
                 config_version=9,
+                context_id=None,
             )
         )
         await update_workspace_connector_settings(uuid4(), request, admin, db)
@@ -598,12 +600,49 @@ async def test_update_settings_response_never_echoes_llm_config():
                 llm_config_present=True,
                 locale=None,
                 config_version=2,
+                context_id=None,
             )
         )
         response = await update_workspace_connector_settings(uuid4(), request, admin, db)
 
     assert response.llm_config_present is True
     assert "sk-secret" not in response.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_update_settings_route_forwards_context_id_repoint():
+    """#1428: a context_id in the PATCH body reaches the service and the new
+    binding comes back in the response."""
+    from api.routes.workspace_connectors import (
+        WorkspaceConnectorSettingsUpdateRequest,
+        update_workspace_connector_settings,
+    )
+    from services.connector_provisioning import ConnectorSettingsUpdateResult
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    workspace_id = uuid4()
+    new_ctx = uuid4()
+    admin = {"user_id": "user-1", "current_workspace_id": workspace_id}
+    request = WorkspaceConnectorSettingsUpdateRequest.model_validate({"context_id": str(new_ctx)})
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.update_connector_settings = AsyncMock(
+            return_value=ConnectorSettingsUpdateResult(
+                channel_ids=["C-kept"],
+                litellm_virtual_key_id=None,
+                llm_config_present=False,
+                locale=None,
+                config_version=5,
+                context_id=new_ctx,
+            )
+        )
+        response = await update_workspace_connector_settings(uuid4(), request, admin, db)
+
+    kwargs = service_cls.return_value.update_connector_settings.await_args.kwargs
+    assert kwargs["context_id"] == new_ctx
+    assert response.context_id == new_ctx
+    db.commit.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -670,6 +670,36 @@ async def test_update_settings_route_rolls_back_on_conflict():
     db.commit.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_update_settings_route_context_not_found_not_masked_as_connector():
+    """#1428: a bad context_id surfaces as "Context" NotFound, not masked as
+    "Connector" by the route's catch-all (regression the re-point path exposes)."""
+    from api.routes.workspace_connectors import (
+        WorkspaceConnectorSettingsUpdateRequest,
+        update_workspace_connector_settings,
+    )
+    from utils.exceptions import NotFoundException
+
+    db = MagicMock()
+    db.rollback = AsyncMock()
+    db.commit = AsyncMock()
+    bad_ctx = uuid4()
+    admin = {"user_id": "user-1", "current_workspace_id": uuid4()}
+    request = WorkspaceConnectorSettingsUpdateRequest.model_validate({"context_id": str(bad_ctx)})
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.update_connector_settings = AsyncMock(
+            side_effect=NotFoundException("Context", str(bad_ctx))
+        )
+        with pytest.raises(NotFoundException) as exc:
+            await update_workspace_connector_settings(uuid4(), request, admin, db)
+
+    assert "Context" in str(exc.value)
+    assert "Connector" not in str(exc.value)
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_awaited()
+
+
 def test_update_settings_request_forbids_unknown_fields():
     """#1376 review: a silently-dropped typo'd field name would read as a
     successful partial update — unknown keys must 422 at the request layer."""

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -575,6 +575,10 @@ def _settings_conn(**over):
         "locale": None,
         "config_version": 3,
         "context_id": uuid4(),
+        # Truthy = already provisioned for a context (has a write key), so a
+        # re-point is allowed. Tests that exercise the no-credentials guard
+        # override this to a falsy value.
+        "kmc_api_key_encrypted": "ENC:kmc",
     }
     base.update(over)
     return _SettingsConn(**base)
@@ -845,6 +849,32 @@ async def test_update_settings_clear_context_to_null():
     assert log_info.call_args.kwargs["changed_fields"] == ["context_id"]
     # Only the connector-lock SELECT ran — null clear needs no context lookup.
     assert db.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_update_settings_repoint_without_write_credentials_rejected():
+    """#1428: re-pointing a context-less connector (no KMC write key) to a
+    context is rejected — it would 200 yet leave the connector un-worker-usable
+    (GET /workers/config needs both context_id and the key). No mutation, no
+    config bump."""
+    conn = _settings_conn(context_id=None, kmc_api_key_encrypted=None)
+    new_ctx = uuid4()
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[_result(one=new_ctx), _result(one=conn)])
+    db.flush = AsyncMock()
+
+    with pytest.raises(ValidationError) as exc:
+        await ConnectorProvisioningService(db).update_connector_settings(
+            workspace_id=conn.workspace_id,
+            connector_id=conn.id,
+            user_id="admin-1",
+            context_id=new_ctx,
+        )
+
+    assert "write credentials" in str(exc.value).lower()
+    assert conn.context_id is None  # untouched
+    assert conn.config_version == 3  # not bumped
+    db.flush.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -574,6 +574,7 @@ def _settings_conn(**over):
         "llm_config_encrypted": None,
         "locale": None,
         "config_version": 3,
+        "context_id": uuid4(),
     }
     base.update(over)
     return _SettingsConn(**base)
@@ -768,6 +769,82 @@ async def test_update_settings_hides_cross_workspace_as_not_found():
             user_id="admin-1",
             channel_ids=["C01"],
         )
+
+
+@pytest.mark.asyncio
+async def test_update_settings_repoint_context_binds_and_bumps():
+    """#1428: a valid same-workspace context re-points the write target in
+    place (no delete→recreate) and context_id counts as a provided field."""
+    conn = _settings_conn()
+    new_ctx = uuid4()
+    db = MagicMock()
+    # First execute: context validation SELECT (found). Second: connector lock.
+    db.execute = AsyncMock(side_effect=[_result(one=new_ctx), _result(one=conn)])
+    db.flush = AsyncMock()
+
+    with patch("services.connector_provisioning.logger.info") as log_info:
+        result = await ConnectorProvisioningService(db).update_connector_settings(
+            workspace_id=conn.workspace_id,
+            connector_id=conn.id,
+            user_id="admin-1",
+            context_id=new_ctx,
+        )
+
+    assert conn.context_id == new_ctx
+    assert conn.channel_ids == ["C-old"]  # untouched
+    assert conn.config_version == 4
+    assert result.context_id == new_ctx
+    assert result.config_version == 4
+    assert log_info.call_args.kwargs["changed_fields"] == ["context_id"]
+    db.flush.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_settings_repoint_cross_workspace_context_not_found():
+    """#1428: a context outside the workspace (or soft-deleted) surfaces as
+    NotFound BEFORE the connector row is locked or mutated."""
+    from utils.exceptions import NotFoundException
+
+    conn = _settings_conn()
+    original_ctx = conn.context_id
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_result(one=None))  # context not found
+    db.flush = AsyncMock()
+
+    with pytest.raises(NotFoundException):
+        await ConnectorProvisioningService(db).update_connector_settings(
+            workspace_id=conn.workspace_id,
+            connector_id=conn.id,
+            user_id="admin-1",
+            context_id=uuid4(),
+        )
+
+    assert conn.context_id == original_ctx  # no mutation
+    db.flush.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_settings_clear_context_to_null():
+    """#1428: explicit null clears the binding (no context-validation query)."""
+    conn = _settings_conn()
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_result(one=conn))
+    db.flush = AsyncMock()
+
+    with patch("services.connector_provisioning.logger.info") as log_info:
+        result = await ConnectorProvisioningService(db).update_connector_settings(
+            workspace_id=conn.workspace_id,
+            connector_id=conn.id,
+            user_id="admin-1",
+            context_id=None,
+        )
+
+    assert conn.context_id is None
+    assert result.context_id is None
+    assert conn.config_version == 4
+    assert log_info.call_args.kwargs["changed_fields"] == ["context_id"]
+    # Only the connector-lock SELECT ran — null clear needs no context lookup.
+    assert db.execute.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/frontend/src/lib/api/workspace-connectors.ts
+++ b/frontend/src/lib/api/workspace-connectors.ts
@@ -211,6 +211,9 @@ export interface UpdateConnectorSettingsRequest {
   // Write-only BYO LLM bundle — never returned (a presence flag is).
   llm_config?: Record<string, unknown> | null;
   locale?: string | null;
+  // #1428: re-point the write-target context in place (no delete→recreate).
+  // Must be a live context in this workspace; null clears the binding.
+  context_id?: string | null;
 }
 
 export interface UpdateConnectorSettingsResponse {
@@ -220,6 +223,7 @@ export interface UpdateConnectorSettingsResponse {
   llm_config_present: boolean;
   locale: string | null;
   config_version: number;
+  context_id: string | null;
 }
 
 export async function updateConnectorSettings(


### PR DESCRIPTION
Closes #1428.

## What
Adds `context_id` to the connector settings PATCH (`update_connector_settings`) so an existing Slack connector's **write-target context can be re-pointed in place**, instead of the delete→recreate previously forced by the one-connector-per-`(type,app_key,team)` uniqueness rule (CREATE was the only writer of the binding).

## Behavior
- Non-null `context_id` → must name a **live, same-workspace** context (soft-deleted / cross-workspace rejected as NotFound), validated **before** the row lock.
- Explicit `null` → clears the binding (legacy no-context state).
- Counts as a provided PATCH field; rides `config_version` bump + `changed_fields` log.
- The KMC write key is **workspace-scoped**, so non-null→non-null re-point needs no re-mint. A context-**less** connector (no key ever minted) is **rejected** on re-point — it would 200 yet stay un-worker-usable — steering to recreate.
- Route now surfaces the `Context` NotFound instead of masking it as `Connector`.
- Frontend api-client types (`UpdateConnectorSettingsRequest/Response`) gain `context_id`.

## Tests
Service: re-point binds+bumps, cross-workspace/soft-deleted → NotFound (no mutation), null clears without a lookup, credential-less re-point rejected. Route: forwarding + Context-NotFound not masked. 68 passed.

## Follow-ups (not in this PR)
- Connector settings **UI** to expose re-point (rides #1426's dialog work; only api-client types touched here).
- `_resolve_context` (CREATE path) does not filter `deleted_at` — pre-existing parity gap, worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)