### PR TITLE
fix(mcp): sleep rollback logger TypeError + setup_resource None return (#1440)

### DIFF
--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -966,6 +966,12 @@ async def handle_setup_resource(
             )
             return _error_response("setup_resource_error", error_str)
 
+    # #1440: an exhausted ``get_db()`` generator must still produce the declared
+    # ``list[TextContent]``. Without this the function fell off the end and
+    # returned None into the MCP transport. Mirrors the fall-through every other
+    # handler in this module already has.
+    return _error_response("internal_error", "Database session unavailable")
+
 
 async def handle_setup_connector(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -3,7 +3,6 @@
 Issue #164: get_sleep_history, get_sleep_report, rollback_sleep_run.
 """
 
-import logging
 import time
 from typing import Any
 from uuid import UUID
@@ -20,8 +19,16 @@ from mcp_server.tools._helpers import (
     _resolve_context_id,
     _success_response,
 )
+from utils.logger import get_logger
 
-logger = logging.getLogger(__name__)
+# #1440: bind through ``utils.logger.get_logger`` (structlog) like the rest of
+# the project. This module previously used stdlib ``logging.getLogger``, whose
+# ``Logger._log()`` rejects unknown kwargs — so the structlog-style
+# ``logger.warning("event", key=value)`` call in the shadow-merge rollback path
+# raised TypeError and was swallowed into ``rollback_summary["errors"]``,
+# turning a benign edge mismatch into a reported ``partial_rollback``. Identical
+# bug class to the one fixed in ``api/routes/auth.py`` (PR #522).
+logger = get_logger(__name__)
 
 
 def _report_to_summary(report: Any) -> dict[str, Any]:

--- a/backend/tests/mcp_server/test_resource_tools.py
+++ b/backend/tests/mcp_server/test_resource_tools.py
@@ -922,3 +922,49 @@ class TestSetupResourceHappyPath:
             )
         data = _json_of(result)
         assert data["error"] == "resource_id_conflict"
+
+
+class TestDatabaseSessionUnavailable:
+    """#1440: every handler must return an error envelope when get_db() yields nothing.
+
+    Each handler declares ``-> list[TextContent]`` and drives its work inside
+    ``async for db in get_db():``. If that generator yields nothing, control
+    falls off the end and the function returns ``None`` — which then propagates
+    into the MCP transport where a list is expected, surfacing far from the
+    cause. Five of the six handlers in this module close with the
+    ``internal_error`` fall-through; ``handle_setup_resource`` was missed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_setup_resource_returns_envelope_not_none(self):
+        async def empty_get_db():
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        with patch("db.base.get_db", new=empty_get_db):
+            result = await handle_setup_resource(
+                {"name": "ctx-1440", "resource_id": "res1440"}, "user", uuid4()
+            )
+
+        assert result is not None, "handler returned None instead of an error envelope"
+        data = _json_of(result)
+        assert data["status"] == "error"
+        assert data["error"] == "internal_error"
+
+    @pytest.mark.asyncio
+    async def test_ingest_events_already_has_the_guard(self):
+        """Pins the sibling that was already correct, so the pair cannot drift."""
+
+        async def empty_get_db():
+            return
+            yield  # pragma: no cover - makes this an async generator
+
+        with patch("db.base.get_db", new=empty_get_db):
+            result = await handle_ingest_events(
+                {"resource_id": "res1440", "events": [{"op": "upsert", "doc_id": "d1"}]},
+                "user",
+                uuid4(),
+            )
+
+        assert result is not None
+        assert _json_of(result)["error"] == "internal_error"

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -494,3 +494,97 @@ class TestRollbackSleepRun:
         data = json.loads(result[0].text)
         assert data["status"] == "error"
         assert data["error"] == "no_actions"
+
+
+class TestShadowMergeRollbackEdgeMismatch:
+    """#1440: the edge-mismatch branch must log a warning, not fail the rollback.
+
+    ``mcp_server.tools.sleep`` bound the STDLIB logger (``logging.getLogger``)
+    while calling it with structlog-style kwargs, so this branch raised
+    ``TypeError: Logger._log() got an unexpected keyword argument 'src_id'``.
+    The per-action ``except`` swallowed it into ``rollback_summary["errors"]``,
+    so an edge mismatch — a benign "log it and carry on" condition — was
+    reported to the operator as ``partial_rollback``, the report was marked
+    ``failed``, and the recorded reason was Python internals rather than the
+    actual mismatch. Same bug class the comment at ``api/routes/auth.py:50``
+    documents being fixed in PR #522.
+    """
+
+    @pytest.fixture
+    def user_id(self):
+        return "user-1440"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_edge_mismatch_does_not_raise(self, user_id, workspace_id):
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+
+        # One shadow-mode merge action whose edge revert comes back False.
+        action = MagicMock()
+        action.action_type = "merge"
+        action.memory_id = uuid4()
+        action.target_id = uuid4()
+        action.details = {"mode": "shadow", "prior_edge": None}
+
+        mock_report_result = MagicMock()
+        mock_report_result.scalar_one_or_none.return_value = report
+        mock_actions_result = MagicMock()
+        mock_actions_result.scalars.return_value.all.return_value = [action]
+
+        mock_db = AsyncMock()
+        results = [mock_report_result, mock_actions_result]
+
+        async def _execute(*_args, **_kwargs):
+            if results:
+                return results.pop(0)
+            generic = MagicMock()
+            generic.rowcount = 1
+            generic.scalars.return_value.all.return_value = []
+            generic.scalar_one_or_none.return_value = None
+            return generic
+
+        mock_db.execute.side_effect = _execute
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.sleep._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "services.sleep.undo.revert_shadow_merge_edge",
+                new_callable=AsyncMock,
+                return_value=False,  # edge mismatch -> the warning branch
+            ),
+        ):
+            result = await handle_rollback_sleep_run(
+                {"report_id": str(report_id)}, user_id, workspace_id
+            )
+
+        data = json.loads(result[0].text)
+        recorded_errors = data.get("rollback_summary", {}).get("errors", [])
+
+        # The warning call itself must not become a rollback error.
+        assert not any("Logger._log()" in e for e in recorded_errors), (
+            f"the logger.warning(...) call raised instead of logging: {recorded_errors}"
+        )
+        # An edge mismatch is a degraded-but-successful rollback, not a failure.
+        assert data.get("error") != "partial_rollback", (
+            f"edge mismatch was misreported as a failed rollback: {data}"
+        )
+        assert recorded_errors == [], f"unexpected rollback errors: {recorded_errors}"
+        # The mismatch is still not counted as a reversal.
+        assert data["rollback_summary"]["merges_reversed"] == 0


