### PR TITLE
docs: describe the downstream connector worker generically in public source

### DIFF
--- a/backend/src/models/worker_app.py
+++ b/backend/src/models/worker_app.py
@@ -2,7 +2,7 @@
 
 An app identity represents one platform application (for example one Slack
 app), not one customer installation.  ``app_key`` is the stable, non-secret
-selector shared with kagura-bridge.  Signing secrets remain server-custody
+selector shared with the connector worker.  Signing secrets remain server-custody
 credentials: only Fernet ciphertext is persisted and plaintext is exposed
 solely by the service-token-protected worker bootstrap endpoint.
 """

--- a/backend/src/models/worker_runtime.py
+++ b/backend/src/models/worker_runtime.py
@@ -7,7 +7,7 @@ from typing import Literal, cast, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
-# #1377: the worker Locale contract, mirroring kagura-bridge's
+# #1377: the worker Locale contract, mirroring the connector worker's
 # WorkerConfigResponse.locale (Literal["en", "ja"]). A non-conforming vended
 # value fails bridge-side validation of the WHOLE config body — the tenant
 # fails closed with only a generic config_unavailable in the logs. This is the

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -365,7 +365,8 @@ async def test_list_connectors_reports_never_written_context_as_zero():
     It must read as "nothing written yet" — the honest fact — and NOT as an
     error. A brand-new or low-traffic connector legitimately has no writes, and
     a row that is permanently red gets ignored exactly like an alert that fires
-    permanently (the same trap kagura-bridge#214 hit with AiWorkerNoSuccessfulAcks).
+    permanently — a "no successful writes" alarm that cannot distinguish "idle"
+    from "broken" trains operators to dismiss it.
     """
     from services.connector_provisioning import ConnectorListItem
 

--- a/docs/connector-ingest-contract.md
+++ b/docs/connector-ingest-contract.md
@@ -147,7 +147,7 @@ worker (connector token)
 
 The config vend (`GET /api/v1/workers/config`) types
 `WorkerConnectorConfig.locale` as `"en" | "ja" | null`, mirroring the bridge's
