### PR TITLE
feat(frontend): make memory_link_template editable from the connectors UI (#1471)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
@@ -1626,4 +1626,177 @@ describe("ConnectorsPage RBAC gate", () => {
     // The dialog stays open on failure.
     expect(screen.getByText("createTitle")).toBeInTheDocument();
   });
+  // ── #1471: memory_link_template is now writable from the UI ──────────
+
+  function connectorWithRuntime(runtime: Record<string, unknown>) {
+    return {
+      connector_id: "connector-1",
+      connector_type: "slack",
+      app_key: "default",
+      resource_id: "slack-t01",
+      context_id: "context-1",
+      config_version: 3,
+      created_at: "2026-07-19T00:00:00Z",
+      created_by: "user-1",
+      runtime,
+      channel_ids: ["C1"],
+      locale: null,
+      litellm_virtual_key_id: null,
+      llm_config_present: false,
+    };
+  }
+
+  it("saves memory_link_template through the runtime endpoint, spreading the existing runtime (#1471)", async () => {
+    setWorkspace("admin");
+    // A tuned runtime: the spread must preserve every one of these. The
+    // endpoint is a COMPLETE replacement, so a partial body would silently
+    // reset them to worker defaults.
+    mockListConnectors.mockResolvedValue([
+      connectorWithRuntime({
+        vision_enabled: false,
+        memory_link_template: null,
+        entity_max: 12,
+      }),
+    ]);
+    mockUpdateConnectorRuntime.mockResolvedValue({
+      connector_id: "connector-1",
+      runtime: {},
+      stored: true,
+      config_version: 4,
+    });
+
+    render(<ConnectorsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "editSettings" }),
+    );
+    fireEvent.change(await screen.findByLabelText("memoryLinkTemplateLabel"), {
+      target: { value: "https://m.example/c/{context_id}?memoryId={memory_id}" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "settingsSave" }));
+
+    await waitFor(() =>
+      expect(mockUpdateConnectorRuntime).toHaveBeenCalledWith(
+        "connector-1",
+        {
+          vision_enabled: false,
+          entity_max: 12,
+          memory_link_template:
+            "https://m.example/c/{context_id}?memoryId={memory_id}",
+        },
+        3,
+      ),
+    );
+    // Nothing else changed, so the vend-settings endpoint must not be touched.
+    expect(mockUpdateConnectorSettings).not.toHaveBeenCalled();
+  });
+
+  it("chains config_version when both endpoints are written (#1471)", async () => {
+    // THE trap this feature introduces: both endpoints consume AND bump
+    // config_version. Sending the same snapshot version to both makes the
+    // second write 409. The second call must ride the version the FIRST
+    // response returned.
+    setWorkspace("admin");
+    mockListConnectors.mockResolvedValue([
+      connectorWithRuntime({ vision_enabled: true, memory_link_template: null }),
+    ]);
+    mockUpdateConnectorSettings.mockResolvedValue({
+      connector_id: "connector-1",
+      channel_ids: ["C1", "C2"],
+      litellm_virtual_key_id: null,
+      llm_config_present: false,
+      locale: null,
+      config_version: 4,
+    });
+    mockUpdateConnectorRuntime.mockResolvedValue({
+      connector_id: "connector-1",
+      runtime: {},
+      stored: true,
+      config_version: 5,
+    });
+
+    render(<ConnectorsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "editSettings" }),
+    );
+    fireEvent.change(await screen.findByLabelText("channelsLabel"), {
+      target: { value: "C1, C2" },
+    });
+    fireEvent.change(screen.getByLabelText("memoryLinkTemplateLabel"), {
+      target: { value: "https://m.example/{context_id}/{memory_id}" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "settingsSave" }));
+
+    await waitFor(() =>
+      expect(mockUpdateConnectorSettings).toHaveBeenCalledWith(
+        "connector-1",
+        { channel_ids: ["C1", "C2"] },
+        3,
+      ),
+    );
+    // 4, not 3 — the version the settings write returned.
+    await waitFor(() =>
+      expect(mockUpdateConnectorRuntime).toHaveBeenCalledWith(
+        "connector-1",
+        expect.objectContaining({
+          memory_link_template: "https://m.example/{context_id}/{memory_id}",
+        }),
+        4,
+      ),
+    );
+  });
+
+  it("clears memory_link_template to null on empty input (#1471)", async () => {
+    // "" must not be stored — it would fail the server's scheme validation and
+    // is semantically "no override", which is null.
+    setWorkspace("admin");
+    mockListConnectors.mockResolvedValue([
+      connectorWithRuntime({
+        vision_enabled: true,
+        memory_link_template: "https://m.example/{context_id}/{memory_id}",
+      }),
+    ]);
+    mockUpdateConnectorRuntime.mockResolvedValue({
+      connector_id: "connector-1",
+      runtime: {},
+      stored: true,
+      config_version: 4,
+    });
+
+    render(<ConnectorsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "editSettings" }),
+    );
+    fireEvent.change(await screen.findByLabelText("memoryLinkTemplateLabel"), {
+      target: { value: "   " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "settingsSave" }));
+
+    await waitFor(() =>
+      expect(mockUpdateConnectorRuntime).toHaveBeenCalledWith(
+        "connector-1",
+        expect.objectContaining({ memory_link_template: null }),
+        3,
+      ),
+    );
+  });
+
+  it("does not write anything when the template is untouched (#1471)", async () => {
+    setWorkspace("admin");
+    mockListConnectors.mockResolvedValue([
+      connectorWithRuntime({
+        vision_enabled: true,
+        memory_link_template: "https://m.example/{context_id}/{memory_id}",
+      }),
+    ]);
+
+    render(<ConnectorsPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: "editSettings" }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "settingsSave" }));
+
+    expect(await screen.findByText("noChanges")).toBeInTheDocument();
+    expect(mockUpdateConnectorRuntime).not.toHaveBeenCalled();
+    expect(mockUpdateConnectorSettings).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -313,6 +313,10 @@ export default function ConnectorsPage() {
     "default",
   );
   const [litellmKey, setLitellmKey] = useState("");
