### PR TITLE
build(ci): clear pyright residuals and gate type-check in CI (#1442)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,14 +55,16 @@ jobs:
           cache: pip
           cache-dependency-path: backend/pyproject.toml
 
-      # The optional extras are NOT decoration here. google-genai and ollama
-      # live in `llm_providers`; with a lean `.[dev]` install pyright reports
-      # them as unresolved imports and stops analysing those modules — which is
-      # exactly how #1443 (Gemini list_models always returning its hardcoded
-      # fallback) stayed hidden. Install what production imports so the gate
-      # sees what production runs.
+      # EVERY optional extra, not just dev. This is load-bearing, not
+      # thoroughness for its own sake: pyright silently stops analysing a module
+      # whose imports it cannot resolve, so a missing extra turns real findings
+      # into a single "unresolved import" line. google-genai/ollama
+      # (`llm_providers`) hid #1443 — Gemini list_models always returning its
+      # hardcoded fallback — behind exactly that. lancedb/pyarrow (`lite`) were
+      # missed on the first attempt at this job and CI caught it.
+      # If a new extra is added to pyproject.toml, add it here too.
       - name: Install dependencies
-        run: cd backend && pip install -e ".[dev,llm_providers,neural]"
+        run: cd backend && pip install -e ".[dev,llm_providers,neural,lite]"
 
       - name: Type check
         run: cd backend && pyright src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,42 @@ jobs:
       - name: Models no-Column guard
         run: make lint-models-no-column
 
+  # Static type gate for the backend (#1442). The frontend has run
+  # `tsc --noEmit` since day one; pyright was configured in
+  # backend/pyproject.toml with a tier-by-tier plan (#599, #612) and a
+  # `make type-check` target, but nothing enforced it — so it drifted red.
+  # Two of the findings it had accumulated were real functional bugs that
+  # ruff and the 6k-test suite both missed (#1440), plus a third (#1443).
+  #
+  # This is a HARD gate on purpose. `continue-on-error` would have surfaced
+  # those bugs exactly as well as having no check at all.
+  #
+  # Kept as its own job rather than folded into `lint`: pyright needs the
+  # project's real dependency tree installed, while `lint` only needs ruff
+  # and stays fast.
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      # The optional extras are NOT decoration here. google-genai and ollama
+      # live in `llm_providers`; with a lean `.[dev]` install pyright reports
+      # them as unresolved imports and stops analysing those modules — which is
+      # exactly how #1443 (Gemini list_models always returning its hardcoded
+      # fallback) stayed hidden. Install what production imports so the gate
+      # sees what production runs.
+      - name: Install dependencies
+        run: cd backend && pip install -e ".[dev,llm_providers,neural]"
+
+      - name: Type check
+        run: cd backend && pyright src/
+
   # Shell-script quality gate for the blue-green deploy script. shellcheck
   # catches the `set -e` / quoting bug class behind #986 (a bare
   # `var=$(curl ...)` dying silently); the bats suite pins the three

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -30,7 +30,14 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth import oauth_endpoints
+# #1442: spelled as an explicit submodule import rather than
+# ``from auth import oauth_endpoints``. This file is itself named ``auth.py``,
+# so within ``api/routes/`` the bare form is ambiguous between the top-level
+# ``auth`` package and this sibling module — pyright resolves it to the sibling
+# and reports every ``oauth_endpoints.*`` call as an unknown attribute. Runtime
+# always resolved it correctly (absolute import); this makes the intent explicit
+# for readers and analyzers alike.
+import auth.oauth_endpoints as oauth_endpoints
 from auth.dependencies import SessionUser
 from auth.oauth2 import OAuth2Manager
 from auth.password import verify_password

--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -1511,7 +1511,7 @@ async def update_context_member_role(
     # regex; the column is Mapped[ContextRole] (a StrEnum). Cast rather than
     # convert so this stays a pure typing fix with no new runtime validation
     # — unifying the request schemas onto the enums is a separate change (#1442).
-    member.role = cast("ContextRole", body.role)
+    member.role = cast(ContextRole, body.role)
     member.updated_at = func.now()
 
     await db.commit()

--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -11,7 +11,7 @@ Each context maps to a separate Qdrant collection for memory isolation.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
@@ -1507,7 +1507,11 @@ async def update_context_member_role(
             )
 
     # Update role
-    member.role = body.role
+    # body.role is constrained to owner|editor|viewer by the request schema's
+    # regex; the column is Mapped[ContextRole] (a StrEnum). Cast rather than
+    # convert so this stays a pure typing fix with no new runtime validation
+    # — unifying the request schemas onto the enums is a separate change (#1442).
+    member.role = cast("ContextRole", body.role)
     member.updated_at = func.now()
 
     await db.commit()

--- a/backend/src/db/redis.py
+++ b/backend/src/db/redis.py
@@ -71,7 +71,7 @@ async def get_cache(key: str) -> str | None:
         # get_redis_client() builds the client with decode_responses=True, so
         # values really are str; the redis-py stub is not parameterized on that
         # flag and widens to bytes | str (#1442).
-        return cast("str | None", await client.get(key))
+        return cast(str | None, await client.get(key))
     except Exception as e:
         logger.error("redis_get_failed", key=key, error=str(e))
         return None

--- a/backend/src/db/redis.py
+++ b/backend/src/db/redis.py
@@ -3,6 +3,8 @@
 Singleton pattern for connection pooling.
 """
 
+from typing import cast
+
 import redis.asyncio as aioredis
 
 from config.database import REDIS_URL
@@ -66,7 +68,10 @@ async def get_cache(key: str) -> str | None:
     """
     client = get_redis_client()
     try:
-        return await client.get(key)
+        # get_redis_client() builds the client with decode_responses=True, so
+        # values really are str; the redis-py stub is not parameterized on that
+        # flag and widens to bytes | str (#1442).
+        return cast("str | None", await client.get(key))
     except Exception as e:
         logger.error("redis_get_failed", key=key, error=str(e))
         return None

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -428,7 +428,7 @@ async def handle_rollback_sleep_run(
                                 # report a restore that never happened).
                                 # Result[Any] at type level, CursorResult at
                                 # runtime — .rowcount lives on the latter (#1442).
-                                restore_rows = cast("CursorResult[Any]", restore_result).rowcount
+                                restore_rows = cast(CursorResult[Any], restore_result).rowcount
                                 if restore_rows == 0 or loser is None:
                                     rollback_summary["errors"].append(
                                         f"merge loser {action.target_id} not restorable — "

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -4,11 +4,12 @@ Issue #164: get_sleep_history, get_sleep_report, rollback_sleep_run.
 """
 
 import time
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from mcp.types import TextContent
 from sqlalchemy import select
+from sqlalchemy.engine import CursorResult
 
 from mcp_server.tools._helpers import (
     _check_viewer_permission,
@@ -425,7 +426,10 @@ async def handle_rollback_sleep_run(
                                 # (the per-merge undo path returns 410 for the
                                 # same state; run-level rollback must not
                                 # report a restore that never happened).
-                                if restore_result.rowcount == 0 or loser is None:
+                                # Result[Any] at type level, CursorResult at
+                                # runtime — .rowcount lives on the latter (#1442).
+                                restore_rows = cast("CursorResult[Any]", restore_result).rowcount
+                                if restore_rows == 0 or loser is None:
                                     rollback_summary["errors"].append(
                                         f"merge loser {action.target_id} not restorable — "
                                         "purged by the retention policy "

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -135,7 +135,15 @@ class HebbianLearner:
                             if act_i.node_id < act_j.node_id
                             else (act_j.node_id, act_i.node_id)
                         )
-                        in_band = repetition_active and sim >= floor_threshold
+                        # ``repetition_active`` already implies
+                        # ``floor_threshold is not None``, but the narrowing does
+                        # not survive the intermediate bool — restate it so the
+                        # comparison is provably float-vs-float (#1442).
+                        in_band = (
+                            repetition_active
+                            and floor_threshold is not None
+                            and sim >= floor_threshold
+                        )
                         evidence = co_activation_counts.get(pair_key, 0) if repetition_active else 0
                         if not (in_band and evidence >= self.config.edge_gate_min_evidence):
                             skipped += 1

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -42,6 +42,7 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import WorkspaceRole
 from config.settings import get_settings
 from db.qdrant import delete_user_points
 from db.redis import clear_co_activations, clear_user_rate_limits, get_redis_client
@@ -943,7 +944,7 @@ class AccountErasureService:
             if locked_ws.owner_user_id != user_id:
                 continue
             locked_ws.owner_user_id = new_owner.user_id
-            new_owner.role = "owner"
+            new_owner.role = WorkspaceRole.OWNER
             # Bump the ownership epoch on every owner change (#1102) so the #1100
             # consumer invalidates external credentials (billing-handoff tokens /
             # sessions) bound to the erased previous owner.

--- a/backend/src/services/llm_pricing_service.py
+++ b/backend/src/services/llm_pricing_service.py
@@ -63,9 +63,9 @@ _PRICING_CACHE_TTL_SECONDS: Final = 3600
 _PRICING_CACHE_MAXSIZE: Final = 1024
 # key: (provider, model, unit_type, started_at.date(), context_tokens)
 # value: (price_per_unit, unit_denominator) | None
-_pricing_cache: TTLCache[tuple[str, str, str, date, int], tuple[float, float] | None] = TTLCache(
-    maxsize=_PRICING_CACHE_MAXSIZE, ttl=_PRICING_CACHE_TTL_SECONDS
-)
+_pricing_cache: TTLCache[tuple[str, str, str, date, int], tuple[float, float] | None] = TTLCache[
+    tuple[str, str, str, date, int], tuple[float, float] | None
+](maxsize=_PRICING_CACHE_MAXSIZE, ttl=_PRICING_CACHE_TTL_SECONDS)
 
 
 def clear_pricing_cache() -> None:

--- a/backend/src/services/llm_providers/gemini_provider.py
+++ b/backend/src/services/llm_providers/gemini_provider.py
@@ -119,13 +119,18 @@ class GeminiProvider(LLMProvider):
     async def list_models(self) -> list[dict]:
         """List available Gemini models."""
         try:
+            # #1443: ``aio.models.list()`` returns an ``AsyncPager``, which IS
+            # the async-iterable of models — it has no ``.models`` attribute.
+            # Reading ``response.models`` raised AttributeError, was swallowed
+            # by the ``except`` below, and made every call return the hardcoded
+            # fallback list instead of the caller's actual models.
             response = await self._ensure_client().aio.models.list()
             return [
                 {
                     "id": _strip_models_prefix(m.name),
                     "name": m.display_name or _strip_models_prefix(m.name),
                 }
-                for m in response.models
+                async for m in response
                 if getattr(m, "name", None)
             ]
         except Exception as e:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1995,7 +1995,7 @@ class MemoryService:
             # are (dst_id, src_id) UUID pairs. Cast rather than switching to
             # .tuples() so the executed call is unchanged (#1442).
             shadow_map: dict[UUID, UUID] = cast(
-                "dict[UUID, UUID]",
+                dict[UUID, UUID],
                 dict(rows.all()),  # type: ignore[arg-type]
             )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -15,7 +15,7 @@ import os
 import statistics
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, cast
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, or_, select
@@ -1991,7 +1991,13 @@ class MemoryService:
                 )
                 .order_by(superseder.created_at.asc(), superseder.id.asc())
             )
-            shadow_map: dict[UUID, UUID] = dict(rows.all())
+            # dict() over a Row sequence infers dict[bytes, bytes]; the rows
+            # are (dst_id, src_id) UUID pairs. Cast rather than switching to
+            # .tuples() so the executed call is unchanged (#1442).
+            shadow_map: dict[UUID, UUID] = cast(
+                "dict[UUID, UUID]",
+                dict(rows.all()),  # type: ignore[arg-type]
+            )
 
             c_rows = await self.db.execute(
                 select(NeuralMemoryEdge.src_id, NeuralMemoryEdge.dst_id).where(

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -907,14 +907,14 @@ class SecretStoreService:
             .group_by(SecretVersion.secret_id)
         )
         # (secret_id, max_version) rows — see the note in memory_service (#1442).
-        ver_map = cast("dict[UUID, int]", dict(ver_rows.all()))  # type: ignore[arg-type]
+        ver_map = cast(dict[UUID, int], dict(ver_rows.all()))  # type: ignore[arg-type]
 
         grant_rows = await self.db.execute(
             select(SecretGrant.secret_id, func.count())
             .where(SecretGrant.secret_id.in_(ids), SecretGrant.revoked_at.is_(None))
             .group_by(SecretGrant.secret_id)
         )
-        grant_map = cast("dict[UUID, int]", dict(grant_rows.all()))  # type: ignore[arg-type]
+        grant_map = cast(dict[UUID, int], dict(grant_rows.all()))  # type: ignore[arg-type]
 
         return [
             {

--- a/backend/src/services/secret_store_service.py
+++ b/backend/src/services/secret_store_service.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, cast
 from uuid import UUID, uuid4
 
 from sqlalchemy import func, select, text, update
@@ -906,14 +906,15 @@ class SecretStoreService:
             .where(SecretVersion.secret_id.in_(ids))
             .group_by(SecretVersion.secret_id)
         )
-        ver_map = dict(ver_rows.all())
+        # (secret_id, max_version) rows — see the note in memory_service (#1442).
+        ver_map = cast("dict[UUID, int]", dict(ver_rows.all()))  # type: ignore[arg-type]
 
         grant_rows = await self.db.execute(
             select(SecretGrant.secret_id, func.count())
             .where(SecretGrant.secret_id.in_(ids), SecretGrant.revoked_at.is_(None))
             .group_by(SecretGrant.secret_id)
         )
-        grant_map = dict(grant_rows.all())
+        grant_map = cast("dict[UUID, int]", dict(grant_rows.all()))  # type: ignore[arg-type]
 
         return [
             {

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -152,12 +152,16 @@ def _split_oversize_cluster(
         edges: an early cap-blocked pair may still end up same-component via
         other edges, and same-component skips are never counted).
     """
+
+    def _ordered(pair: tuple[UUID, UUID, float]) -> tuple[UUID, UUID, float]:
+        # Explicit 3-tuple instead of ``(*sorted(...), score)``: the splat form
+        # widens every slot to ``UUID | float``, which makes ``-p[2]`` untypable
+        # even though the score is always a float (#1442).
+        a, b = sorted((pair[0], pair[1]), key=str)
+        return a, b, pair[2]
+
     internal = sorted(
-        (
-            (*sorted((p[0], p[1]), key=str), p[2])
-            for p in pairs
-            if p[0] in cluster and p[1] in cluster
-        ),
+        (_ordered(p) for p in pairs if p[0] in cluster and p[1] in cluster),
         key=lambda p: (-p[2], str(p[0]), str(p[1])),
     )
 

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -90,7 +90,7 @@ async def revert_shadow_merge_edge(
         )
     # DML through AsyncSession.execute() is typed Result[Any] but is a
     # CursorResult at runtime, which is what carries .rowcount (#1442).
-    return (cast("CursorResult[Any]", result).rowcount or 0) > 0
+    return (cast(CursorResult[Any], result).rowcount or 0) > 0
 
 
 class UndoMergeError(Exception):

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -13,11 +13,12 @@ and the error says so explicitly.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy import update as sa_update
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import Memory
@@ -87,7 +88,9 @@ async def revert_shadow_merge_edge(
                 NeuralMemoryEdge.edge_type == EDGE_TYPE_SUPERSEDES,
             )
         )
-    return (result.rowcount or 0) > 0
+    # DML through AsyncSession.execute() is typed Result[Any] but is a
+    # CursorResult at runtime, which is what carries .rowcount (#1442).
+    return (cast("CursorResult[Any]", result).rowcount or 0) > 0
 
 
 class UndoMergeError(Exception):

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -5,7 +5,7 @@ Issue #115 Phase B-2: Workspace-level Multi-tenancy
 Manages workspaces, memberships, and workspace-level operations.
 """
 
-from typing import Any
+from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select
@@ -714,7 +714,10 @@ class WorkspaceService:
                 )
 
         old_role = member.role
-        member.role = new_role
+        # new_role is validated by the caller's request schema; column is
+        # Mapped[WorkspaceRole] (StrEnum). See the note in api/routes/contexts.py
+        # — cast only, no behaviour change (#1442).
+        member.role = cast("WorkspaceRole", new_role)
         member.updated_at = func.now()
 
         # Issue #234: Clear allowed_context_ids on role change

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -717,7 +717,7 @@ class WorkspaceService:
         # new_role is validated by the caller's request schema; column is
         # Mapped[WorkspaceRole] (StrEnum). See the note in api/routes/contexts.py
         # — cast only, no behaviour change (#1442).
-        member.role = cast("WorkspaceRole", new_role)
+        member.role = cast(WorkspaceRole, new_role)
         member.updated_at = func.now()
 
         # Issue #234: Clear allowed_context_ids on role change

--- a/backend/tests/services/test_llm_providers.py
+++ b/backend/tests/services/test_llm_providers.py
@@ -242,20 +242,41 @@ class TestGeminiProvider:
 
     @pytest.mark.asyncio
     async def test_list_models_returns_models(self):
+        """#1443: the SDK returns an AsyncPager, which IS the iterable of models.
+
+        This test previously stubbed the result as ``MagicMock(models=[...])``
+        — an API shape ``google.genai.pagers.AsyncPager`` does not have (it
+        exposes ``page`` / ``next_page`` and ``__aiter__``, never ``.models``).
+        Asserting against that fabricated shape let the provider's real
+        ``response.models`` AttributeError go unnoticed: it was swallowed by the
+        surrounding ``except Exception`` and every call silently returned the
+        hardcoded fallback list. The stub below matches the real contract.
+        """
         provider = GeminiProvider(api_key="gemini-test")
         mock_model = MagicMock()
         mock_model.name = "models/gemini-3.1-pro"
         mock_model.display_name = "Gemini 3.1 Pro"
-        mock_list = MagicMock()
-        mock_list.models = [mock_model]
+
+        class _AsyncPagerStub:
+            """Async-iterable, with no ``.models`` — like the real AsyncPager."""
+
+            def __init__(self, items):
+                self._items = items
+
+            async def __aiter__(self):
+                for item in self._items:
+                    yield item
 
         mock_client = MagicMock()
-        mock_client.aio.models.list = AsyncMock(return_value=mock_list)
+        mock_client.aio.models.list = AsyncMock(return_value=_AsyncPagerStub([mock_model]))
         provider._client = mock_client
         models = await provider.list_models()
 
         # IDs are normalized by stripping the "models/" prefix.
-        assert models == [{"id": "gemini-3.1-pro", "name": "Gemini 3.1 Pro"}]
+        assert models == [{"id": "gemini-3.1-pro", "name": "Gemini 3.1 Pro"}], (
+            "expected the live model list; the hardcoded fallback means the "
+            "pager was not iterated correctly"
+        )
 
 
 # ============================================================================

--- a/backend/tests/services/test_llm_providers.py
+++ b/backend/tests/services/test_llm_providers.py
@@ -258,14 +258,29 @@ class TestGeminiProvider:
         mock_model.display_name = "Gemini 3.1 Pro"
 
         class _AsyncPagerStub:
-            """Async-iterable, with no ``.models`` — like the real AsyncPager."""
+            """Mirrors ``google.genai.pagers.AsyncPager``'s iteration protocol.
+
+            The real pager implements ``__aiter__`` as a plain ``def`` that
+            resets the cursor and returns ``self``, with the awaiting done in
+            ``__anext__`` — and exposes no ``.models``. Modelled that way here
+            rather than as an async generator: the whole point of this stub is
+            to pin the SDK's actual contract, so it should not paraphrase it.
+            """
 
             def __init__(self, items):
-                self._items = items
+                self._items = list(items)
+                self._idx = 0
 
-            async def __aiter__(self):
-                for item in self._items:
-                    yield item
+            def __aiter__(self):
+                self._idx = 0
+                return self
+
+            async def __anext__(self):
+                if self._idx >= len(self._items):
+                    raise StopAsyncIteration
+                item = self._items[self._idx]
+                self._idx += 1
+                return item
 
         mock_client = MagicMock()
         mock_client.aio.models.list = AsyncMock(return_value=_AsyncPagerStub([mock_model]))


### PR DESCRIPTION
Closes #1442. Closes #1443.

> **Stacked on #1441** (`1440-fix/...`). Three of the errors are fixed there and the gate cannot go
> green without it — **merge #1441 first**.

`pyright` was configured in this repo — `[tool.pyright]`, `pyright` in the `dev` extra, a
`make type-check` target, and a documented tier-by-tier plan (#599, #612) — but **nothing ran it**.
The frontend has run `tsc --noEmit` in CI since day one; the backend had no equivalent, so the gate
drifted red. Two of the findings it had accumulated were real functional bugs (#1440). Clearing the
rest surfaced a third (#1443).

## The gate

A new **`type-check` job**, as a **hard gate**. Not `continue-on-error` — a permanently-red check
nobody reads would have surfaced these bugs exactly as well as no check at all. Kept separate from
`lint` so that job stays ruff-only and fast.

**The install line is load-bearing:**

```yaml
run: cd backend && pip install -e ".[dev,llm_providers,neural]"
```

`google-genai` and `ollama` live in the `llm_providers` extra. With a lean `.[dev]` install, pyright
reports them as unresolved imports and **stops analysing those modules** — which is exactly how
#1443 stayed hidden. Installing what production imports is what makes the gate mean something.

## #1443 — folded in because it blocks the gate

`GeminiProvider.list_models()` read `response.models`, but `aio.models.list()` returns an
`AsyncPager`, which **is** the async-iterable and has no `.models`:

```
AsyncPager attrs: ['config', 'name', 'next_page', 'page', 'page_size', 'sdk_http_response']
has .models?    False
async-iterable? True          # verified against google-genai 2.14.0
```

The `AttributeError` was swallowed by the surrounding `except Exception`, so **every** call silently
returned the hardcoded `["gemini-3.1-pro", "gemini-3.1-flash-lite"]` fallback. BYOK users on Gemini
never saw their actual models — and the response was well-formed, so nothing looked wrong.

**Why the test missed it:** it stubbed the result as `MagicMock(models=[...])` — an API shape the SDK
does not have. It asserted against a fabricated contract. Rewritten against an async-iterable stub;
confirmed red first:

```
gemini_list_models_failed  error="'_AsyncPagerStub' object has no attribute 'models'"
AssertionError: expected the live model list; the hardcoded fallback means the pager was not iterated
```

## Residuals cleared (17)

Each carries an inline reason. **No blanket `reportX = false` was added to `[tool.pyright]`** — that
would re-open the gap this PR closes.

| Site | Was it a bug? | Resolution |
|---|---|---|
| `api/routes/auth.py` (×4) | No, but a real ambiguity | This file is itself `auth.py`, so `from auth import oauth_endpoints` is ambiguous from inside `api/routes/` and pyright resolved it to the **sibling**. Runtime always resolved correctly (absolute import). Spelled as an explicit submodule import — unambiguous for readers too. |
| `neural/hebbian.py` | No | `repetition_active` already implies `floor_threshold is not None`; restate it so narrowing survives |
| `sleep.py`, `sleep/undo.py` | No | `.rowcount` needs `CursorResult` — same cast `account_erasure_service.py` already uses |
| `contexts.py`, `workspace_service.py`, `account_erasure_service.py` | No | role columns are `Mapped[StrEnum]`; values already constrained by the request schemas' regex. **Cast only** — converting via the enum constructor would add runtime validation, which does not belong in a gate PR. Unifying the schemas onto the enums is a follow-up. |
| `db/redis.py` | No | client is built with `decode_responses=True`; the redis-py stub is not parameterized on that flag |
| `sleep/dedup_merge.py` | No | `(*sorted(...), score)` widened every tuple slot to `UUID \| float`; build the 3-tuple explicitly |
| `llm_pricing_service.py` | No | parameterize the `TTLCache` constructor |
| `memory_service.py`, `secret_store_service.py` (×3) | No | `dict()` over a `Row` sequence |

One note on that last row: I first used `.tuples()`, which is the idiomatic SQLAlchemy 2.0 method —
**it broke three tests** that mock `Result`. Reverted to a `cast` so the *executed call is unchanged*.
A typing-only PR should not alter runtime call patterns.

## Verification

- `pyright src/` — **0 errors** (from 20).
- `ruff check src/ tests/` and `ruff format --check` — clean.
- **2 770 passed / 374 skipped**, no pre-existing test weakened. The one test I changed
  (`test_list_models_returns_models`) was asserting a false contract; it is now stricter, not looser.

## Out of scope

Tier C (`reportArgumentType`, ~163 residuals) and Tier D stay disabled in `[tool.pyright]`. This PR
gates the tiers already meant to be on; raising the tier is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)