### PR TITLE
feat(api): referral program with a ledger-backed memory bonus (#1470)

### DIFF
--- a/backend/alembic/versions/e76_1470_referral_program.py
+++ b/backend/alembic/versions/e76_1470_referral_program.py
@@ -1,0 +1,154 @@
+"""Referral program: ledger table + referral bonus column + user referral code.
+
+Issue #1470.
+
+Three additive changes, no backfill:
+
+1. ``workspaces.referral_memory_bonus`` — a memory-quota bonus earned through
+   the referral program, stacked into ``Workspace.effective_memory_limit``.
+
+   This column is deliberately NOT named ``addon_*`` and is deliberately absent
+   from ``internal_billing._ADDON_COLUMNS``, ``admin_plans._ADDON_FIELD_SPECS``
+   and ``AddonCalculatorService``'s bonuses dict. Each of those paths would
+   destroy it: the billing push zeroes every ``_ADDON_COLUMNS`` entry whenever
+   it carries ``addons`` (full-replace), and the addon cache is rewritten with
+   ``SUM(WorkspaceAddon.quantity * unit_value)`` on every recalc — the same
+   class of bug #665 fixed for admin grants. Its source of truth is the
+   ``referral_grants`` ledger below.
+
+2. ``users.referral_code`` — nullable UNIQUE, lazily minted on first read.
+   Never ``users.user_id``: that holds the OAuth ``sub`` claim used by sessions,
+   API keys and MCP auth, and must not appear in a shareable URL.
+
+3. ``referral_grants`` — the payout ledger. ``uq_referral_grants_referred_user``
+   is the idempotency key (a user can be referred at most once, ever), and all
+   four FKs are ``ON DELETE SET NULL`` so account erasure needs no new entry in
+   ``account_erasure_service``'s explicit table sweep and so erasing an invitee
+   does not retroactively void the referrer's earned quota.
+
+Revision ID: e76_1470_referral_program
+Revises: e75_1403_supersede_candidate
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e76_1470_referral_program"
+down_revision = "e75_1403_supersede_candidate"
+branch_labels = None
+depends_on = None
+
+# Kept byte-identical to the literals in ``backend/src/models/referral.py`` and
+# ``models/auth.py`` — ``backend/tests/test_schema_drift.py`` compares them.
+CK_NOT_SELF = (
+    "referrer_user_id IS NULL OR referred_user_id IS NULL OR referrer_user_id <> referred_user_id"
+)
+CK_BONUS_NONNEG = "referrer_bonus_memories >= 0 AND referred_bonus_memories >= 0"
+CK_REFERRAL_BONUS_NONNEG = "referral_memory_bonus >= 0"
+
+
+def upgrade() -> None:
+    """Add the referral bonus column, the user referral code, and the ledger."""
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "referral_memory_bonus",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.create_check_constraint(
+        "referral_memory_bonus_nonneg",
+        "workspaces",
+        CK_REFERRAL_BONUS_NONNEG,
+    )
+
+    op.add_column(
+        "users",
+        sa.Column("referral_code", sa.String(length=24), nullable=True),
+    )
+    op.create_index(
+        "ix_users_referral_code",
+        "users",
+        ["referral_code"],
+        unique=True,
+    )
+
+    op.create_table(
+        "referral_grants",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("referrer_user_id", sa.String(length=255), nullable=True),
+        sa.Column("referrer_workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("referred_user_id", sa.String(length=255), nullable=True),
+        sa.Column("referred_workspace_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("referrer_bonus_memories", sa.Integer(), nullable=False),
+        sa.Column("referred_bonus_memories", sa.Integer(), nullable=False),
+        sa.Column(
+            "granted_at",
+            sa.DateTime(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked_reason", sa.Text(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["referrer_user_id"], ["users.user_id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["referred_user_id"], ["users.user_id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["referrer_workspace_id"], ["workspaces.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["referred_workspace_id"], ["workspaces.id"], ondelete="SET NULL"),
+        sa.UniqueConstraint("referred_user_id", name="uq_referral_grants_referred_user"),
+        sa.CheckConstraint(CK_NOT_SELF, name="ck_referral_grants_not_self"),
+        sa.CheckConstraint(CK_BONUS_NONNEG, name="ck_referral_grants_bonus_nonneg"),
+    )
+    op.create_index(
+        "ix_referral_grants_referrer_user_id",
+        "referral_grants",
+        ["referrer_user_id"],
+    )
+    op.create_index(
+        "ix_referral_grants_referrer_workspace_id",
+        "referral_grants",
+        ["referrer_workspace_id"],
+    )
+    op.create_index(
+        "ix_referral_grants_referred_workspace_id",
+        "referral_grants",
+        ["referred_workspace_id"],
+    )
+    op.create_index(
+        "ix_referral_grants_granted_at",
+        "referral_grants",
+        ["granted_at"],
+    )
+    # Covers the per-referrer cap COUNT, which always filters on
+    # ``revoked_at IS NULL``.
+    op.create_index(
+        "ix_referral_grants_referrer_active",
+        "referral_grants",
+        ["referrer_user_id", "revoked_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the ledger, the referral code, and the bonus column."""
+    op.drop_index("ix_referral_grants_referrer_active", table_name="referral_grants")
+    op.drop_index("ix_referral_grants_granted_at", table_name="referral_grants")
+    op.drop_index("ix_referral_grants_referred_workspace_id", table_name="referral_grants")
+    op.drop_index("ix_referral_grants_referrer_workspace_id", table_name="referral_grants")
+    op.drop_index("ix_referral_grants_referrer_user_id", table_name="referral_grants")
+    op.drop_table("referral_grants")
+
+    op.drop_index("ix_users_referral_code", table_name="users")
+    op.drop_column("users", "referral_code")
+
+    op.drop_constraint("referral_memory_bonus_nonneg", "workspaces", type_="check")
+    op.drop_column("workspaces", "referral_memory_bonus")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -265,6 +265,14 @@ openapi_tags = [
             "workspace owner + Pro tier + per-day quota + workspace allowlist."
         ),
     },
+    {
+        "name": "referrals",
+        "description": (
+            "Referral program (Issue #1470): the caller's own referral code and "
+            "standing, plus code redemption. Session auth only, and the whole "
+            "surface 404s unless the deployment sets ENABLE_REFERRALS."
+        ),
+    },
     # Public API
     {"name": "public-search", "description": "Public REST API for search"},
     {"name": "mcp-api", "description": "MCP server tools listing and status"},
@@ -280,6 +288,10 @@ openapi_tags = [
         "description": "Admin: per-context memory health diagnosis and signal breakdown",
     },
     {"name": "admin-neural", "description": "Admin: trigger Neural Memory recalibration"},
