### PR TITLE
fix(api): 404 not-ready when llm_config cannot vend (#1447)

### DIFF
--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -135,6 +135,34 @@ def _etag(revision: str) -> str:
     return f'"{revision}"'
 
 
+# The keys the bridge's ``LLMConfig`` requires to construct a client. Note the
+# asymmetry with ``ConnectorProvisioningService._validate_llm_config``, which
+# deliberately does NOT require ``api_key`` (provider-dependent — local ollama
+# has none): a bundle can be valid to *store* and still be un-vendable. This
+# gate follows the consumer, not the writer.
+_VENDABLE_LLM_KEYS = ("provider", "model", "api_key")
+
+
+def _is_vendable_llm_config(config: Any) -> bool:
+    """Whether an LLM bundle is complete enough for the worker to use (#1447).
+
+    Args:
+        config: The decrypted ``llm_config`` document, or ``None`` when unset.
+            Typed ``Any`` because the column stores arbitrary decrypted JSON —
+            a drifted row may hold a non-dict, which must be rejected here
+            rather than 500 in response validation.
+
+    Returns:
+        True when every key in :data:`_VENDABLE_LLM_KEYS` is a non-blank
+        string. Extra keys pass through opaquely (provider-specific options).
+    """
+    if not isinstance(config, dict):
+        return False
+    return all(
+        isinstance(config.get(key), str) and config[key].strip() for key in _VENDABLE_LLM_KEYS
+    )
+
+
 def _vend_locale(connector: Any) -> WorkerLocale | None:
     """Best-effort normalization of a stored locale to ``WORKER_LOCALES``.
 
@@ -244,8 +272,10 @@ async def get_worker_config(
 ) -> WorkerConnectorConfig | Response:
     """Return the connector config for a platform team (worker dispatch).
 
-    404 when no connector serves the team, or the connector has no write-target
-    context yet (registration incomplete) — the worker treats both as not-ready.
+    404 when no connector serves the team, the connector has no write-target
+    context yet (registration incomplete), it has no KMC write key, or its
+    ``llm_config`` cannot vend (#1447) — the worker treats all of them as
+    not-ready and skips the team rather than failing the dispatch.
     """
     selected_app_key = app_key or "default"
     app_config_version = 0
@@ -276,6 +306,84 @@ async def get_worker_config(
     if connector is None or connector.context_id is None:
         raise WorkerConnectorNotReadyError()
 
+    # #1447: readiness is decided BEFORE the conditional-GET short-circuit. A 304
+    # asserts "your cached representation is still valid" — but when the resource
+    # would now be a 404, the cached 200 body is precisely what has to be thrown
+    # away. ``config_revision`` is derived from ids + config_version only, so any
+    # readiness change that does not bump config_version (a deployment flipping
+    # ``enable_managed_connectors``, a rotated encryption key) would otherwise
+    # keep a poisoned config alive behind a matching ETag indefinitely. The cost
+    # is decrypting on the 304 path too, which is negligible beside the connector
+    # lookup already performed above.
+    #
+    # Because the decrypt now also runs on the cache-hit path, a corrupt or
+    # unrotatable ciphertext must not become a 500 there (review round 2): a
+    # credential we cannot read is a credential the connector does not have.
+    try:
+        kmc_api_key = connector.get_kmc_api_key()
+    except Exception as exc:
+        logger.warning(
+            "worker_config_kmc_key_undecryptable",
+            connector_id=str(connector.id),
+            error_type=type(exc).__name__,
+        )
+        raise WorkerConnectorNotReadyError() from None
+    if not kmc_api_key:
+        raise WorkerConnectorNotReadyError()
+
+    # #1447: an un-vendable LLM bundle is a not-ready connector, not a ready one
+    # with a hole in it. Vending 200 here poisons the tenant: the worker rejects
+    # the config, the Slack webhook still answers 200, and events are dropped
+    # with no retry and no error anywhere — a 2026-07-21..27 production outage
+    # ran 6 days that way. 404 is the state the worker already handles (skip).
+    #
+    # Managed SaaS (#1426) is the documented exception: there the shared bridge
+    # supplies the pre-compile LLM, which is exactly what
+    # ``enable_managed_connectors`` already means ("stops flagging a missing
+    # per-connector LLM"). This aligns the vend gate with the flag the admin UI
+    # has been honouring all along.
+    #
+    # The carve-out covers an ABSENT bundle only. A present-but-broken one is
+    # not-ready in every mode: the worker would try to use it and fail closed,
+    # and silently falling back to the shared LLM would hide a half-finished
+    # BYO setup. (It also keeps a drifted non-dict document from reaching
+    # response validation, where it raises a 500 instead of a 404.)
+    try:
+        llm_config = connector.get_llm_config()
+    except Exception as exc:
+        # A stored bundle that cannot be decrypted or parsed (rotated Fernet key,
+        # corrupted ciphertext) is un-vendable in exactly the same sense — it must
+        # take the 404 path the worker already handles, not surface as a 500 the
+        # worker has no rule for. Same fail-soft principle as the undecryptable
+        # signing secret in ``get_worker_apps`` above.
+        #
+        # The catch is deliberately broad: a readiness boundary that lets an
+        # unanticipated exception through takes the tenant down, which is the
+        # failure mode this whole change exists to remove. ``error_type`` is
+        # logged so a masked programming error (a renamed column, a changed
+        # return type) is still visible rather than reading as a benign
+        # not-ready connector.
+        logger.warning(
+            "worker_config_llm_undecryptable",
+            connector_id=str(connector.id),
+            error_type=type(exc).__name__,
+        )
+        raise WorkerConnectorNotReadyError() from None
+
+    managed = get_settings().enable_managed_connectors
+    if not _is_vendable_llm_config(llm_config) and not (managed and llm_config is None):
+        # Fires on every poll while the connector stays broken, which is the
+        # intended cadence for a state an operator must act on (and is the same
+        # cadence as ``connector_kmc_key_expired`` below). #1449 adds the durable
+        # admin-UI surface so this log is not the only place it shows up.
+        logger.warning(
+            "worker_config_llm_not_vendable",
+            connector_id=str(connector.id),
+            # Key names only — never the bundle, which holds the API key.
+            present_keys=sorted(llm_config) if isinstance(llm_config, dict) else [],
+        )
+        raise WorkerConnectorNotReadyError()
+
     config_revision = opaque_revision(
         connector.id,
         connector.config_version,
@@ -287,10 +395,6 @@ async def get_worker_config(
     if if_none_match == etag:
         return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)
     response.headers.update(headers)
-
-    kmc_api_key = connector.get_kmc_api_key()
-    if not kmc_api_key:
-        raise WorkerConnectorNotReadyError()
 
     from utils.datetime import utcnow
 
@@ -344,7 +448,7 @@ async def get_worker_config(
         slack=slack,
         kmc={"mcp_url": get_settings().kmc_mcp_url, "api_key": kmc_api_key},
         resource=resource_block,
-        llm=connector.get_llm_config(),
+        llm=llm_config,
         pii_guardrail_config=connector.pii_guardrail_config,
         # Lenient rehydrate (#1350 review): a stored document drifted across
         # releases must degrade to "no runtime block, worker defaults" — a

--- a/backend/tests/api/test_workers.py
+++ b/backend/tests/api/test_workers.py
@@ -16,9 +16,22 @@ from api.routes.workers import (
 )
 from utils.datetime import utcnow
 
+# #1447: the minimum bundle the bridge's ``LLMConfig`` accepts. A connector
+# missing any of these cannot vend, so the readiness gate rejects it.
+_VENDABLE_LLM = {"provider": "anthropic", "model": "m", "api_key": "sk"}
 
-def _settings(token: str = "wt-secret", mcp_url: str = "https://mcp.example/mcp"):
-    return SimpleNamespace(worker_service_token=token, kmc_mcp_url=mcp_url)
+
+def _settings(
+    token: str = "wt-secret",
+    mcp_url: str = "https://mcp.example/mcp",
+    managed_connectors: bool = False,
+):
+    return SimpleNamespace(
+        worker_service_token=token,
+        kmc_mcp_url=mcp_url,
+        # #1447: mirrors the production default (OSS / self-host, BYO LLM).
+        enable_managed_connectors=managed_connectors,
+    )
 
 
 def test_worker_config_omits_only_absent_runtime_block():
@@ -145,7 +158,9 @@ def _minimal_ready_conn(locale):
     conn.get_kmc_api_key.return_value = "kagura_writekey"
     conn.kmc_api_key_expires_at = None
     conn.get_resource_token.return_value = None
-    conn.get_llm_config.return_value = None
+    # #1447: "ready" now includes a vendable LLM bundle — a connector without
+    # one is not-ready and never reaches the locale/runtime assertions below.
+    conn.get_llm_config.return_value = dict(_VENDABLE_LLM)
     return conn
 
 
@@ -202,7 +217,7 @@ async def test_get_worker_config_revision_changes_when_runtime_revision_changes(
     conn.get_kmc_api_key.return_value = "kagura_writekey"
     conn.kmc_api_key_expires_at = None
     conn.get_resource_token.return_value = None
-    conn.get_llm_config.return_value = None
+    conn.get_llm_config.return_value = dict(_VENDABLE_LLM)
 
     with (
         patch("api.routes.workers.get_settings", return_value=_settings()),
@@ -266,7 +281,7 @@ async def test_get_worker_config_includes_resource_block_when_token_present():
     conn.get_kmc_api_key.return_value = "kagura_writekey"
     conn.kmc_api_key_expires_at = None
     conn.get_resource_token.return_value = "kgr_resource_token"
-    conn.get_llm_config.return_value = None
+    conn.get_llm_config.return_value = dict(_VENDABLE_LLM)
 
     with (
         patch("api.routes.workers.get_settings", return_value=_settings()),
@@ -340,6 +355,229 @@ async def test_get_worker_config_404_when_context_not_ready():
     assert exc.value.status_code == 404
 
 
+def _llm_gate_conn(llm_config):
+    """A connector complete in every respect except its LLM bundle (#1447)."""
+    conn = MagicMock()
+    conn.id = uuid4()
+    conn.workspace_id = uuid4()
+    conn.context_id = uuid4()
+    conn.connector_type = "slack"
+    conn.locale = None
+    conn.external_team_id = "T01"
+    conn.config_version = 1
+    conn.channel_ids = ["C01"]
+    conn.pii_guardrail_config = None
+    conn.runtime_config = None
+    conn.get_oauth_tokens.return_value = {"bot_token": "xoxb-x"}
+    conn.get_kmc_api_key.return_value = "kagura_writekey"
+    conn.kmc_api_key_expires_at = None
+    conn.get_resource_token.return_value = None
+    conn.get_llm_config.return_value = llm_config
+    return conn
+
+
+async def _vend_with_llm(llm_config, *, managed: bool = False):
+    with (
+        patch(
+            "api.routes.workers.get_settings",
+            return_value=_settings(managed_connectors=managed),
+        ),
+        patch("api.routes.workers.ConnectorProvisioningService") as svc,
+        patch("api.routes.workers.WorkerAppIdentityService") as app_svc,
+    ):
+        app_svc.return_value.get_identity = AsyncMock(return_value=None)
+        svc.return_value.get_connector_for_dispatch = AsyncMock(
+            return_value=_llm_gate_conn(llm_config)
+        )
+        return await get_worker_config(
+            response=Response(),
+            platform="slack",
+            team_id="T01",
+            app_key=None,
+            if_none_match=None,
+            _=None,
+            db=MagicMock(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_404_when_llm_config_absent():
+    """#1447: ``llm: null`` used to vend 200; the worker then fails closed on
+    every event and drops it, so the tenant loses data silently. Not-ready is
+    the honest answer — the worker treats 404 as "skip", not as a failure."""
+    from utils.exceptions import WorkerConnectorNotReadyError
+
+    with pytest.raises(WorkerConnectorNotReadyError) as exc:
+        await _vend_with_llm(None)
+    assert exc.value.status_code == 404
+    assert exc.value.error_code == "WORKER-CONNECTOR-001"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "llm_config",
+    [
+        pytest.param({"provider": "anthropic", "model": "m"}, id="no-api-key"),
+        pytest.param({"provider": "anthropic", "model": "m", "api_key": "  "}, id="blank-api-key"),
+        pytest.param({"provider": "anthropic", "api_key": "sk"}, id="no-model"),
+        pytest.param({"model": "m", "api_key": "sk"}, id="no-provider"),
+        pytest.param({}, id="empty"),
+        pytest.param("anthropic", id="not-a-dict"),
+    ],
+)
+async def test_get_worker_config_404_when_llm_config_cannot_vend(llm_config):
+    """#1447: ``_validate_llm_config`` deliberately does not require ``api_key``
+    (local ollama has none), but the bridge's ``LLMConfig`` does — so a bundle
+    that stores fine is still un-vendable. The gate follows the bridge."""
+    from utils.exceptions import WorkerConnectorNotReadyError
+
+    with pytest.raises(WorkerConnectorNotReadyError) as exc:
+        await _vend_with_llm(llm_config)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_vends_without_llm_in_managed_mode():
+    """#1447: managed SaaS (#1426) is the one deployment where ``llm: null`` is
+    legitimate — the shared bridge supplies the pre-compile LLM (bridge #216).
+    The gate must not fail those tenants closed."""
+    result = await _vend_with_llm(None, managed=True)
+    assert result.llm is None
+    assert result.kmc["api_key"] == "kagura_writekey"
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_404_in_managed_mode_when_bundle_is_broken():
+    """#1447: the managed carve-out covers an ABSENT bundle, not a broken one.
+    A half-configured BYO bundle would fail the worker closed anyway; silently
+    falling back to the shared LLM would hide the misconfiguration."""
+    from utils.exceptions import WorkerConnectorNotReadyError
+
+    with pytest.raises(WorkerConnectorNotReadyError) as exc:
+        await _vend_with_llm({"provider": "anthropic", "model": "m"}, managed=True)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_404_when_llm_config_undecryptable():
+    """#1447: a bundle that cannot be decrypted or parsed (rotated Fernet key,
+    corrupted ciphertext) must take the 404 path the worker already handles,
+    not a 500 it has no rule for."""
+    from cryptography.fernet import InvalidToken
+
+    from utils.exceptions import WorkerConnectorNotReadyError
+
+    conn = _llm_gate_conn(None)
+    conn.get_llm_config.side_effect = InvalidToken()
+
+    with (
+        patch("api.routes.workers.get_settings", return_value=_settings()),
+        patch("api.routes.workers.ConnectorProvisioningService") as svc,
+        patch("api.routes.workers.WorkerAppIdentityService") as app_svc,
+    ):
+        app_svc.return_value.get_identity = AsyncMock(return_value=None)
+        svc.return_value.get_connector_for_dispatch = AsyncMock(return_value=conn)
+        with pytest.raises(WorkerConnectorNotReadyError) as exc:
+            await get_worker_config(
+                response=Response(),
+                platform="slack",
+                team_id="T01",
+                app_key=None,
+                if_none_match=None,
+                _=None,
+                db=MagicMock(),
+            )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_404_when_kmc_key_undecryptable():
+    """#1447 (review round 2): moving readiness above the 304 put the KMC
+    decrypt on the cache-hit path too, so a rotated encryption key would have
+    turned a previously-quiet 304 into a 500. A credential we cannot read is a
+    credential the connector does not have — not-ready, like every other gate."""
+    from cryptography.fernet import InvalidToken
+
+    from utils.exceptions import WorkerConnectorNotReadyError
+
+    conn = _llm_gate_conn(dict(_VENDABLE_LLM))
+    conn.get_kmc_api_key.side_effect = InvalidToken()
+
+    with (
+        patch("api.routes.workers.get_settings", return_value=_settings()),
+        patch("api.routes.workers.ConnectorProvisioningService") as svc,
+        patch("api.routes.workers.WorkerAppIdentityService") as app_svc,
+    ):
+        app_svc.return_value.get_identity = AsyncMock(return_value=None)
+        svc.return_value.get_connector_for_dispatch = AsyncMock(return_value=conn)
+        with pytest.raises(WorkerConnectorNotReadyError) as exc:
+            await get_worker_config(
+                response=Response(),
+                platform="slack",
+                team_id="T01",
+                app_key=None,
+                if_none_match=None,
+                _=None,
+                db=MagicMock(),
+            )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_404_beats_304_when_llm_becomes_unvendable():
+    """#1447 (review): a matching ETag must not resurrect a poisoned config.
+
+    ``config_revision`` covers ids + config_version only, so a readiness change
+    that does not bump config_version — a deployment flipping
+    ``enable_managed_connectors``, a rotated encryption key — leaves the worker
+    holding a still-matching ETag. If readiness were evaluated after the
+    conditional-GET short-circuit, that worker would keep its cached ``llm:
+    null`` config forever and never see the 404 this fix exists to deliver.
+    """
+    from utils.exceptions import WorkerConnectorNotReadyError
+
+    conn = _llm_gate_conn(dict(_VENDABLE_LLM))
+    with (
+        patch("api.routes.workers.get_settings", return_value=_settings()),
+        patch("api.routes.workers.ConnectorProvisioningService") as svc,
+        patch("api.routes.workers.WorkerAppIdentityService") as app_svc,
+    ):
+        app_svc.return_value.get_identity = AsyncMock(return_value=None)
+        svc.return_value.get_connector_for_dispatch = AsyncMock(return_value=conn)
+        ready = await get_worker_config(
+            response=Response(),
+            platform="slack",
+            team_id="T01",
+            app_key=None,
+            if_none_match=None,
+            _=None,
+            db=MagicMock(),
+        )
+
+        # The bundle goes away without any config_version bump — the worker's
+        # cached ETag still matches byte for byte.
+        conn.get_llm_config.return_value = None
+
+        with pytest.raises(WorkerConnectorNotReadyError) as exc:
+            await get_worker_config(
+                response=Response(),
+                platform="slack",
+                team_id="T01",
+                app_key=None,
+                if_none_match=f'"{ready.config_revision}"',
+                _=None,
+                db=MagicMock(),
+            )
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_vends_complete_llm_bundle_unchanged():
+    """#1447 regression guard: a ready connector's response is untouched."""
+    result = await _vend_with_llm(dict(_VENDABLE_LLM))
+    assert result.llm == _VENDABLE_LLM
+
+
 @pytest.mark.asyncio
 async def test_get_worker_config_uses_app_qualified_selector():
     db = MagicMock()
@@ -362,7 +600,7 @@ async def test_get_worker_config_uses_app_qualified_selector():
     conn.get_kmc_api_key.return_value = "kmc-key"
     conn.get_oauth_tokens.return_value = {"bot_token": "xoxb"}
     conn.get_resource_token.return_value = None
-    conn.get_llm_config.return_value = None
+    conn.get_llm_config.return_value = dict(_VENDABLE_LLM)
 
     with (
         patch("api.routes.workers.WorkerAppIdentityService") as app_service,
@@ -391,7 +629,11 @@ async def test_get_worker_config_uses_app_qualified_selector():
 
     assert result.app_key == "sales"
     assert not_modified.status_code == 304
-    assert conn.get_kmc_api_key.call_count == 1
+    # #1447: was 1 — readiness now runs BEFORE the 304 short-circuit, so the key
+    # is read on the cache-hit path too. That decrypt-per-poll is the deliberate
+    # price of never answering 304 for a connector that has become not-ready
+    # (see test_get_worker_config_404_beats_304_when_llm_becomes_unvendable).
+    assert conn.get_kmc_api_key.call_count == 2
     connector_service.return_value.get_connector_for_dispatch.assert_awaited_with(
         connector_type="slack", external_team_id="T01", app_key="sales"
     )

--- a/backend/tests/api/test_workers.py
+++ b/backend/tests/api/test_workers.py
@@ -1,11 +1,13 @@
 """Tests for the ai-worker config endpoint (Spec 2026-06-02, Plan 3)."""
 
 from datetime import timedelta
+from json import JSONDecodeError
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from cryptography.fernet import InvalidToken
 from fastapi import Response
 
 from api.routes.workers import (
@@ -355,6 +357,18 @@ async def test_get_worker_config_404_when_context_not_ready():
     assert exc.value.status_code == 404
 
 
+# What a failed secret read actually looks like. ``Encryptor.decrypt`` wraps
+# Fernet's ``InvalidToken`` into a ``ValueError`` (utils/encryption.py), so that
+# is the real shape; the bare ``InvalidToken`` case guards the readiness
+# boundary against that wrapping ever going away, and ``JSONDecodeError`` covers
+# a decryptable-but-unparseable document.
+_DECRYPT_FAILURES = [
+    pytest.param(ValueError("Invalid encrypted value or wrong encryption key"), id="wrapped"),
+    pytest.param(InvalidToken(), id="raw-invalid-token"),
+    pytest.param(JSONDecodeError("Expecting value", "", 0), id="unparseable"),
+]
+
+
 def _llm_gate_conn(llm_config):
     """A connector complete in every respect except its LLM bundle (#1447)."""
     conn = MagicMock()
@@ -459,16 +473,15 @@ async def test_get_worker_config_404_in_managed_mode_when_bundle_is_broken():
 
 
 @pytest.mark.asyncio
-async def test_get_worker_config_404_when_llm_config_undecryptable():
+@pytest.mark.parametrize("failure", _DECRYPT_FAILURES)
+async def test_get_worker_config_404_when_llm_config_undecryptable(failure):
     """#1447: a bundle that cannot be decrypted or parsed (rotated Fernet key,
     corrupted ciphertext) must take the 404 path the worker already handles,
     not a 500 it has no rule for."""
-    from cryptography.fernet import InvalidToken
-
     from utils.exceptions import WorkerConnectorNotReadyError
 
     conn = _llm_gate_conn(None)
-    conn.get_llm_config.side_effect = InvalidToken()
+    conn.get_llm_config.side_effect = failure
 
     with (
         patch("api.routes.workers.get_settings", return_value=_settings()),
@@ -491,17 +504,16 @@ async def test_get_worker_config_404_when_llm_config_undecryptable():
 
 
 @pytest.mark.asyncio
-async def test_get_worker_config_404_when_kmc_key_undecryptable():
+@pytest.mark.parametrize("failure", _DECRYPT_FAILURES)
+async def test_get_worker_config_404_when_kmc_key_undecryptable(failure):
     """#1447 (review round 2): moving readiness above the 304 put the KMC
     decrypt on the cache-hit path too, so a rotated encryption key would have
     turned a previously-quiet 304 into a 500. A credential we cannot read is a
     credential the connector does not have — not-ready, like every other gate."""
-    from cryptography.fernet import InvalidToken
-
     from utils.exceptions import WorkerConnectorNotReadyError
 
     conn = _llm_gate_conn(dict(_VENDABLE_LLM))
-    conn.get_kmc_api_key.side_effect = InvalidToken()
+    conn.get_kmc_api_key.side_effect = failure
 
     with (
         patch("api.routes.workers.get_settings", return_value=_settings()),


### PR DESCRIPTION
Closes #1447

## What

`GET /api/v1/workers/config` gated on a **vendable** `llm_config`. A bundle that
the worker cannot use is now `404 WORKER-CONNECTOR-001` (not-ready) instead of a
`200` the worker is guaranteed to reject.

"Vendable" = a dict with non-blank string `provider`, `model` **and** `api_key`.

## Why 404 rather than 200-with-a-hole

The worker already handles 404 as "not registered → skip". A 200 with an
unusable body poisons the tenant: the worker raises, the Slack webhook still
answers 200, Slack never retries, and nothing logs an error. That is the exact
shape of the 6-day outage in the issue.

## The `enable_managed_connectors` carve-out

The setting's own description already says it: OFF → "treats a per-connector LLM
as required"; ON → "the shared worker/bridge provides the pre-compile LLM ...
stops flagging a missing per-connector LLM". The **admin UI has been honouring
that all along — only the vend gate wasn't.** This aligns them.

The carve-out covers an **absent** bundle only:

| `enable_managed_connectors` | `llm_config` | result |
|---|---|---|
| false | `None` | 404 |
| false | broken / non-dict | 404 |
| false | vendable | 200 |
| true | `None` | 200 |
| true | broken / non-dict | 404 |
| true | vendable | 200 |

A half-filled BYO bundle in managed mode would fail the worker closed anyway;
silently falling back to the shared LLM would hide the misconfiguration.

## Readiness now runs *before* the `If-None-Match` short-circuit

Found by review — and it is what made the rest of the fix work. `config_revision`
is derived from ids + `config_version` only, so a readiness change that does not
bump `config_version` (a deployment flipping `enable_managed_connectors`, a
rotated encryption key) leaves the worker holding a **still-matching ETag**. With
readiness below the 304, that worker keeps its cached `llm: null` config forever
and never sees the 404 this PR exists to deliver. A 304 asserts "your cached
representation is still valid", which is false when the resource would now 404.

Pinned by `test_get_worker_config_404_beats_304_when_llm_becomes_unvendable`.

### Trade-offs this reordering makes, deliberately

- **One extra decrypt per cache-hit poll.** `test_get_worker_config_uses_app_qualified_selector`
  changed from `get_kmc_api_key.call_count == 1` to `== 2`. That assertion pinned
  "don't decrypt on cache hits", which is directly incompatible with "readiness
  beats 304". Symmetric crypto on a short string, next to a DB round-trip that
  already happened.
- **Both decrypts are now fail-soft.** Putting the KMC decrypt on the 304 path
  meant a corrupt/rotated ciphertext would newly 500 there — a regression this PR
  would have introduced. Both now log and fall to not-ready: a credential we
  cannot read is a credential the connector does not have.
- A raised 404 no longer stamps `ETag`/`Cache-Control` on the response object.
  Not observable — `memory_cloud_exception_handler` builds a fresh `JSONResponse`.

## Blast radius

`enable_managed_connectors` defaults to `False`. Any self-hosted deployment with
a connector whose `llm_config` is null flips from 200 to 404 on upgrade — but
those connectors were not working, they were poisoned. No non-bridge consumer of
this endpoint exists in-repo.

**One case to be explicit about:** `_validate_llm_config` deliberately does *not*
require `api_key` ("provider-dependent — e.g. local ollama has none"), while the
bridge's `LLMConfig` declares `api_key: SecretStr`. So a bundle can be valid to
*store* and still be un-vendable. This gate follows the consumer. A self-hosted
ollama operator with no api_key now gets a 404 instead of a silently-broken 200 —
worse-looking, strictly more honest.

## Tests

`backend/tests/api/test_workers.py`, 36 passing in this file:

- absent bundle → 404
- 6 un-vendable shapes (no api_key / blank api_key / no model / no provider / empty / non-dict) → 404
- managed mode + absent → 200 with `llm: null`
- managed mode + broken → 404
- unreadable `llm_config` → 404, not 500 — parametrized over the three shapes that
  can actually reach the gate: the `ValueError` `Encryptor.decrypt` wraps
  `InvalidToken` into, a raw `InvalidToken`, and a `JSONDecodeError`
- unreadable KMC key → 404, not 500 (same parametrization)
- matching ETag on a now-un-vendable connector → 404, not 304
- complete bundle → unchanged response

Four pre-existing fixtures moved from `get_llm_config -> None` to a valid bundle:
those tests cover locale / runtime / resource / app-selector behaviour and need a
connector that is *ready* to reach that code. "Ready" now includes a vendable LLM.

`ruff check` clean, `pyright src/api/routes/workers.py` clean.

## Reviewed

Two adversarial review rounds (codex, read-only). Round 1 returned **red** on the
304 bypass; round 2 returned **yellow** and caught the KMC-decrypt regression the
round-1 fix introduced. Both are fixed above.

Note: the local full-suite run is not authoritative here — this worktree has no
database, so DB-backed suites error out. CI is the gate.

## Noticed, not fixed here

`Encryptor.decrypt`'s docstring advertises `Raises: InvalidToken` for a tampered
value, but the implementation catches `InvalidToken` and re-raises it as
`ValueError`. Callers written against that docstring (`except InvalidToken`)
would never fire. Documentation-only; no live caller is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)