### PR TITLE
fix(ops): make an active-color marker that lies impossible to ignore (#1448)

### DIFF
--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -252,8 +252,12 @@ named `blue` with no blue container:
 If you hit that error, look at what is actually running and write it back:
 
 ```bash
+# Which color is actually up?
 docker ps --format '{{.Names}}' | grep kagura-api-
-echo <blue|green> > /opt/kagura-memory/active-color
+
+# Write that one back — run whichever line matches:
+echo blue  > /opt/kagura-memory/active-color
+echo green > /opt/kagura-memory/active-color
 ```
 
 Once everything is healthy, enable the systemd unit so the stack comes back

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -231,6 +231,31 @@ echo "blue" > /opt/kagura-memory/active-color
 
 The first build takes several minutes (backend + frontend images).
 
+### The active-color marker (#1448)
+
+`/opt/kagura-memory/active-color` names the color **serving traffic right now** —
+never the one a switch is heading toward. Every writer updates it only after the
+new color is up and has passed readiness (`deploy.sh` Step 5; rollback after
+`wait_for_readiness`), and the old color is drained only after Caddy has been
+pointed away. An interrupted run therefore leaves the marker on the color that
+is still serving, which is the recoverable state.
+
+`deploy.sh` reads it to derive **both** colors, so a marker that disagrees with
+reality makes the next deploy build the color that is live and drain the one
+that is not. Two guards exist because of a 65-hour incident where the marker
+named `blue` with no blue container:
+
+- a missing or empty marker is a hard error, not a silent fallback to `blue`
+- `--status` reports a marker whose color is not running, and `deploy` refuses
+  to start from one
+
+If you hit that error, look at what is actually running and write it back:
+
+```bash
+docker ps --format '{{.Names}}' | grep kagura-api-
+echo <blue|green> > /opt/kagura-memory/active-color
+```
+
 Once everything is healthy, enable the systemd unit so the stack comes back
 after a reboot:
 

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -89,12 +89,21 @@ get_active_color() {
     # say so instead of guessing (#1448).
     if [ ! -s "$MARKER_FILE" ]; then
         error "Marker file $MARKER_FILE is missing or empty. It must name the
-       color serving traffic right now. Recover with:
+       color serving traffic right now. Find it, then write it back:
            docker ps --format '{{.Names}}' | grep kagura-api-
-           echo <blue|green> > $MARKER_FILE"
+           echo blue  > $MARKER_FILE
+           echo green > $MARKER_FILE"
     fi
+    # -s says non-empty, not readable: a root-owned or IO-failing marker passes
+    # that check and then dies inside the command substitution, where `set -e`
+    # aborts with no message of ours (Copilot review on #1462). An operator
+    # mid-incident needs the reason, so catch the read explicitly.
     local color
-    color="$(cat "$MARKER_FILE")"
+    if ! color="$(cat "$MARKER_FILE" 2>/dev/null)"; then
+        error "Marker file $MARKER_FILE exists but could not be read.
+       Check ownership and permissions:
+           ls -l $MARKER_FILE"
+    fi
     # Validate — must be exactly "blue" or "green"
     if [ "$color" != "blue" ] && [ "$color" != "green" ]; then
         error "Marker file $MARKER_FILE contains invalid value: '$color'. Expected 'blue' or 'green'."

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -73,14 +73,62 @@ on_exit() {
     fi
 }
 
+# The marker names the color that is LIVE right now — never the one a switch is
+# heading toward. Every writer updates it only AFTER the new color is up and has
+# passed its readiness check (deploy Step 5; rollback after wait_for_readiness),
+# and the old color is drained only after Caddy has been pointed away. Keep that
+# order: writing the marker first would publish a color that cannot serve, and
+# an interrupted run would leave it that way (#1448).
 get_active_color() {
+    # A missing marker used to default to "blue" silently. That is the one
+    # failure mode this file cannot absorb: with no marker, every reader
+    # *agrees* on a color nobody selected, so a host whose marker was lost
+    # (fresh volume, interrupted bootstrap, unclean shutdown truncating the
+    # file) looks healthy while Caddy and the deploy script disagree with
+    # reality. The bootstrap in README.md writes it explicitly; if it is gone,
+    # say so instead of guessing (#1448).
+    if [ ! -s "$MARKER_FILE" ]; then
+        error "Marker file $MARKER_FILE is missing or empty. It must name the
+       color serving traffic right now. Recover with:
+           docker ps --format '{{.Names}}' | grep kagura-api-
+           echo <blue|green> > $MARKER_FILE"
+    fi
     local color
-    color="$(cat "$MARKER_FILE" 2>/dev/null || echo "blue")"
+    color="$(cat "$MARKER_FILE")"
     # Validate — must be exactly "blue" or "green"
     if [ "$color" != "blue" ] && [ "$color" != "green" ]; then
         error "Marker file $MARKER_FILE contains invalid value: '$color'. Expected 'blue' or 'green'."
     fi
     echo "$color"
+}
+
+# Report a marker that names a color with no running container (#1448).
+#
+# That state means a switch was interrupted after the marker moved but before
+# the color it names came up — or that the color died afterwards. It is not
+# cosmetic: `get_inactive_color` is derived from the marker, so the next deploy
+# would build the color that IS live and drain the one that is not. Downstream,
+# kagura-bridge's connect-level cross-color fallback (kagura-ai/kagura-bridge#211)
+# masks the mismatch instead of surfacing it — it absorbed 4162 calls over 65
+# hours in the 2026-07-21..24 incident, turning a safety net into the normal
+# path and burying every other warning in its noise.
+#
+# Reports rather than exits: this runs on the read-only status path, where the
+# operator needs the diagnosis, not a dead command.
+check_marker_matches_live() {
+    local color="$1"
+    if is_container_running "$color"; then
+        return 0
+    fi
+    log "WARNING: marker says '$color' but kagura-api-${color} is NOT running."
+    log "         A switch was likely interrupted, or the live color died."
+    log "         Traffic is only being served via cross-color fallback, if at all."
+    local other
+    if [ "$color" = "blue" ]; then other="green"; else other="blue"; fi
+    if is_container_running "$other"; then
+        log "         kagura-api-${other} IS running — it is probably the real live color."
+    fi
+    return 1
 }
 
 get_inactive_color() {
@@ -102,6 +150,10 @@ cmd_status() {
     active="$(get_active_color)"
     log "Active color: $active"
     log "Marker file:  $MARKER_FILE"
+
+    # #1448: the whole point of a status command is to catch this before the
+    # next deploy computes its target color from a marker that is lying.
+    check_marker_matches_live "$active" || true
 
     # Show container states
     dc ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null \
@@ -147,6 +199,15 @@ cmd_deploy() {
     active="$(get_active_color)"
     inactive="$(get_inactive_color)"
     log "Current active: $active — deploying to: $inactive"
+
+    # #1448: both colors below are derived from the marker. If it names a color
+    # that is not running, this deploy would build the color that IS serving and
+    # drain the one that is not — the opposite of what was asked. Surface it and
+    # stop; recovering is a one-line marker write, guessing is not recoverable.
+    if ! check_marker_matches_live "$active"; then
+        error "Refusing to deploy from a marker that does not match reality.
+       Point $MARKER_FILE at the color actually serving traffic, then re-run."
+    fi
 
     # Step 1: Build new image
     DEPLOY_STAGE="Step 1/7: build api-${inactive} image"

--- a/terraform/single-server/scripts/tests/deploy_marker_integrity.bats
+++ b/terraform/single-server/scripts/tests/deploy_marker_integrity.bats
@@ -133,3 +133,38 @@ teardown() {
     [ "$status" -eq 1 ] || return 1
     [ -z "$output" ] || return 1
 }
+
+@test "an existing but unreadable marker gets its own error, not a bare abort" {
+    # A directory passes `-s` (non-empty) but `cat` fails on it — the same shape
+    # as a root-owned file or an IO error, without needing to drop privileges.
+    # Before this branch, `set -e` killed the run inside the command
+    # substitution with no message of ours (Copilot review on #1462).
+    MARKER_FILE="$TMP/as-a-directory"
+    mkdir -p "$MARKER_FILE/x"
+    run get_active_color
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"could not be read"* ]] || return 1
+    [[ "$output" == *"ls -l"* ]] || return 1
+}
+
+@test "recovery instructions are safe to paste" {
+    # `echo <blue|green> > file` looks like a placeholder but `<` and `|` are
+    # shell operators — pasted mid-incident it redirects and pipes instead of
+    # writing (Copilot review on #1462). Both the error text and the README
+    # must spell the two commands out.
+    run bash -o pipefail -c 'grep -nE "echo <" "$1"' _ "$DEPLOY_SH"
+    [ "$status" -eq 1 ] || return 1
+    [ -z "$output" ] || return 1
+
+    run get_active_color
+    [[ "$output" == *"echo blue"* ]] || return 1
+    [[ "$output" == *"echo green"* ]] || return 1
+}
+
+@test "the README recovery snippet is safe to paste too" {
+    readme="$BATS_TEST_DIRNAME/../../README.md"
+    [ -r "$readme" ] || return 1
+    run bash -o pipefail -c 'grep -nE "echo <" "$1"' _ "$readme"
+    [ "$status" -eq 1 ] || return 1
+    [ -z "$output" ] || return 1
+}

--- a/terraform/single-server/scripts/tests/deploy_marker_integrity.bats
+++ b/terraform/single-server/scripts/tests/deploy_marker_integrity.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# =============================================================================
+# #1448: the active-color marker must never quietly disagree with reality.
+#
+# Production ran 65 hours with the marker naming `blue` while no blue container
+# existed. Every control-plane call reached the API only through kagura-bridge's
+# connect-level cross-color fallback (kagura-ai/kagura-bridge#211) — 4162 times —
+# turning a safety net into the normal path and filling 99.7% of the bridge log
+# with one warning.
+#
+# The issue proposed reordering the switch (start → health → marker → drain).
+# That order was ALREADY implemented (deploy Step 2→7, and rollback starts and
+# waits for readiness before writing the marker), so reordering would have been
+# a no-op. What was missing:
+#
+#   1. a missing marker resolved to "blue" silently, so every reader agreed on a
+#      color nobody selected;
+#   2. nothing ever compared the marker against which container was running.
+#
+# deploy.sh guards `main` behind BASH_SOURCE, so these call the real functions
+# rather than grepping for them. No docker, no network.
+# =============================================================================
+
+DEPLOY_SH="$BATS_TEST_DIRNAME/../deploy.sh"
+
+setup() {
+    [ -r "$DEPLOY_SH" ] || return 1
+    TMP="$(mktemp -d)"
+    # shellcheck disable=SC1090
+    source "$DEPLOY_SH"
+    MARKER_FILE="$TMP/active-color"
+    # Neutralize the EXIT trap the script installs: bats runs each assertion in
+    # its own subshell, and a stray final-status line would pollute $output.
+    trap - EXIT
+    # deploy.sh sets `-euo pipefail` and sourcing leaves those on here.
+    #
+    # `-e` must STAY ON: bats detects a failing test through it, so `set +e`
+    # makes every assertion advisory — a body ending in `false || return 1`
+    # still reports `ok`. (Confirmed the hard way while checking these guards
+    # are not vacuous.) Only `-u` is dropped, because an unbound-variable death
+    # inside a test aborts the file instead of failing one case.
+    #
+    # Assertions still carry an explicit `|| return 1` so the intent survives
+    # even if someone later relaxes `-e`.
+    #
+    # Known rough edge: when one of these guards DOES catch a regression, `-e`
+    # kills the body before bats can name it, so the run reports
+    # "Executed 7 instead of expected 11" rather than `not ok 1 ...`. The run
+    # still exits non-zero, so CI fails correctly — but if you see that warning,
+    # the missing numbers are the failures.
+    set +u
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+@test "a missing marker is an error, not a silent 'blue'" {
+    run get_active_color
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"missing or empty"* ]] || return 1
+    # It must not answer with a color it invented.
+    [[ "$output" != *$'\n'"blue" ]] || return 1
+}
+
+@test "an empty marker is an error too (truncated by an unclean shutdown)" {
+    : > "$MARKER_FILE"
+    run get_active_color
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"missing or empty"* ]] || return 1
+}
+
+@test "the error names the file and shows how to recover" {
+    run get_active_color
+    [[ "$output" == *"$MARKER_FILE"* ]] || return 1
+    [[ "$output" == *"docker ps"* ]] || return 1
+}
+
+@test "a valid marker still round-trips" {
+    echo "green" > "$MARKER_FILE"
+    run get_active_color
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" = "green" ] || return 1
+}
+
+@test "an invalid marker value is still rejected" {
+    echo "purple" > "$MARKER_FILE"
+    run get_active_color
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"invalid value"* ]] || return 1
+}
+
+@test "a marker naming a color that is not running is reported" {
+    is_container_running() { return 1; }
+    run check_marker_matches_live "blue"
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"is NOT running"* ]] || return 1
+}
+
+@test "the report points at the color that IS running" {
+    # blue is dead, green is alive — the operator needs to be told which.
+    is_container_running() { [ "$1" = "green" ]; }
+    run check_marker_matches_live "blue"
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"kagura-api-green IS running"* ]] || return 1
+}
+
+@test "a marker that matches the running color is silent" {
+    is_container_running() { return 0; }
+    run check_marker_matches_live "blue"
+    [ "$status" -eq 0 ] || return 1
+    [ -z "$output" ] || return 1
+}
+
+@test "deploy refuses to run from a marker that does not match reality" {
+    # Static: the guard must sit in cmd_deploy, before the colors it derives are
+    # used. Calling cmd_deploy for real would start containers.
+    run bash -o pipefail -c 'sed -n "/^cmd_deploy()/,/^}/p" "$1" | grep -c "check_marker_matches_live"' _ "$DEPLOY_SH"
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "status reports the mismatch instead of dying on it" {
+    run bash -o pipefail -c 'sed -n "/^cmd_status()/,/^}/p" "$1" | grep -c "check_marker_matches_live"' _ "$DEPLOY_SH"
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "no reader falls back to a default color" {
+    # The regression this whole file exists for: `|| echo "blue"` (or any
+    # variant) reintroduces the silent agreement on an unselected color.
+    run bash -o pipefail -c 'grep -nE "cat .*MARKER_FILE.*\|\|" "$1"' _ "$DEPLOY_SH"
+    [ "$status" -eq 1 ] || return 1
+    [ -z "$output" ] || return 1
+}


### PR DESCRIPTION
Closes #1448.

## The proposed fix would have been a no-op

The issue asks for the switch to be reordered to "new color up → healthy →
marker → drain old". **`deploy.sh` already does exactly that**: Step 2 starts
the inactive color, Step 3 waits for readiness, Step 4 migrates, Step 5 writes
the marker, Step 6 switches Caddy, Step 7 drains. `cmd_rollback` likewise starts
the target color and waits for readiness *before* writing.

The evidence does not fit "marker written too early" either. The marker named
`blue` while the blue container **did not exist** — `Created 2026-07-24`, 65
hours later. A premature write would have left blue present-but-stopped.

## What actually allowed it

```bash
color="$(cat "$MARKER_FILE" 2>/dev/null || echo "blue")"
```

A missing marker resolved to `blue` **silently**. Every reader then *agreed* on
a color nobody selected, so a host whose marker was lost — fresh volume,
interrupted bootstrap, an unclean shutdown truncating the file — looked healthy
while Caddy and the deploy script disagreed with reality.

Note the asymmetry it replaced: an *invalid* value (`purple`) hard-errored on
the very next line, but an *absent* one was quietly invented.

And nothing ever compared the marker against which container was running, so the
only symptom was kagura-bridge's cross-color fallback absorbing 4162 calls over
65 hours (kagura-ai/kagura-bridge#211) — a safety net promoted to the normal
path, filling 99.7% of the bridge log with one warning.

## Changes

- **a missing or empty marker is a hard error**, naming the file and the recovery
  command instead of guessing
- **`check_marker_matches_live`** reports a marker whose color is not running,
  and says which color *is*. `--status` shows it; **`deploy` refuses to start
  from one** — it derives *both* colors from the marker, so it would otherwise
  rebuild the live color and drain the dead one
- the ordering rationale is recorded above `get_active_color` and in the
  single-server README (the issue's third acceptance criterion)

## Acceptance criteria

- [x] the switch order is "new color up → healthy → marker update → drain old" —
      it already was; now documented with its rationale rather than left implicit
- [x] an interrupted switch cannot leave the marker naming a non-live color
      unnoticed — `--status` and `deploy` both surface it
- [x] rationale left as a comment in the script and the README

## Tests

`terraform/single-server/scripts/tests/deploy_marker_integrity.bats`, 11 cases.
`deploy.sh` guards `main` behind `BASH_SOURCE`, so these **call the real
functions** rather than grepping for them.

Verified against a copy with the old silent default restored: the four tests
that guard the fix stop passing, the seven that describe unchanged behaviour
still pass.

Two things I got wrong on the way there, both recorded in the file's comments
because they are easy to repeat:

- I first added `set +eu` in `setup()` to quiet the sourced script's flags.
  **bats detects failure through `set -e`** — with it off, a body ending in
  `false || return 1` still reports `ok`. Every guard was silently vacuous.
  Only `-u` is dropped now.
- When a guard does fire, `-e` kills the body before bats can name it, so the
  run reports `Executed 7 instead of expected 11` rather than `not ok 1`. The
  exit status is still non-zero (CI fails correctly); the comment explains that
  the missing numbers are the failures.

Also rewrote one `A && B || C` as an explicit `if` — shellcheck flags that shape
(SC2015) and shellcheck is a required CI job I cannot run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)