### PR DESCRIPTION
Closes #1440.

Two functional bugs, both surfaced by running `make type-check` (`pyright src/`) — configured in
this repo but **not run by CI**. Neither is caught by ruff or by the 6 433-test suite.

## Bug 1 — `sleep.py` misreports a benign edge mismatch as a failed rollback

`mcp_server/tools/sleep.py:24` bound the **stdlib** logger, then called it with structlog-style
kwargs on the shadow-merge rollback edge-mismatch branch:

```python
logger = logging.getLogger(__name__)          # stdlib
...
logger.warning("shadow_merge_rollback_edge_mismatch", src_id=..., dst_id=...)
```

`logging.Logger._log()` rejects unknown kwargs → `TypeError`. A per-action `except` catches it into
`rollback_summary["errors"]`, so the observed behaviour was:

```json
{
  "error": "partial_rollback",
  "message": "Rollback completed with 1 error(s). Report marked as 'failed' — inspect errors and retry if needed.",
  "rollback_summary": {
    "merges_reversed": 0,
    "errors": ["Action <...> (merge): Logger._log() got an unexpected keyword argument 'src_id'"]
  }
}
```

An edge mismatch is a *"log it and carry on"* condition. Instead the operator is told the rollback
**failed**, the report is marked `failed`, and the recorded reason is Python internals rather than
the mismatch — so "inspect errors and retry" points at a message that says nothing about the cause.
The rest of the rollback does complete; it is not aborted. (My original issue text said the rollback
"dies" — corrected [in a comment](https://github.com/kagura-ai/memory-cloud/issues/1440#issuecomment-5082366591).)

**This is a recurrence.** `api/routes/auth.py:50` carries a comment documenting the identical bug
class being fixed in PR #522, and `.claude/rules/backend.md` states the structlog rule.

Fix: bind via `utils.logger.get_logger`. **Blast radius is exactly two call sites** — `sleep.py` has
only the broken one and one positional f-string `logger.warning(...)`, which structlog accepts
unchanged. `import logging` is removed; no other `logging.*` usage remained.

## Bug 2 — `handle_setup_resource` returns `None`

Declared `-> list[TextContent]`, but nothing followed its `async for db in get_db():`, so an
exhausted generator fell off the end and returned `None` into the MCP transport — surfacing far from
the cause instead of as the intended error envelope.

The **five sibling handlers in the same module** all close with
`return _error_response("internal_error", "Database session unavailable")` (lines 291, 401, 533, 687,
1129). This one was missed. pyright's `reportReturnType` is whole-program and flags exactly one
handler, so this is the only occurrence — no wider sweep needed.

## Tests — written first, confirmed red

```
tests/mcp_server/test_sleep_tools.py::TestShadowMergeRollbackEdgeMismatch
tests/mcp_server/test_resource_tools.py::TestDatabaseSessionUnavailable
```

Before the fix:

```
AssertionError: the logger.warning(...) call raised instead of logging:
  ["Action <...> (merge): Logger._log() got an unexpected keyword argument 'src_id'"]
AssertionError: handler returned None instead of an error envelope
```

The sleep test drives the real `handle_rollback_sleep_run` down to the mismatch branch (patching
`revert_shadow_merge_edge` to return `False`) and asserts no `Logger._log()` string reaches
`rollback_summary["errors"]`, that the run is **not** reported as `partial_rollback`, that `errors`
is empty, and that the mismatch is still **not** counted as a reversal — so the fix cannot pass by
silently treating a mismatch as success.

`TestDatabaseSessionUnavailable` also pins `handle_ingest_events` (already correct) alongside the
fixed handler, so the pair cannot drift apart again.

## Verification

- New tests red before / green after; `2767 passed, 374 skipped` across the unit suites
  (`tests/services tests/mcp_server tests/repositories tests/neural tests/models tests/db` + MCP
  tool tests) — no pre-existing test modified.
- `ruff check src/ tests/` clean, `ruff format` clean.
- `pyright` no longer reports `sleep.py:402`, `:403`, or `resource.py:692`. The remaining
  `sleep.py:428 rowcount` error is a separate Tier-A/B residual, handled in the follow-up that adds
  pyright to CI.
**On review:** the codex-in-WSL second opinion used on #1438 **did not complete here** — WSL hung and
I killed it rather than wait. So the questions I would have asked it, I verified directly instead:

- *Does swapping the logger change behaviour at the other call sites?* No — `sleep.py` has exactly
  **two** `logger.*` calls: the fixed one and a positional f-string `logger.warning(...)`, which
  structlog's `BoundLogger` accepts unchanged. `import logging` is removed and no `logging.*` usage
  remains (ruff F401 confirms).
- *Could the new `return` mask a real error?* No. An AST check of `handle_setup_resource` shows every
  terminal path inside the `async for` body returns or raises, so the fall-through is reachable
  **only** when `get_db()` yields nothing — exactly the path that previously returned `None`.
- *Do the tests pass for the wrong reason?* Both were confirmed red before the fix with the specific
  assertions above. An instrumented run proves the sleep test reaches the branch
  (`revert_shadow_merge_edge` called once, the `TypeError` observed in `rollback_summary["errors"]`),
  and the resource test's pre-fix failure was `handler returned None`, which is only reachable at the
  fall-through.
- *Do the patch targets work for function-body imports?* Yes — both handlers import inside the
  function, so the attribute is resolved from the patched module at call time; the red→green
  transition demonstrates it.

A second opinion on this diff is still welcome in review.

## Follow-ups

Adding `pyright src/` as a CI gate (the reason these went unnoticed) and an automated guard against
this stdlib-logger bug class recurring a third time are tracked separately under v0.61.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