+  // #1471: runtime.memory_link_template. Lives in the settings dialog for
+  // proximity, but saves through the RUNTIME endpoint, not the vend-settings
+  // one — see handleSettingsSave for why the two writes must be sequenced.
+  const [memoryLinkTemplate, setMemoryLinkTemplate] = useState("");
   const [llmProvider, setLlmProvider] = useState("");
   const [llmModel, setLlmModel] = useState("");
   const [llmApiKey, setLlmApiKey] = useState("");
@@ -491,6 +495,7 @@ export default function ConnectorsPage() {
         c.locale === "en" || c.locale === "ja" ? c.locale : "default",
       );
       setLitellmKey(c.litellm_virtual_key_id ?? "");
+      setMemoryLinkTemplate(c.runtime?.memory_link_template ?? "");
       setLlmProvider("");
       setLlmModel("");
       setLlmApiKey("");
@@ -567,20 +572,44 @@ export default function ConnectorsPage() {
         ...(llmApiKey.trim() ? { api_key: llmApiKey.trim() } : {}),
       };
     }
-    if (Object.keys(patch).length === 0) {
+    // #1471: memory_link_template is a RUNTIME field, so it rides the other
+    // endpoint. Empty input clears the override to null rather than storing "".
+    const newLinkTemplate = memoryLinkTemplate.trim() || null;
+    const linkTemplateChanged =
+      newLinkTemplate !== (settingsFor.runtime?.memory_link_template ?? null);
+
+    if (Object.keys(patch).length === 0 && !linkTemplateChanged) {
       setSettingsError(t("noChanges"));
       return;
     }
 
     setSettingsSaving(true);
     try {
-      await updateConnectorSettings(
-        settingsFor.connector_id,
-        patch,
-        // Snapshot version rides along as the optimistic-concurrency guard
-        // (server 409s on staleness instead of silently reverting).
-        settingsFor.config_version,
-      );
+      // Both endpoints consume AND bump config_version, so writing one
+      // invalidates the snapshot the other would send. Chain them: take the
+      // fresh version out of the first response and hand it to the second.
+      // Doing them independently from the same snapshot 409s the second write.
+      let version = settingsFor.config_version;
+      if (Object.keys(patch).length > 0) {
+        const settingsResult = await updateConnectorSettings(
+          settingsFor.connector_id,
+          patch,
+          // Snapshot version rides along as the optimistic-concurrency guard
+          // (server 409s on staleness instead of silently reverting).
+          version,
+        );
+        version = settingsResult.config_version;
+      }
+      if (linkTemplateChanged) {
+        // Spread the CURRENT runtime: this endpoint is a complete normalized
+        // replacement, so a partial body silently resets every other tuned
+        // field (buffer, flush, lifecycle, …) to worker defaults.
+        await updateConnectorRuntime(
+          settingsFor.connector_id,
+          { ...settingsFor.runtime, memory_link_template: newLinkTemplate },
+          version,
+        );
+      }
       toast({ title: t("settingsSaved") });
       setSettingsFor(null);
       void reload();
@@ -597,6 +626,7 @@ export default function ConnectorsPage() {
     chText,
     localeSel,
     litellmKey,
+    memoryLinkTemplate,
     llmProvider,
     llmModel,
     llmApiKey,
@@ -1704,6 +1734,28 @@ export default function ConnectorsPage() {
                     />
                     <p className="mt-1 text-xs text-muted-foreground">
                       {t("litellmKeyNote")}
+                    </p>
+                  </div>
+                  {/* #1471: memory_link_template was persistable via the API and
+                    readable in the frontend type, but had no input — so the
+                    feature could only be turned on by hand. Empty clears to
+                    null; the server validates the scheme and template syntax. */}
+                  <div className="mt-3">
+                    <label
+                      htmlFor="conn-settings-memory-link"
+                      className="mb-1 block text-sm font-medium"
+                    >
+                      {t("memoryLinkTemplateLabel")}
+                    </label>
+                    <Input
+                      id="conn-settings-memory-link"
+                      aria-label={t("memoryLinkTemplateLabel")}
+                      value={memoryLinkTemplate}
+                      onChange={(e) => setMemoryLinkTemplate(e.target.value)}
+                      placeholder={t("memoryLinkTemplatePlaceholder")}
+                    />
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t("memoryLinkTemplateNote")}
                     </p>
                   </div>
                 </details>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -4082,6 +4082,9 @@
     "llmDeleted": "LLM configuration deleted",
     "advancedSettings": "Advanced settings",
     "litellmKeyNote": "Stored but not used by ingestion yet (reserved for an upcoming feature).",
+    "memoryLinkTemplateLabel": "Memory link template",
+    "memoryLinkTemplatePlaceholder": "https://example.com/contexts/'{context_id}'/memories/'{memory_id}'",
+    "memoryLinkTemplateNote": "Makes recalled memories clickable in chat. Keep {context_id} and {memory_id} as placeholders — they are filled per result. Leave empty to show no link (a broken link is worse than none).",
     "missingListSeparator": " / ",
     "connectProvider": "Connect {name}",
     "comingSoon": "Coming soon",
@@ -4105,7 +4108,6 @@
     "memoryLinkTemplate": "Memory link template",
     "memoryLinkTemplateTooltipLabel": "About the memory link template",
     "memoryLinkTemplateTooltip": "When set, the worker turns each recalled memory into a link using this URL template. Leave it empty and no link is rendered.",
-    "memoryLinkTemplatePlaceholder": "https://example.com/contexts/'{context_id}'/memories/'{memory_id}'",
     "memoryLinkTemplateHelp": "Must be an http:// or https:// URL and include both '{context_id}' and '{memory_id}'. Leave empty to render no link."
   },
   "accountDeletion": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -4082,6 +4082,9 @@
     "llmDeleted": "LLM 設定を削除しました",
     "advancedSettings": "詳細設定",
     "litellmKeyNote": "保存されますが、現在の取り込み処理ではまだ使用されません(将来の機能向け)。",
+    "memoryLinkTemplateLabel": "記憶リンクのテンプレート",
+    "memoryLinkTemplatePlaceholder": "https://example.com/contexts/'{context_id}'/memories/'{memory_id}'",
+    "memoryLinkTemplateNote": "チャットの検索結果から記憶へリンクできるようになります。{context_id} と {memory_id} はプレースホルダのまま残してください（結果ごとに埋められます）。空欄にするとリンクを表示しません（壊れたリンクより無い方が良いため）。",
     "missingListSeparator": "・",
     "connectProvider": "{name} を接続",
     "comingSoon": "近日対応",
@@ -4105,7 +4108,6 @@
     "memoryLinkTemplate": "メモリリンクのテンプレート",
     "memoryLinkTemplateTooltipLabel": "メモリリンクのテンプレートについて",
     "memoryLinkTemplateTooltip": "設定すると、ワーカーが想起した各メモリをこの URL テンプレートでリンク化します。空のままならリンクは表示されません。",
-    "memoryLinkTemplatePlaceholder": "https://example.com/contexts/'{context_id}'/memories/'{memory_id}'",
     "memoryLinkTemplateHelp": "http:// または https:// の URL で、'{context_id}' と '{memory_id}' の両方を含める必要があります。空にするとリンクを表示しません。"
   },
   "accountDeletion": {


### PR DESCRIPTION
Closes #1471.

## Problem

`memory_link_template` was persistable via the API and readable in the frontend
type, but had **no input**. `updateConnectorRuntime` had exactly one call site
(`handleVisionEnabledChange`), so the connectors page could edit exactly one
runtime field.

The failure was silent by design: an unset template makes the consuming worker
render no link rather than a broken one. So the feature simply never appeared,
with nothing in the UI to explain why or to turn it on. Setting it required
calling the API by hand.

## Change

Adds the field to the settings dialog's **Advanced settings** section, keeping
the two properties `handleVisionEnabledChange` already gets right:

- **Spread the current runtime** — the endpoint is a *complete normalized
  replacement*, so a partial body silently resets every other tuned field
  (`buffer`, `flush`, `lifecycle`, …) to worker defaults. Tested against a
  runtime carrying unrelated values (`vision_enabled: false`, `entity_max: 12`).
- **Pass `config_version`** for optimistic concurrency.

## The trap this introduces, and how it is handled

The template is a **runtime** field while the rest of the dialog is **vend
settings** — so one save button can now write two endpoints. Both consume *and
bump* `config_version`, so sending the same snapshot version to both makes the
second write 409.

The calls are **chained**: the settings response's fresh version is what the
runtime call rides.

```
snapshot v3
  ├─ updateConnectorSettings(…, 3)  → returns config_version 4
  └─ updateConnectorRuntime(…, 4)   ← not 3
```

`test_chains config_version when both endpoints are written` pins exactly this.

## Details

| Input | Behavior |
|---|---|
| a template | saved via the runtime endpoint |
| empty / whitespace | cleared to `null` — `""` fails the server's scheme validation, and "no override" is semantically null |
| untouched | neither endpoint is called (`noChanges`) |

Server-side validation (scheme, template syntax, length cap) is unchanged and
surfaces through the existing dialog error path rather than being reimplemented
in the client.

## Tests

4 new, all in `page.test.tsx` (59 pass in that file):

- saves through the runtime endpoint, **spreading** an unrelated tuned runtime
- **chains `config_version`** across the two writes
- empty input clears to `null`
- untouched template writes nothing

`tsc --noEmit` clean; i18n added for `en` and `ja`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZpvFKGhBZrEQ4jyFRpTwJ