### PR TITLE
fix(mcp): report a merge the rollback could not reverse (#1450)

### DIFF
--- a/backend/src/api/routes/admin_sleep.py
+++ b/backend/src/api/routes/admin_sleep.py
@@ -338,10 +338,10 @@ _UNDO_ERROR_STATUS = {
     "action_not_found": 404,
     "memory_purged": 410,
     "already_restored": 409,
-    # #1450: distinct from ``already_restored`` — same 409, but the merge is
-    # still in effect rather than already undone, so the error_code is what
+    # #1450: distinct from ``already_restored`` — same 409, but the undo did
+    # not happen rather than having happened already, so the error_code is what
     # tells an operator whether anything needs doing.
-    "edge_retyped": 409,
+    "edge_changed": 409,
     "not_a_merge": 400,
     "not_merge_deleted": 409,
 }
@@ -354,7 +354,17 @@ _UNDO_ERROR_STATUS = {
     responses={
         400: {"description": "The action is not a dedup merge."},
         404: {"description": "Action not found or not owned by the caller."},
-        409: {"description": "Memory already restored, or deleted by something else."},
+        409: {
+            "description": (
+                "Conflicts with current state. ``SLEEP-UNDO-already_restored``: "
+                "the memory or shadow edge is already back in its post-undo "
+                "state (no-op). ``SLEEP-UNDO-not_merge_deleted``: the memory was "
+                "deleted by something other than this merge. "
+                "``SLEEP-UNDO-edge_changed`` (#1450): a later writer changed or "
+                "removed the shadow edge, so the pre-merge state could not be "
+                "restored — unlike the other two, the undo did NOT happen."
+            )
+        },
         410: {
             "description": "The merge loser was hard-deleted by the retention "
             "policy (sleep_merge_retention_days) — no longer restorable."

--- a/backend/src/api/routes/admin_sleep.py
+++ b/backend/src/api/routes/admin_sleep.py
@@ -338,6 +338,10 @@ _UNDO_ERROR_STATUS = {
     "action_not_found": 404,
     "memory_purged": 410,
     "already_restored": 409,
+    # #1450: distinct from ``already_restored`` — same 409, but the merge is
+    # still in effect rather than already undone, so the error_code is what
+    # tells an operator whether anything needs doing.
+    "edge_retyped": 409,
     "not_a_merge": 400,
     "not_merge_deleted": 409,
 }

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1424,7 +1424,7 @@ Requires action recording (reports created before this feature have no actions t
 
 Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, merges_unreversible, importance_restored, promotions_reversed, archives_restored, errors}}. Re-embedding is best-effort - check rollback_summary.errors.
 
-merges_unreversible (#1450) counts shadow merges left standing because a later writer changed the edge — reversing them would discard that newer state. Those runs report error='partial_rollback'; a rollback is only complete when this is 0.""",
+merges_unreversible (#1450) counts shadow merges this run did NOT reverse because a later writer changed or removed the edge — restoring the pre-merge state would have discarded that newer state. Those runs report error='partial_rollback'; a rollback is only complete when this is 0.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["report_id"],

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1422,7 +1422,9 @@ and stays rollbackable). After rollback, the report is marked
 ⚠️ This is a destructive operation — use with care.
 Requires action recording (reports created before this feature have no actions to rollback).
 
-Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, importance_restored, promotions_reversed, archives_restored, errors}}. Re-embedding is best-effort - check rollback_summary.errors.""",
+Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, merges_unreversible, importance_restored, promotions_reversed, archives_restored, errors}}. Re-embedding is best-effort - check rollback_summary.errors.
+
+merges_unreversible (#1450) counts shadow merges left standing because a later writer changed the edge — reversing them would discard that newer state. Those runs report error='partial_rollback'; a rollback is only complete when this is 0.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["report_id"],

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -31,9 +31,9 @@ from utils.logger import get_logger
 # bug class to the one fixed in ``api/routes/auth.py`` (PR #522).
 #
 # #1450 follow-up: that mismatch was never one situation. Only "already undone"
-# is benign; "a later writer retyped the edge" means the merge is still in
-# effect, and #1440's fix made THAT case silent. The helper now returns a
-# tri-state and the two are handled apart, below.
+# is benign; "a later writer changed or removed the edge" means the action was
+# not reversed at all, and #1440's fix made THAT case silent. The helper now
+# returns a tri-state and the two are handled apart, below.
 logger = get_logger(__name__)
 
 
@@ -425,22 +425,22 @@ async def handle_rollback_sleep_run(
                                             dst_id=str(action.target_id),
                                         )
                                     else:
-                                        # #1450: a later writer changed the edge,
-                                        # so this merge is STILL IN EFFECT. Both
-                                        # zero-row causes used to land in the
-                                        # branch above, which made an unreversed
-                                        # merge indistinguishable from a clean
-                                        # rollback outside of a stdout warning.
-                                        # Same treatment as its sibling below
-                                        # (a loser that could not be restored):
-                                        # it is an error, so the run reports
-                                        # partial_rollback rather than success.
+                                        # #1450: a later writer changed or removed
+                                        # the edge, so this action was NOT
+                                        # reversed. Both zero-row causes used to
+                                        # land in the branch above, which made an
+                                        # unreversed merge indistinguishable from
+                                        # a clean rollback outside of a stdout
+                                        # warning. Same treatment as its sibling
+                                        # below (a loser that could not be
+                                        # restored): it is an error, so the run
+                                        # reports partial_rollback, not success.
                                         rollback_summary["merges_unreversible"] += 1
                                         rollback_summary["errors"].append(
                                             f"shadow merge {action.memory_id} → "
-                                            f"{action.target_id} not reversible — the edge "
-                                            "was changed by a later writer; the merge is "
-                                            "still in effect"
+                                            f"{action.target_id} not reversed — the edge "
+                                            "was changed or removed by a later writer, so "
+                                            "the pre-merge state could not be restored"
                                         )
                                         logger.warning(
                                             "shadow_merge_rollback_blocked_by_newer_state",

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -27,8 +27,13 @@ from utils.logger import get_logger
 # ``Logger._log()`` rejects unknown kwargs — so the structlog-style
 # ``logger.warning("event", key=value)`` call in the shadow-merge rollback path
 # raised TypeError and was swallowed into ``rollback_summary["errors"]``,
-# turning a benign edge mismatch into a reported ``partial_rollback``. Identical
+# turning an edge mismatch into a reported ``partial_rollback``. Identical
 # bug class to the one fixed in ``api/routes/auth.py`` (PR #522).
+#
+# #1450 follow-up: that mismatch was never one situation. Only "already undone"
+# is benign; "a later writer retyped the edge" means the merge is still in
+# effect, and #1440's fix made THAT case silent. The helper now returns a
+# tri-state and the two are handled apart, below.
 logger = get_logger(__name__)
 
 
@@ -328,6 +333,11 @@ async def handle_rollback_sleep_run(
             rollback_summary = {
                 "edges_deleted": 0,
                 "merges_reversed": 0,
+                # #1450: recorded merges the rollback could NOT reverse because a
+                # later writer changed the edge. Counted separately from
+                # ``merges_reversed`` so "0 reversed" stops being the only hint
+                # that something was left standing.
+                "merges_unreversible": 0,
                 "importance_restored": 0,
                 "promotions_reversed": 0,
                 "archives_restored": 0,
@@ -392,6 +402,7 @@ async def handle_rollback_sleep_run(
                                 # so the two paths cannot drift.
                                 if action.memory_id:
                                     from services.sleep.undo import (
+                                        ShadowEdgeRevert,
                                         revert_shadow_merge_edge,
                                     )
 
@@ -402,11 +413,37 @@ async def handle_rollback_sleep_run(
                                         loser_id=action.target_id,
                                         prior_edge=(action.details or {}).get("prior_edge"),
                                     )
-                                    if reverted:
+                                    if reverted is ShadowEdgeRevert.RESTORED:
                                         rollback_summary["merges_reversed"] += 1
-                                    else:
+                                    elif reverted is ShadowEdgeRevert.ALREADY_UNDONE:
+                                        # Benign: the edge is already in its
+                                        # post-undo state. Nothing to reverse,
+                                        # nothing to report (#1441).
                                         logger.warning(
-                                            "shadow_merge_rollback_edge_mismatch",
+                                            "shadow_merge_rollback_already_undone",
+                                            src_id=str(action.memory_id),
+                                            dst_id=str(action.target_id),
+                                        )
+                                    else:
+                                        # #1450: a later writer changed the edge,
+                                        # so this merge is STILL IN EFFECT. Both
+                                        # zero-row causes used to land in the
+                                        # branch above, which made an unreversed
+                                        # merge indistinguishable from a clean
+                                        # rollback outside of a stdout warning.
+                                        # Same treatment as its sibling below
+                                        # (a loser that could not be restored):
+                                        # it is an error, so the run reports
+                                        # partial_rollback rather than success.
+                                        rollback_summary["merges_unreversible"] += 1
+                                        rollback_summary["errors"].append(
+                                            f"shadow merge {action.memory_id} → "
+                                            f"{action.target_id} not reversible — the edge "
+                                            "was changed by a later writer; the merge is "
+                                            "still in effect"
+                                        )
+                                        logger.warning(
+                                            "shadow_merge_rollback_blocked_by_newer_state",
                                             src_id=str(action.memory_id),
                                             dst_id=str(action.target_id),
                                         )

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -88,8 +88,8 @@ async def revert_shadow_merge_edge(
 
     Returns:
         A :class:`ShadowEdgeRevert`. Callers MUST treat
-        ``BLOCKED_BY_NEWER_STATE`` as a failure to reverse — it is the case
-        where the merge is still in effect.
+        ``BLOCKED_BY_NEWER_STATE`` as a failure to reverse — the recorded action
+        could not be undone without discarding newer edge state.
     """
     from sqlalchemy import delete as sa_delete
 

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -48,9 +48,15 @@ class ShadowEdgeRevert(StrEnum):
     """Nothing to do: the edge is already in its post-undo state. Benign."""
 
     BLOCKED_BY_NEWER_STATE = "blocked_by_newer_state"
-    """A later writer changed the edge, so the merge could not be reversed
-    without clobbering that newer state. NOT benign — the recorded action
-    still stands."""
+    """A later writer changed or removed the edge, so the pre-merge state could
+    not be restored without discarding that newer state. NOT benign — the
+    recorded action was not reversed.
+
+    Note this does NOT mean a ``supersedes`` edge is still shadowing the loser:
+    reaching this state means the guarded statement found none. What is left
+    un-reversed is the edge state the merge overwrote (or, without a snapshot,
+    an edge the merge created that a later writer has since repurposed and that
+    this undo must not delete)."""
 
 
 async def revert_shadow_merge_edge(
@@ -154,7 +160,7 @@ class UndoMergeError(Exception):
     Attributes:
         code: Stable machine-readable reason (``action_not_found`` |
             ``not_a_merge`` | ``memory_purged`` | ``already_restored`` |
-            ``edge_retyped`` | ``not_merge_deleted``).
+            ``edge_changed`` | ``not_merge_deleted``).
         message: Human-readable explanation.
     """
 
@@ -309,10 +315,11 @@ async def undo_merge_action(
             )
         if reverted is ShadowEdgeRevert.BLOCKED_BY_NEWER_STATE:
             raise UndoMergeError(
-                "edge_retyped",
-                f"The edge {winner_id} → {loser_id} was changed by a later writer, "
-                "so this shadow merge could not be reversed without discarding that "
-                "newer state. The merge is still in effect.",
+                "edge_changed",
+                f"The edge {winner_id} → {loser_id} was changed or removed by a later "
+                "writer, so this shadow merge's pre-merge edge state could not be "
+                "restored without discarding that newer state. The merge was not "
+                "reversed; the edge needs a look before retrying.",
             )
         undo_action = SleepAction(
             report_id=action.report_id,

--- a/backend/src/services/sleep/undo.py
+++ b/backend/src/services/sleep/undo.py
@@ -13,6 +13,7 @@ and the error says so explicitly.
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import Any, cast
 from uuid import UUID
 
@@ -29,6 +30,29 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+class ShadowEdgeRevert(StrEnum):
+    """Outcome of undoing one shadow merge's supersedes edge (#1450).
+
+    This was a ``bool`` until #1450. ``False`` meant two materially different
+    things — "there was nothing left to do" and "a recorded merge action could
+    NOT be reversed because newer state is in the way" — and both callers
+    collapsed them, so a rollback that left a merge standing still reported
+    success. The three states are kept apart here so neither caller can
+    re-conflate them.
+    """
+
+    RESTORED = "restored"
+    """The pre-merge edge was restored, or the merge-created edge was deleted."""
+
+    ALREADY_UNDONE = "already_undone"
+    """Nothing to do: the edge is already in its post-undo state. Benign."""
+
+    BLOCKED_BY_NEWER_STATE = "blocked_by_newer_state"
+    """A later writer changed the edge, so the merge could not be reversed
+    without clobbering that newer state. NOT benign — the recorded action
+    still stands."""
+
+
 async def revert_shadow_merge_edge(
     db: AsyncSession,
     *,
@@ -36,7 +60,7 @@ async def revert_shadow_merge_edge(
     winner_id: UUID,
     loser_id: UUID,
     prior_edge: dict[str, Any] | None,
-) -> bool:
+) -> ShadowEdgeRevert:
     """Undo ONE shadow-mode merge's supersedes edge (#1208).
 
     Shared by run-level rollback and per-merge undo so the two paths cannot
@@ -52,10 +76,14 @@ async def revert_shadow_merge_edge(
       on (user, src, dst) regardless of edge_type, so a blind delete could
       remove an unrelated association written since.
 
+    When the guarded statement matches no row, the current edge is read back to
+    tell the two zero-row causes apart (#1450). ``unique_edge`` is keyed on
+    (user, src, dst), so there is at most one row to inspect.
+
     Returns:
-        True if an edge was restored or deleted; False if nothing matched
-        (the shadow merge was already undone, or the edge was retyped by a
-        later writer).
+        A :class:`ShadowEdgeRevert`. Callers MUST treat
+        ``BLOCKED_BY_NEWER_STATE`` as a failure to reverse — it is the case
+        where the merge is still in effect.
     """
     from sqlalchemy import delete as sa_delete
 
@@ -90,7 +118,34 @@ async def revert_shadow_merge_edge(
         )
     # DML through AsyncSession.execute() is typed Result[Any] but is a
     # CursorResult at runtime, which is what carries .rowcount (#1442).
-    return (cast(CursorResult[Any], result).rowcount or 0) > 0
+    if (cast(CursorResult[Any], result).rowcount or 0) > 0:
+        return ShadowEdgeRevert.RESTORED
+
+    current_type = (
+        await db.execute(
+            select(NeuralMemoryEdge.edge_type).where(
+                NeuralMemoryEdge.user_id == user_id,
+                NeuralMemoryEdge.src_id == winner_id,
+                NeuralMemoryEdge.dst_id == loser_id,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if prior_edge:
+        # The undo target is the snapshot's type. Finding exactly that means a
+        # previous undo already landed; anything else — a different type, or no
+        # edge at all — means the snapshot can no longer be restored from here.
+        expected = prior_edge.get("edge_type") or "neural_association"
+        if current_type == expected:
+            return ShadowEdgeRevert.ALREADY_UNDONE
+        return ShadowEdgeRevert.BLOCKED_BY_NEWER_STATE
+
+    # The merge created the edge, so the undo target is "no edge". Absent is
+    # the desired end state; a surviving edge of some other type is a later
+    # writer's association that this undo must not delete.
+    if current_type is None:
+        return ShadowEdgeRevert.ALREADY_UNDONE
+    return ShadowEdgeRevert.BLOCKED_BY_NEWER_STATE
 
 
 class UndoMergeError(Exception):
@@ -99,7 +154,7 @@ class UndoMergeError(Exception):
     Attributes:
         code: Stable machine-readable reason (``action_not_found`` |
             ``not_a_merge`` | ``memory_purged`` | ``already_restored`` |
-            ``not_merge_deleted``).
+            ``edge_retyped`` | ``not_merge_deleted``).
         message: Human-readable explanation.
     """
 
@@ -241,11 +296,23 @@ async def undo_merge_action(
             loser_id=loser_id,
             prior_edge=(action.details or {}).get("prior_edge"),
         )
-        if not reverted:
+        # #1450: these were one 409 ``already_restored`` until the two zero-row
+        # causes were told apart. Both stay 409 (the caller's request conflicts
+        # with current state either way) but the codes differ, because the
+        # remedies do: "already undone" is a no-op, "blocked" means the merge is
+        # STILL IN EFFECT and someone must look at the newer edge.
+        if reverted is ShadowEdgeRevert.ALREADY_UNDONE:
             raise UndoMergeError(
                 "already_restored",
                 f"No supersedes edge {winner_id} → {loser_id} exists — this shadow "
-                "merge was already undone, or the edge was since retyped.",
+                "merge was already undone.",
+            )
+        if reverted is ShadowEdgeRevert.BLOCKED_BY_NEWER_STATE:
+            raise UndoMergeError(
+                "edge_retyped",
+                f"The edge {winner_id} → {loser_id} was changed by a later writer, "
+                "so this shadow merge could not be reversed without discarding that "
+                "newer state. The merge is still in effect.",
             )
         undo_action = SleepAction(
             report_id=action.report_id,

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -605,7 +605,7 @@ class TestShadowMergeRollbackEdgeMismatch:
 
         Before this, the retyped-edge case took the same log-and-continue path
         as "already undone", so the run answered ``status=success`` /
-        ``errors=[]`` while the merge was still in effect — a zero counter was
+        ``errors=[]`` while the action had not been reversed — a zero counter was
         the only trace, and only for someone who thought to look.
         """
         report_id = uuid4()

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -649,7 +649,7 @@ class TestShadowMergeRollbackEdgeMismatch:
         assert summary["merges_unreversible"] == 1
         assert summary["merges_reversed"] == 0
         # Visible in the response, not only in a log line.
-        assert any("still in effect" in e for e in summary["errors"]), summary["errors"]
+        assert any("not reversed" in e for e in summary["errors"]), summary["errors"]
         assert data.get("error") == "partial_rollback", (
             f"an un-reversed merge was reported as a clean rollback: {data}"
         )

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -16,6 +16,7 @@ from mcp_server.tools.sleep import (
     handle_rollback_sleep_run,
 )
 from services.sleep.prompts import EDGE_DISCOVERY_PROMPT_REVISION
+from services.sleep.undo import ShadowEdgeRevert
 
 
 class TestGetSleepHistory:
@@ -518,22 +519,9 @@ class TestShadowMergeRollbackEdgeMismatch:
     def workspace_id(self):
         return uuid4()
 
-    @pytest.mark.asyncio
-    async def test_edge_mismatch_does_not_raise(self, user_id, workspace_id):
-        report_id = uuid4()
-        report = MagicMock()
-        report.id = report_id
-        report.user_id = user_id
-        report.status = "completed"
-        report.context_id = uuid4()
-
-        # One shadow-mode merge action whose edge revert comes back False.
-        action = MagicMock()
-        action.action_type = "merge"
-        action.memory_id = uuid4()
-        action.target_id = uuid4()
-        action.details = {"mode": "shadow", "prior_edge": None}
-
+    @staticmethod
+    def _rollback_db_for_shadow_merge(report, action):
+        """AsyncSession double that yields one shadow merge action (#1440)."""
         mock_report_result = MagicMock()
         mock_report_result.scalar_one_or_none.return_value = report
         mock_actions_result = MagicMock()
@@ -553,6 +541,26 @@ class TestShadowMergeRollbackEdgeMismatch:
 
         mock_db.execute.side_effect = _execute
         mock_db.rollback = AsyncMock()
+        return mock_db
+
+    @pytest.mark.asyncio
+    async def test_edge_mismatch_does_not_raise(self, user_id, workspace_id):
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+
+        # One shadow-mode merge action whose edge was ALREADY undone — the
+        # benign half of what used to be a single `False` (#1450).
+        action = MagicMock()
+        action.action_type = "merge"
+        action.memory_id = uuid4()
+        action.target_id = uuid4()
+        action.details = {"mode": "shadow", "prior_edge": None}
+
+        mock_db = self._rollback_db_for_shadow_merge(report, action)
 
         async def mock_get_db():
             yield mock_db
@@ -567,7 +575,7 @@ class TestShadowMergeRollbackEdgeMismatch:
             patch(
                 "services.sleep.undo.revert_shadow_merge_edge",
                 new_callable=AsyncMock,
-                return_value=False,  # edge mismatch -> the warning branch
+                return_value=ShadowEdgeRevert.ALREADY_UNDONE,
             ),
         ):
             result = await handle_rollback_sleep_run(
@@ -588,3 +596,60 @@ class TestShadowMergeRollbackEdgeMismatch:
         assert recorded_errors == [], f"unexpected rollback errors: {recorded_errors}"
         # The mismatch is still not counted as a reversal.
         assert data["rollback_summary"]["merges_reversed"] == 0
+        # …nor as something that could not be reversed (#1450).
+        assert data["rollback_summary"]["merges_unreversible"] == 0
+
+    @pytest.mark.asyncio
+    async def test_retyped_edge_is_reported_not_silently_successful(self, user_id, workspace_id):
+        """#1450: a merge the rollback could NOT reverse must reach the response.
+
+        Before this, the retyped-edge case took the same log-and-continue path
+        as "already undone", so the run answered ``status=success`` /
+        ``errors=[]`` while the merge was still in effect — a zero counter was
+        the only trace, and only for someone who thought to look.
+        """
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+
+        action = MagicMock()
+        action.action_type = "merge"
+        action.memory_id = uuid4()
+        action.target_id = uuid4()
+        action.details = {"mode": "shadow", "prior_edge": None}
+
+        mock_db = self._rollback_db_for_shadow_merge(report, action)
+
+        async def mock_get_db():
+            yield mock_db
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.sleep._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "services.sleep.undo.revert_shadow_merge_edge",
+                new_callable=AsyncMock,
+                return_value=ShadowEdgeRevert.BLOCKED_BY_NEWER_STATE,
+            ),
+        ):
+            result = await handle_rollback_sleep_run(
+                {"report_id": str(report_id)}, user_id, workspace_id
+            )
+
+        data = json.loads(result[0].text)
+        summary = data["rollback_summary"]
+
+        assert summary["merges_unreversible"] == 1
+        assert summary["merges_reversed"] == 0
+        # Visible in the response, not only in a log line.
+        assert any("still in effect" in e for e in summary["errors"]), summary["errors"]
+        assert data.get("error") == "partial_rollback", (
+            f"an un-reversed merge was reported as a clean rollback: {data}"
+        )

--- a/backend/tests/services/sleep/test_undo_merge.py
+++ b/backend/tests/services/sleep/test_undo_merge.py
@@ -243,8 +243,8 @@ async def test_shadow_undo_retyped_edge_is_not_already_restored() -> None:
     with pytest.raises(UndoMergeError) as exc:
         await undo_merge_action(db, 42, acting_user_id="admin-user")
 
-    assert exc.value.code == "edge_retyped"
-    assert "still in effect" in exc.value.message
+    assert exc.value.code == "edge_changed"
+    assert "not reversed" in exc.value.message
     db.add.assert_not_called()
 
 
@@ -281,4 +281,27 @@ async def test_shadow_undo_snapshot_overwritten_is_blocked() -> None:
     with pytest.raises(UndoMergeError) as exc:
         await undo_merge_action(db, 42, acting_user_id="admin-user")
 
-    assert exc.value.code == "edge_retyped"
+    assert exc.value.code == "edge_changed"
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_snapshot_edge_deleted_is_blocked_without_claiming_shadow() -> None:
+    """#1450 (review): with a snapshot, a DELETED edge is also un-restorable.
+
+    Still blocked — the pre-merge weight/origin/metadata cannot be put back —
+    but the message must not claim a live shadow edge is in the way. Reaching
+    ANY blocked state means the guarded statement found no ``supersedes`` row,
+    so nothing is shadowing the loser; what is lost is the edge state the merge
+    overwrote. The first wording of this error said "the merge is still in
+    effect", which is false in every blocked case.
+    """
+    prior = {"edge_type": "neural_association", "origin": "hebbian"}
+    action = _shadow_action(prior_edge=prior)
+    db = _shadow_db((action, _report()), revert_rowcount=0, current_edge_type=None)
+
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert exc.value.code == "edge_changed"
+    assert "changed or removed" in exc.value.message
+    assert "still in effect" not in exc.value.message

--- a/backend/tests/services/sleep/test_undo_merge.py
+++ b/backend/tests/services/sleep/test_undo_merge.py
@@ -134,15 +134,27 @@ def _shadow_action(prior_edge=None) -> MagicMock:
     return action
 
 
-def _shadow_db(first_row, revert_rowcount: int) -> AsyncMock:
+def _shadow_db(
+    first_row,
+    revert_rowcount: int,
+    current_edge_type: str | None = None,
+) -> AsyncMock:
     """AsyncMock db: 1st execute -> (action, report) join, 2nd -> the edge
-    revert (UPDATE restore or verified DELETE) with the given rowcount."""
+    revert (UPDATE restore or verified DELETE) with the given rowcount.
+
+    #1450: when the revert matches no row, the helper reads the edge back to
+    tell "already undone" from "a later writer got there first", so a third
+    execute is served — ``current_edge_type`` is what that read finds (None =
+    no edge at all).
+    """
     db = AsyncMock()
     join_result = MagicMock()
     join_result.first.return_value = first_row
     revert_result = MagicMock()
     revert_result.rowcount = revert_rowcount
-    db.execute.side_effect = [join_result, revert_result]
+    current_result = MagicMock()
+    current_result.scalar_one_or_none.return_value = current_edge_type
+    db.execute.side_effect = [join_result, revert_result, current_result]
     db.add = MagicMock()
     return db
 
@@ -202,13 +214,71 @@ async def test_shadow_undo_without_snapshot_deletes() -> None:
 
 @pytest.mark.asyncio
 async def test_shadow_undo_gone_edge_is_already_restored() -> None:
-    """Edge already gone (or retyped by a later writer) → stable error,
-    nothing audited."""
+    """Edge already gone → benign no-op, stable error, nothing audited."""
     action = _shadow_action(prior_edge=None)
-    db = _shadow_db((action, _report()), revert_rowcount=0)
+    db = _shadow_db((action, _report()), revert_rowcount=0, current_edge_type=None)
 
     with pytest.raises(UndoMergeError) as exc:
         await undo_merge_action(db, 42, acting_user_id="admin-user")
 
     assert exc.value.code == "already_restored"
     db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_retyped_edge_is_not_already_restored() -> None:
+    """#1450: a later writer's edge is NOT "already undone".
+
+    Both matched zero rows and so shared one ``already_restored`` code, but the
+    outcomes differ: nothing to do vs. the merge is still in effect and someone
+    has to look at the newer edge. Same 409, distinguishable ``error_code``.
+    """
+    action = _shadow_action(prior_edge=None)
+    db = _shadow_db(
+        (action, _report()),
+        revert_rowcount=0,
+        current_edge_type="neural_association",
+    )
+
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert exc.value.code == "edge_retyped"
+    assert "still in effect" in exc.value.message
+    db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_snapshot_already_restored_is_benign() -> None:
+    """#1450: with a snapshot, "already undone" means the edge is back at the
+    snapshot's type — that must not read as a later writer's interference."""
+    prior = {"edge_type": "neural_association", "origin": "hebbian"}
+    action = _shadow_action(prior_edge=prior)
+    db = _shadow_db(
+        (action, _report()),
+        revert_rowcount=0,
+        current_edge_type="neural_association",
+    )
+
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert exc.value.code == "already_restored"
+
+
+@pytest.mark.asyncio
+async def test_shadow_undo_snapshot_overwritten_is_blocked() -> None:
+    """#1450: with a snapshot, an edge of some OTHER type means the snapshot
+    can no longer be restored from here — blocked, not already-undone."""
+    prior = {"edge_type": "neural_association", "origin": "hebbian"}
+    action = _shadow_action(prior_edge=prior)
+    db = _shadow_db(
+        (action, _report()),
+        revert_rowcount=0,
+        current_edge_type="contradicts",
+    )
+
+    with pytest.raises(UndoMergeError) as exc:
+        await undo_merge_action(db, 42, acting_user_id="admin-user")
+
+    assert exc.value.code == "edge_retyped"

--- a/backend/tests/services/sleep/test_undo_merge.py
+++ b/backend/tests/services/sleep/test_undo_merge.py
@@ -230,8 +230,8 @@ async def test_shadow_undo_retyped_edge_is_not_already_restored() -> None:
     """#1450: a later writer's edge is NOT "already undone".
 
     Both matched zero rows and so shared one ``already_restored`` code, but the
-    outcomes differ: nothing to do vs. the merge is still in effect and someone
-    has to look at the newer edge. Same 409, distinguishable ``error_code``.
+    outcomes differ: nothing to do vs. the undo did not happen and someone has
+    to look at the newer edge. Same 409, distinguishable ``error_code``.
     """
     action = _shadow_action(prior_edge=None)
     db = _shadow_db(


### PR DESCRIPTION
Closes #1450

## The bug

`revert_shadow_merge_edge` returned `bool`, and `False` meant two different
things — its own docstring said so:

1. **already undone** — benign, nothing to do
2. **a later writer changed the edge** — the recorded merge was **not reversed**

Both callers collapsed them. For case 2 the run-level rollback answered:

| field | value |
|---|---|
| `status` | success |
| `error` | *absent* |
| `rollback_summary.errors` | `[]` |
| `rollback_summary.merges_reversed` | `0` |

A zero counter was the only thing separating "rolled back cleanly" from "one
recorded action was left un-reversed", and the real signal never left stdout.

## Why it was invisible until now

Before #1441 this branch crashed (stdlib logger + structlog kwargs) and case 2
surfaced as `partial_rollback` — loudly, for a nonsense reason. #1441 restored
the intended log-and-continue, correct for case 1, silent for case 2. **The
intent itself never distinguished them**; the crash was masking that.

## The fix

`ShadowEdgeRevert` StrEnum — `RESTORED` / `ALREADY_UNDONE` /
`BLOCKED_BY_NEWER_STATE` — so neither caller can re-conflate them.

On a zero-row match the edge is read back to classify. `unique_edge` is keyed on
`(user, src, dst)`, so there is at most one row:

| | no edge found | edge of the snapshot's type | any other edge |
|---|---|---|---|
| **with `prior_edge`** | BLOCKED | ALREADY_UNDONE | BLOCKED |
| **no snapshot** (merge created it) | ALREADY_UNDONE | — | BLOCKED |

With a snapshot the undo target *is* the snapshot's type, which is what tells a
completed undo from an overwrite. Without one the target is "no edge", so a
surviving edge is a later writer's association this undo must not delete.

### Callers

- **run-level rollback** — `BLOCKED` increments a new `merges_unreversible`
  counter **and** appends to `errors`, so the run reports `partial_rollback`.
  That is exactly what its sibling case (a merge loser that could not be
  restored) has always done. The counter alone would leave callers who check
  only top-level `status`/`error` in the original silent-success hole.
  `ALREADY_UNDONE` keeps #1441's log-and-carry-on.
- **per-merge undo** — `BLOCKED` raises `edge_changed` instead of
  `already_restored`. Both stay **409** (the request conflicts with current state
  either way); the `error_code` is what says whether anything needs doing.

The MCP tool description declares the new counter — "visible in the response" is
the whole point.

## A wording correction from review

The first draft said the blocked case meant "the merge is still in effect".
**That is false.** Reaching a blocked state means the guarded statement found
*no* `supersedes` edge, so nothing is shadowing the loser in *any* blocked case.
What is actually un-reversed is the edge state the merge overwrote.

This also fixed a naming hole: `edge_retyped` did not cover a snapshot that
cannot be restored because a later writer **deleted** the edge outright. Renamed
to `edge_changed`, with a test asserting the message does not make the old claim.

Also from review: the endpoint's OpenAPI `409` described only two of the three
conflict reasons — now all three, with their error codes.

## Tests

`tests/services/sleep/test_undo_merge.py` + `tests/mcp_server/test_sleep_tools.py`
(718 passing across `tests/services/sleep/` and `tests/mcp_server/`):

- no snapshot: edge gone → `already_restored`; edge survives → `edge_changed`
- with snapshot: back at snapshot type → `already_restored`; other type →
  `edge_changed`; deleted → `edge_changed` **and** no "still in effect" claim
- run-level `BLOCKED` → `merges_unreversible == 1`, message in
  `rollback_summary.errors`, `error == "partial_rollback"`
- #1440's regression guard kept — its stub moved `False` → `ALREADY_UNDONE`,
  which is the branch that still makes the structlog-kwargs `logger.warning`
  call, so it guards the same thing

`ruff` clean, `pyright` clean on all three changed modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)