### PR TITLE
refactor(mcp): dispatch rollback actions through a handler table (#1456)

### DIFF
--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -4,7 +4,7 @@ Issue #164: get_sleep_history, get_sleep_report, rollback_sleep_run.
 """
 
 import time
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 from uuid import UUID
 
 from mcp.types import TextContent
@@ -247,16 +247,254 @@ async def handle_get_sleep_report(
     return _error_response("db_error", "Database unavailable.")
 
 
+class _RollbackCtx(NamedTuple):
+    """Per-run values every action handler needs (#1456).
+
+    Bundled so the handlers take ``(db, action, ctx, summary)`` instead of eight
+    positional arguments each. Everything here is resolved once, before the
+    dispatch loop.
+    """
+
+    user_id: str
+    ws_id: str
+    ctx_id_str: str
+    collection_name: str
+    embedding_svc: Any
+    # Rows pre-fetched for re-embedding, keyed by id. A miss means the row is
+    # gone (retention purge) — the merge handler treats that as an error rather
+    # than reporting a restore that never happened.
+    memory_cache: dict[UUID, Any]
+    edge_repo: Any
+
+
+async def _undo_create_edge(
+    db: Any, action: Any, ctx: _RollbackCtx, summary: dict[str, Any]
+) -> None:
+    """Delete an edge the run created."""
+    if not (action.memory_id and action.target_id):
+        return
+    await ctx.edge_repo.delete_edge(
+        user_id=ctx.user_id,
+        src_id=action.memory_id,
+        dst_id=action.target_id,
+        workspace_id=ctx.ws_id or None,
+        context_id=ctx.ctx_id_str or None,
+    )
+    summary["edges_deleted"] += 1
+
+
+async def _undo_shadow_merge(
+    db: Any, action: Any, ctx: _RollbackCtx, summary: dict[str, Any]
+) -> None:
+    """Revert a #1208 shadow merge's supersedes edge.
+
+    The loser was never deleted, so undoing the merge means reverting the edge
+    (winner=memory_id → loser=target_id): restore the pre-merge edge from the
+    ``prior_edge`` snapshot, or verified-delete it when the merge created the
+    edge. Shared helper with per-merge undo so the two paths cannot drift.
+    """
+    from services.sleep.undo import ShadowEdgeRevert, revert_shadow_merge_edge
+
+    if not action.memory_id:
+        return
+
+    reverted = await revert_shadow_merge_edge(
+        db,
+        user_id=ctx.user_id,
+        winner_id=action.memory_id,
+        loser_id=action.target_id,
+        prior_edge=(action.details or {}).get("prior_edge"),
+    )
+    if reverted is ShadowEdgeRevert.RESTORED:
+        summary["merges_reversed"] += 1
+    elif reverted is ShadowEdgeRevert.ALREADY_UNDONE:
+        # Benign: the edge is already in its post-undo state. Nothing to
+        # reverse, nothing to report (#1441).
+        logger.warning(
+            "shadow_merge_rollback_already_undone",
+            src_id=str(action.memory_id),
+            dst_id=str(action.target_id),
+        )
+    else:
+        # #1450: a later writer changed or removed the edge, so this action was
+        # NOT reversed. Both zero-row causes used to land in the branch above,
+        # which made an unreversed merge indistinguishable from a clean rollback
+        # outside of a stdout warning. Same treatment as the hard-merge sibling
+        # below (a loser that could not be restored): an error, so the run
+        # reports partial_rollback rather than success.
+        summary["merges_unreversible"] += 1
+        summary["errors"].append(
+            f"shadow merge {action.memory_id} → {action.target_id} not reversed — "
+            "the edge was changed or removed by a later writer, so the pre-merge "
+            "state could not be restored"
+        )
+        logger.warning(
+            "shadow_merge_rollback_blocked_by_newer_state",
+            src_id=str(action.memory_id),
+            dst_id=str(action.target_id),
+        )
+
+
+async def _undo_merge(db: Any, action: Any, ctx: _RollbackCtx, summary: dict[str, Any]) -> None:
+    """Restore a merge loser (row + vector), or revert a shadow merge's edge."""
+    from sqlalchemy import update as sa_update
+
+    from models.memory import Memory
+
+    if not action.target_id:
+        return
+    if (action.details or {}).get("mode") == "shadow":
+        await _undo_shadow_merge(db, action, ctx, summary)
+        return
+
+    restore_result = await db.execute(
+        sa_update(Memory)
+        .where(Memory.id == action.target_id, Memory.user_id == ctx.user_id)
+        .values(deleted_at=None, deleted_by=None)
+    )
+    loser = ctx.memory_cache.get(action.target_id)
+    # #1209: a loser hard-deleted by the merge retention window matches 0 rows —
+    # record it as an error instead of a phantom "reversed" (the per-merge undo
+    # path returns 409 for the same state; run-level rollback must not report a
+    # restore that never happened). Result[Any] at type level, CursorResult at
+    # runtime — .rowcount lives on the latter (#1442).
+    restore_rows = cast(CursorResult[Any], restore_result).rowcount
+    if restore_rows == 0 or loser is None:
+        summary["errors"].append(
+            f"merge loser {action.target_id} not restorable — purged by the "
+            "retention policy (sleep_merge_retention_days)"
+        )
+        return
+
+    await _re_embed_to_qdrant(
+        loser, ctx.user_id, ctx.embedding_svc, ctx.ws_id, ctx.ctx_id_str, ctx.collection_name
+    )
+    summary["merges_reversed"] += 1
+
+
+async def _undo_update_importance(
+    db: Any, action: Any, ctx: _RollbackCtx, summary: dict[str, Any]
+) -> None:
+    """Restore the pre-run importance, best-effort syncing the Qdrant payload."""
+    from sqlalchemy import update as sa_update
+
+    from db.qdrant import update_memory_payload_in_qdrant
+    from models.memory import Memory
+    from utils.datetime import utcnow
+
+    old_importance = (action.details or {}).get("old_importance")
+    if not (action.memory_id and old_importance is not None):
+        return
+
+    await db.execute(
+        sa_update(Memory)
+        .where(Memory.id == action.memory_id, Memory.user_id == ctx.user_id)
+        .values(importance=old_importance, updated_at=utcnow())
+    )
+    try:
+        await update_memory_payload_in_qdrant(
+            memory_id=action.memory_id,
+            payload_updates={"importance": old_importance},
+            collection_name=ctx.collection_name,
+        )
+    except Exception:
+        pass  # Non-fatal: Qdrant payload sync
+    summary["importance_restored"] += 1
+
+
+async def _undo_promote(db: Any, action: Any, ctx: _RollbackCtx, summary: dict[str, Any]) -> None:
+    """Send a promoted memory back to the working scope."""
+    from sqlalchemy import update as sa_update
+
+    from models.memory import Memory
+    from utils.datetime import utcnow
+
+    if not action.memory_id:
+        return
+    await db.execute(
+        sa_update(Memory)
+        .where(Memory.id == action.memory_id, Memory.user_id == ctx.user_id)
+        .values(scope="working", promoted_at=None, updated_at=utcnow())
+    )
+    summary["promotions_reversed"] += 1
+
+
+async def _undo_archive(db: Any, action: Any, ctx: _RollbackCtx, summary: dict[str, Any]) -> None:
+    """Un-delete an archived memory and rebuild its vector."""
+    from sqlalchemy import update as sa_update
+
+    from models.memory import Memory
+
+    if not action.memory_id:
+        return
+    await db.execute(
+        sa_update(Memory)
+        .where(Memory.id == action.memory_id, Memory.user_id == ctx.user_id)
+        .values(deleted_at=None, deleted_by=None)
+    )
+    mem = ctx.memory_cache.get(action.memory_id)
+    if mem:
+        await _re_embed_to_qdrant(
+            mem, ctx.user_id, ctx.embedding_svc, ctx.ws_id, ctx.ctx_id_str, ctx.collection_name
+        )
+    summary["archives_restored"] += 1
+
+
+# Action type → undoer. An action type absent from this table is skipped
+# silently, which is the pre-existing behaviour of the if/elif chain this
+# replaces — ``undo_merge`` rows (written by the per-merge undo onto the same
+# report) rely on it.
+_UNDO_HANDLERS = {
+    "create_edge": _undo_create_edge,
+    "merge": _undo_merge,
+    "update_importance": _undo_update_importance,
+    "promote": _undo_promote,
+    "archive": _undo_archive,
+}
+
+
+async def _resolve_rollback_workspace_id(db: Any, report: Any) -> str:
+    """Report's workspace id, falling back to its context's (#1456 extract)."""
+    if report.workspace_id:
+        return str(report.workspace_id)
+    if not report.context_id:
+        return ""
+    from models.auth import Context
+
+    ctx_result = await db.execute(
+        select(Context.workspace_id).where(Context.id == report.context_id)
+    )
+    ctx_ws = ctx_result.scalar_one_or_none()
+    return str(ctx_ws) if ctx_ws else ""
+
+
+async def _prefetch_rollback_memories(db: Any, actions: list[Any]) -> dict[UUID, Any]:
+    """Rows the rollback will re-embed, fetched in one query.
+
+    #1208: shadow-mode merges never deleted the loser's vector, so they need no
+    re-embed — their undo is reverting the edge.
+    """
+    from models.memory import Memory
+
+    re_embed_ids: set[UUID] = set()
+    for a in actions:
+        if a.action_type == "merge" and a.target_id and (a.details or {}).get("mode") != "shadow":
+            re_embed_ids.add(a.target_id)
+        elif a.action_type == "archive" and a.memory_id:
+            re_embed_ids.add(a.memory_id)
+    if not re_embed_ids:
+        return {}
+    mem_result = await db.execute(select(Memory).where(Memory.id.in_(list(re_embed_ids))))
+    return {m.id: m for m in mem_result.scalars().all()}
+
+
 async def handle_rollback_sleep_run(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None
 ) -> list[TextContent]:
     """Rollback all actions from a completed sleep maintenance run."""
-    from sqlalchemy import update as sa_update
-
     from db.base import get_db
-    from db.qdrant import get_collection_name, update_memory_payload_in_qdrant
+    from db.qdrant import get_collection_name
     from models.config import ContextSearchConfig
-    from models.memory import Memory
     from models.sleep import SleepAction, SleepReport
     from repositories.neural_edge import NeuralEdgeRepository
     from services.embedding_service import EmbeddingService
@@ -329,7 +567,6 @@ async def handle_rollback_sleep_run(
                     )
                     embedding_model = search_config.embedding_model
 
-            edge_repo = NeuralEdgeRepository(db)
             rollback_summary = {
                 "edges_deleted": 0,
                 "merges_reversed": 0,
@@ -344,206 +581,26 @@ async def handle_rollback_sleep_run(
                 "errors": [],
             }
 
-            ctx_id_str = str(report.context_id) if report.context_id else ""
-            # Resolve workspace_id — required by add_memory_to_qdrant
-            ws_id = str(report.workspace_id) if report.workspace_id else ""
-            if not ws_id and report.context_id:
-                from models.auth import Context
-
-                ctx_stmt = select(Context.workspace_id).where(Context.id == report.context_id)
-                ctx_result = await db.execute(ctx_stmt)
-                ctx_ws = ctx_result.scalar_one_or_none()
-                if ctx_ws:
-                    ws_id = str(ctx_ws)
-            embedding_svc = EmbeddingService(db, model=embedding_model)
-
-            # Pre-fetch all memories that need re-embedding (merge/archive).
-            # #1208: shadow-mode merges never deleted the loser's vector, so
-            # they need no re-embed — their undo is deleting the edge below.
-            re_embed_ids: set[UUID] = set()
-            for a in actions:
-                if (
-                    a.action_type == "merge"
-                    and a.target_id
-                    and (a.details or {}).get("mode") != "shadow"
-                ):
-                    re_embed_ids.add(a.target_id)
-                elif a.action_type == "archive" and a.memory_id:
-                    re_embed_ids.add(a.memory_id)
-            memory_cache: dict[UUID, Any] = {}
-            if re_embed_ids:
-                mem_stmt = select(Memory).where(Memory.id.in_(list(re_embed_ids)))
-                mem_result = await db.execute(mem_stmt)
-                memory_cache = {m.id: m for m in mem_result.scalars().all()}
+            ctx = _RollbackCtx(
+                user_id=user_id,
+                ws_id=await _resolve_rollback_workspace_id(db, report),
+                ctx_id_str=str(report.context_id) if report.context_id else "",
+                collection_name=collection_name,
+                embedding_svc=EmbeddingService(db, model=embedding_model),
+                memory_cache=await _prefetch_rollback_memories(db, actions),
+                edge_repo=NeuralEdgeRepository(db),
+            )
 
             for action in actions:
+                handler = _UNDO_HANDLERS.get(action.action_type)
+                if handler is None:
+                    continue
                 try:
-                    if action.action_type == "create_edge":
-                        if action.memory_id and action.target_id:
-                            await edge_repo.delete_edge(
-                                user_id=user_id,
-                                src_id=action.memory_id,
-                                dst_id=action.target_id,
-                                workspace_id=ws_id or None,
-                                context_id=ctx_id_str or None,
-                            )
-                            rollback_summary["edges_deleted"] += 1
-
-                    elif action.action_type == "merge":
-                        if action.target_id:
-                            if (action.details or {}).get("mode") == "shadow":
-                                # #1208 shadow-mode merge: the loser was never
-                                # deleted — undoing the merge means reverting
-                                # the supersedes edge (winner=memory_id →
-                                # loser=target_id): restore the pre-merge
-                                # edge from the prior_edge snapshot, or
-                                # verified-delete it when the merge created
-                                # the edge. Shared helper with per-merge undo
-                                # so the two paths cannot drift.
-                                if action.memory_id:
-                                    from services.sleep.undo import (
-                                        ShadowEdgeRevert,
-                                        revert_shadow_merge_edge,
-                                    )
-
-                                    reverted = await revert_shadow_merge_edge(
-                                        db,
-                                        user_id=user_id,
-                                        winner_id=action.memory_id,
-                                        loser_id=action.target_id,
-                                        prior_edge=(action.details or {}).get("prior_edge"),
-                                    )
-                                    if reverted is ShadowEdgeRevert.RESTORED:
-                                        rollback_summary["merges_reversed"] += 1
-                                    elif reverted is ShadowEdgeRevert.ALREADY_UNDONE:
-                                        # Benign: the edge is already in its
-                                        # post-undo state. Nothing to reverse,
-                                        # nothing to report (#1441).
-                                        logger.warning(
-                                            "shadow_merge_rollback_already_undone",
-                                            src_id=str(action.memory_id),
-                                            dst_id=str(action.target_id),
-                                        )
-                                    else:
-                                        # #1450: a later writer changed or removed
-                                        # the edge, so this action was NOT
-                                        # reversed. Both zero-row causes used to
-                                        # land in the branch above, which made an
-                                        # unreversed merge indistinguishable from
-                                        # a clean rollback outside of a stdout
-                                        # warning. Same treatment as its sibling
-                                        # below (a loser that could not be
-                                        # restored): it is an error, so the run
-                                        # reports partial_rollback, not success.
-                                        rollback_summary["merges_unreversible"] += 1
-                                        rollback_summary["errors"].append(
-                                            f"shadow merge {action.memory_id} → "
-                                            f"{action.target_id} not reversed — the edge "
-                                            "was changed or removed by a later writer, so "
-                                            "the pre-merge state could not be restored"
-                                        )
-                                        logger.warning(
-                                            "shadow_merge_rollback_blocked_by_newer_state",
-                                            src_id=str(action.memory_id),
-                                            dst_id=str(action.target_id),
-                                        )
-                            else:
-                                restore_result = await db.execute(
-                                    sa_update(Memory)
-                                    .where(
-                                        Memory.id == action.target_id,
-                                        Memory.user_id == user_id,
-                                    )
-                                    .values(deleted_at=None, deleted_by=None)
-                                )
-                                loser = memory_cache.get(action.target_id)
-                                # #1209: a loser hard-deleted by the merge
-                                # retention window matches 0 rows — record it
-                                # as an error instead of a phantom "reversed"
-                                # (the per-merge undo path returns 410 for the
-                                # same state; run-level rollback must not
-                                # report a restore that never happened).
-                                # Result[Any] at type level, CursorResult at
-                                # runtime — .rowcount lives on the latter (#1442).
-                                restore_rows = cast(CursorResult[Any], restore_result).rowcount
-                                if restore_rows == 0 or loser is None:
-                                    rollback_summary["errors"].append(
-                                        f"merge loser {action.target_id} not restorable — "
-                                        "purged by the retention policy "
-                                        "(sleep_merge_retention_days)"
-                                    )
-                                else:
-                                    await _re_embed_to_qdrant(
-                                        loser,
-                                        user_id,
-                                        embedding_svc,
-                                        ws_id,
-                                        ctx_id_str,
-                                        collection_name,
-                                    )
-                                    rollback_summary["merges_reversed"] += 1
-
-                    elif action.action_type == "update_importance":
-                        details = action.details or {}
-                        old_importance = details.get("old_importance")
-                        if action.memory_id and old_importance is not None:
-                            await db.execute(
-                                sa_update(Memory)
-                                .where(
-                                    Memory.id == action.memory_id,
-                                    Memory.user_id == user_id,
-                                )
-                                .values(importance=old_importance, updated_at=utcnow())
-                            )
-                            try:
-                                await update_memory_payload_in_qdrant(
-                                    memory_id=action.memory_id,
-                                    payload_updates={"importance": old_importance},
-                                    collection_name=collection_name,
-                                )
-                            except Exception:
-                                pass  # Non-fatal: Qdrant payload sync
-                            rollback_summary["importance_restored"] += 1
-
-                    elif action.action_type == "promote":
-                        if action.memory_id:
-                            await db.execute(
-                                sa_update(Memory)
-                                .where(
-                                    Memory.id == action.memory_id,
-                                    Memory.user_id == user_id,
-                                )
-                                .values(
-                                    scope="working",
-                                    promoted_at=None,
-                                    updated_at=utcnow(),
-                                )
-                            )
-                            rollback_summary["promotions_reversed"] += 1
-
-                    elif action.action_type == "archive":
-                        if action.memory_id:
-                            await db.execute(
-                                sa_update(Memory)
-                                .where(
-                                    Memory.id == action.memory_id,
-                                    Memory.user_id == user_id,
-                                )
-                                .values(deleted_at=None, deleted_by=None)
-                            )
-                            mem = memory_cache.get(action.memory_id)
-                            if mem:
-                                await _re_embed_to_qdrant(
-                                    mem,
-                                    user_id,
-                                    embedding_svc,
-                                    ws_id,
-                                    ctx_id_str,
-                                    collection_name,
-                                )
-                            rollback_summary["archives_restored"] += 1
-
+                    await handler(db, action, ctx, rollback_summary)
                 except Exception as e:
+                    # Per-action isolation: one failed undo must not abandon the
+                    # rest of the run. The error lands in the summary, which is
+                    # what flips the report to partial_rollback below.
                     logger.warning(
                         f"rollback_action_failed: action={action.id} "
                         f"type={action.action_type} error={e}"

--- a/backend/src/mcp_server/tools/sleep.py
+++ b/backend/src/mcp_server/tools/sleep.py
@@ -468,11 +468,20 @@ async def _resolve_rollback_workspace_id(db: Any, report: Any) -> str:
     return str(ctx_ws) if ctx_ws else ""
 
 
-async def _prefetch_rollback_memories(db: Any, actions: list[Any]) -> dict[UUID, Any]:
+async def _prefetch_rollback_memories(db: Any, actions: list[Any], user_id: str) -> dict[UUID, Any]:
     """Rows the rollback will re-embed, fetched in one query.
 
     #1208: shadow-mode merges never deleted the loser's vector, so they need no
     re-embed — their undo is reverting the edge.
+
+    Scoped to ``user_id`` (Copilot review on #1460). ``SleepAction.memory_id`` /
+    ``target_id`` are plain UUID columns, not foreign keys, so a corrupted or
+    tampered action can name any row. Every rollback WRITE is already
+    user-scoped, but the archive undo re-embeds from THIS cache without
+    re-checking, which would push another user's summary and content into the
+    caller's Qdrant space. Every sleep phase selects with
+    ``Memory.user_id == user_id``, so a legitimate action can only ever name the
+    report owner's rows — the predicate costs nothing and closes the gap.
     """
     from models.memory import Memory
 
@@ -484,7 +493,9 @@ async def _prefetch_rollback_memories(db: Any, actions: list[Any]) -> dict[UUID,
             re_embed_ids.add(a.memory_id)
     if not re_embed_ids:
         return {}
-    mem_result = await db.execute(select(Memory).where(Memory.id.in_(list(re_embed_ids))))
+    mem_result = await db.execute(
+        select(Memory).where(Memory.id.in_(list(re_embed_ids)), Memory.user_id == user_id)
+    )
     return {m.id: m for m in mem_result.scalars().all()}
 
 
@@ -587,7 +598,7 @@ async def handle_rollback_sleep_run(
                 ctx_id_str=str(report.context_id) if report.context_id else "",
                 collection_name=collection_name,
                 embedding_svc=EmbeddingService(db, model=embedding_model),
-                memory_cache=await _prefetch_rollback_memories(db, actions),
+                memory_cache=await _prefetch_rollback_memories(db, actions, user_id),
                 edge_repo=NeuralEdgeRepository(db),
             )
 

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -929,3 +929,59 @@ class TestRollbackActionDispatch:
         assert any("sleep_merge_retention_days" in e for e in summary["errors"]), summary
         re_embed.assert_not_awaited()
         assert data.get("error") == "partial_rollback"
+
+    @pytest.mark.asyncio
+    async def test_prefetch_is_scoped_to_the_caller(self, user_id, workspace_id):
+        """#1460 review: the re-embed cache must not reach another user's rows.
+
+        ``SleepAction.memory_id`` / ``target_id`` are plain UUID columns, not
+        foreign keys, so a corrupted or tampered action can name any row. Every
+        rollback WRITE is user-scoped already, but the archive undo re-embeds
+        straight from this cache without re-checking — an unscoped prefetch
+        would push another user's summary and content into the caller's Qdrant
+        space.
+        """
+        captured = []
+
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+        report.workspace_id = uuid4()
+
+        action = self._action("archive", id=1)
+        config_result = MagicMock()
+        config_result.scalar_one_or_none.return_value = None
+        prefetch_result = MagicMock()
+        prefetch_result.scalars.return_value.all.return_value = []
+        db = self._db(report, [action], [config_result, prefetch_result])
+
+        original = db.execute.side_effect
+
+        async def _capture(*args, **kwargs):
+            if args:
+                captured.append(str(args[0]))
+            return await original(*args, **kwargs)
+
+        db.execute.side_effect = _capture
+
+        async def mock_get_db():
+            yield db
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.sleep._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            await handle_rollback_sleep_run({"report_id": str(report_id)}, user_id, workspace_id)
+
+        prefetch_sql = [s for s in captured if "memories.id IN" in s]
+        assert prefetch_sql, f"no prefetch query issued; saw: {captured}"
+        assert "memories.user_id = " in prefetch_sql[0], (
+            f"re-embed prefetch is not scoped to the caller: {prefetch_sql[0]}"
+        )

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -3,6 +3,7 @@
 Issue #164: get_sleep_history, get_sleep_report, rollback_sleep_run.
 """
 
+import contextlib
 import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -653,3 +654,278 @@ class TestShadowMergeRollbackEdgeMismatch:
         assert data.get("error") == "partial_rollback", (
             f"an un-reversed merge was reported as a clean rollback: {data}"
         )
+
+
+class TestRollbackActionDispatch:
+    """#1456: the per-action dispatch, after if/elif became a handler table.
+
+    The old chain fell through silently for any action_type it did not name,
+    and the rewrite must keep that: ``undo_merge`` rows are written onto the
+    SAME report by the per-merge undo path (services/sleep/undo.py), so a
+    rollback run reads them back and MUST ignore them. Turning that silence
+    into an error — or worse, into a handler lookup that raises — would make
+    every report that had one memory individually undone un-rollbackable.
+    """
+
+    @staticmethod
+    def _db(report, actions, extra=None):
+        """AsyncSession double.
+
+        ``extra`` is appended to the positional result queue, which the handler
+        drains in order: report → actions → embedding config (report has a
+        context) → workspace fallback (only when the report has no
+        workspace_id) → re-embed prefetch. Pass results for the queries a given
+        test needs to control; anything past the queue gets a permissive
+        generic result.
+        """
+        report_result = MagicMock()
+        report_result.scalar_one_or_none.return_value = report
+        actions_result = MagicMock()
+        actions_result.scalars.return_value.all.return_value = actions
+
+        db = AsyncMock()
+        queued = [report_result, actions_result, *(extra or [])]
+
+        async def _execute(*_args, **_kwargs):
+            if queued:
+                return queued.pop(0)
+            generic = MagicMock()
+            generic.rowcount = 1
+            generic.scalars.return_value.all.return_value = []
+            generic.scalar_one_or_none.return_value = None
+            return generic
+
+        db.execute.side_effect = _execute
+        db.rollback = AsyncMock()
+        return db
+
+    @staticmethod
+    def _action(action_type, **kw):
+        a = MagicMock()
+        a.action_type = action_type
+        a.id = kw.pop("id", 1)
+        a.memory_id = kw.pop("memory_id", uuid4())
+        a.target_id = kw.pop("target_id", uuid4())
+        a.details = kw.pop("details", {})
+        return a
+
+    async def _run(self, actions, user_id, workspace_id):
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+        # Real UUIDs: the edge repository parses these, so a bare MagicMock
+        # surfaces as "badly formed hexadecimal UUID string" inside a handler.
+        report.workspace_id = uuid4()
+        db = self._db(report, actions)
+
+        async def mock_get_db():
+            yield db
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.sleep._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "mcp_server.tools.sleep._re_embed_to_qdrant",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await handle_rollback_sleep_run(
+                {"report_id": str(report_id)}, user_id, workspace_id
+            )
+        return json.loads(result[0].text)
+
+    @pytest.fixture
+    def user_id(self):
+        return "user-1456"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_unknown_action_type_is_skipped_not_an_error(self, user_id, workspace_id):
+        """An ``undo_merge`` row must not fail the run or inflate any counter."""
+        data = await self._run(
+            [self._action("undo_merge", details={"undone_action_id": 7})],
+            user_id,
+            workspace_id,
+        )
+
+        assert data.get("error") != "partial_rollback", data
+        summary = data["rollback_summary"]
+        assert summary["errors"] == []
+        assert all(
+            summary[k] == 0
+            for k in (
+                "edges_deleted",
+                "merges_reversed",
+                "merges_unreversible",
+                "importance_restored",
+                "promotions_reversed",
+                "archives_restored",
+            )
+        ), summary
+
+    @pytest.mark.asyncio
+    async def test_each_action_type_reaches_its_own_undoer(self, user_id, workspace_id):
+        """Every non-merge counter moves exactly once, nothing bleeds across.
+
+        ``merge`` is covered separately below — it needs the re-embed prefetch
+        primed, and it is the branch most worth pinning on its own (review).
+        """
+        actions = [
+            self._action("create_edge", id=1),
+            self._action("promote", id=2),
+            self._action("archive", id=3),
+            self._action("update_importance", id=4, details={"old_importance": 0.4}),
+            # Unknown type mixed in — it must not disturb its neighbours.
+            self._action("undo_merge", id=5),
+        ]
+        data = await self._run(actions, user_id, workspace_id)
+
+        summary = data["rollback_summary"]
+        assert summary["errors"] == [], summary
+        assert summary["edges_deleted"] == 1
+        assert summary["promotions_reversed"] == 1
+        assert summary["archives_restored"] == 1
+        assert summary["importance_restored"] == 1
+        assert summary["merges_reversed"] == 0
+
+    @pytest.mark.asyncio
+    async def test_one_failing_action_does_not_abandon_the_rest(self, user_id, workspace_id):
+        """Per-action isolation: the loop keeps going and records the failure."""
+        boom = self._action("create_edge", id=1)
+        ok = self._action("promote", id=2)
+
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+        report.workspace_id = uuid4()
+        db = self._db(report, [boom, ok])
+
+        async def mock_get_db():
+            yield db
+
+        class _ExplodingEdgeRepo:
+            def __init__(self, _db):
+                pass
+
+            async def delete_edge(self, **_kw):
+                raise RuntimeError("edge store unavailable")
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.sleep._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch("repositories.neural_edge.NeuralEdgeRepository", new=_ExplodingEdgeRepo),
+        ):
+            result = await handle_rollback_sleep_run(
+                {"report_id": str(report_id)}, user_id, workspace_id
+            )
+
+        data = json.loads(result[0].text)
+        summary = data["rollback_summary"]
+        # The failure is recorded…
+        assert any("edge store unavailable" in e for e in summary["errors"]), summary
+        # …and the following action still ran.
+        assert summary["promotions_reversed"] == 1, summary
+        assert data.get("error") == "partial_rollback"
+
+    async def _run_with_extra(self, actions, extra, user_id, workspace_id, patch_re_embed=True):
+        report_id = uuid4()
+        report = MagicMock()
+        report.id = report_id
+        report.user_id = user_id
+        report.status = "completed"
+        report.context_id = uuid4()
+        report.workspace_id = uuid4()
+        db = self._db(report, actions, extra)
+
+        async def mock_get_db():
+            yield db
+
+        stack = [
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.sleep._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ]
+        re_embed = AsyncMock(return_value=None)
+        if patch_re_embed:
+            stack.append(patch("mcp_server.tools.sleep._re_embed_to_qdrant", new=re_embed))
+
+        with contextlib.ExitStack() as es:
+            for cm in stack:
+                es.enter_context(cm)
+            result = await handle_rollback_sleep_run(
+                {"report_id": str(report_id)}, user_id, workspace_id
+            )
+        return json.loads(result[0].text), re_embed
+
+    @pytest.mark.asyncio
+    async def test_hard_merge_restores_the_loser_and_re_embeds(self, user_id, workspace_id):
+        """#1456: the non-shadow merge branch — the one the mixed test omits.
+
+        A restored loser must be un-deleted AND re-embedded: the merge hard-
+        deleted its vector, so a row restored without a vector is invisible to
+        every search path.
+        """
+        loser_id = uuid4()
+        loser = MagicMock()
+        loser.id = loser_id
+
+        config_result = MagicMock()
+        config_result.scalar_one_or_none.return_value = None  # no per-context config
+        prefetch_result = MagicMock()
+        prefetch_result.scalars.return_value.all.return_value = [loser]
+
+        action = self._action("merge", id=1, target_id=loser_id, details={})
+        data, re_embed = await self._run_with_extra(
+            [action], [config_result, prefetch_result], user_id, workspace_id
+        )
+
+        summary = data["rollback_summary"]
+        assert summary["errors"] == [], summary
+        assert summary["merges_reversed"] == 1, summary
+        re_embed.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hard_merge_reports_a_purged_loser_instead_of_a_phantom_restore(
+        self, user_id, workspace_id
+    ):
+        """#1209 semantics survive the extraction: a loser the retention policy
+        purged is an ERROR, not a counted reversal. Reporting a restore that
+        never happened is the failure mode this branch exists to prevent."""
+        loser_id = uuid4()
+        config_result = MagicMock()
+        config_result.scalar_one_or_none.return_value = None
+        prefetch_result = MagicMock()
+        prefetch_result.scalars.return_value.all.return_value = []  # purged
+
+        action = self._action("merge", id=1, target_id=loser_id, details={})
+        data, re_embed = await self._run_with_extra(
+            [action], [config_result, prefetch_result], user_id, workspace_id
+        )
+
+        summary = data["rollback_summary"]
+        assert summary["merges_reversed"] == 0, summary
+        assert any("not restorable" in e for e in summary["errors"]), summary
+        assert any("sleep_merge_retention_days" in e for e in summary["errors"]), summary
+        re_embed.assert_not_awaited()
+        assert data.get("error") == "partial_rollback"


### PR DESCRIPTION
Part of #1456 (item 2 of 8). Follows #1459 (`list_memories`).

| | lines | complexity |
|---|---:|---:|
| before | 347 | 58 |
| after | 163 | **22** |

## This one changes control flow

Item 1 was a pure extraction. This is not: the five-branch `if/elif` over
`action.action_type` became a `_UNDO_HANDLERS` table, with one handler per
action type taking `(db, action, ctx, summary)` and a `_RollbackCtx` NamedTuple
carrying the per-run values (ws_id, collection, embedding service, memory cache,
edge repo).

Control-flow rewrites are where "behaviour-preserving" actually breaks, so the
verification below matters more than the numbers above.

## The property that was almost easy to lose

The old chain had **no `else`** — an `action_type` it did not name fell through
silently. That is not incidental:

`services/sleep/undo.py` writes **`undo_merge` rows onto the same report** when
a user undoes one merge individually. Every subsequent rollback reads them back.

A naive `_UNDO_HANDLERS[action.action_type]` instead of `.get(...)` turns each of
those into a `KeyError` caught by the per-action handler → a recorded error →
`partial_rollback`. Concretely: **any report where a single memory had been
undone would become un-rollbackable.**

There was no test for this. There is now, and I verified it by injecting the
naive form — 2 of the new tests fail, with
`errors: ["Action 1 (undo_merge): 'undo_merge'"]`.

## Also newly pinned: the non-shadow merge branch

It had no direct coverage either, despite being the riskiest handler:

- a restored loser must be un-deleted **and** re-embedded — the merge hard-deleted
  its vector, so a row restored without one is invisible to every search path
- a loser purged by the retention window must be an **error**, not a counted
  reversal (#1209 — reporting a restore that never happened is exactly what that
  branch exists to prevent)

## One deliberate exception to "behaviour-preserving"

Copilot review found that `_prefetch_rollback_memories` selects by memory id
with **no user scope**. `SleepAction.memory_id` / `target_id` are plain UUID
columns, not foreign keys, so a corrupted or tampered action can name any row.

Every rollback WRITE is user-scoped already, and the merge undo is incidentally
protected by its rowcount check (0 rows → error branch, no re-embed). The
**archive** undo is not — it re-embeds straight from the cache whenever the id
is present, which would push another user's summary and content into the
caller's Qdrant space.

Pre-existing: `origin/main` selects the same way, and this refactor moved the
query verbatim. Fixed here rather than deferred because it is one predicate and
every sleep phase already selects with `Memory.user_id == user_id`, so no
legitimate action can name another user's row and nothing that works today
changes. Pinned by a test that inspects the emitted prefetch SQL and fails when
the scope is removed.

This is the only place this PR changes behaviour.

## Review

One adversarial round (codex, read-only): **"No production behavior findings"**
across all five attack categories —

- **dispatch equivalence** — the table holds exactly the old five types; `undo_merge`
  and `purge` remain absent and skipped, matching the old fallthrough
- **guard-clause inversion** — every `if cond: work` → `if not cond: return` checked,
  including `(action.details or {}).get(...)` equivalence
- **DB round-trip order and count** — unchanged (report → actions → config → workspace
  fallback → prefetch); `NeuralEdgeRepository(db)` moved later but its constructor
  only stores `db`
- **`_undo_merge` delegation** — the early return after the shadow path cannot skip
  the hard path
- **exception scope** — the per-action `try` and the inner Qdrant-sync `try/except
  pass` both still cover what they used to

Its one finding was about my test, not the code: `test_each_action_type_reaches_
its_own_undoer` claimed "one of each" while omitting `merge`. Fixed — the docstring
no longer overclaims, and `merge` now has two dedicated tests (restore path and
purged-loser path).

Copilot's finding is the user-scope one above.

## Tests

`tests/mcp_server/` + `tests/services/sleep/`: **724 passed**, 40 skipped.
`ruff` clean, `ruff format` clean, `pyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)