+    {
+        "name": "admin-referrals",
+        "description": "Admin: referral grant ledger and per-grant revocation",
+    },
     {
         "name": "admin-signup-gate",
         "description": "Admin: signup-gate configuration and allowlist management",
@@ -581,6 +593,7 @@ from api.routes import (  # noqa: E402
     admin_memory_health,  # Issue #1211: consolidated memory-health report
     admin_neural,  # Issue #406: Manual kNN calibration recalibrate trigger
     admin_plans,
+    admin_referrals,  # Issue #1470: referral ledger + per-grant revoke
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
     admin_sleep,  # Issue #247: Manual Sleep Maintenance trigger
     agent_state,  # Issue #906: REST surface for the agent session-state lane
@@ -610,6 +623,7 @@ from api.routes import (  # noqa: E402
     neural_config,
     oauth,
     public_search,  # Issue #238: Public Search API
+    referrals,  # Issue #1470: user-facing referral code + redeem
     resource_indexer,  # Issue #326: Indexer status visibility API
     resource_ingest,  # Issue #238: Resource Ingest API
     resource_schema,  # Issue #238: Schema Management API
@@ -709,6 +723,12 @@ app.include_router(admin_neural.router, prefix="/api/v1")
 
 # Admin signup gate (Issue #358: admin-configurable signup gate)
 app.include_router(admin_signup_gate.router, prefix="/api/v1")
+
+# Referral program (Issue #1470). The user-facing routes 404 unless
+# settings.enable_referrals; the admin ledger/revoke stays reachable regardless
+# so an operator can unwind grants after flipping the kill switch off.
+app.include_router(referrals.router, prefix="/api/v1")
+app.include_router(admin_referrals.router, prefix="/api/v1")
 
 # BM25 IDF Drift admin (Issue #343 - cron disabled by default until v0.14.0)
 app.include_router(bm25_drift.router, prefix="/api/v1")

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -979,12 +979,20 @@ async def _count_addon_usage(db: AsyncSession, workspace_id: UUID, guard_kind: s
     raise ValueError(f"unknown guard_kind: {guard_kind!r}")
 
 
-def _effective_for_guard(plan_tier, guard_kind: str, requested_bonus: int) -> int:
+def _effective_for_guard(
+    plan_tier, guard_kind: str, requested_bonus: int, extra_bonus: int = 0
+) -> int:
     """New effective limit for an LD-7 guard, mirroring ``_zero_floor``.
 
     A tier with base ``0`` always yields ``0`` regardless of the addon —
     matches the runtime ``Workspace.effective_*`` properties so admins
     cannot bypass the tier gate via a manual grant (#569 defense).
+
+    ``extra_bonus`` carries entitlement that stacks into the same effective
+    limit but lives OUTSIDE the addon machinery — today only #1470's
+    ``Workspace.referral_memory_bonus`` on the ``memory`` guard. Without it the
+    guard computes a limit lower than the one actually in force and rejects
+    admin reductions that are in fact safe.
     """
     base_map = {
         "memory": plan_tier.memory_limit,
@@ -995,7 +1003,7 @@ def _effective_for_guard(plan_tier, guard_kind: str, requested_bonus: int) -> in
     base = base_map[guard_kind]
     if base == 0:
         return 0
-    return base + requested_bonus
+    return base + requested_bonus + extra_bonus
 
 
 @router.put("/workspaces/{workspace_id}/quotas")
@@ -1137,7 +1145,13 @@ async def update_workspace_quotas(
         #     touched persistent-addon field — admin-only path, acceptable.
         if spec.guard_kind is not None:
             usage_count = await _count_addon_usage(db, ws_uuid, spec.guard_kind)
-            new_effective = _effective_for_guard(plan_tier, spec.guard_kind, requested)
+            # #1470: the referral bonus stacks into effective_memory_limit but is
+            # not an addon, so the guard must be told about it explicitly or it
+            # under-computes the post-change limit for the ``memory`` kind.
+            extra_bonus = (
+                (workspace.referral_memory_bonus or 0) if spec.guard_kind == "memory" else 0
+            )
+            new_effective = _effective_for_guard(plan_tier, spec.guard_kind, requested, extra_bonus)
             if usage_count > new_effective:
                 raise HTTPException(
                     status_code=400,

--- a/backend/src/api/routes/admin_referrals.py
+++ b/backend/src/api/routes/admin_referrals.py
@@ -1,0 +1,191 @@
+"""Admin referral ledger + revoke (Issue #1470).
+
+Routes under ``/api/v1/admin/referrals`` — system-admin only via ``AdminUser``.
+
+These ship in the SAME change as the grant engine on purpose. A feature that
+mints entitlement without a ledger view and a per-grant undo cannot answer
+"who got what, and why" during an abuse incident, and the only alternative
+remediation would be hand-editing production rows.
+
+Note the deliberate divergence from the closest precedent: ``SignupGateService``
+writes its config with no ``AuditLog`` row and not even a log line
+(``services/signup_gate_service.py`` ``update_config``). That is tolerable for a
+boolean gate; it is not tolerable here, because a revoke removes quota a user is
+actively storing against. The audit shape is copied from the
+``workspace_slot_bonus`` PATCH in ``api/routes/admin.py`` instead, including its
+required-reason rule.
+
+Unlike the user-facing routes, these are NOT gated on
+``settings.enable_referrals``: an operator must be able to inspect and unwind
+existing grants after flipping the kill switch off.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import AdminUser
+from db.base import get_db
+from models.api_base import TZAwareBaseModel
+from models.auth import AuditLog
+from services.referral_service import ReferralService
+from utils.db_helpers import db_transaction
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/admin/referrals", tags=["admin-referrals"])
+
+
+class AdminReferralGrantResponse(TZAwareBaseModel):
+    """A ledger row with both sides visible."""
+
+    id: str
+    referrer_user_id: str | None
+    referrer_workspace_id: str | None
+    referred_user_id: str | None
+    referred_workspace_id: str | None
+    referrer_bonus_memories: int
+    referred_bonus_memories: int
+    granted_at: datetime
+    revoked_at: datetime | None
+    revoked_reason: str | None
+
+
+class AdminReferralListResponse(BaseModel):
+    """Paged ledger listing."""
+
+    items: list[AdminReferralGrantResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+class RevokeRequest(BaseModel):
+    """Revocation payload.
+
+    ``reason`` is required — not optional-with-a-default. Revoking shrinks a
+    live quota, so there is no non-destructive case in which an empty reason
+    would be acceptable (contrast ``admin.py``'s conditional-reason rule for
+    ``workspace_slot_bonus``, where a non-negative delta is harmless).
+    """
+
+    reason: str = Field(min_length=1, max_length=500)
+
+
+def _to_response(grant) -> AdminReferralGrantResponse:  # noqa: ANN001 - ORM row
+    """Map a ledger row onto the admin read model."""
+    return AdminReferralGrantResponse(
+        id=str(grant.id),
+        referrer_user_id=grant.referrer_user_id,
+        referrer_workspace_id=(
+            str(grant.referrer_workspace_id) if grant.referrer_workspace_id else None
+        ),
+        referred_user_id=grant.referred_user_id,
+        referred_workspace_id=(
+            str(grant.referred_workspace_id) if grant.referred_workspace_id else None
+        ),
+        referrer_bonus_memories=grant.referrer_bonus_memories,
+        referred_bonus_memories=grant.referred_bonus_memories,
+        granted_at=grant.granted_at,
+        revoked_at=grant.revoked_at,
+        revoked_reason=grant.revoked_reason,
+    )
+
+
+@router.get("", response_model=AdminReferralListResponse)
+async def list_referral_grants(
+    user: AdminUser,
+    referrer_user_id: str | None = Query(default=None),
+    include_revoked: bool = Query(default=True),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+) -> AdminReferralListResponse:
+    """List referral grants, newest first.
+
+    Args:
+        user: Authenticated system admin.
+        referrer_user_id: Restrict to a single inviter.
+        include_revoked: Include already-revoked rows (default true).
+        limit: Page size.
+        offset: Page offset.
+        db: Database session.
+
+    Returns:
+        A page of ledger rows plus the total count.
+    """
+    service = ReferralService(db)
+    rows, total = await service.list_grants(
+        referrer_user_id=referrer_user_id,
+        include_revoked=include_revoked,
+        limit=limit,
+        offset=offset,
+    )
+    return AdminReferralListResponse(
+        items=[_to_response(row) for row in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.post("/{grant_id}/revoke", response_model=AdminReferralGrantResponse)
+async def revoke_referral_grant(
+    grant_id: uuid.UUID,
+    payload: RevokeRequest,
+    user: AdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> AdminReferralGrantResponse:
+    """Revoke a grant and recompute both sides' referral bonuses.
+
+    Idempotent: revoking an already-revoked grant is a no-op that still returns
+    the row, so an admin retry (or a double-click) is harmless.
+
+    Args:
+        grant_id: The ledger row to revoke.
+        payload: Revocation reason.
+        user: Authenticated system admin.
+        db: Database session.
+
+    Returns:
+        The revoked grant.
+
+    Raises:
+        HTTPException: 404 if no such grant exists.
+    """
+    service = ReferralService(db)
+    actor_id = user.get("user_id", "unknown")
+
+    async with db_transaction(db, "revoke_referral_grant", "Failed to revoke referral grant"):
+        grant = await service.revoke(grant_id=grant_id, reason=payload.reason)
+        if grant is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Referral grant not found",
+            )
+        audit = AuditLog(
+            user_email=user.get("email", actor_id),
+            user_id=actor_id,
+            action="referral_grant_revoke",
+            resource=f"referral_grant:{grant_id}",
+            old_value_hash=str(grant.referrer_bonus_memories + grant.referred_bonus_memories),
+            new_value_hash="0",
+            user_metadata={
+                "actor_user_id": actor_id,
+                "referrer_user_id": grant.referrer_user_id,
+                "referred_user_id": grant.referred_user_id,
+                "referrer_bonus_memories": grant.referrer_bonus_memories,
+                "referred_bonus_memories": grant.referred_bonus_memories,
+                "reason": payload.reason,
+            },
+        )
+        db.add(audit)
+        await db.commit()
+
+    return _to_response(grant)

--- a/backend/src/api/routes/admin_referrals.py
+++ b/backend/src/api/routes/admin_referrals.py
@@ -163,29 +163,34 @@ async def revoke_referral_grant(
     actor_id = user.get("user_id", "unknown")
 
     async with db_transaction(db, "revoke_referral_grant", "Failed to revoke referral grant"):
-        grant = await service.revoke(grant_id=grant_id, reason=payload.reason)
+        grant, changed = await service.revoke(grant_id=grant_id, reason=payload.reason)
         if grant is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Referral grant not found",
             )
-        audit = AuditLog(
-            user_email=user.get("email", actor_id),
-            user_id=actor_id,
-            action="referral_grant_revoke",
-            resource=f"referral_grant:{grant_id}",
-            old_value_hash=str(grant.referrer_bonus_memories + grant.referred_bonus_memories),
-            new_value_hash="0",
-            user_metadata={
-                "actor_user_id": actor_id,
-                "referrer_user_id": grant.referrer_user_id,
-                "referred_user_id": grant.referred_user_id,
-                "referrer_bonus_memories": grant.referrer_bonus_memories,
-                "referred_bonus_memories": grant.referred_bonus_memories,
-                "reason": payload.reason,
-            },
-        )
-        db.add(audit)
+        # Audit ONLY the call that actually revoked. Writing a row on a retry
+        # would record ``payload.reason`` against a grant whose stored
+        # ``revoked_reason`` is the original one — an audit trail that disagrees
+        # with the ledger, claiming a revocation for a reason never recorded.
+        if changed:
+            audit = AuditLog(
+                user_email=user.get("email", actor_id),
+                user_id=actor_id,
+                action="referral_grant_revoke",
+                resource=f"referral_grant:{grant_id}",
+                old_value_hash=str(grant.referrer_bonus_memories + grant.referred_bonus_memories),
+                new_value_hash="0",
+                user_metadata={
+                    "actor_user_id": actor_id,
+                    "referrer_user_id": grant.referrer_user_id,
+                    "referred_user_id": grant.referred_user_id,
+                    "referrer_bonus_memories": grant.referrer_bonus_memories,
+                    "referred_bonus_memories": grant.referred_bonus_memories,
+                    "reason": payload.reason,
+                },
+            )
+            db.add(audit)
         await db.commit()
 
     return _to_response(grant)

--- a/backend/src/api/routes/referrals.py
+++ b/backend/src/api/routes/referrals.py
@@ -1,0 +1,137 @@
+"""User-facing referral endpoints (Issue #1470).
+
+Routes under ``/api/v1/referrals``. Session-authenticated only — a referral is
+an act by a human in a browser, and allowing an API key to redeem would hand a
+farmer a scriptable endpoint.
+
+Every route 404s when ``settings.enable_referrals`` is false, matching the BYOK
+(#1167) and Plan-page (#1145) precedent: the deployment flag is surfaced
+read-only via ``GET /api/v1/system/info`` ``features.referrals`` so the web UI
+hides the card instead of rendering a control that always fails.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import SessionUser
+from config.settings import get_settings
+from db.base import get_db
+from models.api_base import TZAwareBaseModel
+from services.referral_service import ReferralService
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/referrals", tags=["referrals"])
+
+
+def _require_enabled() -> None:
+    """404 the whole surface when the program is switched off for this deployment."""
+    if not get_settings().enable_referrals:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Referral program is not enabled",
+        )
+
+
+class ReferralSummaryResponse(BaseModel):
+    """The inviter's own standing.
+
+    Reward amounts are included because the user is being asked to share a link
+    — they need to know what they and their invitee get. This is not the same as
+    exposing them publicly: the route requires a session.
+    """
+
+    code: str
+    max_grants: int
+    used_grants: int
+    remaining_grants: int
+    referee_reward_memories: int
+    referrer_reward_memories: int
+    earned_memories: int
+
+
+class RedeemRequest(BaseModel):
+    """A referral code submitted by a newly-signed-up user."""
+
+    code: str = Field(min_length=1, max_length=24)
+
+
+class ReferralGrantResponse(TZAwareBaseModel):
+    """A ledger row as seen by the user who earned it.
+
+    Inherits ``TZAwareBaseModel`` (not ``BaseModel``) because it carries
+    datetimes: the naive-UTC columns must serialize with a ``Z`` suffix or JS
+    clients read them as local time.
+    """
+
+    id: str
+    granted_at: datetime
+    referrer_bonus_memories: int
+    referred_bonus_memories: int
+    revoked_at: datetime | None
+
+
+@router.get("/me", response_model=ReferralSummaryResponse)
+async def get_my_referral(
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> ReferralSummaryResponse:
+    """Return the caller's referral code and standing, minting a code on first call.
+
+    Args:
+        user: Authenticated session user.
+        db: Database session.
+
+    Returns:
+        The caller's referral summary.
+    """
+    _require_enabled()
+    service = ReferralService(db)
+    summary = await service.get_summary(user["user_id"])
+    return ReferralSummaryResponse(
+        code=summary.code,
+        max_grants=summary.max_grants,
+        used_grants=summary.used_grants,
+        remaining_grants=max(0, summary.max_grants - summary.used_grants),
+        referee_reward_memories=summary.referee_reward_memories,
+        referrer_reward_memories=summary.referrer_reward_memories,
+        earned_memories=summary.earned_memories,
+    )
+
+
+@router.post("/redeem", response_model=ReferralGrantResponse, status_code=status.HTTP_201_CREATED)
+async def redeem_referral(
+    payload: RedeemRequest,
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> ReferralGrantResponse:
+    """Redeem a referral code and credit both parties.
+
+    Refusals are 400s with a ``REFERRAL-*`` error code (see
+    ``utils/exceptions.py``); they are deliberately uniform so probing a code
+    reveals nothing about whether it exists or who owns it.
+
+    Args:
+        payload: The submitted code.
+        user: Authenticated session user (the invitee).
+        db: Database session.
+
+    Returns:
+        The created grant.
+    """
+    _require_enabled()
+    service = ReferralService(db)
+    grant = await service.redeem(referred_user_id=user["user_id"], code=payload.code)
+    return ReferralGrantResponse(
+        id=str(grant.id),
+        granted_at=grant.granted_at,
+        referrer_bonus_memories=grant.referrer_bonus_memories,
+        referred_bonus_memories=grant.referred_bonus_memories,
+        revoked_at=grant.revoked_at,
+    )

--- a/backend/src/api/routes/referrals.py
+++ b/backend/src/api/routes/referrals.py
@@ -27,8 +27,6 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/referrals", tags=["referrals"])
-
 
 def _require_enabled() -> None:
     """404 the whole surface when the program is switched off for this deployment."""
@@ -37,6 +35,18 @@ def _require_enabled() -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Referral program is not enabled",
         )
+
+
+# Declared as a ROUTER-level dependency, listed first, so it is evaluated before
+# the per-route auth dependency. As an in-body call it ran *after* auth, which
+# meant an unauthenticated caller got 401 while an authenticated one got 404 —
+# i.e. the "the whole surface is absent" contract silently only held for
+# logged-in users, and the 401/404 split advertised the endpoint's existence.
+router = APIRouter(
+    prefix="/referrals",
+    tags=["referrals"],
+    dependencies=[Depends(_require_enabled)],
+)
 
 
 class ReferralSummaryResponse(BaseModel):
@@ -91,7 +101,6 @@ async def get_my_referral(
     Returns:
         The caller's referral summary.
     """
-    _require_enabled()
     service = ReferralService(db)
     summary = await service.get_summary(user["user_id"])
     return ReferralSummaryResponse(
@@ -125,7 +134,6 @@ async def redeem_referral(
     Returns:
         The created grant.
     """
-    _require_enabled()
     service = ReferralService(db)
     grant = await service.redeem(referred_user_id=user["user_id"], code=payload.code)
     return ReferralGrantResponse(

--- a/backend/src/api/routes/referrals.py
+++ b/backend/src/api/routes/referrals.py
@@ -29,12 +29,16 @@ logger = get_logger(__name__)
 
 
 def _require_enabled() -> None:
-    """404 the whole surface when the program is switched off for this deployment."""
+    """404 the whole surface when the program is switched off for this deployment.
+
+    The detail is Starlette's default ``"Not Found"`` string, deliberately: a
+    feature-specific message ("referral program is not enabled") would make the
+    route distinguishable from one that does not exist at all, which is the same
+    enumeration leak the uniform ``REFERRAL-001`` refusals close. The reason the
+    deployment said no belongs in the operator's config, not in the response.
+    """
     if not get_settings().enable_referrals:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Referral program is not enabled",
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not Found")
 
 
 # Declared as a ROUTER-level dependency, listed first, so it is evaluated before

--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -135,6 +135,11 @@ async def system_info():
             # the connectors UI hides the BYO manual-bind form and stops
             # requiring a per-connector LLM (the shared worker provides it).
             "managed_connectors": settings.enable_managed_connectors,
+            # Issue #1470: default-off. When false the referral endpoints 404
+            # and the web UI hides the invite card. Only the deployment-level
+            # availability is exposed here — never the reward amounts, which
+            # would tell a farmer exactly what a fresh account is worth.
+            "referrals": settings.enable_referrals,
         },
     }
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -15,6 +15,19 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from utils.media_types import MEDIA_TYPE_RE, normalize_media_type
 
+# Issue #1470: the total memory quota one inviter's referral chain may mint.
+#
+# Derived from the FREE -> BASIC memory gap: ``PLAN_BASIC.memory_limit (10000) -
+# PLAN_FREE.memory_limit (1000)``. If a fully-used referral chain could close
+# that gap, the referral program would BE the paid tier, for free.
+#
+# Hardcoded rather than imported from ``config.plan_tiers`` because that module
+# calls ``get_settings()`` at import time (``_apply_settings_overrides``), so
+# importing it here would be circular. The coupling is instead pinned by
+# ``tests/api/test_referrals.py::test_payout_budget_matches_the_free_to_basic_gap``,
+# which fails if the tier values move and this constant does not.
+REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES = 9000
+
 
 def _validate_handoff_base_url(value: str) -> str:
     """Validate/normalize the optional billing handoff base URL (#1118).
@@ -510,6 +523,63 @@ class Settings(BaseSettings):
             "paths. Surfaced to the frontend via GET /api/v1/system/info features.byok."
         ),
     )
+    enable_referrals: bool = Field(
+        default=False,
+        description=(
+            "Enable the referral program (#1470) — a user invites another user "
+            "and both sides earn a memory-quota bonus. OFF by default: it mints "
+            "entitlement, so it must be an explicit opt-in for OSS / self-hosted. "
+            "This is also the KILL SWITCH: flipping it false stops all new "
+            "redemptions (already-granted bonuses are unaffected and are reversed "
+            "individually via the admin revoke endpoint). Surfaced to the frontend "
+            "via GET /api/v1/system/info features.referrals."
+        ),
+    )
+    # Issue #1470: referral reward tuning. The ``le=`` bounds are the first
+    # safety rail — an operator typo becomes a fail-closed startup error rather
+    # than a payout incident. They are NOT sufficient on their own: per-field
+    # bounds cannot express a *product* constraint, and the product of these
+    # ceilings (10 x 2000 = 20000) would blow past the FREE -> BASIC memory gap.
+    # ``_validate_referral_payout_budget`` below is the guard that actually
+    # holds the tier ladder; see REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES.
+    #
+    # The referrer and referee amounts are SEPARATE fields on purpose — setting
+    # the referrer side to 0 during an abuse burst removes the farming incentive
+    # while the onboarding gift keeps working, which a single on/off flag cannot
+    # express.
+    referral_referee_reward_memories: int = Field(
+        default=500,
+        ge=0,
+        le=2000,
+        description="Memory-quota bonus granted to the invited user on redemption (#1470).",
+    )
+    referral_referrer_reward_memories: int = Field(
+        default=500,
+        ge=0,
+        le=2000,
+        description="Memory-quota bonus granted to the inviter per successful referral (#1470).",
+    )
+    referral_max_grants_per_referrer: int = Field(
+        default=3,
+        ge=0,
+        le=10,
+        description=(
+            "Lifetime cap on successful referrals per inviter (#1470). Launched at "
+            "3 rather than 5 because raising the cap is non-breaking while lowering "
+            "it strands users who already earned the higher slots."
+        ),
+    )
+    referral_redeem_window_hours: int = Field(
+        default=72,
+        ge=1,
+        le=720,
+        description=(
+            "How long after signup a user may redeem a referral code (#1470). This "
+            "is the 'is this genuinely a new user' check: it is cheap, observable "
+            "from users.created_at, and it stops an established account from "
+            "redeeming a code long after the fact."
+        ),
+    )
     enable_managed_connectors: bool = Field(
         default=False,
         description=(
@@ -963,6 +1033,41 @@ class Settings(BaseSettings):
                     "(ISO 8601 timestamp when ops accepted the Resend DPA — "
                     "see https://resend.com/legal/dpa)"
                 )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_referral_payout_budget(self) -> "Settings":
+        """Fail-fast when the referral config could close the FREE -> BASIC gap (#1470).
+
+        The per-field ``le=`` bounds cannot express this: they bound each knob
+        independently, but the thing that matters is the PRODUCT
+        ``max_grants x reward``. At the individual ceilings that product reaches
+        10 x 2000 = 20000, more than double the 9000-memory gap — i.e. an
+        operator could hand out the paid tier for free without ever exceeding a
+        single field's bound.
+
+        Checked against the larger of the two reward sides because a chain pays
+        the referrer once per referral; bounding on the max keeps the guard
+        correct no matter which side is set higher.
+
+        Only enforced when the program is enabled, so an OSS deployment that
+        never turns referrals on is not forced to keep the numbers coherent.
+        """
+        if not self.enable_referrals:
+            return self
+        worst_case = self.referral_max_grants_per_referrer * max(
+            self.referral_referrer_reward_memories,
+            self.referral_referee_reward_memories,
+        )
+        if worst_case > REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES:
+            raise ValueError(
+                "Referral config would mint up to "
+                f"{worst_case} memories per inviter, above the "
+                f"{REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES}-memory budget "
+                "(the FREE->BASIC gap). Lower REFERRAL_MAX_GRANTS_PER_REFERRER "
+                "or the reward amounts — otherwise a fully-used referral chain "
+                "hands out the paid tier for free."
+            )
         return self
 
     @model_validator(mode="after")

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -1046,18 +1046,21 @@ class Settings(BaseSettings):
         operator could hand out the paid tier for free without ever exceeding a
         single field's bound.
 
-        Checked against the larger of the two reward sides because a chain pays
-        the referrer once per referral; bounding on the max keeps the guard
-        correct no matter which side is set higher.
+        The formula counts what actually accrues to ONE workspace, which is what
+        ``ReferralService._recompute_workspace_bonus`` sums: a user is the
+        referee at most once (``UNIQUE(referred_user_id)``) and the referrer up
+        to ``max_grants`` times. Using ``max(referrer, referee)`` instead would
+        undercount by a whole referee reward and let an in-bounds config close
+        the gap anyway.
 
         Only enforced when the program is enabled, so an OSS deployment that
         never turns referrals on is not forced to keep the numbers coherent.
         """
         if not self.enable_referrals:
             return self
-        worst_case = self.referral_max_grants_per_referrer * max(
-            self.referral_referrer_reward_memories,
-            self.referral_referee_reward_memories,
+        worst_case = (
+            self.referral_max_grants_per_referrer * self.referral_referrer_reward_memories
+            + self.referral_referee_reward_memories
         )
         if worst_case > REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES:
             raise ValueError(

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -1062,10 +1062,14 @@ class Settings(BaseSettings):
             self.referral_max_grants_per_referrer * self.referral_referrer_reward_memories
             + self.referral_referee_reward_memories
         )
-        if worst_case > REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES:
+        # EXCLUSIVE bound: the budget IS the gap, so equality means a
+        # fully-used chain lands exactly ON the BASIC limit — the paid tier,
+        # for free. ">=" is what makes "cannot reach BASIC" true rather than
+        # "cannot exceed BASIC".
+        if worst_case >= REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES:
             raise ValueError(
                 "Referral config would mint up to "
-                f"{worst_case} memories per inviter, above the "
+                f"{worst_case} memories per inviter, reaching the "
                 f"{REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES}-memory budget "
                 "(the FREE->BASIC gap). Lower REFERRAL_MAX_GRANTS_PER_REFERRER "
                 "or the reward amounts — otherwise a fully-used referral chain "

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -16,6 +16,7 @@ import models.llm_call_log  # noqa: F401  # Issue #474: comprehensive call ledge
 import models.llm_pricing  # noqa: F401
 import models.measurement  # noqa: F401  # Issue #1333: HOW-MUCH measurement lane
 import models.memory_access_event  # noqa: F401  # Issue #1278: agent access audit (P0-5)
+import models.referral  # noqa: F401  # Issue #1470: referral program ledger
 import models.retrieval_feedback  # noqa: F401  # Issue #888: retrieval feedback signal
 import models.secrets  # noqa: F401  # Issue #1128: zero-knowledge secret store
 import models.sleep  # noqa: F401

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -154,6 +154,16 @@ class User(Base):
         Integer, nullable=False, default=0, server_default="0"
     )
 
+    # Issue #1470: the user's shareable referral code. Lazily minted on the
+    # first GET /referrals/me (``secrets.token_urlsafe``), so there is no
+    # backfill and users who never open the page never get a row update.
+    # Deliberately NOT ``user_id``: that column holds the OAuth ``sub`` claim,
+    # which is the primary auth identifier for sessions, API keys and MCP auth
+    # and must never appear in a URL the user is encouraged to share.
+    referral_code: Mapped[str | None] = mapped_column(
+        String(24), nullable=True, unique=True, index=True
+    )
+
     # Relationships
     current_workspace: Mapped["Workspace | None"] = relationship(
         "Workspace", foreign_keys=[current_workspace_id]
@@ -1578,6 +1588,36 @@ class Workspace(Base):
         Integer, nullable=False, server_default="0"
     )  # Spec 2026-06-02: extra ai-worker connector seats addon
 
+    # Issue #1470: memory-quota bonus earned through the referral program.
+    #
+    # DO NOT add this column to any of the three addon collections:
+    #   - ``internal_billing._ADDON_COLUMNS``
+    #   - ``admin_plans._ADDON_FIELD_SPECS``
+    #   - ``AddonCalculatorService.recalculate_workspace_bonuses``'s bonuses dict
+    #
+    # It is deliberately named WITHOUT the ``addon_`` prefix and kept outside
+    # that machinery, because each of those paths would destroy it:
+    #   1. ``internal_billing.py`` zeroes every column in ``_ADDON_COLUMNS`` on
+    #      any billing push that carries ``addons`` (full-replace semantics).
+    #      Billing knows nothing about referrals, so the reward would silently
+    #      evaporate at the exact moment a referred user converts to paid.
+    #   2. ``addon_*`` columns are a CACHE of ``SUM(WorkspaceAddon.quantity x
+    #      unit_value)`` and are rewritten with that absolute value on every
+    #      recalc; a referral-written value with no backing ``WorkspaceAddon``
+    #      row is reset to 0 and reported as drift by
+    #      ``GET /admin/plans/addon-cache-consistency``. (#665 fixed exactly
+    #      this bug for admin grants — see ``admin_plans.py`` cmd_deploy notes.)
+    #   3. ``ADDON_UNIT_VALUES["extra_memory"]`` is 10000 and the admin quota
+    #      PUT rejects non-multiples, so the reward amount is not even
+    #      expressible through that path.
+    #
+    # This column's own source of truth is the ``referral_grants`` ledger; it is
+    # recomputed as an absolute SUM over non-revoked rows, never incremented.
+    # ``tests/api/test_referral_addon_isolation.py`` guards the three absences.
+    referral_memory_bonus: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )  # Issue #1470
+
     # Issue #1095: provenance of the current entitlement. ``admin_grant`` (default)
     # = locally-owned, protected from the external billing reconciler;
     # ``external_billing`` = billing-owned, reconcilable. See the module-level
@@ -1619,8 +1659,22 @@ class Workspace(Base):
 
     @property
     def effective_memory_limit(self) -> int:
-        """Memory limit including addon bonus."""
-        return _zero_floor(self._plan_tier.memory_limit, self.addon_memory_bonus)
+        """Memory limit including addon bonus and the referral bonus (#1470).
+
+        The two bonuses are summed *before* ``_zero_floor`` so the zero-base
+        guard still applies to the total: a tier with ``memory_limit == 0``
+        cannot be lifted above 0 by a referral any more than by an addon.
+
+        Each operand is coalesced individually rather than relying on
+        ``_zero_floor``'s single ``or 0``: both columns are ``nullable=False``
+        with ``server_default="0"``, but a transient (unflushed) ORM object can
+        still carry ``None``, and ``None + 0`` raises before the helper is ever
+        reached.
+        """
+        return _zero_floor(
+            self._plan_tier.memory_limit,
+            (self.addon_memory_bonus or 0) + (self.referral_memory_bonus or 0),
+        )
 
     @property
     def effective_mcp_calls_per_day(self) -> int:
@@ -1815,6 +1869,12 @@ class Workspace(Base):
             f"entitlement_source IN ({', '.join(repr(s) for s in ENTITLEMENT_SOURCES)})",
             name="valid_entitlement_source",
         ),
+        # Issue #1470: keep the ORM CHECK in lockstep with alembic e76_1470 so
+        # ``Base.metadata.create_all()``-built schemas (used by some tests)
+        # reject a negative referral bonus too. Mirrors the
+        # ``workspace_slot_bonus_nonneg`` precedent; tests/test_schema_drift.py
+        # verifies the SQL text matches the migration's ADD CONSTRAINT.
+        CheckConstraint("referral_memory_bonus >= 0", name="referral_memory_bonus_nonneg"),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -87,6 +87,13 @@ OPERATIONAL_TABLES: frozenset[str] = frozenset(
         "workspace_members",
         "workspace_invitations",
         "workspace_addons",
+        # Referral payout ledger (#1470) — entitlement plumbing in the same
+        # family as workspace_addons / plan_changes: it records how much quota
+        # was granted and why, not anything the user authored and nothing the
+        # system learned. Erasure NULLs its user FKs (ON DELETE SET NULL) so the
+        # row survives as an anonymous accounting record; that is deliberate, and
+        # it is why the table needs no entry in account_erasure_service's sweep.
+        "referral_grants",
         "workspace_connectors",
         # Global external-app verification control plane (#1315). Contains
         # Fernet ciphertext and lifecycle metadata, never user-authored memory.

--- a/backend/src/models/referral.py
+++ b/backend/src/models/referral.py
@@ -1,0 +1,147 @@
+"""Referral program models (Issue #1470).
+
+A referral is user-scoped and deliberately separate from ``WorkspaceInvitation``
+(``models/auth.py``), which is a Pro-only *team member* invite requiring at least
+one shared context. Free users cannot send those at all
+(``plan_tiers.py`` ``max_members_per_workspace == 1`` on FREE/BASIC), which is
+precisely the audience a growth referral has to reach.
+
+``ReferralGrant`` is the **ledger** — the authoritative record of every payout.
+``Workspace.referral_memory_bonus`` is a derived cache recomputed as the absolute
+SUM over this table's non-revoked rows, never incremented in place. That contract
+is what makes the grant idempotent (a retried redemption converges on the same
+value) and reversible (revoke + recompute subtracts exactly what was added).
+
+The applied amounts are **snapshotted per row** rather than read from config at
+display time. This is what decouples the tunable reward from history: lowering
+``settings.referral_referee_reward_memories`` can never retro-shrink a limit a
+user is already storing against, and a revoke always subtracts the amount that
+was actually granted.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+# Kept in lockstep with the alembic e76_1470 migration literals. tests/test_schema_drift.py
+# compares the SQL text of every named CheckConstraint against the migration's, so these
+# strings must stay byte-identical to the ones in the migration file.
+CK_NOT_SELF = (
+    "referrer_user_id IS NULL OR referred_user_id IS NULL OR referrer_user_id <> referred_user_id"
+)
+CK_BONUS_NONNEG = "referrer_bonus_memories >= 0 AND referred_bonus_memories >= 0"
+
+
+class ReferralGrant(Base):
+    """One successful referral: who referred whom, and what each side was paid.
+
+    Idempotency is enforced by the database, not by application logic:
+    ``uq_referral_grants_referred_user`` means a given user can be referred at
+    most once, ever. The redemption path is a single
+    ``INSERT ... ON CONFLICT DO NOTHING RETURNING id`` — a retried request, a
+    duplicated submit, or two concurrent redemptions all insert zero rows and
+    pay zero. PostgreSQL treats NULLs as distinct in a UNIQUE index, so rows
+    whose ``referred_user_id`` has been NULLed by account erasure do not block
+    anything.
+
+    All four FKs are ``ON DELETE SET NULL`` on purpose:
+
+    - Account erasure (``services/account_erasure_service.py``) enumerates the
+      tables it sweeps explicitly. SET NULL means this table needs no new entry
+      there — the row survives as an anonymous audit record.
+    - Erasing an invitee must NOT retroactively void the referrer's earned
+      quota. The cache is recomputed from non-revoked rows and the amounts are
+      snapshotted on the row, so a NULLed counterparty leaves the payout intact.
+
+    Attributes:
+        id: Primary key (UUID).
+        referrer_user_id: The inviter's user ID (OAuth sub). NULL after erasure.
+        referrer_workspace_id: Workspace credited on the inviter's side. NULL
+            means "earned but not yet applied" — see ``referred_workspace_id``.
+        referred_user_id: The invitee's user ID. NULL after erasure. Carries the
+            uniqueness constraint that makes payout idempotent.
+        referred_workspace_id: Workspace credited on the invitee's side. NULL
+            when no owned workspace could be resolved at redemption time —
+            ``api/routes/auth.py`` skips personal-workspace creation entirely
+            when a user has pending team invitations, so this genuinely happens.
+            The grant is recorded anyway and applied on the next resolution.
+        referrer_bonus_memories: Amount applied to the referrer, snapshotted.
+        referred_bonus_memories: Amount applied to the referee, snapshotted.
+        granted_at: When the referral was redeemed.
+        revoked_at: Set by an admin revoke; excludes the row from the cache SUM.
+        revoked_reason: Required free text supplied by the revoking admin.
+    """
+
+    __tablename__ = "referral_grants"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+
+    referrer_user_id: Mapped[str | None] = mapped_column(
+        String(255),
+        ForeignKey("users.user_id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    referrer_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    referred_user_id: Mapped[str | None] = mapped_column(
+        String(255),
+        ForeignKey("users.user_id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    referred_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+
+    referrer_bonus_memories: Mapped[int] = mapped_column(Integer, nullable=False)
+    referred_bonus_memories: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    granted_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), index=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    revoked_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        # THE idempotency key. Postgres allows multiple NULLs in a UNIQUE index,
+        # so erased referees never collide.
+        UniqueConstraint("referred_user_id", name="uq_referral_grants_referred_user"),
+        CheckConstraint(CK_NOT_SELF, name="ck_referral_grants_not_self"),
+        CheckConstraint(CK_BONUS_NONNEG, name="ck_referral_grants_bonus_nonneg"),
+        Index("ix_referral_grants_referrer_active", "referrer_user_id", "revoked_at"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ReferralGrant(id='{self.id}', referrer='{self.referrer_user_id}', "
+            f"referred='{self.referred_user_id}')>"
+        )

--- a/backend/src/services/downgrade_eligibility_service.py
+++ b/backend/src/services/downgrade_eligibility_service.py
@@ -262,7 +262,14 @@ class DowngradeEligibilityService:
         check(
             DowngradeDimension.MEMORIES,
             usage.memories,
-            _zero_floor(tier.memory_limit, workspace.addon_memory_bonus),
+            # #1470: must mirror ``Workspace.effective_memory_limit`` exactly —
+            # the referral bonus survives a plan change (it is locally-owned,
+            # not billing-derived), so omitting it here would tell the user to
+            # delete memories they are still entitled to keep.
+            _zero_floor(
+                tier.memory_limit,
+                (workspace.addon_memory_bonus or 0) + (workspace.referral_memory_bonus or 0),
+            ),
             DowngradeCleanup.DELETE_MEMORIES,
         )
         # Resource tokens are tier-fixed (no addon → effective == base).

--- a/backend/src/services/referral_service.py
+++ b/backend/src/services/referral_service.py
@@ -1,0 +1,456 @@
+"""Referral program service (Issue #1470).
+
+Design contract, in one paragraph: ``referral_grants`` is the ledger and
+``Workspace.referral_memory_bonus`` is a derived cache. The cache is **never
+incremented** — it is recomputed as the absolute SUM of non-revoked ledger rows
+for that workspace. That single rule buys three properties at once:
+
+- **Idempotent.** Running the recompute twice, or in either order across the two
+  affected workspaces, converges on the same value.
+- **Reversible.** Revoke sets ``revoked_at`` and recomputes; the bonus drops by
+  exactly what that row contributed, never by whatever the config happens to say
+  today.
+- **Non-retroactive.** The applied amounts are snapshotted onto the row at grant
+  time, so lowering ``settings.referral_referee_reward_memories`` cannot
+  retro-shrink a limit a user is already storing against.
+
+The same rule is why the reward does not live in ``ADDON_UNIT_VALUES``: that
+constant *is* a re-valuing multiplier, and changing it would silently re-price
+every existing grant on the next recalc.
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, cast
+
+from sqlalchemy import CursorResult, func, select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.settings import get_settings
+from models.auth import User, Workspace
+from models.referral import ReferralGrant
+from utils.datetime import utcnow
+from utils.exceptions import (
+    ReferralAlreadyRedeemedError,
+    ReferralCapReachedError,
+    ReferralCodeInvalidError,
+    ReferralSelfError,
+    ReferralWindowClosedError,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# 12 bytes of entropy -> 16 URL-safe characters, comfortably inside the
+# VARCHAR(24) column. Sized to be pasteable and to make guessing a live code
+# pointless (2^96), since a valid code is the only thing standing between an
+# attacker and knowing that some account exists.
+_REFERRAL_CODE_BYTES = 12
+_MAX_CODE_MINT_ATTEMPTS = 5
+
+
+@dataclass(frozen=True)
+class ReferralSummary:
+    """What a user sees about their own referral standing."""
+
+    code: str
+    max_grants: int
+    used_grants: int
+    referee_reward_memories: int
+    referrer_reward_memories: int
+    earned_memories: int
+
+
+class ReferralService:
+    """Mint referral codes, redeem them idempotently, and revoke grants."""
+
+    def __init__(self, db: AsyncSession):
+        """Initialize.
+
+        Args:
+            db: Async database session.
+        """
+        self.db = db
+        self.settings = get_settings()
+
+    # ------------------------------------------------------------------
+    # Codes
+    # ------------------------------------------------------------------
+
+    async def get_or_create_referral_code(self, user_id: str) -> str:
+        """Return the user's referral code, minting one on first use.
+
+        Lazily minted rather than backfilled so the migration stays additive and
+        users who never open the invite page never get a row update.
+
+        Args:
+            user_id: The user's OAuth ``sub``.
+
+        Returns:
+            The user's referral code.
+
+        Raises:
+            ReferralCodeInvalidError: If the user does not exist.
+            RuntimeError: If a unique code could not be minted (astronomically
+                unlikely; surfaced rather than looped forever).
+        """
+        user = await self.db.scalar(select(User).where(User.user_id == user_id))
+        if user is None:
+            raise ReferralCodeInvalidError()
+        if user.referral_code:
+            return user.referral_code
+
+        # Retry on the UNIQUE index rather than pre-checking: the pre-check
+        # would be racy anyway, and the index is the authority.
+        for _ in range(_MAX_CODE_MINT_ATTEMPTS):
+            candidate = secrets.token_urlsafe(_REFERRAL_CODE_BYTES)
+            result = await self.db.execute(
+                update(User)
+                .where(User.user_id == user_id, User.referral_code.is_(None))
+                .values(referral_code=candidate)
+                .returning(User.referral_code)
+            )
+            minted = result.scalar_one_or_none()
+            if minted:
+                await self.db.commit()
+                return minted
+            # Either someone else minted concurrently (re-read wins) or the
+            # candidate collided. Re-read before deciding.
+            await self.db.rollback()
+            existing = await self.db.scalar(
+                select(User.referral_code).where(User.user_id == user_id)
+            )
+            if existing:
+                return existing
+
+        raise RuntimeError(f"Could not mint a unique referral code for user {user_id}")
+
+    # ------------------------------------------------------------------
+    # Redemption
+    # ------------------------------------------------------------------
+
+    async def redeem(self, *, referred_user_id: str, code: str) -> ReferralGrant:
+        """Redeem ``code`` on behalf of ``referred_user_id`` and pay both sides.
+
+        The whole method is a single transaction. The cap check takes a row lock
+        on the referrer so two concurrent redemptions of the same code cannot
+        both observe "one slot left"; the payout itself is guarded by
+        ``uq_referral_grants_referred_user`` so a retry pays zero regardless.
+
+        Args:
+            referred_user_id: The redeeming (invited) user's OAuth ``sub``.
+            code: The referral code they were given.
+
+        Returns:
+            The created :class:`ReferralGrant`.
+
+        Raises:
+            ReferralCodeInvalidError: Code does not resolve to a user.
+            ReferralSelfError: The code belongs to the redeeming user.
+            ReferralWindowClosedError: The account is older than the redeem window.
+            ReferralCapReachedError: The referrer has no slots left.
+            ReferralAlreadyRedeemedError: This user was already referred.
+        """
+        referee = await self.db.scalar(select(User).where(User.user_id == referred_user_id))
+        if referee is None:
+            raise ReferralCodeInvalidError()
+
+        normalized = (code or "").strip()
+        if not normalized:
+            raise ReferralCodeInvalidError()
+
+        referrer_id = await self.db.scalar(
+            select(User.user_id).where(User.referral_code == normalized)
+        )
+        if referrer_id is None:
+            raise ReferralCodeInvalidError()
+        if referrer_id == referred_user_id:
+            raise ReferralSelfError()
+
+        self._assert_within_redeem_window(referee)
+
+        # Lock the referrer row for the duration of the cap check + insert. No
+        # lock-ordering hazard: this is the only row lock the redemption path
+        # takes.
+        await self.db.execute(
+            select(User.user_id).where(User.user_id == referrer_id).with_for_update()
+        )
+
+        used = await self._count_active_grants(referrer_id)
+        if used >= self.settings.referral_max_grants_per_referrer:
+            raise ReferralCapReachedError()
+
+        referrer_workspace_id = await self._resolve_owned_workspace_id(referrer_id)
+        referred_workspace_id = await self._resolve_owned_workspace_id(referred_user_id)
+
+        stmt = (
+            pg_insert(ReferralGrant)
+            .values(
+                referrer_user_id=referrer_id,
+                referrer_workspace_id=referrer_workspace_id,
+                referred_user_id=referred_user_id,
+                referred_workspace_id=referred_workspace_id,
+                referrer_bonus_memories=self.settings.referral_referrer_reward_memories,
+                referred_bonus_memories=self.settings.referral_referee_reward_memories,
+                granted_at=utcnow(),
+            )
+            .on_conflict_do_nothing(constraint="uq_referral_grants_referred_user")
+            .returning(ReferralGrant.id)
+        )
+        grant_id = await self.db.scalar(stmt)
+        if grant_id is None:
+            # Zero rows inserted => this user already has a grant. Nothing was
+            # paid, so there is nothing to roll back.
+            raise ReferralAlreadyRedeemedError()
+
+        for workspace_id in (referrer_workspace_id, referred_workspace_id):
+            await self._recompute_workspace_bonus(workspace_id)
+
+        await self.db.commit()
+
+        logger.info(
+            "referral_redeemed",
+            grant_id=str(grant_id),
+            referrer_user_id=referrer_id,
+            referred_user_id=referred_user_id,
+            referrer_workspace_id=str(referrer_workspace_id) if referrer_workspace_id else None,
+            referred_workspace_id=str(referred_workspace_id) if referred_workspace_id else None,
+        )
+
+        grant = await self.db.get(ReferralGrant, grant_id)
+        if grant is None:  # pragma: no cover - just inserted in this transaction
+            raise ReferralAlreadyRedeemedError()
+        return grant
+
+    def _assert_within_redeem_window(self, referee: User) -> None:
+        """Reject redemption by an account older than the configured window.
+
+        This is the "is this genuinely a new user" check. It is deliberately
+        based on ``users.created_at`` rather than on any behavioural signal:
+        it is observable with no extra query, and it stops an established
+        account from being farmed for a code long after signup.
+        """
+        window_hours = self.settings.referral_redeem_window_hours
+        if referee.created_at is None:
+            return
+        if utcnow() - referee.created_at > timedelta(hours=window_hours):
+            raise ReferralWindowClosedError(window_hours=window_hours)
+
+    async def _count_active_grants(self, referrer_user_id: str) -> int:
+        """Count non-revoked grants attributed to a referrer."""
+        return (
+            await self.db.scalar(
+                select(func.count(ReferralGrant.id)).where(
+                    ReferralGrant.referrer_user_id == referrer_user_id,
+                    ReferralGrant.revoked_at.is_(None),
+                )
+            )
+            or 0
+        )
+
+    async def _resolve_owned_workspace_id(self, user_id: str) -> uuid.UUID | None:
+        """Return the user's oldest live OWNED workspace, or ``None``.
+
+        Deliberately not ``users.current_workspace_id``: that column is mutable
+        and can point at a workspace the user merely belongs to, which would
+        gift quota to somebody else's workspace.
+
+        ``None`` is a legitimate outcome, not an error. ``api/routes/auth.py``
+        skips personal-workspace creation entirely when the user has pending
+        team invitations, so a brand-new referee may genuinely own nothing yet.
+        The grant is still recorded; it is applied by
+        :meth:`apply_pending_grants` once a workspace exists.
+        """
+        return await self.db.scalar(
+            select(Workspace.id)
+            .where(
+                Workspace.owner_user_id == user_id,
+                Workspace.deleted_at.is_(None),
+            )
+            .order_by(Workspace.created_at.asc())
+            .limit(1)
+        )
+
+    async def _recompute_workspace_bonus(self, workspace_id: uuid.UUID | None) -> None:
+        """Rewrite ``referral_memory_bonus`` as the absolute SUM of live grants.
+
+        Absolute, never incremental — see the module docstring. A workspace with
+        no grants converges to 0, which is also how revocation takes effect.
+        """
+        if workspace_id is None:
+            return
+
+        referrer_total = func.coalesce(
+            func.sum(ReferralGrant.referrer_bonus_memories).filter(
+                ReferralGrant.referrer_workspace_id == workspace_id
+            ),
+            0,
+        )
+        referred_total = func.coalesce(
+            func.sum(ReferralGrant.referred_bonus_memories).filter(
+                ReferralGrant.referred_workspace_id == workspace_id
+            ),
+            0,
+        )
+        total = await self.db.scalar(
+            select(referrer_total + referred_total).where(
+                ReferralGrant.revoked_at.is_(None),
+                (ReferralGrant.referrer_workspace_id == workspace_id)
+                | (ReferralGrant.referred_workspace_id == workspace_id),
+            )
+        )
+        await self.db.execute(
+            update(Workspace)
+            .where(Workspace.id == workspace_id)
+            .values(referral_memory_bonus=int(total or 0))
+        )
+
+    async def apply_pending_grants(self, user_id: str) -> int:
+        """Attach a workspace to this user's grants that were recorded without one.
+
+        Called after workspace creation. Grants earned while the user owned no
+        workspace (pending team invitations suppress personal-workspace
+        bootstrap) would otherwise stay invisible forever.
+
+        Args:
+            user_id: The user whose grants should be re-resolved.
+
+        Returns:
+            Number of grant rows updated.
+        """
+        workspace_id = await self._resolve_owned_workspace_id(user_id)
+        if workspace_id is None:
+            return 0
+
+        updated = 0
+        for user_col, workspace_col in (
+            (ReferralGrant.referrer_user_id, ReferralGrant.referrer_workspace_id),
+            (ReferralGrant.referred_user_id, ReferralGrant.referred_workspace_id),
+        ):
+            result = await self.db.execute(
+                update(ReferralGrant)
+                .where(
+                    user_col == user_id,
+                    workspace_col.is_(None),
+                    ReferralGrant.revoked_at.is_(None),
+                )
+                .values({workspace_col.key: workspace_id})
+            )
+            # ``AsyncSession.execute`` is typed as returning ``Result``, which has
+            # no ``rowcount``; a DML statement always yields a ``CursorResult`` at
+            # runtime. Narrow explicitly rather than suppressing the diagnostic.
+            updated += cast(CursorResult[Any], result).rowcount or 0
+
+        if updated:
+            await self._recompute_workspace_bonus(workspace_id)
+            await self.db.commit()
+            logger.info(
+                "referral_pending_grants_applied",
+                user_id=user_id,
+                workspace_id=str(workspace_id),
+                grants_applied=updated,
+            )
+        return updated
+
+    # ------------------------------------------------------------------
+    # Read models
+    # ------------------------------------------------------------------
+
+    async def get_summary(self, user_id: str) -> ReferralSummary:
+        """Build the user-facing referral summary, minting a code if needed."""
+        code = await self.get_or_create_referral_code(user_id)
+        used = await self._count_active_grants(user_id)
+        earned = (
+            await self.db.scalar(
+                select(func.coalesce(func.sum(ReferralGrant.referrer_bonus_memories), 0)).where(
+                    ReferralGrant.referrer_user_id == user_id,
+                    ReferralGrant.revoked_at.is_(None),
+                )
+            )
+            or 0
+        )
+        return ReferralSummary(
+            code=code,
+            max_grants=self.settings.referral_max_grants_per_referrer,
+            used_grants=used,
+            referee_reward_memories=self.settings.referral_referee_reward_memories,
+            referrer_reward_memories=self.settings.referral_referrer_reward_memories,
+            earned_memories=int(earned),
+        )
+
+    async def list_grants(
+        self,
+        *,
+        referrer_user_id: str | None = None,
+        include_revoked: bool = True,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> tuple[list[ReferralGrant], int]:
+        """List ledger rows, newest first, with a total count.
+
+        Args:
+            referrer_user_id: Restrict to one referrer (the admin filter).
+            include_revoked: When False, hide revoked rows.
+            limit: Page size.
+            offset: Page offset.
+
+        Returns:
+            ``(rows, total)``.
+        """
+        filters = []
+        if referrer_user_id is not None:
+            filters.append(ReferralGrant.referrer_user_id == referrer_user_id)
+        if not include_revoked:
+            filters.append(ReferralGrant.revoked_at.is_(None))
+
+        total = (await self.db.scalar(select(func.count(ReferralGrant.id)).where(*filters))) or 0
+        rows = list(
+            await self.db.scalars(
+                select(ReferralGrant)
+                .where(*filters)
+                .order_by(ReferralGrant.granted_at.desc())
+                .limit(limit)
+                .offset(offset)
+            )
+        )
+        return rows, total
+
+    # ------------------------------------------------------------------
+    # Revocation
+    # ------------------------------------------------------------------
+
+    async def revoke(self, *, grant_id: uuid.UUID, reason: str) -> ReferralGrant | None:
+        """Revoke a grant and recompute both sides' bonuses.
+
+        Idempotent: revoking an already-revoked grant leaves ``revoked_at``
+        untouched and still returns the row, so an admin retry is harmless.
+
+        Args:
+            grant_id: The ledger row to revoke.
+            reason: Required free text; recorded on the row and in the audit log.
+
+        Returns:
+            The grant, or ``None`` if no such row exists.
+        """
+        grant = await self.db.get(ReferralGrant, grant_id)
+        if grant is None:
+            return None
+
+        if grant.revoked_at is None:
+            grant.revoked_at = utcnow()
+            grant.revoked_reason = reason
+            await self.db.flush()
+            for workspace_id in (grant.referrer_workspace_id, grant.referred_workspace_id):
+                await self._recompute_workspace_bonus(workspace_id)
+            logger.info(
+                "referral_revoked",
+                grant_id=str(grant_id),
+                referrer_user_id=grant.referrer_user_id,
+                referred_user_id=grant.referred_user_id,
+            )
+        return grant

--- a/backend/src/services/referral_service.py
+++ b/backend/src/services/referral_service.py
@@ -37,6 +37,7 @@ from models.auth import User, Workspace
 from models.referral import ReferralGrant
 from utils.datetime import utcnow
 from utils.exceptions import (
+    NotFoundException,
     ReferralAlreadyRedeemedError,
     ReferralCapReachedError,
     ReferralCodeInvalidError,
@@ -143,13 +144,19 @@ class ReferralService:
             The user's referral code.
 
         Raises:
-            ReferralCodeInvalidError: If the user does not exist.
+            NotFoundException: If the user row does not exist.
             RuntimeError: If a unique code could not be minted (astronomically
                 unlikely; surfaced rather than looped forever).
         """
         user = await self.db.scalar(select(User).where(User.user_id == user_id))
         if user is None:
-            raise ReferralCodeInvalidError()
+            # 404, not a REFERRAL-* refusal. The caller is session-authenticated
+            # and submitted no code — a missing ``users`` row is a
+            # resource-not-found condition (an erased account with a live
+            # session), and answering "this referral code is not valid" would be
+            # a lie about a code that was never sent. Keeps the REFERRAL-* codes
+            # meaning "your redemption was refused".
+            raise NotFoundException("User", user_id)
         if user.referral_code:
             return user.referral_code
 
@@ -211,6 +218,7 @@ class ReferralService:
             The created :class:`ReferralGrant`.
 
         Raises:
+            NotFoundException: The redeeming user's own row is missing.
             ReferralCodeInvalidError: Code does not resolve to a user.
             ReferralSelfError: The code belongs to the redeeming user.
             ReferralWindowClosedError: The account is older than the redeem window.
@@ -219,7 +227,10 @@ class ReferralService:
         """
         referee = await self.db.scalar(select(User).where(User.user_id == referred_user_id))
         if referee is None:
-            raise ReferralCodeInvalidError()
+            # See get_or_create_referral_code: the redeemer's own missing row is
+            # 404, independent of whatever code they submitted. It leaks nothing
+            # about the code — it is a fact about the caller.
+            raise NotFoundException("User", referred_user_id)
 
         # Caller-state checks FIRST, before the code is ever looked up. Ordering
         # is load-bearing for the enumeration story: if the window check ran

--- a/backend/src/services/referral_service.py
+++ b/backend/src/services/referral_service.py
@@ -29,6 +29,7 @@ from typing import Any, cast
 
 from sqlalchemy import CursorResult, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config.settings import get_settings
@@ -107,21 +108,34 @@ class ReferralService:
 
         # Retry on the UNIQUE index rather than pre-checking: the pre-check
         # would be racy anyway, and the index is the authority.
+        #
+        # Each attempt runs inside a SAVEPOINT. Without one, a unique collision
+        # aborts the whole transaction and every subsequent statement fails with
+        # InFailedSQLTransactionError — i.e. the loop would look like it retries
+        # but could not. ``begin_nested`` releases the savepoint on success and
+        # rolls back only to it on IntegrityError, leaving the outer transaction
+        # (which may belong to the caller) usable.
         for _ in range(_MAX_CODE_MINT_ATTEMPTS):
             candidate = secrets.token_urlsafe(_REFERRAL_CODE_BYTES)
-            result = await self.db.execute(
-                update(User)
-                .where(User.user_id == user_id, User.referral_code.is_(None))
-                .values(referral_code=candidate)
-                .returning(User.referral_code)
-            )
-            minted = result.scalar_one_or_none()
+            try:
+                async with self.db.begin_nested():
+                    result = await self.db.execute(
+                        update(User)
+                        .where(User.user_id == user_id, User.referral_code.is_(None))
+                        .values(referral_code=candidate)
+                        .returning(User.referral_code)
+                    )
+                    minted = result.scalar_one_or_none()
+            except IntegrityError:
+                # Candidate collided with an existing code (2^96 odds) — try again.
+                continue
+
             if minted:
                 await self.db.commit()
                 return minted
-            # Either someone else minted concurrently (re-read wins) or the
-            # candidate collided. Re-read before deciding.
-            await self.db.rollback()
+
+            # Zero rows updated => the ``referral_code IS NULL`` predicate failed,
+            # i.e. a concurrent request already minted one. Re-read and use it.
             existing = await self.db.scalar(
                 select(User.referral_code).where(User.user_id == user_id)
             )
@@ -160,6 +174,12 @@ class ReferralService:
         if referee is None:
             raise ReferralCodeInvalidError()
 
+        # Caller-state checks FIRST, before the code is ever looked up. Ordering
+        # is load-bearing for the enumeration story: if the window check ran
+        # after code resolution, receiving REFERRAL-004 rather than -001 would
+        # itself prove the submitted code exists.
+        self._assert_within_redeem_window(referee)
+
         normalized = (code or "").strip()
         if not normalized:
             raise ReferralCodeInvalidError()
@@ -172,17 +192,25 @@ class ReferralService:
         if referrer_id == referred_user_id:
             raise ReferralSelfError()
 
-        self._assert_within_redeem_window(referee)
-
-        # Lock the referrer row for the duration of the cap check + insert. No
-        # lock-ordering hazard: this is the only row lock the redemption path
-        # takes.
+        # Lock the referrer row for the duration of the cap check + insert, so
+        # two invitees redeeming the same code cannot both see the last free
+        # slot. Taken before any workspace lock, and the workspace locks
+        # themselves are UUID-ordered (``_recompute_workspace_bonuses``), so the
+        # global lock order is: referrer user row, then workspaces ascending.
         await self.db.execute(
             select(User.user_id).where(User.user_id == referrer_id).with_for_update()
         )
 
         used = await self._count_active_grants(referrer_id)
         if used >= self.settings.referral_max_grants_per_referrer:
+            # Logged with the true reason; the client sees REFERRAL-001, the
+            # same code an unknown referral code returns.
+            logger.info(
+                "referral_cap_reached",
+                referrer_user_id=referrer_id,
+                referred_user_id=referred_user_id,
+                used=used,
+            )
             raise ReferralCapReachedError()
 
         referrer_workspace_id = await self._resolve_owned_workspace_id(referrer_id)
@@ -208,8 +236,7 @@ class ReferralService:
             # paid, so there is nothing to roll back.
             raise ReferralAlreadyRedeemedError()
 
-        for workspace_id in (referrer_workspace_id, referred_workspace_id):
-            await self._recompute_workspace_bonus(workspace_id)
+        await self._recompute_workspace_bonuses(referrer_workspace_id, referred_workspace_id)
 
         await self.db.commit()
 
@@ -276,14 +303,40 @@ class ReferralService:
             .limit(1)
         )
 
+    async def _recompute_workspace_bonuses(self, *workspace_ids: uuid.UUID | None) -> None:
+        """Recompute several workspaces in a deadlock-free, de-duplicated order.
+
+        Callers pass workspaces by ROLE (referrer, then referee). Locking in that
+        order deadlocks on mutual referrals: A-invites-B locks (Wa, Wb) while
+        B-invites-A locks (Wb, Wa). Sorting by UUID gives a total order shared by
+        every transaction in the system, and de-duplication avoids locking (and
+        recomputing) the same workspace twice when both sides resolve to one
+        workspace — reachable after an ownership transfer.
+        """
+        for workspace_id in sorted({w for w in workspace_ids if w is not None}):
+            await self._recompute_workspace_bonus(workspace_id)
+
     async def _recompute_workspace_bonus(self, workspace_id: uuid.UUID | None) -> None:
         """Rewrite ``referral_memory_bonus`` as the absolute SUM of live grants.
 
         Absolute, never incremental — see the module docstring. A workspace with
         no grants converges to 0, which is also how revocation takes effect.
+
+        The SELECT-then-UPDATE pair is not atomic on its own: under READ
+        COMMITTED the UPDATE's row lock serializes the write but not the SUM, so
+        two concurrent recomputes would each stamp a value computed from their
+        own pre-commit snapshot and the later commit would silently drop the
+        other's ledger change. Locking the workspace row first makes the read and
+        the write one critical section. Prefer ``_recompute_workspace_bonuses``
+        over calling this directly with more than one workspace — that wrapper
+        supplies the ordering that keeps these locks deadlock-free.
         """
         if workspace_id is None:
             return
+
+        await self.db.execute(
+            select(Workspace.id).where(Workspace.id == workspace_id).with_for_update()
+        )
 
         referrer_total = func.coalesce(
             func.sum(ReferralGrant.referrer_bonus_memories).filter(
@@ -313,9 +366,16 @@ class ReferralService:
     async def apply_pending_grants(self, user_id: str) -> int:
         """Attach a workspace to this user's grants that were recorded without one.
 
-        Called after workspace creation. Grants earned while the user owned no
-        workspace (pending team invitations suppress personal-workspace
-        bootstrap) would otherwise stay invisible forever.
+        Called after workspace creation. Two states are re-homed here:
+
+        - grants earned while the user owned NO workspace (pending team
+          invitations suppress personal-workspace bootstrap), and
+        - grants pointing at a workspace the user has since SOFT-DELETED.
+
+        The second case matters because the bonus rides on a specific workspace
+        row: without re-homing, deleting that workspace strands the grant
+        forever while ``get_summary`` keeps reporting it as earned — the user
+        sees a bonus they no longer have anywhere.
 
         Args:
             user_id: The user whose grants should be re-resolved.
@@ -327,6 +387,11 @@ class ReferralService:
         if workspace_id is None:
             return 0
 
+        # Workspaces the grant may currently point at that no longer count:
+        # soft-deleted ones. Collected as a subquery so the UPDATE stays a
+        # single statement.
+        dead_workspaces = select(Workspace.id).where(Workspace.deleted_at.is_not(None))
+
         updated = 0
         for user_col, workspace_col in (
             (ReferralGrant.referrer_user_id, ReferralGrant.referrer_workspace_id),
@@ -336,7 +401,8 @@ class ReferralService:
                 update(ReferralGrant)
                 .where(
                     user_col == user_id,
-                    workspace_col.is_(None),
+                    workspace_col.is_(None) | workspace_col.in_(dead_workspaces),
+                    workspace_col.is_not(workspace_id),
                     ReferralGrant.revoked_at.is_(None),
                 )
                 .values({workspace_col.key: workspace_id})
@@ -445,8 +511,9 @@ class ReferralService:
             grant.revoked_at = utcnow()
             grant.revoked_reason = reason
             await self.db.flush()
-            for workspace_id in (grant.referrer_workspace_id, grant.referred_workspace_id):
-                await self._recompute_workspace_bonus(workspace_id)
+            await self._recompute_workspace_bonuses(
+                grant.referrer_workspace_id, grant.referred_workspace_id
+            )
             logger.info(
                 "referral_revoked",
                 grant_id=str(grant_id),

--- a/backend/src/services/referral_service.py
+++ b/backend/src/services/referral_service.py
@@ -55,6 +55,53 @@ _REFERRAL_CODE_BYTES = 12
 _MAX_CODE_MINT_ATTEMPTS = 5
 
 
+def build_pending_grant_update(
+    user_col: Any,
+    workspace_col: Any,
+    user_id: str,
+    workspace_id: uuid.UUID,
+) -> Any:
+    """Build the UPDATE that re-homes one side of a user's unresolved grants.
+
+    Extracted from :meth:`ReferralService.apply_pending_grants` so the emitted
+    SQL is assertable without a live database — see
+    ``tests/api/test_referrals.py::TestPendingGrantSQL``. The predicate mixes
+    three-valued logic in a way that is easy to get wrong and that only fails at
+    runtime, which is exactly the class of defect a compile-time assertion
+    catches cheaply.
+
+    Selects grants for ``user_id`` whose workspace on this side is either unset
+    or points at a soft-deleted workspace, and is not already the target.
+
+    Args:
+        user_col: ``referrer_user_id`` or ``referred_user_id``.
+        workspace_col: The matching ``*_workspace_id`` column.
+        user_id: Owner of the grants being re-homed.
+        workspace_id: The live workspace to point them at.
+
+    Returns:
+        A SQLAlchemy ``Update`` statement.
+    """
+    # Workspaces a grant may currently point at that no longer count. A subquery
+    # keeps this a single statement.
+    dead_workspaces = select(Workspace.id).where(Workspace.deleted_at.is_not(None))
+    return (
+        update(ReferralGrant)
+        .where(
+            user_col == user_id,
+            workspace_col.is_(None) | workspace_col.in_(dead_workspaces),
+            # NULL-safe inequality, and it has to be. ``!=`` evaluates to NULL
+            # (not TRUE) for exactly the NULL rows this UPDATE exists to fix, so
+            # it would silently match nothing. ``is_not`` emits SQL
+            # ``IS NOT <uuid>``, which PostgreSQL accepts only for
+            # NULL / TRUE / FALSE / UNKNOWN — a syntax error against a UUID.
+            workspace_col.is_distinct_from(workspace_id),
+            ReferralGrant.revoked_at.is_(None),
+        )
+        .values({workspace_col.key: workspace_id})
+    )
+
+
 @dataclass(frozen=True)
 class ReferralSummary:
     """What a user sees about their own referral standing."""
@@ -387,25 +434,13 @@ class ReferralService:
         if workspace_id is None:
             return 0
 
-        # Workspaces the grant may currently point at that no longer count:
-        # soft-deleted ones. Collected as a subquery so the UPDATE stays a
-        # single statement.
-        dead_workspaces = select(Workspace.id).where(Workspace.deleted_at.is_not(None))
-
         updated = 0
         for user_col, workspace_col in (
             (ReferralGrant.referrer_user_id, ReferralGrant.referrer_workspace_id),
             (ReferralGrant.referred_user_id, ReferralGrant.referred_workspace_id),
         ):
             result = await self.db.execute(
-                update(ReferralGrant)
-                .where(
-                    user_col == user_id,
-                    workspace_col.is_(None) | workspace_col.in_(dead_workspaces),
-                    workspace_col.is_not(workspace_id),
-                    ReferralGrant.revoked_at.is_(None),
-                )
-                .values({workspace_col.key: workspace_id})
+                build_pending_grant_update(user_col, workspace_col, user_id, workspace_id)
             )
             # ``AsyncSession.execute`` is typed as returning ``Result``, which has
             # no ``rowcount``; a DML statement always yields a ``CursorResult`` at
@@ -490,34 +525,47 @@ class ReferralService:
     # Revocation
     # ------------------------------------------------------------------
 
-    async def revoke(self, *, grant_id: uuid.UUID, reason: str) -> ReferralGrant | None:
+    async def revoke(
+        self, *, grant_id: uuid.UUID, reason: str
+    ) -> tuple[ReferralGrant | None, bool]:
         """Revoke a grant and recompute both sides' bonuses.
 
-        Idempotent: revoking an already-revoked grant leaves ``revoked_at``
-        untouched and still returns the row, so an admin retry is harmless.
+        Idempotent: revoking an already-revoked grant leaves ``revoked_at`` and
+        the original ``revoked_reason`` untouched, so an admin retry (or a
+        double-click) changes nothing.
+
+        The ``changed`` flag exists because "idempotent" has to cover the side
+        effects too. Callers that write an audit row must key off it: auditing
+        unconditionally would stamp a *new* reason onto a no-op, producing an
+        audit trail that disagrees with the ``revoked_reason`` actually stored on
+        the row — the log would claim a revocation happened for a reason that was
+        never recorded anywhere.
 
         Args:
             grant_id: The ledger row to revoke.
             reason: Required free text; recorded on the row and in the audit log.
 
         Returns:
-            The grant, or ``None`` if no such row exists.
+            ``(grant, changed)``. ``grant`` is ``None`` if no such row exists;
+            ``changed`` is True only when this call performed the revocation.
         """
         grant = await self.db.get(ReferralGrant, grant_id)
         if grant is None:
-            return None
+            return None, False
 
-        if grant.revoked_at is None:
-            grant.revoked_at = utcnow()
-            grant.revoked_reason = reason
-            await self.db.flush()
-            await self._recompute_workspace_bonuses(
-                grant.referrer_workspace_id, grant.referred_workspace_id
-            )
-            logger.info(
-                "referral_revoked",
-                grant_id=str(grant_id),
-                referrer_user_id=grant.referrer_user_id,
-                referred_user_id=grant.referred_user_id,
-            )
-        return grant
+        if grant.revoked_at is not None:
+            return grant, False
+
+        grant.revoked_at = utcnow()
+        grant.revoked_reason = reason
+        await self.db.flush()
+        await self._recompute_workspace_bonuses(
+            grant.referrer_workspace_id, grant.referred_workspace_id
+        )
+        logger.info(
+            "referral_revoked",
+            grant_id=str(grant_id),
+            referrer_user_id=grant.referrer_user_id,
+            referred_user_id=grant.referred_user_id,
+        )
+        return grant, True

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -198,21 +198,24 @@ class WorkspaceService:
         # session where every subsequent statement fails with
         # InFailedSQLTransactionError — turning a cosmetic bonus problem into a
         # broken request. The workspace itself is already committed above.
-        from config.settings import get_settings
+        # Deliberately NOT gated on ``settings.enable_referrals``. This call
+        # mints nothing — it only re-homes ledger rows that were already earned
+        # and recomputes a cache from them. Gating it would strand grants earned
+        # while the program was on if the kill switch is flipped off before the
+        # beneficiary creates a workspace, contradicting the documented
+        # "already-granted bonuses are unaffected by the kill switch".
+        try:
+            from services.referral_service import ReferralService
 
-        if get_settings().enable_referrals:
-            try:
-                from services.referral_service import ReferralService
-
-                await ReferralService(self.db).apply_pending_grants(owner_user_id)
-            except Exception as exc:  # pragma: no cover - defensive
-                await self.db.rollback()
-                logger.warning(
-                    "referral_pending_grants_apply_failed",
-                    workspace_id=str(workspace.id),
-                    owner_user_id=owner_user_id,
-                    error=str(exc),
-                )
+            await ReferralService(self.db).apply_pending_grants(owner_user_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            await self.db.rollback()
+            logger.warning(
+                "referral_pending_grants_apply_failed",
+                workspace_id=str(workspace.id),
+                owner_user_id=owner_user_id,
+                error=str(exc),
+            )
 
         return workspace
 

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -181,6 +181,28 @@ class WorkspaceService:
             f"default context: {default_context.id if default_context else 'none'}"
         )
 
+        # Issue #1470: a referral grant can be earned before the beneficiary owns
+        # any workspace — ``api/routes/auth.py`` skips personal-workspace bootstrap
+        # entirely when the user has pending team invitations. Those grants are
+        # recorded with a NULL workspace_id and applied here, once a workspace
+        # exists. This is the single funnel: ``ensure_personal_workspace`` and
+        # ``create_personal_workspace`` both route through this method.
+        #
+        # Non-blocking on purpose: workspace creation must never fail because a
+        # bonus could not be applied. The grant row survives either way, so a
+        # later workspace creation (or an admin) can still resolve it.
+        try:
+            from services.referral_service import ReferralService
+
+            await ReferralService(self.db).apply_pending_grants(owner_user_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                "referral_pending_grants_apply_failed",
+                workspace_id=str(workspace.id),
+                owner_user_id=owner_user_id,
+                error=str(exc),
+            )
+
         return workspace
 
     async def ensure_personal_workspace(

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -191,17 +191,28 @@ class WorkspaceService:
         # Non-blocking on purpose: workspace creation must never fail because a
         # bonus could not be applied. The grant row survives either way, so a
         # later workspace creation (or an admin) can still resolve it.
-        try:
-            from services.referral_service import ReferralService
+        #
+        # The rollback in the handler is NOT optional. A failure here (e.g. a
+        # constraint violation) leaves the session in an aborted transaction, and
+        # swallowing the exception without rolling back would hand the caller a
+        # session where every subsequent statement fails with
+        # InFailedSQLTransactionError — turning a cosmetic bonus problem into a
+        # broken request. The workspace itself is already committed above.
+        from config.settings import get_settings
 
-            await ReferralService(self.db).apply_pending_grants(owner_user_id)
-        except Exception as exc:  # pragma: no cover - defensive
-            logger.warning(
-                "referral_pending_grants_apply_failed",
-                workspace_id=str(workspace.id),
-                owner_user_id=owner_user_id,
-                error=str(exc),
-            )
+        if get_settings().enable_referrals:
+            try:
+                from services.referral_service import ReferralService
+
+                await ReferralService(self.db).apply_pending_grants(owner_user_id)
+            except Exception as exc:  # pragma: no cover - defensive
+                await self.db.rollback()
+                logger.warning(
+                    "referral_pending_grants_apply_failed",
+                    workspace_id=str(workspace.id),
+                    owner_user_id=owner_user_id,
+                    error=str(exc),
+                )
 
         return workspace
 

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -426,6 +426,87 @@ class BonusBelowZeroError(MemoryCloudException):
         )
 
 
+class ReferralError(MemoryCloudException):
+    """Base for referral-redemption refusals (#1470).
+
+    Every subclass is a 400 with a distinct ``REFERRAL-*`` code so SDK
+    consumers and the web UI can route on the reason without string-matching
+    the message. All of them describe a *business-rule* refusal on a
+    well-formed request, which is why they are 400 rather than 422.
+
+    Deliberately uniform and vague about the referrer: none of these messages
+    reveal whether a submitted code exists, who owns it, or how many slots it
+    has left. A farmer probing codes learns nothing beyond "not usable".
+    """
+
+    def __init__(self, message: str, *, error_code: str, **details: Any) -> None:
+        super().__init__(message, status_code=400, error_code=error_code, **details)
+
+
+class ReferralCodeInvalidError(ReferralError):
+    """The submitted referral code does not resolve to a usable referrer (400)."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "This referral code is not valid.",
+            error_code="REFERRAL-001",
+        )
+
+
+class ReferralSelfError(ReferralError):
+    """A user submitted their own referral code (400).
+
+    Also enforced by the ``ck_referral_grants_not_self`` CHECK; this app-level
+    guard exists so the caller gets a routable code instead of a generic
+    IntegrityError.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "You cannot redeem your own referral code.",
+            error_code="REFERRAL-002",
+        )
+
+
+class ReferralAlreadyRedeemedError(ReferralError):
+    """This user has already been referred (400).
+
+    The authoritative guard is ``uq_referral_grants_referred_user``; a
+    concurrent double-submit surfaces here via the zero-row
+    ``ON CONFLICT DO NOTHING`` result rather than as a 500.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "You have already redeemed a referral code.",
+            error_code="REFERRAL-003",
+        )
+
+
+class ReferralWindowClosedError(ReferralError):
+    """The account is too old to redeem a referral code (400)."""
+
+    def __init__(self, *, window_hours: int) -> None:
+        super().__init__(
+            f"Referral codes can only be redeemed within {window_hours} hours of signup.",
+            error_code="REFERRAL-004",
+            window_hours=window_hours,
+        )
+
+
+class ReferralCapReachedError(ReferralError):
+    """The referrer has used every referral slot they have (400).
+
+    Message intentionally does not name the referrer or the cap value.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "This referral code is not valid.",
+            error_code="REFERRAL-005",
+        )
+
+
 # Rate Limiting & Quota Errors (429)
 
 

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -437,6 +437,15 @@ class ReferralError(MemoryCloudException):
     Deliberately uniform and vague about the referrer: none of these messages
     reveal whether a submitted code exists, who owns it, or how many slots it
     has left. A farmer probing codes learns nothing beyond "not usable".
+
+    That uniformity has to hold for the ``error_code`` too, not just the message
+    — a distinct code IS an oracle. So every refusal whose reachability depends
+    on the SUBMITTED CODE (unknown code, exhausted referrer) goes out as
+    ``REFERRAL-001``; only refusals about the CALLER'S OWN state
+    (``REFERRAL-002`` self-referral, ``-003`` already redeemed, ``-004`` window
+    closed) get a distinguishing code, and ``ReferralService.redeem`` checks
+    those before it ever looks the code up so their reachability leaks nothing
+    either. The precise reason is kept in the structured log.
     """
 
     def __init__(self, message: str, *, error_code: str, **details: Any) -> None:
@@ -497,13 +506,17 @@ class ReferralWindowClosedError(ReferralError):
 class ReferralCapReachedError(ReferralError):
     """The referrer has used every referral slot they have (400).
 
-    Message intentionally does not name the referrer or the cap value.
+    Emits ``REFERRAL-001`` — byte-identical to ``ReferralCodeInvalidError`` on
+    the wire, message AND code. A dedicated ``REFERRAL-005`` would tell a prober
+    "this code exists but is exhausted", which is exactly the code-enumeration
+    signal the uniform messages were meant to deny. The class stays distinct so
+    the server can log (and test) the real reason.
     """
 
     def __init__(self) -> None:
         super().__init__(
             "This referral code is not valid.",
-            error_code="REFERRAL-005",
+            error_code="REFERRAL-001",
         )
 
 

--- a/backend/tests/api/test_internal_downgrade_eligibility.py
+++ b/backend/tests/api/test_internal_downgrade_eligibility.py
@@ -32,6 +32,7 @@ def _make_ws(plan_name: str = "pro"):
     ws.addon_connector_bonus = 0
     ws.addon_sleep_contexts_bonus = 0
     ws.addon_storage_bonus_mb = 0
+    ws.referral_memory_bonus = 0  # #1470: stacks into the memory limit, not an addon
     return ws
 
 

--- a/backend/tests/api/test_referral_addon_isolation.py
+++ b/backend/tests/api/test_referral_addon_isolation.py
@@ -1,0 +1,105 @@
+"""``referral_memory_bonus`` must stay OUT of the addon machinery (Issue #1470).
+
+READ THIS BEFORE "FIXING" A FAILURE HERE.
+
+If one of these tests goes red, the correct fix is almost never to update the
+test. It is to remove ``referral_memory_bonus`` from whichever addon collection
+it was just added to. The referral reward is deliberately NOT an addon, and each
+of the three collections guarded below would destroy it:
+
+1. ``internal_billing._ADDON_COLUMNS`` — the billing push has FULL-REPLACE
+   semantics: when the payload carries ``addons`` it zeroes every column in this
+   map before applying the provided values. Billing knows nothing about
+   referrals, so a referral bonus listed here evaporates the moment a referred
+   user converts to paid — the worst possible time.
+
+2. ``AddonCalculatorService.recalculate_workspace_bonuses``'s bonuses dict — the
+   ``addon_*`` columns are a CACHE of ``SUM(WorkspaceAddon.quantity x
+   unit_value)``, rewritten with that absolute value on every recalc. A referral
+   bonus has no backing ``WorkspaceAddon`` row, so listing it here resets it to
+   0 on the next recalc. #665 fixed exactly this class of bug for admin grants.
+
+3. ``admin_plans._ADDON_FIELD_SPECS`` — drives the admin quota PUT, whose
+   divisibility check would reject the reward amount outright
+   (``ADDON_UNIT_VALUES["extra_memory"]`` is 10000, so the minimum grantable
+   memory addon is 20x a single referral reward), and whose absolute
+   ``admin_grant_quantity`` arithmetic would treat the referral portion as an
+   admin grant to be re-derived.
+
+The reward's source of truth is the ``referral_grants`` ledger; the column is
+recomputed as an absolute SUM over non-revoked rows by ``ReferralService``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from api.routes.admin_plans import _ADDON_FIELD_SPECS
+from api.routes.internal_billing import _ADDON_COLUMNS
+from models.auth import Workspace
+from services.addon_calculator_service import ADDON_UNIT_VALUES, AddonCalculatorService
+
+REFERRAL_COLUMN = "referral_memory_bonus"
+
+_WHY = (
+    f"{REFERRAL_COLUMN} must stay outside the addon machinery (#1470) — see this "
+    "module's docstring. Remove it from the collection rather than updating this test."
+)
+
+
+def test_referral_column_absent_from_billing_addon_columns() -> None:
+    """The billing push must not be able to zero the referral bonus."""
+    assert REFERRAL_COLUMN not in _ADDON_COLUMNS.values(), (
+        f"{_WHY} internal_billing._ADDON_COLUMNS full-replaces every column it "
+        "lists, so a referral bonus here is wiped by any billing push carrying "
+        "`addons` — i.e. at the exact moment a referred user converts to paid."
+    )
+    assert REFERRAL_COLUMN not in _ADDON_COLUMNS, _WHY
+
+
+def test_referral_column_absent_from_addon_cache_recalc() -> None:
+    """The addon cache recalc must not overwrite the referral bonus."""
+    source = inspect.getsource(AddonCalculatorService.recalculate_workspace_bonuses)
+    assert REFERRAL_COLUMN not in source, (
+        f"{_WHY} recalculate_workspace_bonuses writes the ABSOLUTE "
+        "SUM(WorkspaceAddon.quantity * unit_value) into every column it names. A "
+        "referral bonus has no backing WorkspaceAddon row, so it would be reset "
+        "to 0 on the next recalc (the #665 bug, reintroduced)."
+    )
+
+
+def test_referral_column_absent_from_admin_quota_field_specs() -> None:
+    """The admin quota PUT must not treat the referral bonus as an addon."""
+    field_names = {spec.field_name for spec in _ADDON_FIELD_SPECS}
+    assert REFERRAL_COLUMN not in field_names, (
+        f"{_WHY} _ADDON_FIELD_SPECS drives the admin quota PUT, whose "
+        "divisibility check would reject the reward amount and whose absolute "
+        "admin_grant_quantity arithmetic would re-derive the referral portion as "
+        "an admin grant."
+    )
+
+
+def test_referral_column_has_no_addon_unit_value() -> None:
+    """No ``ADDON_UNIT_VALUES`` entry may exist for the referral reward.
+
+    A unit value is a *re-valuing multiplier*: changing it re-prices every
+    existing row at the next recalc. The referral amounts are snapshotted per
+    ledger row precisely so that cannot happen.
+    """
+    assert not any("referral" in key for key in ADDON_UNIT_VALUES), (
+        f"{_WHY} ADDON_UNIT_VALUES is a re-valuing multiplier; referral amounts "
+        "are snapshotted per ledger row instead."
+    )
+
+
+def test_referral_column_is_not_addon_prefixed() -> None:
+    """The naming itself is load-bearing.
+
+    Several of the guarded collections are maintained by pattern-matching on the
+    ``addon_`` prefix. Renaming this column to ``addon_referral_memory_bonus``
+    would invite exactly the mistakes the other tests here forbid.
+    """
+    assert not REFERRAL_COLUMN.startswith("addon_"), _WHY
+    assert hasattr(Workspace, REFERRAL_COLUMN), (
+        "Workspace.referral_memory_bonus is missing — the referral reward has no column to land in."
+    )

--- a/backend/tests/api/test_referrals.py
+++ b/backend/tests/api/test_referrals.py
@@ -53,6 +53,19 @@ def _upper_bound(field_name: str) -> int:
     raise AssertionError(f"Settings.{field_name} has no `le=` ceiling — it must be bounded.")
 
 
+def _worst_case(settings: Settings) -> int:
+    """Mirror ``Settings._validate_referral_payout_budget``'s arithmetic.
+
+    A workspace is the referee at most once (``UNIQUE(referred_user_id)``) and
+    the referrer up to ``max_grants`` times, so both terms accrue to the SAME
+    workspace and both must be counted.
+    """
+    return (
+        settings.referral_max_grants_per_referrer * settings.referral_referrer_reward_memories
+        + settings.referral_referee_reward_memories
+    )
+
+
 class TestPayoutBudget:
     """The cross-field guard that per-field ``le=`` bounds cannot express (#1470)."""
 
@@ -81,11 +94,7 @@ class TestPayoutBudget:
 
     def test_defaults_are_within_budget(self) -> None:
         settings = get_settings()
-        worst = settings.referral_max_grants_per_referrer * max(
-            settings.referral_referrer_reward_memories,
-            settings.referral_referee_reward_memories,
-        )
-        assert worst <= REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
+        assert _worst_case(settings) <= REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
 
     def test_over_budget_config_fails_closed_at_load(self) -> None:
         """An operator cannot dial away the tier ladder one field at a time."""
@@ -96,6 +105,32 @@ class TestPayoutBudget:
                 referral_referrer_reward_memories=2000,
                 referral_referee_reward_memories=2000,
             )
+
+    def test_budget_counts_the_referee_reward_too(self) -> None:
+        """A workspace is referee once AND referrer up to max_grants times.
+
+        4 x 2000 = 8000 is under the 9000 budget on its own, but the workspace
+        also collects its own 2000-memory referee reward, reaching 10000. A guard
+        that took ``max(referrer, referee)`` would wave this through — and the
+        FREE base plus 10000 lands exactly on BASIC's limit.
+        """
+        with pytest.raises(ValidationError, match="above the"):
+            Settings(
+                enable_referrals=True,
+                referral_max_grants_per_referrer=4,
+                referral_referrer_reward_memories=2000,
+                referral_referee_reward_memories=2000,
+            )
+
+    def test_budget_formula_matches_what_the_recompute_can_sum(self) -> None:
+        """Pin the validator's arithmetic to the ledger SUM it is bounding."""
+        settings = Settings(
+            enable_referrals=True,
+            referral_max_grants_per_referrer=3,
+            referral_referrer_reward_memories=500,
+            referral_referee_reward_memories=400,
+        )
+        assert _worst_case(settings) == 3 * 500 + 400
 
     def test_budget_guard_is_inert_when_referrals_are_disabled(self) -> None:
         """OSS deployments that never enable referrals need not keep these coherent."""
@@ -152,6 +187,60 @@ class TestEffectiveMemoryLimit:
         ws = Workspace(plan_name="free", addon_memory_bonus=0, referral_memory_bonus=500)
         object.__setattr__(ws, "_plan_tier", MagicMock(memory_limit=0))
         assert ws.effective_memory_limit == 0
+
+
+class TestEntitlementConsistency:
+    """Every consumer of the memory limit must agree with the ORM property (#1470).
+
+    The referral bonus stacks into ``effective_memory_limit`` but lives outside
+    the addon machinery, so any code that recomputes a memory limit from
+    ``plan_tier + addon_memory_bonus`` silently under-reports. Each test here
+    pins one such consumer to the property.
+    """
+
+    def test_admin_quota_guard_matches_effective_memory_limit(self) -> None:
+        """``_effective_for_guard`` drives the LD-7 wedge in the admin quota PUT.
+
+        Under-computing there rejects admin addon reductions that are actually
+        safe, telling the operator the workspace is over a limit it is not over.
+        """
+        from api.routes.admin_plans import _effective_for_guard
+
+        tier = PLAN_TIERS["free"]
+        ws = Workspace(
+            plan_name="free",
+            addon_memory_bonus=10000,
+            referral_memory_bonus=1500,
+        )
+        assert (
+            _effective_for_guard(tier, "memory", ws.addon_memory_bonus, ws.referral_memory_bonus)
+            == ws.effective_memory_limit
+        )
+
+    def test_admin_quota_guard_keeps_the_zero_base_gate(self) -> None:
+        """A referral bonus must not open a dimension the tier excludes."""
+        from api.routes.admin_plans import _effective_for_guard
+
+        tier = PLAN_TIERS["free"]
+        # public_calls_per_day is 0 on FREE; the guard's zero-base rule must win
+        # regardless of any extra bonus passed in.
+        assert _effective_for_guard(tier, "sleep_contexts", 5, 1500) == 0
+
+    def test_downgrade_eligibility_uses_the_same_memory_limit(self) -> None:
+        """The MEMORIES downgrade blocker must not ignore the referral bonus.
+
+        Otherwise a user is told to delete memories they are still entitled to
+        keep — the bonus survives a plan change because it is locally-owned.
+        """
+        from models.auth import _zero_floor
+
+        tier = PLAN_TIERS["basic"]
+        ws = Workspace(plan_name="basic", addon_memory_bonus=0, referral_memory_bonus=1500)
+        downgrade_limit = _zero_floor(
+            tier.memory_limit,
+            (ws.addon_memory_bonus or 0) + (ws.referral_memory_bonus or 0),
+        )
+        assert downgrade_limit == ws.effective_memory_limit
 
 
 def _session_user() -> dict:
@@ -225,6 +314,25 @@ class TestKillSwitch:
         response = client.get("/api/v1/admin/referrals")
         assert response.status_code == 200
 
+    def test_disabled_surface_404s_for_unauthenticated_callers_too(self, monkeypatch) -> None:
+        """The kill switch must be evaluated BEFORE auth.
+
+        If it ran after, an anonymous caller would get 401 while a logged-in one
+        got 404 — the split itself advertises that the endpoint exists.
+        """
+        monkeypatch.setattr(get_settings(), "enable_referrals", False)
+
+        async def mock_db():
+            yield MagicMock()
+
+        app.dependency_overrides[get_db] = mock_db
+        try:
+            unauth = TestClient(app, raise_server_exceptions=False)
+            assert unauth.get("/api/v1/referrals/me").status_code == 404
+            assert unauth.post("/api/v1/referrals/redeem", json={"code": "x"}).status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
     def test_system_info_exposes_the_flag(self, client) -> None:
         features = client.get("/api/v1/system/info").json()["features"]
         assert "referrals" in features
@@ -291,7 +399,8 @@ class TestRedeem:
             (ReferralSelfError(), "REFERRAL-002"),
             (ReferralAlreadyRedeemedError(), "REFERRAL-003"),
             (ReferralWindowClosedError(window_hours=72), "REFERRAL-004"),
-            (ReferralCapReachedError(), "REFERRAL-005"),
+            # Cap-reached deliberately shares 001 — see the next test.
+            (ReferralCapReachedError(), "REFERRAL-001"),
         ],
     )
     def test_refusals_map_to_400_with_routable_codes(
@@ -305,11 +414,30 @@ class TestRedeem:
         assert response.status_code == 400
         assert expected_code in response.text
 
-    def test_invalid_code_and_cap_reached_are_indistinguishable_to_the_caller(
-        self,
-    ) -> None:
-        """Probing a code must not reveal whether it exists or who owns it."""
-        assert ReferralCodeInvalidError().message == ReferralCapReachedError().message
+    def test_invalid_code_and_cap_reached_are_byte_identical_to_the_caller(self) -> None:
+        """Probing a code must not reveal whether it exists or who owns it.
+
+        Both the message AND the error_code have to match: a distinct code is
+        just as good an oracle as a distinct message, and would tell a prober
+        "this code is real, merely exhausted".
+        """
+        invalid, capped = ReferralCodeInvalidError(), ReferralCapReachedError()
+        assert invalid.message == capped.message
+        assert invalid.error_code == capped.error_code
+
+    def test_caller_state_refusals_keep_distinct_codes(self) -> None:
+        """Refusals about the CALLER's own state may stay distinguishable.
+
+        They leak nothing about the submitted code because ``redeem`` evaluates
+        them before it ever looks the code up.
+        """
+        codes = {
+            ReferralSelfError().error_code,
+            ReferralAlreadyRedeemedError().error_code,
+            ReferralWindowClosedError(window_hours=72).error_code,
+        }
+        assert len(codes) == 3
+        assert ReferralCodeInvalidError().error_code not in codes
 
     def test_empty_code_is_rejected_before_the_service(self, client, referrals_enabled) -> None:
         assert client.post("/api/v1/referrals/redeem", json={"code": ""}).status_code == 422

--- a/backend/tests/api/test_referrals.py
+++ b/backend/tests/api/test_referrals.py
@@ -515,6 +515,39 @@ class TestRedeem:
         assert invalid.message == capped.message
         assert invalid.error_code == capped.error_code
 
+    def test_missing_user_row_is_404_not_a_referral_refusal(
+        self, client, referrals_enabled, monkeypatch
+    ) -> None:
+        """A missing ``users`` row is resource-not-found, not a code refusal.
+
+        The caller is session-authenticated; an absent row means an erased
+        account with a live session. Answering ``REFERRAL-001`` ("this referral
+        code is not valid") would be a lie for ``GET /referrals/me``, where no
+        code was submitted at all, and would blur what the REFERRAL-* codes mean.
+        """
+        from utils.exceptions import NotFoundException
+
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.get_summary",
+            AsyncMock(side_effect=NotFoundException("User", "user_referee")),
+        )
+        response = client.get("/api/v1/referrals/me")
+        assert response.status_code == 404
+        assert "REFERRAL-" not in response.text
+
+    def test_missing_user_row_on_redeem_is_also_404(
+        self, client, referrals_enabled, monkeypatch
+    ) -> None:
+        from utils.exceptions import NotFoundException
+
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.redeem",
+            AsyncMock(side_effect=NotFoundException("User", "user_referee")),
+        )
+        response = client.post("/api/v1/referrals/redeem", json={"code": "abc123"})
+        assert response.status_code == 404
+        assert "REFERRAL-" not in response.text
+
     def test_caller_state_refusals_keep_distinct_codes(self) -> None:
         """Refusals about the CALLER's own state may stay distinguishable.
 

--- a/backend/tests/api/test_referrals.py
+++ b/backend/tests/api/test_referrals.py
@@ -11,6 +11,7 @@ Split in two:
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
@@ -189,6 +190,49 @@ class TestEffectiveMemoryLimit:
         assert ws.effective_memory_limit == 0
 
 
+class TestPendingGrantSQL:
+    """The re-homing UPDATE must emit SQL PostgreSQL actually accepts (#1470).
+
+    None of the other tests touch a database, so a predicate that only fails at
+    execution time would ship silently. Compiling the statement is the cheap
+    assertion that catches it.
+    """
+
+    def _sql(self) -> str:
+        from sqlalchemy.dialects import postgresql
+
+        from models.referral import ReferralGrant
+        from services.referral_service import build_pending_grant_update
+
+        stmt = build_pending_grant_update(
+            ReferralGrant.referrer_user_id,
+            ReferralGrant.referrer_workspace_id,
+            "user_1",
+            uuid4(),
+        )
+        return str(stmt.compile(dialect=postgresql.dialect()))
+
+    def test_uses_null_safe_inequality(self) -> None:
+        assert "IS DISTINCT FROM" in self._sql()
+
+    def test_does_not_emit_is_not_against_a_uuid(self) -> None:
+        """``IS NOT <uuid>`` is a PostgreSQL syntax error.
+
+        PostgreSQL allows ``IS NOT`` only against NULL / TRUE / FALSE / UNKNOWN.
+        SQLAlchemy's ``is_not()`` happily compiles it for any operand.
+        """
+        sql = self._sql()
+        assert "IS NOT DISTINCT FROM" not in sql  # wrong polarity
+        # The only legitimate IS NOT in this statement is the NULL check on
+        # workspaces.deleted_at inside the dead-workspace subquery.
+        assert sql.count("IS NOT NULL") == 1
+        assert re.search(r"IS NOT (?!NULL|DISTINCT|TRUE|FALSE|UNKNOWN)", sql) is None
+
+    def test_matches_rows_whose_workspace_is_unset(self) -> None:
+        """The NULL branch is the whole point — assert it survives compilation."""
+        assert "IS NULL" in self._sql()
+
+
 class TestEntitlementConsistency:
     """Every consumer of the memory limit must agree with the ORM property (#1470).
 
@@ -313,6 +357,20 @@ class TestKillSwitch:
         )
         response = client.get("/api/v1/admin/referrals")
         assert response.status_code == 200
+
+    def test_disabled_404_is_indistinguishable_from_a_missing_route(
+        self, client, monkeypatch
+    ) -> None:
+        """A feature-specific detail would make the route enumerable.
+
+        "Referral program is not enabled" tells a prober the endpoint exists and
+        what it is — the same leak the uniform REFERRAL-001 refusals close.
+        """
+        monkeypatch.setattr(get_settings(), "enable_referrals", False)
+        disabled = client.get("/api/v1/referrals/me")
+        missing = client.get("/api/v1/this-route-does-not-exist")
+        assert disabled.status_code == missing.status_code == 404
+        assert disabled.json() == missing.json()
 
     def test_disabled_surface_404s_for_unauthenticated_callers_too(self, monkeypatch) -> None:
         """The kill switch must be evaluated BEFORE auth.
@@ -451,12 +509,81 @@ class TestAdminRevoke:
     def test_revoke_404s_for_unknown_grant(self, client, monkeypatch) -> None:
         monkeypatch.setattr(
             "services.referral_service.ReferralService.revoke",
-            AsyncMock(return_value=None),
+            AsyncMock(return_value=(None, False)),
         )
         response = client.post(
             f"/api/v1/admin/referrals/{uuid4()}/revoke", json={"reason": "abuse"}
         )
         assert response.status_code == 404
+
+    def _revoke_client(self, monkeypatch, grant, changed: bool) -> tuple[TestClient, list[dict]]:
+        """A client whose session can actually commit, capturing AuditLog rows.
+
+        The shared ``client`` fixture yields a bare ``MagicMock`` session, so
+        ``await db.commit()`` raises — fine for the paths that reject before
+        committing, not for these.
+        """
+
+        async def mock_admin():
+            return _admin_user()
+
+        db = MagicMock()
+        db.commit = AsyncMock()
+        db.rollback = AsyncMock()
+
+        async def mock_db():
+            yield db
+
+        added: list[dict] = []
+
+        def capture(**kwargs):
+            added.append(kwargs)
+            return MagicMock()
+
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.revoke",
+            AsyncMock(return_value=(grant, changed)),
+        )
+        monkeypatch.setattr("api.routes.admin_referrals.AuditLog", capture)
+        app.dependency_overrides[require_admin] = mock_admin
+        app.dependency_overrides[get_db] = mock_db
+        return TestClient(app, raise_server_exceptions=False), added
+
+    def test_first_revoke_writes_an_audit_row(self, monkeypatch) -> None:
+        grant = _mock_grant()
+        client, added = self._revoke_client(monkeypatch, grant, changed=True)
+        try:
+            response = client.post(
+                f"/api/v1/admin/referrals/{grant.id}/revoke", json={"reason": "farming"}
+            )
+            assert response.status_code == 200
+            assert len(added) == 1
+            assert added[0]["user_metadata"]["reason"] == "farming"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_retried_revoke_writes_no_second_audit_row(self, monkeypatch) -> None:
+        """A no-op retry must not record a reason the ledger never stored.
+
+        ``ReferralService.revoke`` keeps the ORIGINAL ``revoked_reason`` on a
+        repeat call, so auditing unconditionally would leave an audit trail
+        claiming a revocation happened for a reason written nowhere.
+        """
+        grant = _mock_grant()
+        grant.revoked_at = datetime(2026, 8, 1, tzinfo=UTC)
+        grant.revoked_reason = "farming"
+        client, added = self._revoke_client(monkeypatch, grant, changed=False)
+        try:
+            response = client.post(
+                f"/api/v1/admin/referrals/{grant.id}/revoke",
+                json={"reason": "a different reason"},
+            )
+            assert response.status_code == 200
+            assert added == []
+            # The row is still returned, so the retry looks successful to the admin.
+            assert response.json()["revoked_reason"] == "farming"
+        finally:
+            app.dependency_overrides.clear()
 
     def test_non_admin_is_rejected(self) -> None:
         """The signup-gate router never got this test; this one does.

--- a/backend/tests/api/test_referrals.py
+++ b/backend/tests/api/test_referrals.py
@@ -95,11 +95,40 @@ class TestPayoutBudget:
 
     def test_defaults_are_within_budget(self) -> None:
         settings = get_settings()
-        assert _worst_case(settings) <= REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
+        # Strictly under: the budget is the gap itself, so landing ON it means
+        # landing on BASIC's limit.
+        assert _worst_case(settings) < REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
+
+    def test_a_config_that_lands_exactly_on_basic_is_rejected(self) -> None:
+        """Equality is not "within budget" — it IS the paid tier.
+
+        4 x 2000 + 1000 = 9000 exactly. FREE base 1000 + 9000 = 10000 =
+        BASIC's memory_limit, so a config that exactly closes the gap hands out
+        BASIC for free. The guard therefore has to be an EXCLUSIVE bound; with
+        ``>`` this config would have been accepted.
+        """
+        assert 4 * 2000 + 1000 == REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
+        with pytest.raises(ValidationError, match="reaching the"):
+            Settings(
+                enable_referrals=True,
+                referral_max_grants_per_referrer=4,
+                referral_referrer_reward_memories=2000,
+                referral_referee_reward_memories=1000,
+            )
+
+    def test_one_memory_under_the_budget_is_accepted(self) -> None:
+        """The bound is exclusive, not a blanket ban near the gap."""
+        settings = Settings(
+            enable_referrals=True,
+            referral_max_grants_per_referrer=4,
+            referral_referrer_reward_memories=2000,
+            referral_referee_reward_memories=999,
+        )
+        assert _worst_case(settings) == REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES - 1
 
     def test_over_budget_config_fails_closed_at_load(self) -> None:
         """An operator cannot dial away the tier ladder one field at a time."""
-        with pytest.raises(ValidationError, match="above the"):
+        with pytest.raises(ValidationError, match="reaching the"):
             Settings(
                 enable_referrals=True,
                 referral_max_grants_per_referrer=10,
@@ -115,7 +144,7 @@ class TestPayoutBudget:
         that took ``max(referrer, referee)`` would wave this through — and the
         FREE base plus 10000 lands exactly on BASIC's limit.
         """
-        with pytest.raises(ValidationError, match="above the"):
+        with pytest.raises(ValidationError, match="reaching the"):
             Settings(
                 enable_referrals=True,
                 referral_max_grants_per_referrer=4,
@@ -164,19 +193,22 @@ class TestEffectiveMemoryLimit:
         ws = Workspace(plan_name="basic", addon_memory_bonus=0, referral_memory_bonus=0)
         assert ws.effective_memory_limit == 10000
 
-    def test_budget_at_the_free_to_basic_gap_does_not_reach_basic(self) -> None:
-        """A fully-used chain at the payout budget must stay under BASIC.
+    def test_any_config_the_validator_accepts_stays_under_basic(self) -> None:
+        """The ladder invariant, stated as the validator enforces it.
 
-        This is the ladder invariant the payout budget exists to hold: the
-        referral program must never be a way to get the paid tier for free.
+        The budget EQUALS the gap, so ``free_base + budget`` lands exactly on
+        BASIC. That is why the validator rejects ``worst_case >= budget`` rather
+        than ``>``: the strictest config it accepts is one memory short of
+        BASIC, never at it.
         """
-        free_base = Workspace(
+        free_only = Workspace(
             plan_name="free", addon_memory_bonus=0, referral_memory_bonus=0
         ).effective_memory_limit
-        basic_base = Workspace(
+        basic_only = Workspace(
             plan_name="basic", addon_memory_bonus=0, referral_memory_bonus=0
         ).effective_memory_limit
-        assert free_base + REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES <= basic_base
+        max_accepted = REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES - 1
+        assert free_only + max_accepted < basic_only
 
     def test_zero_floor_still_applies(self) -> None:
         """A tier that excludes memories cannot be lifted by a referral.

--- a/backend/tests/api/test_referrals.py
+++ b/backend/tests/api/test_referrals.py
@@ -1,0 +1,351 @@
+"""Referral program tests (Issue #1470).
+
+Split in two:
+
+- ``TestEffectiveMemoryLimit`` exercises the entitlement math directly on the
+  ORM object (no DB) — that property is the only existing quota path this
+  feature changes, so it gets a dedicated regression net.
+- The HTTP classes patch the service layer and assert wiring: the deployment
+  kill switch, the refusal-to-error-code mapping, and admin-only access.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from api.main import app
+from auth.dependencies import require_admin, require_session_auth
+from config.plan_tiers import PLAN_TIERS
+from config.settings import (
+    REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES,
+    Settings,
+    get_settings,
+)
+from db.base import get_db
+from models.auth import Workspace
+from services.referral_service import ReferralSummary
+from utils.exceptions import (
+    ReferralAlreadyRedeemedError,
+    ReferralCapReachedError,
+    ReferralCodeInvalidError,
+    ReferralSelfError,
+    ReferralWindowClosedError,
+)
+
+
+def _upper_bound(field_name: str) -> int:
+    """Read a ``Field(le=...)`` ceiling off the Settings model.
+
+    Read from the model rather than hardcoded here so that raising a ceiling in
+    ``settings.py`` is what trips the bounds tests — a copied number would
+    silently agree with any change.
+    """
+    for constraint in Settings.model_fields[field_name].metadata:
+        bound = getattr(constraint, "le", None)
+        if bound is not None:
+            return int(bound)
+    raise AssertionError(f"Settings.{field_name} has no `le=` ceiling — it must be bounded.")
+
+
+class TestPayoutBudget:
+    """The cross-field guard that per-field ``le=`` bounds cannot express (#1470)."""
+
+    def test_payout_budget_matches_the_free_to_basic_gap(self) -> None:
+        """Pin the hardcoded budget to the tier values it was derived from.
+
+        ``settings.py`` cannot import ``plan_tiers`` (that module calls
+        ``get_settings()`` at import time), so the constant is hardcoded there
+        and pinned here instead. If someone retunes the FREE or BASIC memory
+        limit, this is what tells them the referral budget moved too.
+        """
+        assert REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES == (
+            PLAN_TIERS["basic"].memory_limit - PLAN_TIERS["free"].memory_limit
+        )
+
+    def test_per_field_ceilings_alone_would_blow_the_budget(self) -> None:
+        """Documents WHY the cross-field validator has to exist.
+
+        If this ever stops being true the validator may look redundant — it is
+        not: it is what makes the individually-bounded fields safe *together*.
+        """
+        product = _upper_bound("referral_referee_reward_memories") * _upper_bound(
+            "referral_max_grants_per_referrer"
+        )
+        assert product > REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
+
+    def test_defaults_are_within_budget(self) -> None:
+        settings = get_settings()
+        worst = settings.referral_max_grants_per_referrer * max(
+            settings.referral_referrer_reward_memories,
+            settings.referral_referee_reward_memories,
+        )
+        assert worst <= REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES
+
+    def test_over_budget_config_fails_closed_at_load(self) -> None:
+        """An operator cannot dial away the tier ladder one field at a time."""
+        with pytest.raises(ValidationError, match="above the"):
+            Settings(
+                enable_referrals=True,
+                referral_max_grants_per_referrer=10,
+                referral_referrer_reward_memories=2000,
+                referral_referee_reward_memories=2000,
+            )
+
+    def test_budget_guard_is_inert_when_referrals_are_disabled(self) -> None:
+        """OSS deployments that never enable referrals need not keep these coherent."""
+        settings = Settings(
+            enable_referrals=False,
+            referral_max_grants_per_referrer=10,
+            referral_referrer_reward_memories=2000,
+            referral_referee_reward_memories=2000,
+        )
+        assert settings.referral_max_grants_per_referrer == 10
+
+    def test_field_ceilings_still_reject_a_single_absurd_value(self) -> None:
+        with pytest.raises(ValidationError):
+            Settings(enable_referrals=True, referral_referee_reward_memories=500000)
+
+
+class TestEffectiveMemoryLimit:
+    """``Workspace.effective_memory_limit`` stacks the referral bonus (#1470)."""
+
+    def test_referral_bonus_stacks_on_free(self) -> None:
+        ws = Workspace(plan_name="free", addon_memory_bonus=0, referral_memory_bonus=500)
+        # FREE base is 1000 -> a felt +50%, which is the whole point of the number.
+        assert ws.effective_memory_limit == 1500
+
+    def test_referral_and_addon_bonuses_both_apply(self) -> None:
+        ws = Workspace(plan_name="free", addon_memory_bonus=10000, referral_memory_bonus=500)
+        assert ws.effective_memory_limit == 11500
+
+    def test_zero_bonus_is_unchanged_from_plan_base(self) -> None:
+        ws = Workspace(plan_name="basic", addon_memory_bonus=0, referral_memory_bonus=0)
+        assert ws.effective_memory_limit == 10000
+
+    def test_budget_at_the_free_to_basic_gap_does_not_reach_basic(self) -> None:
+        """A fully-used chain at the payout budget must stay under BASIC.
+
+        This is the ladder invariant the payout budget exists to hold: the
+        referral program must never be a way to get the paid tier for free.
+        """
+        free_base = Workspace(
+            plan_name="free", addon_memory_bonus=0, referral_memory_bonus=0
+        ).effective_memory_limit
+        basic_base = Workspace(
+            plan_name="basic", addon_memory_bonus=0, referral_memory_bonus=0
+        ).effective_memory_limit
+        assert free_base + REFERRAL_TOTAL_PAYOUT_BUDGET_MEMORIES <= basic_base
+
+    def test_zero_floor_still_applies(self) -> None:
+        """A tier that excludes memories cannot be lifted by a referral.
+
+        ``_zero_floor`` is the #569 defense-in-depth guard. The referral bonus is
+        summed with the addon bonus *before* that guard precisely so it inherits
+        the protection rather than bypassing it.
+        """
+        ws = Workspace(plan_name="free", addon_memory_bonus=0, referral_memory_bonus=500)
+        object.__setattr__(ws, "_plan_tier", MagicMock(memory_limit=0))
+        assert ws.effective_memory_limit == 0
+
+
+def _session_user() -> dict:
+    return {"user_id": "user_referee", "email": "referee@test.com", "role": "user"}
+
+
+def _admin_user() -> dict:
+    return {"user_id": "admin_1", "email": "admin@test.com", "role": "admin"}
+
+
+@pytest.fixture
+def client():
+    async def mock_session():
+        return _session_user()
+
+    async def mock_admin():
+        return _admin_user()
+
+    async def mock_db():
+        yield MagicMock()
+
+    app.dependency_overrides[require_session_auth] = mock_session
+    app.dependency_overrides[require_admin] = mock_admin
+    app.dependency_overrides[get_db] = mock_db
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def referrals_enabled(monkeypatch):
+    """Turn the deployment kill switch on for the duration of a test."""
+    settings = get_settings()
+    monkeypatch.setattr(settings, "enable_referrals", True)
+    return settings
+
+
+def _mock_grant() -> MagicMock:
+    return MagicMock(
+        id=uuid4(),
+        referrer_user_id="user_referrer",
+        referrer_workspace_id=uuid4(),
+        referred_user_id="user_referee",
+        referred_workspace_id=uuid4(),
+        referrer_bonus_memories=500,
+        referred_bonus_memories=500,
+        granted_at=datetime(2026, 8, 1, tzinfo=UTC),
+        revoked_at=None,
+        revoked_reason=None,
+    )
+
+
+class TestKillSwitch:
+    """``enable_referrals`` gates the user-facing surface but not the admin one."""
+
+    def test_summary_404s_when_disabled(self, client, monkeypatch) -> None:
+        monkeypatch.setattr(get_settings(), "enable_referrals", False)
+        assert client.get("/api/v1/referrals/me").status_code == 404
+
+    def test_redeem_404s_when_disabled(self, client, monkeypatch) -> None:
+        monkeypatch.setattr(get_settings(), "enable_referrals", False)
+        response = client.post("/api/v1/referrals/redeem", json={"code": "abc"})
+        assert response.status_code == 404
+
+    def test_admin_ledger_stays_reachable_when_disabled(self, client, monkeypatch) -> None:
+        """An operator must be able to unwind grants after hitting the kill switch."""
+        monkeypatch.setattr(get_settings(), "enable_referrals", False)
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.list_grants",
+            AsyncMock(return_value=([], 0)),
+        )
+        response = client.get("/api/v1/admin/referrals")
+        assert response.status_code == 200
+
+    def test_system_info_exposes_the_flag(self, client) -> None:
+        features = client.get("/api/v1/system/info").json()["features"]
+        assert "referrals" in features
+
+    def test_system_info_does_not_leak_reward_amounts(self, client) -> None:
+        """Telling an unauthenticated caller what a fresh account is worth is free
+        reconnaissance for a farmer."""
+        body = client.get("/api/v1/system/info").text
+        assert "reward" not in body.lower()
+
+
+class TestSummary:
+    def test_returns_code_and_remaining_slots(self, client, referrals_enabled, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.get_summary",
+            AsyncMock(
+                return_value=ReferralSummary(
+                    code="abc123",
+                    max_grants=3,
+                    used_grants=1,
+                    referee_reward_memories=500,
+                    referrer_reward_memories=500,
+                    earned_memories=500,
+                )
+            ),
+        )
+        body = client.get("/api/v1/referrals/me").json()
+        assert body["code"] == "abc123"
+        assert body["remaining_grants"] == 2
+        assert body["earned_memories"] == 500
+
+    def test_remaining_never_goes_negative(self, client, referrals_enabled, monkeypatch) -> None:
+        """The cap can be lowered by config while users sit above it."""
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.get_summary",
+            AsyncMock(
+                return_value=ReferralSummary(
+                    code="abc123",
+                    max_grants=1,
+                    used_grants=4,
+                    referee_reward_memories=500,
+                    referrer_reward_memories=500,
+                    earned_memories=2000,
+                )
+            ),
+        )
+        assert client.get("/api/v1/referrals/me").json()["remaining_grants"] == 0
+
+
+class TestRedeem:
+    def test_success_returns_the_grant(self, client, referrals_enabled, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.redeem",
+            AsyncMock(return_value=_mock_grant()),
+        )
+        response = client.post("/api/v1/referrals/redeem", json={"code": "abc123"})
+        assert response.status_code == 201
+        assert response.json()["referred_bonus_memories"] == 500
+
+    @pytest.mark.parametrize(
+        ("exc", "expected_code"),
+        [
+            (ReferralCodeInvalidError(), "REFERRAL-001"),
+            (ReferralSelfError(), "REFERRAL-002"),
+            (ReferralAlreadyRedeemedError(), "REFERRAL-003"),
+            (ReferralWindowClosedError(window_hours=72), "REFERRAL-004"),
+            (ReferralCapReachedError(), "REFERRAL-005"),
+        ],
+    )
+    def test_refusals_map_to_400_with_routable_codes(
+        self, client, referrals_enabled, monkeypatch, exc, expected_code
+    ) -> None:
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.redeem",
+            AsyncMock(side_effect=exc),
+        )
+        response = client.post("/api/v1/referrals/redeem", json={"code": "abc123"})
+        assert response.status_code == 400
+        assert expected_code in response.text
+
+    def test_invalid_code_and_cap_reached_are_indistinguishable_to_the_caller(
+        self,
+    ) -> None:
+        """Probing a code must not reveal whether it exists or who owns it."""
+        assert ReferralCodeInvalidError().message == ReferralCapReachedError().message
+
+    def test_empty_code_is_rejected_before_the_service(self, client, referrals_enabled) -> None:
+        assert client.post("/api/v1/referrals/redeem", json={"code": ""}).status_code == 422
+
+
+class TestAdminRevoke:
+    def test_revoke_requires_a_reason(self, client) -> None:
+        response = client.post(f"/api/v1/admin/referrals/{uuid4()}/revoke", json={"reason": ""})
+        assert response.status_code == 422
+
+    def test_revoke_404s_for_unknown_grant(self, client, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "services.referral_service.ReferralService.revoke",
+            AsyncMock(return_value=None),
+        )
+        response = client.post(
+            f"/api/v1/admin/referrals/{uuid4()}/revoke", json={"reason": "abuse"}
+        )
+        assert response.status_code == 404
+
+    def test_non_admin_is_rejected(self) -> None:
+        """The signup-gate router never got this test; this one does.
+
+        No ``with`` block: entering the TestClient context runs the app lifespan,
+        which needs a live Redis. These routes are reachable without it.
+        """
+
+        async def mock_db():
+            yield MagicMock()
+
+        app.dependency_overrides[get_db] = mock_db
+        try:
+            unauth = TestClient(app, raise_server_exceptions=False)
+            assert unauth.get("/api/v1/admin/referrals").status_code in (401, 403)
+            assert unauth.post(
+                f"/api/v1/admin/referrals/{uuid4()}/revoke", json={"reason": "x"}
+            ).status_code in (401, 403)
+        finally:
+            app.dependency_overrides.clear()

--- a/backend/tests/models/test_auth_effective_limits.py
+++ b/backend/tests/models/test_auth_effective_limits.py
@@ -69,6 +69,24 @@ EFFECTIVE_PROPERTIES = [
 ]
 
 
+def _mock_workspace(tier: MagicMock, addon_attr: str, addon_value: int | None) -> MagicMock:
+    """Build a stand-in workspace exposing exactly the columns a property reads.
+
+    ``MagicMock`` auto-creates attributes, so any column an ``effective_*``
+    property reads but the test does not set would arrive as a MagicMock and
+    make the arithmetic silently produce another MagicMock instead of an int.
+    ``effective_memory_limit`` reads a SECOND column (#1470's
+    ``referral_memory_bonus``, deliberately outside the addon machinery), so it
+    is zeroed here for every case; the referral stacking itself is covered by
+    ``tests/api/test_referrals.py::TestEffectiveMemoryLimit``.
+    """
+    ws = MagicMock()
+    ws._plan_tier = tier
+    ws.referral_memory_bonus = 0
+    setattr(ws, addon_attr, addon_value)
+    return ws
+
+
 class TestZeroBaseBypassClosed:
     """For every ``effective_*_limit``, a synthetic tier with base=0 and
     a positive addon must still report effective=0. This is the core
@@ -87,9 +105,7 @@ class TestZeroBaseBypassClosed:
     def test_zero_base_with_addon_returns_zero(self, prop_name, tier_attr, addon_attr, addon_scale):
         tier = MagicMock()
         setattr(tier, tier_attr, 0)
-        ws = MagicMock()
-        ws._plan_tier = tier
-        setattr(ws, addon_attr, 5)  # any positive addon must be ignored
+        ws = _mock_workspace(tier, addon_attr, 5)  # any positive addon must be ignored
         assert getattr(Workspace, prop_name).fget(ws) == 0
 
     @pytest.mark.parametrize(
@@ -100,9 +116,7 @@ class TestZeroBaseBypassClosed:
     def test_nonzero_base_stacks_addon(self, prop_name, tier_attr, addon_attr, addon_scale):
         tier = MagicMock()
         setattr(tier, tier_attr, 100)
-        ws = MagicMock()
-        ws._plan_tier = tier
-        setattr(ws, addon_attr, 5)
+        ws = _mock_workspace(tier, addon_attr, 5)
         assert getattr(Workspace, prop_name).fget(ws) == 100 + 5 * addon_scale
 
     @pytest.mark.parametrize(
@@ -120,9 +134,7 @@ class TestZeroBaseBypassClosed:
         """
         tier = MagicMock()
         setattr(tier, tier_attr, 100)
-        ws = MagicMock()
-        ws._plan_tier = tier
-        setattr(ws, addon_attr, None)
+        ws = _mock_workspace(tier, addon_attr, None)
         assert getattr(Workspace, prop_name).fget(ws) == 100
 
 

--- a/backend/tests/services/test_downgrade_eligibility_service.py
+++ b/backend/tests/services/test_downgrade_eligibility_service.py
@@ -26,8 +26,24 @@ BASIC = PLAN_TIERS["basic"]
 PRO = PLAN_TIERS["pro"]
 
 
-def _ws(plan_name="pro", *, member=0, context=0, memory=0, connector=0, sleep=0, storage_mb=0):
-    """A minimal workspace stand-in carrying the addon bonuses the math reads."""
+def _ws(
+    plan_name="pro",
+    *,
+    member=0,
+    context=0,
+    memory=0,
+    connector=0,
+    sleep=0,
+    storage_mb=0,
+    referral_memory=0,
+):
+    """A minimal workspace stand-in carrying the bonuses the math reads.
+
+    ``referral_memory`` (#1470) is NOT an addon — it stacks into the same
+    effective memory limit from outside the addon machinery, so the downgrade
+    math has to read it too or it tells users to delete memories they are still
+    entitled to keep.
+    """
     return types.SimpleNamespace(
         id=uuid4(),
         plan_name=plan_name,
@@ -37,6 +53,7 @@ def _ws(plan_name="pro", *, member=0, context=0, memory=0, connector=0, sleep=0,
         addon_connector_bonus=connector,
         addon_sleep_contexts_bonus=sleep,
         addon_storage_bonus_mb=storage_mb,
+        referral_memory_bonus=referral_memory,
     )
 
 
@@ -130,6 +147,38 @@ def test_addons_are_kept_and_raise_the_target_effective_limit():
     over = _svc()._evaluate_tier(ws, _usage(contexts=9), BASIC)
     b = _by_dim(over)["contexts"]
     assert (b.limit, b.overage) == (8, 1)  # base(3) + addon(5) = 8
+
+
+def test_referral_bonus_is_kept_and_raises_the_target_memory_limit():
+    """#1470: the referral bonus survives a downgrade and must raise the limit.
+
+    It is locally-owned entitlement, not billing-derived, so a plan change does
+    not take it away. Omitting it here would block an otherwise-eligible
+    downgrade and tell the user to delete memories they still have room for.
+    """
+    # FREE memory base 1000, +1500 referral → effective 2500.
+    ws = _ws(referral_memory=1500)
+    assert _svc()._evaluate_tier(ws, _usage(memories=2500), FREE).eligible is True
+    over = _svc()._evaluate_tier(ws, _usage(memories=2501), FREE)
+    b = _by_dim(over)["memories"]
+    assert (b.limit, b.overage) == (2500, 1)
+
+
+def test_referral_bonus_stacks_with_the_memory_addon():
+    """Both bonuses accrue to the same limit; neither may shadow the other."""
+    ws = _ws(memory=10000, referral_memory=1500)
+    # FREE base 1000 + addon 10000 + referral 1500 = 12500.
+    result = _svc()._evaluate_tier(ws, _usage(memories=12501), FREE)
+    assert _by_dim(result)["memories"].limit == 12500
+
+
+def test_referral_bonus_cannot_lift_a_zero_base_dimension():
+    """The bonus rides the same ``_zero_floor`` guard the addons do (#569)."""
+    ws = _ws(plan_name="pro", referral_memory=1500)
+    # PRO analysis_runs_per_day is a separate dimension; the referral bonus is
+    # memory-only, so a huge referral must not leak into any other check.
+    result = _svc()._evaluate_tier(ws, _usage(contexts=25), FREE)
+    assert _by_dim(result)["contexts"].limit == FREE.max_contexts_per_workspace
 
 
 def test_multiple_blockers_collected():

--- a/backend/tests/smoke/test_all_routes.py
+++ b/backend/tests/smoke/test_all_routes.py
@@ -54,6 +54,7 @@ PARAM_DEFAULTS = {
     "client_id": "1",
     "invitation_id": "1",
     "token_id": "1",
+    "grant_id": "00000000-0000-0000-0000-000000000003",  # Issue #1470: referral ledger row
     "resource_id": "test-resource",
     "token": "dummy-token",
     "key": "test-key",

--- a/backend/tests/test_schema_drift.py
+++ b/backend/tests/test_schema_drift.py
@@ -97,6 +97,7 @@ _MODEL_MODULES: tuple[str, ...] = (
     "models.llm_pricing",
     "models.memory",
     "models.neural",
+    "models.referral",
     "models.resource",
     "models.signup_gate",
     "models.sleep",


### PR DESCRIPTION
Closes #1470

招待した人と招待された人の双方にメモリ枠ボーナスが付く紹介 (referral) 導線を追加します。バックエンドのみ。既定 OFF (`ENABLE_REFERRALS=false`) なので、マージしても既存の挙動は一切変わりません。

既存の `WorkspaceInvitation` は **Pro 専用のチームメンバー招待**で、`max_members_per_workspace` が Free/Basic とも 1、かつ共有コンテキスト（Pro 専用）を1つ以上要求するため、**Free ユーザーは構造的に誰も招待できません**。紹介が届くべき相手がまさにそこなので、別導線として新設しています。

## 前提の明示

報酬の単位は **メモリ件数**です。`+500 contexts` は Free の base=1 に対して 501、Pro の上限 20 の 25 倍になり、しかも `ADDON_UNIT_VALUES["extra_contexts"] = 5` で 500 は割り切れるため**バリデーションを通過してしまいます**（`quota_service.py:455-457` は `_zero_floor` を通さない生加算）。エラーで止まらない分メモリ解釈より危険なので、意図的に採りませんでした。

## なぜ addon 機構を使わないのか

本 PR の中心的な設計判断です。3つの経路がいずれもボーナスを破壊します（すべて実コードで検証済み）:

1. **`internal_billing.py:217-221` は full-replace** — `addons` を含む billing push が来ると `_ADDON_COLUMNS` の10列を全て 0 にしてから入れ直します。billing は紹介ボーナスを知らないので、**ユーザーが課金した瞬間にボーナスが消えます**。
2. **`addon_*` 列は台帳ではなくキャッシュ** — `recalculate_workspace_bonuses` が `SUM(WorkspaceAddon.quantity × unit_value)` を**絶対値で**書き込みます。裏付ける `WorkspaceAddon` 行のない値は次の recalc で 0 になり、`GET /admin/plans/addon-cache-consistency` に drift として検出されます。**#665 で一度踏んだバグ**です (`admin_plans.py:1008-1013`)。
3. **+500 は表現不能** — `ADDON_UNIT_VALUES["extra_memory"] = 10000` で、admin PUT が非倍数を 400 で拒否。最小付与が Free 全体量の10倍。

なお **`entitlement_source` は保護になりません**。`backend/src` 全体で条件式として読んでいる箇所がゼロで、`internal_billing.py:211-212` は無条件に `external_billing` へ上書きします（コメント自身が "a prior admin/comp grant is overwritten here" と明言）。外部 reconciler 向けの advisory フラグです。

→ **`addon_` 接頭辞を持たない専用列 `workspaces.referral_memory_bonus`** を新設し、3つのコレクションすべての外側に置きました。`tests/api/test_referral_addon_isolation.py` が3箇所からの不在を、**理由をアサーションメッセージに書いて**固定しています。将来の contributor が赤いテストを見て「テストを直す」判断をしないように、列の docstring にも同じ警告を置いています。

## 台帳とキャッシュの契約

`referral_grants` が台帳、`workspaces.referral_memory_bonus` は**非 revoke 行の絶対 SUM で再計算される派生キャッシュ**（インクリメントしない）。この1つの規則で3つの性質が同時に手に入ります:

- **冪等** — `UNIQUE(referred_user_id)` + `INSERT ... ON CONFLICT DO NOTHING RETURNING id`。再送も競合も0行挿入・0円支払い
- **可逆** — revoke は `revoked_at` を立てて再計算。減算ではないので、付与した分だけ正確に戻る
- **非遡及** — 付与額を行にスナップショットするので、設定を下げても既存ユーザーの上限は縮まない

## スキーマ

```
ALTER TABLE workspaces ADD COLUMN referral_memory_bonus INTEGER NOT NULL DEFAULT 0
  CHECK (referral_memory_bonus >= 0)
ALTER TABLE users ADD COLUMN referral_code VARCHAR(24) NULL UNIQUE   -- 遅延生成
CREATE TABLE referral_grants (...)
  UNIQUE (referred_user_id)                     -- 冪等性キー
  CHECK  (referrer_user_id <> referred_user_id) -- 自己招待禁止
```

`referral_code` は `users.user_id`（OAuth sub、セッション/APIキー/MCP 認証の主識別子）を共有 URL に出さないための別列です。FK は4本とも `ON DELETE SET NULL` — `account_erasure_service` の明示的テーブル掃除リストに新エントリを足さずに済み、かつ被招待者の退会が招待者の獲得済み枠を遡って消しません。

## 設定: v1 は env、admin UI は v2

```
ENABLE_REFERRALS=false                             # キルスイッチ
REFERRAL_REFEREE_REWARD_MEMORIES=500       (0..2000)
REFERRAL_REFERRER_REWARD_MEMORIES=500      (0..2000)   ← 招待者側は別フィールド
REFERRAL_MAX_GRANTS_PER_REFERRER=3         (0..10)
REFERRAL_REDEEM_WINDOW_HOURS=72            (1..720)
```

- **招待者側と被招待者側を別フィールドに**しています。`referrer = 0` にすれば farming の動機だけが消えて、オンボーディング特典としては生き残る — オン/オフ1個では表現できない中間対応です。
- **上限3で launch**。3→5 は非破壊、5→3 は既に4・5人目を獲得した人を宙吊りにします。env で上げられます。
- **DB シングルトンの設定 UI は意図的に v2 送り**。`SignupGateConfig` 一式は約2,500行あり付与エンジン本体より大きく、付与額は行にスナップショットされるので retroactivity が起きず「今すぐ変えないと」が発生しません。台帳が実際のチューニング頻度を示したら、**データ移行なしの純粋な追加**として移行できます。
- 一方 **台帳一覧と per-grant revoke（reason 必須 + AuditLog）は初日から同梱**。entitlement を発行する機能に undo がないとインシデント時に運用できません。`SignupGateService.update_config` が AuditLog もログ行も残さない点は、意図的に踏襲していません。

### 単項の `le=` では足りない

`Field(le=...)` は各フィールドを独立に縛るだけで、**効くのは積**です。個別上限の積は 10 × 2000 = 20,000 で FREE→BASIC の差 9,000 の倍以上。cross-field validator (`_validate_referral_payout_budget`) が起動時に fail-closed します。式は `max_grants × referrer + referee` — 1つのワークスペースは被招待者に1回・招待者に max_grants 回なれるので、両方が同じワークスペースに積み上がります。

この欠陥は**開発中に自分のテストが検出**しました。

## API

| | |
|---|---|
| `GET /api/v1/referrals/me` | 自分のコード・残枠・獲得量（session 認証のみ） |
| `POST /api/v1/referrals/redeem` | コード引き換え |
| `GET /api/v1/admin/referrals` | 台帳一覧（system-admin） |
| `POST /api/v1/admin/referrals/{id}/revoke` | 個別取り消し（reason 必須 + AuditLog） |

ユーザー向けは `ENABLE_REFERRALS=false` のとき **auth より前に** 404 になります（未認証 401 / 認証済み 404 の差は、それ自体がエンドポイントの存在を広告するため）。admin 側はキルスイッチ OFF 後も既存 grant を巻き戻せるよう到達可能なままです。

API キーではなく session 認証限定にしているのは、引き換えをスクリプト可能なエンドポイントにしないためです。

## レビューで潰した13件

5観点 × 各指摘の独立 refutation でレビューし、confirmed 13 / refuted 6。実質的に重かったもの:

- **統合漏れ2件** — `downgrade_eligibility_service` と `admin_plans._effective_for_guard` が `plan_tier + addon_memory_bonus` から限界値を再計算しており `effective_memory_limit` と乖離。前者は「まだ保持できるメモリを消せ」と誤案内、後者は安全な admin 操作を誤って拒否していました
- **予算式の undercount** — `max(referrer, referee)` では被招待者報酬まるごと1個分足りず、`(4, 2000, 2000)` が 8000 で通過して実際は 10000 を発行（BASIC ちょうど）
- **enumeration oracle** — `REFERRAL-005` の存在自体が「実在するが枯渇したコード」を教えていました。001 に統合し、真の理由は構造化ログへ。redeem-window チェックもコード解決の前へ移動（004 到達もコード実在の証拠になっていたため）
- **並行性3件** — recompute の SELECT-then-UPDATE に workspace ロックなし / role 順ロックが相互招待でデッドロック（UUID 順 + 重複排除に変更）/ code mint のリトライループが unique 衝突後に実際には retry できていなかった（SAVEPOINT 化）
- **セッション破壊** — `create_workspace` のフックが rollback なしで例外を握り潰し、caller に aborted transaction を返していました

## 検証

| | |
|---|---|
| `ruff check` / `ruff format --check` | clean（861 files） |
| `pyright src/` | **0 errors** |
| backend unit（CI と同一の除外セット） | **5423 passed** / 527 skipped |
| smoke | 48 passed |
| schema drift | pass（ORM の CHECK 文言と migration が一致） |

残る6件のローカル失敗は `tests/test_models_no_column_guard.py`（Windows の `grep` が exit 2）と `tests/cli/`（Windows の chmod セマンティクス）で、`git diff --name-only origin/main` により**本 diff が対象ファイルを一切触っていない**ことを確認済みの環境起因です。

## 非スコープ（フォローアップ）

- フロントエンドの紹介カード / admin 台帳ページ
- admin 設定 UI（`referral_program_config` シングルトン）
- OAuth コールバックでの自動アトリビューション（現状は明示的な `POST /redeem`。ホットな認証経路を触らない判断で、`ReferralService.redeem` をそのまま呼べる形にしてあります）
- 支払いトリガーを「初回 remember 到達」に変更する案

🤖 Generated with [Claude Code](https://claude.com/claude-code)
