### PR TITLE
fix(api): size a cleared context_summary/details as cleared (#1458)

### DIFF
--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -686,7 +686,7 @@ class MemoryService:
         if request.content is not None and request.content != memory.content:
             needs_reembed = True
 
-        self._update_guard_size(memory, request)
+        self._update_guard_size(memory, request, normalized_summary, normalized_ctx_summary)
         effective_details = self._update_apply_fields(
             memory, request, normalized_summary, normalized_ctx_summary
         )
@@ -775,34 +775,46 @@ class MemoryService:
         return memory
 
     @staticmethod
-    def _update_guard_size(memory: Any, request: UpdateMemoryRequest) -> None:
+    def _update_guard_size(
+        memory: Any,
+        request: UpdateMemoryRequest,
+        normalized_summary: str | None,
+        normalized_ctx_summary: str | None,
+    ) -> None:
         """Reject an update that would push the row past ``MAX_CONTENT_SIZE``.
 
-        Preserved as-is from before the #1439 split, including a known quirk:
-        the truthy ``or`` fallbacks are NOT equivalent to the PATCH sibling's
-        explicit ``is None`` checks. ``context_summary`` has no ``min_length``
-        and ``details`` is a free dict, so ``""`` and ``{}`` are valid values
-        that :meth:`_update_apply_fields` does write to the row — but they are
-        falsy, so this guard falls back to the stored value and sizes the row as
-        if the field were untouched. An update that CLEARS a large
-        ``context_summary`` can therefore be rejected for being too big while
-        actually shrinking the row.
+        Sizes the row as it will be AFTER the update, using explicit ``is None``
+        rather than truthy fallbacks (#1458). On this surface ``None`` means
+        "leave this field alone", but ``""`` and ``{}`` are values a client can
+        legitimately send — ``context_summary`` has no ``min_length`` and
+        ``details`` is a free dict — and :meth:`_update_apply_fields` does write
+        them. Under the old ``or`` fallbacks those fell through to the STORED
+        value, so an update that CLEARED a large ``context_summary`` was
+        measured as though it had not, and could be rejected for being too big
+        while actually shrinking the row.
 
-        Left alone deliberately: #1439 is a behaviour-preserving decomposition,
-        and this fails in the safe direction (a spurious rejection, never an
-        oversized row). Tracked separately — do not "tidy" it into ``is None``
-        here without a test for the clearing case.
+        Takes the normalized summaries rather than the raw request fields so the
+        measurement matches what actually lands on the row. (Both are bounded by
+        ``max_length`` 500 / 2000, so the difference cannot move a 1 MB verdict —
+        it is for correctness, not headroom.) Mirrors ``_patch_guard_size``.
 
         Raises:
             QuotaExceededError: the post-update size exceeds the limit.
         """
         from config.constants import MAX_CONTENT_SIZE
 
+        next_summary = normalized_summary if normalized_summary is not None else memory.summary
+        next_ctx_summary = (
+            normalized_ctx_summary if normalized_ctx_summary is not None else memory.context_summary
+        )
+        next_content = request.content if request.content is not None else memory.content
+        next_details = request.details if request.details is not None else memory.details
+
         content_size = (
-            len(request.summary or memory.summary or "")
-            + len(request.context_summary or memory.context_summary or "")
-            + len(request.content or memory.content or "")
-            + len(str(request.details or memory.details or ""))
+            len(next_summary if next_summary is not None else "")
+            + len(next_ctx_summary if next_ctx_summary is not None else "")
+            + len(next_content if next_content is not None else "")
+            + len(str(next_details) if next_details is not None else "")
         )
         if content_size > MAX_CONTENT_SIZE:
             from utils.exceptions import QuotaExceededError

--- a/backend/tests/services/test_update_guard_size.py
+++ b/backend/tests/services/test_update_guard_size.py
@@ -1,0 +1,126 @@
+"""Regression tests for ``MemoryService._update_guard_size`` (#1458).
+
+The guard sized the post-update row with truthy ``or`` fallbacks. On this
+surface ``None`` means "leave this field alone", but ``""`` and ``{}`` are
+values a client can legitimately send — ``context_summary`` has no
+``min_length`` and ``details`` is a free dict — and ``_update_apply_fields``
+writes them. Being falsy, they fell through to the STORED value, so an update
+that CLEARED a large field was measured as though it had not, and could be
+rejected with ``QuotaExceededError`` while actually shrinking the row.
+
+``summary`` (``min_length=10``) and ``content`` (``min_length=1``) reject ``""``
+at the schema, so only ``context_summary`` and ``details`` were reachable.
+"""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from config.constants import MAX_CONTENT_SIZE
+from models.schemas import UpdateMemoryRequest
+from services.memory_service import MemoryService
+from utils.exceptions import QuotaExceededError
+
+
+def _guard(memory, request):
+    """Call the guard the way ``update_memory`` does.
+
+    The caller pre-normalizes the two summary fields and hands them in, so the
+    measurement matches what lands on the row. ``normalize_for_search`` is
+    identity for the ASCII used here.
+    """
+    MemoryService._update_guard_size(
+        memory,
+        request,
+        request.summary,
+        request.context_summary,
+    )
+
+
+def _stored(*, summary="stored summary", context_summary="", content="", details=None):
+    return SimpleNamespace(
+        summary=summary,
+        context_summary=context_summary,
+        content=content,
+        details=details,
+    )
+
+
+def test_clearing_a_large_context_summary_is_not_rejected():
+    """#1458 core case: the update SHRINKS the row, so it must be allowed.
+
+    The stored row sits just under the limit only because of its
+    context_summary; clearing it takes the row far below. The old guard read
+    the stored value back (``"" or stored``) and rejected the update.
+    """
+    stored = _stored(
+        context_summary="c" * 2000,
+        content="x" * (MAX_CONTENT_SIZE - 1000),
+    )
+    request = UpdateMemoryRequest(memory_id=uuid4(), context_summary="")
+
+    _guard(stored, request)  # must not raise
+
+
+def test_replacing_large_details_with_an_empty_dict_is_not_rejected():
+    """Same defect through the other reachable field.
+
+    The stored ``details`` alone exceed the limit, so falling back to them (the
+    pre-fix behaviour) rejects the update; the post-update row is 402 bytes.
+    """
+    stored = _stored(
+        details={"blob": "d" * MAX_CONTENT_SIZE},
+        content="x" * 400,
+    )
+    request = UpdateMemoryRequest(memory_id=uuid4(), details={})
+
+    _guard(stored, request)  # must not raise
+
+
+def test_empty_details_counts_as_its_own_two_bytes_not_zero():
+    """``{}`` is a value, not an absence: ``len(str({})) == 2``.
+
+    Pins the distinction the fix rests on — the sibling ``_patch_guard_size``
+    documents the same rule.
+    """
+    stored = _stored(details={"blob": "d" * 100}, content="x" * MAX_CONTENT_SIZE)
+    request = UpdateMemoryRequest(memory_id=uuid4(), details={})
+
+    # content alone is exactly at the limit; the two bytes of "{}" push it over.
+    with pytest.raises(QuotaExceededError):
+        _guard(stored, request)
+
+
+def test_a_genuinely_oversized_update_is_still_rejected():
+    """The guard must still do its job — the fix is not a loosening."""
+    stored = _stored(content="x" * 100)
+    request = UpdateMemoryRequest(
+        memory_id=uuid4(),
+        content="y" * (MAX_CONTENT_SIZE + 1),
+    )
+
+    with pytest.raises(QuotaExceededError) as exc:
+        _guard(stored, request)
+    assert "exceeds limit" in str(exc.value)
+
+
+def test_omitted_fields_are_sized_from_the_stored_row():
+    """``None`` still means "leave alone" — that semantic is unchanged.
+
+    An importance-only update on an already-at-limit row must still be measured
+    against the stored content, or the guard would stop guarding.
+    """
+    stored = _stored(content="x" * (MAX_CONTENT_SIZE + 1))
+    request = UpdateMemoryRequest(memory_id=uuid4(), importance=0.9)
+
+    with pytest.raises(QuotaExceededError):
+        _guard(stored, request)
+
+
+def test_a_none_stored_field_does_not_crash_the_measurement():
+    """Legacy rows carry NULL content / details; ``len(None)`` would raise."""
+    stored = _stored(summary="s" * 10, context_summary=None, content=None, details=None)
+    request = UpdateMemoryRequest(memory_id=uuid4(), importance=0.5)
+
+    _guard(stored, request)  # must not raise


### PR DESCRIPTION
Closes #1458. Found by Copilot on #1457, which flagged it as low confidence; it is real.

## The defect

`MemoryService._update_guard_size` sized the post-update row with truthy `or`
fallbacks:

```python
len(request.context_summary or memory.context_summary or "")
+ len(str(request.details or memory.details or ""))
```

On this surface `None` means "leave this field alone" — but `""` and `{}` are
values a client can legitimately send (`context_summary` has no `min_length`,
`details` is a free dict), and `_update_apply_fields` **does** write them.

Being falsy, they fell through to the **stored** value. An update that *cleared*
a large `context_summary` was measured as though it had not, and could be
rejected with `QuotaExceededError` **while actually shrinking the row**. The
operator's only recourse was to shrink something else first.

`summary` (`min_length=10`) and `content` (`min_length=1`) reject `""` at the
schema, so only those two fields were reachable.

## The fix

Explicit `is None`, mirroring `_patch_guard_size` — the PATCH sibling got this
right because that surface *had* to distinguish omitted from explicit-null. The
MCP path never had that pressure.

Also takes the normalized summaries rather than the raw request fields, so the
measurement matches what actually lands on the row. Both are `max_length`-bounded
(500 / 2000), so that part cannot move a 1 MB verdict — it is for correctness,
not headroom, and I am not claiming it closes anything.

## Verified by reverting

The tests are only worth what they'd catch, so I ran them against the old guard:

| test | vs. old guard | vs. new guard |
|---|---|---|
| clearing a large `context_summary` | ❌ fails | ✅ passes |
| replacing large `details` with `{}` | ❌ fails | ✅ passes |
| genuinely oversized update still rejected | ✅ | ✅ |
| omitted fields still sized from the row | ✅ | ✅ |
| `{}` counts as its own 2 bytes, not 0 | ✅ | ✅ |
| `None` stored fields don't crash the measurement | ✅ | ✅ |

The first draft of the `details` test passed against *both* — the stored blob was
not large enough for the fallback to breach the limit, so it proved nothing.
Re-tuned so the stored `details` alone exceed `MAX_CONTENT_SIZE`.

The last four are non-regression guards; they should pass either way. Only the
first two pin the fix.

## Also from #1439

Removes the `do not "tidy" it into is None here without a test for the clearing
case` note that #1439 left in the docstring. The test it asked for is in this PR.

`tests/services/` + memory list suites: **1854 passed**, 284 skipped.
`ruff` clean, `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)