-`WorkerConfigResponse.locale` (`Literal["en", "ja"]` in kagura-bridge
+`WorkerConfigResponse.locale` (`Literal["en", "ja"]` in the connector worker
 `models.py::Locale`). A vended value outside that enum fails the bridge's
 validation of the **whole** config body and the tenant fails closed
 (`config_unavailable`), so both sides of the contract are pinned:
@@ -155,7 +155,7 @@ validation of the **whole** config body and the tenant fails closed
 - **memory-cloud** — single source `models.worker_runtime.WORKER_LOCALES`
   (write boundary rejects/normalizes at connector create/update; vend boundary
   degrades non-conforming legacy rows to `null` = worker default).
-- **kagura-bridge** — `models.py::Locale`.
+- **connector worker** — `models.py::Locale`.
 
 Widening the enum (e.g. adding `ko`) requires a coordinated change to **both**
 repos: bridge `Locale` first (workers tolerate `null`), then `WORKER_LOCALES`.

--- a/docs/design/2026-07-24-workspace-management-key-separation.md
+++ b/docs/design/2026-07-24-workspace-management-key-separation.md
@@ -19,7 +19,7 @@ Two related problems, one operational and one structural:
    invisible even though it is real.
 2. **Ambient authority (structural).** A key's power is derived entirely
    from its owner's current workspace role. Every key an admin/owner mints —
-   including keys intended purely for data-plane automation (kagura-bridge
+   including keys intended purely for data-plane automation (connector workers
    writers, CI ingest, `.mcp.json`) — can also call connector setup, secret
    management, and member management. There is no way to mint a
    least-privilege data-only key as an owner.
@@ -64,7 +64,7 @@ Two related problems, one operational and one structural:
 Honest security accounting (drove the phase split): with grandfathering, the
 automatic day-one security gain is **zero**. The capability model's real
 security value is *enabling* data-only owner keys (de-privileging
-kagura-bridge / CI credentials) — an opt-in gain realized only when keys are
+connector-worker / CI credentials) — an opt-in gain realized only when keys are
 rotated. Operational clarity, the acute problem, does not need the schema
 change at all. Hence Phase 1 ships clarity; Phase 2 ships the mechanism.
 

--- a/docs/design/platform-borne-connector-llm.md
+++ b/docs/design/platform-borne-connector-llm.md
@@ -27,10 +27,9 @@ the `llm` block resolves in this order:
   **virtual key** so usage is metered per tenant. `litellm_virtual_key_id`
   identifies that key; the vend hands the worker a proxy base URL + the
   virtual key instead of a raw provider credential.
-- Must align with the kagura-bridge dedicated-LLM-credential vend design
-  ([kagura-bridge#179](https://github.com/kagura-ai/kagura-bridge/issues/179))
-  — reference only; no cross-repo scope in this note. The convergence
-  requirement: one vend shape both consumers can read
+- Must align with the downstream connector worker's dedicated-LLM-credential
+  vend design — reference only; no cross-repo scope in this note. The
+  convergence requirement: one vend shape both consumers can read
   (`{mode: "byok" | "virtual-key" | "platform", ...}` rather than an opaque
   dict whose meaning depends on who filled it).
 
@@ -81,4 +80,4 @@ count — #1388/#1389). When a platform lane exists:
 - Sleep/analysis LLM provider selection is a separate lane (BYOK-scoped
   today) and out of scope.
 
-Refs: #1376, #1380, #1388, #1389, #1393, kagura-bridge#179.
+Refs: #1376, #1380, #1388, #1389, #1393.

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
@@ -819,7 +819,7 @@ describe("ConnectorsPage RBAC gate", () => {
 
     render(<ConnectorsPage />);
 
-    // The virtual key is stored but not vended (kagura-bridge#179): the row
+    // The virtual key is stored but not vended to the worker: the row
     // must agree with the dialog readiness rule instead of contradicting it.
     expect(await screen.findByText("llmNotBound")).toBeInTheDocument();
     expect(screen.queryByText("llmBound")).not.toBeInTheDocument();

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -1453,7 +1453,7 @@ export default function ConnectorsPage() {
                   llmFieldsBlock
                 )}
                 {/* #1388: LiteLLM virtual key demoted to an advanced fold —
-                  stored but not vended yet (kagura-bridge#179). Keyed by
+                  stored but not vended to the worker yet. Keyed by
                   connector so the uncontrolled <details> open state never
                   leaks from one connector's dialog into another's. */}
                 <details

--- a/frontend/src/lib/api/workspace-connectors.ts
+++ b/frontend/src/lib/api/workspace-connectors.ts
@@ -82,8 +82,8 @@ export interface ConnectorReadiness {
 
 // #1388: vend-readiness rule, mirrored from what the worker actually needs
 // to serve a connector today: an ingest channel selection plus a stored BYO
-// LLM bundle. litellm_virtual_key_id is stored but not vended yet
-// (kagura-bridge#179), so it must NOT count toward readiness — a connector
+// LLM bundle. litellm_virtual_key_id is stored but not vended to the worker
+// yet, so it must NOT count toward readiness — a connector
 // with only a virtual key would read "ready" while the worker gets llm=null.
 // Single source for every readiness surface (dialog summary, row indicators);
 // the #1392 platform-LLM lane changes this rule in exactly one place.

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -116,11 +116,11 @@ get_active_color() {
 # That state means a switch was interrupted after the marker moved but before
 # the color it names came up — or that the color died afterwards. It is not
 # cosmetic: `get_inactive_color` is derived from the marker, so the next deploy
-# would build the color that IS live and drain the one that is not. Downstream,
-# kagura-bridge's connect-level cross-color fallback (kagura-ai/kagura-bridge#211)
-# masks the mismatch instead of surfacing it — it absorbed 4162 calls over 65
-# hours in the 2026-07-21..24 incident, turning a safety net into the normal
-# path and burying every other warning in its noise.
+# would build the color that IS live and drain the one that is not. Downstream
+# consumers that implement a connect-level failover to the other color then mask
+# the mismatch instead of surfacing it: the failover carries the traffic, so the
+# system keeps looking healthy while a safety net quietly serves as the normal
+# path and its warnings drown out every other signal.
 #
 # Reports rather than exits: this runs on the read-only status path, where the
 # operator needs the diagnosis, not a dead command.

--- a/terraform/single-server/scripts/tests/deploy_marker_integrity.bats
+++ b/terraform/single-server/scripts/tests/deploy_marker_integrity.bats
@@ -2,11 +2,11 @@
 # =============================================================================
 # #1448: the active-color marker must never quietly disagree with reality.
 #
-# Production ran 65 hours with the marker naming `blue` while no blue container
-# existed. Every control-plane call reached the API only through kagura-bridge's
-# connect-level cross-color fallback (kagura-ai/kagura-bridge#211) — 4162 times —
-# turning a safety net into the normal path and filling 99.7% of the bridge log
-# with one warning.
+# Production once ran for an extended period with the marker naming `blue` while
+# no blue container existed. Control-plane calls still reached the API, but only
+# via a downstream consumer's connect-level failover to the other color — turning
+# a safety net into the normal path and burying every other signal under a single
+# repeated warning.
 #
 # The issue proposed reordering the switch (start → health → marker → drain).
 # That order was ALREADY implemented (deploy Step 2→7, and rollback starts and


### PR DESCRIPTION
Comments, docstrings and design notes in this public repository identified a
specific downstream consumer by repository name, linked its issue numbers, and
quoted production incident specifics (durations, call counts, dates). None of
that detail is needed to explain the behavior those comments exist to explain.

## Change

Each reference is rewritten to describe the consumer by **role** rather than by
name:

- `the connector worker` / `downstream consumers that implement a connect-level
  failover`
- incident specifics replaced with the general failure mode

The engineering intent every comment carried is preserved:

| Location | Intent kept |
|---|---|
| `terraform/.../deploy.sh` | why `check_marker_matches_live` exists — a downstream failover masks a marker/reality mismatch, so the system looks healthy while a safety net serves as the normal path |
| `terraform/.../tests/deploy_marker_integrity.bats` | the same, as the test's rationale |
| `backend/tests/services/test_connector_provisioning.py` | why "no writes yet" must not read as an error — a permanently-red row trains operators to dismiss it |
| `frontend/...`, `lib/api/workspace-connectors.ts` | why a stored-but-unvended virtual key must not count toward readiness |
| `docs/...` | the locale contract and the key-separation rationale |

## Scope

**Comments, docstrings and Markdown only. No executable line is changed.**

Verified: every changed line is non-executable (module docstrings, test
docstrings, shell comments, Markdown prose); `bash -n` passes on `deploy.sh`;
no tracked file references the private repository name afterward.

Deliberately **not** touched: this repository's own worker-facing API surface
(`worker_runtime`, `worker_app`, `/api/v1/workers/config`, …). Those are
memory-cloud's own feature, not a reference to anyone else, and renaming them
would be a breaking API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZpvFKGhBZrEQ4jyFRpTwJ