### PR TITLE
fix(infra): restart the bridge worker after a blue-green color flip (#1476)

### DIFF
--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -373,8 +373,18 @@ cd terraform/single-server
 ```
 
 The script handles building, migrations, readiness checks, Caddy reload,
-and draining automatically. Use `./scripts/deploy.sh --status` to see
-which color is active, or `./scripts/deploy.sh --rollback` to switch back.
+the bridge-worker restart, and draining automatically. Use
+`./scripts/deploy.sh --status` to see which color is active, or
+`./scripts/deploy.sh --rollback` to switch back.
+
+> **No manual bridge restart.** Both the deploy and the rollback path restart
+> the co-resident `kagura-bridge-worker-1` right after the Caddy switch (Step
+> 6b), because the worker pins its API connections to a color and a flip would
+> otherwise leave it talking to the color being drained — surviving only on
+> kagura-bridge's cross-color fallback, which masks the mismatch instead of
+> reporting it ([#1476](https://github.com/kagura-ai/memory-cloud/issues/1476)).
+> A host without that container logs a skip; a restart that fails logs a
+> warning and does **not** abort the deploy.
 
 Tunable environment variables:
 
@@ -384,6 +394,7 @@ Tunable environment variables:
 | `DRAIN_TIMEOUT` | 30 | Seconds to drain old container |
 | `WORKERS_GATE_TIMEOUT` | 30 | Seconds to wait for the post-switch security gate (`/api/v1/workers/*` blocked at Caddy) before aborting and leaving the old color running |
 | `WORKERS_GATE_INTERVAL` | 2 | Seconds between security-gate retries |
+| `BRIDGE_WORKER_CONTAINER` | `kagura-bridge-worker-1` | Co-resident chat-bridge worker to restart after a color flip. Not a compose service of this stack, so it is addressed by container name; skipped when not running |
 
 ### Update the frontend (in-place rebuild)
 

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -47,6 +47,19 @@ WORKERS_GATE_INTERVAL="${WORKERS_GATE_INTERVAL:-2}"   # seconds between security
 # leaves it unset and resolves to the real curl — behaviour is unchanged.
 CURL="${CURL:-curl}"
 
+# docker indirection, same pattern as CURL above: only the bridge-restart step
+# goes through "$DOCKER" so the bats suite can stub it
+# (tests/deploy_bridge_restart.bats). Every other docker call in this file
+# either runs through dc() or belongs to a flow the suite never exercises.
+DOCKER="${DOCKER:-docker}"
+
+# The chat-bridge worker is NOT a service in this repo's docker-compose.prod.yml
+# — it is a separate co-resident stack sharing this VM and docker network. That
+# is why the restart below uses plain `docker` and not dc(): compose would not
+# know the container. Overridable so a host that names it differently (or a test)
+# can point at the right one (#1476).
+BRIDGE_WORKER_CONTAINER="${BRIDGE_WORKER_CONTAINER:-kagura-bridge-worker-1}"
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -151,6 +164,65 @@ is_container_running() {
     docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null | grep -q "true"
 }
 
+# Is the co-resident bridge worker running on this host right now?
+#
+# Deliberately NOT `docker ps ... | grep -qx`: `grep -q` exits at the first
+# match and can SIGPIPE `docker ps`, which under `set -o pipefail` surfaces as a
+# failed pipeline — i.e. a *running* container intermittently reported as
+# absent. That is the exact shape of the #986 silent-death bug. Capture first,
+# then compare whole lines, so no pipeline status is involved. Whole-line
+# equality also means a container named `kagura-bridge-worker-10` never
+# satisfies the check for `kagura-bridge-worker-1`.
+bridge_worker_is_running() {
+    local names name
+    names="$("$DOCKER" ps --format '{{.Names}}' 2>/dev/null || true)"
+    while IFS= read -r name; do
+        if [ "$name" = "$BRIDGE_WORKER_CONTAINER" ]; then
+            return 0
+        fi
+    done <<< "$names"
+    return 1
+}
+
+# Restart the chat-bridge worker after the active API color changes (#1476).
+#
+# The worker resolves the API container by color when it connects and then holds
+# those connections. A flip leaves it talking to the color this script is about
+# to drain, and it stays up only through kagura-bridge's connect-level
+# cross-color fallback (kagura-ai/kagura-bridge#211) — which absorbed 4162 calls
+# over 65 hours in the 2026-07-21..24 incident, turning a safety net into the
+# normal path and burying every other warning in its noise. The same gap left
+# Slack ingest down for ~30 hours on 2026-07-29 before anyone noticed.
+#
+# Nothing else in the system knows a flip happened, so this is the only place
+# the restart can be triggered from.
+#
+# Call it AFTER Caddy has been switched: restarting while the old color still
+# serves would just re-pin the worker to the color being drained.
+restart_bridge_worker() {
+    # Presence-gated: deploy.sh is also the OSS single-server script, and a host
+    # without the bridge stack must log a skip, not an error.
+    if ! bridge_worker_is_running; then
+        log "  ${BRIDGE_WORKER_CONTAINER} is not running on this host — skipping bridge restart."
+        return 0
+    fi
+
+    log "  Restarting ${BRIDGE_WORKER_CONTAINER} (active API color changed)..."
+    if "$DOCKER" restart "$BRIDGE_WORKER_CONTAINER" > /dev/null 2>&1; then
+        log "  ${BRIDGE_WORKER_CONTAINER} restarted."
+        return 0
+    fi
+
+    # Non-fatal on purpose. By this point the API cutover has completed and the
+    # new color is serving; a bridge that will not come back is a bridge
+    # problem. Aborting here would report a healthy deploy as failed and invite
+    # an unnecessary rollback. Say it loudly instead.
+    log "WARNING: ${BRIDGE_WORKER_CONTAINER} failed to restart. Chat ingest may still be"
+    log "         pinned to the drained API color. Restart it manually:"
+    log "             docker restart ${BRIDGE_WORKER_CONTAINER}"
+    return 0
+}
+
 # ---------------------------------------------------------------------------
 # Commands
 # ---------------------------------------------------------------------------
@@ -197,6 +269,12 @@ cmd_rollback() {
     reload_caddy
     verify_workers_blocked
     verify_internal_blocked
+
+    # A rollback is a color flip too, so the bridge worker is left pointing at
+    # the color we just switched away from — same failure as an ordinary deploy
+    # (#1476). The issue only named cmd_deploy; this path needs it just as much.
+    DEPLOY_STAGE="rollback: restart bridge worker"
+    restart_bridge_worker
 
     DEPLOY_STAGE="rollback complete (active: ${inactive})"
     log "Rollback complete. Active: $inactive"
@@ -259,6 +337,13 @@ cmd_deploy() {
     reload_caddy
     verify_workers_blocked
     verify_internal_blocked
+
+    # Step 6b: Restart the co-resident bridge worker now that the color moved.
+    # Numbered 6b rather than renumbering to /8 because it rides on Step 6's
+    # switch — it is only correct once Caddy points at the new color.
+    DEPLOY_STAGE="Step 6b/7: restart ${BRIDGE_WORKER_CONTAINER}"
+    log "Step 6b/7: Restarting the bridge worker after the color switch..."
+    restart_bridge_worker
 
     # Step 7: Drain and stop old container
     # Disable restart policy first — otherwise `restart: always` revives
@@ -570,12 +655,13 @@ main() {
             echo "  --generate-caddyfile  Render ./Caddyfile from Caddyfile.tpl (bootstrap; no deploy)"
             echo ""
             echo "Environment variables:"
-            echo "  READINESS_TIMEOUT      Seconds to wait for API /readiness (default: 60)"
-            echo "  DRAIN_TIMEOUT          Seconds to drain old API container (default: 30)"
-            echo "  WEB_READINESS_TIMEOUT  Seconds to wait for web /api/health (default: 30)"
-            echo "  WEB_READINESS_INTERVAL Seconds between web health checks (default: 2)"
-            echo "  WORKERS_GATE_TIMEOUT   Seconds to wait for an edge-blocked path (/api/v1/workers/*, /internal/*) to 404 at Caddy (default: 30)"
-            echo "  WORKERS_GATE_INTERVAL  Seconds between security-gate checks; shared by the workers + internal gates (default: 2)"
+            echo "  READINESS_TIMEOUT        Seconds to wait for API /readiness (default: 60)"
+            echo "  DRAIN_TIMEOUT            Seconds to drain old API container (default: 30)"
+            echo "  WEB_READINESS_TIMEOUT    Seconds to wait for web /api/health (default: 30)"
+            echo "  WEB_READINESS_INTERVAL   Seconds between web health checks (default: 2)"
+            echo "  WORKERS_GATE_TIMEOUT     Seconds to wait for an edge-blocked path (/api/v1/workers/*, /internal/*) to 404 at Caddy (default: 30)"
+            echo "  WORKERS_GATE_INTERVAL    Seconds between security-gate checks; shared by the workers + internal gates (default: 2)"
+            echo "  BRIDGE_WORKER_CONTAINER  Co-resident chat-bridge worker restarted after a color flip; skipped when absent (default: kagura-bridge-worker-1)"
             ;;
         "")
             cmd_deploy

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -166,6 +166,16 @@ is_container_running() {
 
 # Is the co-resident bridge worker running on this host right now?
 #
+#   0 — running
+#   1 — definitively not running (docker answered, the name was not in the list)
+#   2 — could not be determined (the docker query itself failed)
+#
+# 1 and 2 are kept apart deliberately. Collapsing them would let an unreachable
+# or permission-denied docker daemon read as "no bridge on this host", so the
+# deploy would print a benign skip and move on having never attempted the
+# restart — a silent absorption of exactly the kind this whole step exists to
+# stop.
+#
 # Deliberately NOT `docker ps ... | grep -qx`: `grep -q` exits at the first
 # match and can SIGPIPE `docker ps`, which under `set -o pipefail` surfaces as a
 # failed pipeline — i.e. a *running* container intermittently reported as
@@ -175,9 +185,12 @@ is_container_running() {
 # satisfies the check for `kagura-bridge-worker-1`.
 bridge_worker_is_running() {
     local names name
-    names="$("$DOCKER" ps --format '{{.Names}}' 2>/dev/null || true)"
+    # `|| return 2` also exempts the assignment from `set -e`.
+    names="$("$DOCKER" ps --format '{{.Names}}' 2>/dev/null)" || return 2
     while IFS= read -r name; do
-        if [ "$name" = "$BRIDGE_WORKER_CONTAINER" ]; then
+        # An empty `names` still feeds the loop one empty line, so guard -n
+        # rather than letting "" match an empty container name.
+        if [ -n "$name" ] && [ "$name" = "$BRIDGE_WORKER_CONTAINER" ]; then
             return 0
         fi
     done <<< "$names"
@@ -200,11 +213,24 @@ bridge_worker_is_running() {
 # Call it AFTER Caddy has been switched: restarting while the old color still
 # serves would just re-pin the worker to the color being drained.
 restart_bridge_worker() {
+    # `|| presence=$?` keeps a non-zero return from killing the run under `set -e`.
+    local presence=0
+    bridge_worker_is_running || presence=$?
+
     # Presence-gated: deploy.sh is also the OSS single-server script, and a host
     # without the bridge stack must log a skip, not an error.
-    if ! bridge_worker_is_running; then
+    if [ "$presence" -eq 1 ]; then
         log "  ${BRIDGE_WORKER_CONTAINER} is not running on this host — skipping bridge restart."
         return 0
+    fi
+
+    # presence == 2: docker could not be queried. Try the restart anyway rather
+    # than skipping — if docker is genuinely down the restart fails and drops
+    # into the loud warning below, which is the honest outcome; if only the
+    # query was broken, the restart still does its job.
+    if [ "$presence" -ne 0 ]; then
+        log "WARNING: could not query docker to check for ${BRIDGE_WORKER_CONTAINER}."
+        log "         Attempting the restart anyway rather than silently skipping it."
     fi
 
     log "  Restarting ${BRIDGE_WORKER_CONTAINER} (active API color changed)..."

--- a/terraform/single-server/scripts/tests/deploy_bridge_restart.bats
+++ b/terraform/single-server/scripts/tests/deploy_bridge_restart.bats
@@ -1,0 +1,261 @@
+#!/usr/bin/env bats
+# =============================================================================
+# #1476: after a blue-green color flip, deploy.sh must restart the co-resident
+# chat-bridge worker.
+#
+# The worker resolves the API container by color when it connects and then holds
+# those connections. Without this restart it keeps talking to the color being
+# drained and survives only through kagura-bridge's connect-level cross-color
+# fallback — which absorbed 4162 calls over 65 hours in the 2026-07-21..24
+# incident, and let Slack ingest sit dead for ~30 hours on 2026-07-29 before
+# anyone noticed. The step was missing across v0.61.0, v0.62.0 and v0.63.0, each
+# needing the operator to remember a manual `docker restart`.
+#
+# The three properties that make it safe to run unconditionally, and which this
+# file pins:
+#   1. present  -> restarts it
+#   2. absent   -> logs a skip and succeeds (deploy.sh is also the OSS script)
+#   3. failing  -> logs a warning and does NOT abort a completed cutover
+#
+# deploy.sh guards `main` behind BASH_SOURCE, so these call the real functions
+# through an injected `$DOCKER` stub. No docker, no network.
+# =============================================================================
+
+DEPLOY_SH="$BATS_TEST_DIRNAME/../deploy.sh"
+
+# Stub for the docker indirection. Driven by files so the third test's fresh
+# `bash -c` child (which re-sources the script) can share the same state:
+#   $PS_FILE      — what `docker ps --format '{{.Names}}'` prints
+#   $RESTART_LOG  — appended with the container name on every `docker restart`
+#   $RESTART_RC   — exit code `docker restart` returns (default 0)
+mock_docker() {
+    case "${1:-}" in
+        ps)
+            cat "$PS_FILE"
+            ;;
+        restart)
+            echo "$2" >> "$RESTART_LOG"
+            return "${RESTART_RC:-0}"
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+setup() {
+    [ -r "$DEPLOY_SH" ] || return 1
+
+    # `mktemp -d` rather than $BATS_TEST_TMPDIR: that variable only exists from
+    # bats-core 1.4, and the distro bats on older runners (1.2.1 on Ubuntu
+    # 22.04) leaves it unset — under which every path below collapses to `/ps`
+    # and the whole file fails in setup(). deploy_marker_integrity.bats already
+    # uses mktemp for the same reason.
+    TMP="$(mktemp -d)"
+    export PS_FILE="$TMP/ps"
+    export RESTART_LOG="$TMP/restarts"
+    export RESTART_RC=0
+    : > "$PS_FILE"
+    : > "$RESTART_LOG"
+
+    # Exported so a child `bash -c` that re-sources deploy.sh keeps the stub
+    # (the script's own `DOCKER="${DOCKER:-docker}"` preserves it).
+    export DOCKER=mock_docker
+    export -f mock_docker
+
+    # shellcheck disable=SC1090
+    source "$DEPLOY_SH"
+
+    # Neutralize the EXIT trap deploy.sh installs — a stray final-status line
+    # would pollute $output.
+    trap - EXIT
+
+    # deploy.sh sets `-euo pipefail` and sourcing leaves those on.
+    #
+    # `-e` must STAY ON: bats detects a failing test through it, so `set +e`
+    # would make every assertion advisory (a body ending in `false || return 1`
+    # would still report `ok`). Only `-u` is dropped, because an unbound-variable
+    # death inside a test aborts the whole file instead of failing one case.
+    set +u
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# --- 1. present -> restarts -------------------------------------------------
+
+@test "the bridge worker is restarted when it is running" {
+    printf 'kagura-api-blue\nkagura-bridge-worker-1\nkagura-web\n' > "$PS_FILE"
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"Restarting kagura-bridge-worker-1"* ]] || return 1
+    [[ "$output" == *"restarted."* ]] || return 1
+    [ "$(cat "$RESTART_LOG")" = "kagura-bridge-worker-1" ] || return 1
+}
+
+@test "BRIDGE_WORKER_CONTAINER overrides which container is restarted" {
+    BRIDGE_WORKER_CONTAINER="bridge-staging"
+    printf 'bridge-staging\n' > "$PS_FILE"
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [ "$(cat "$RESTART_LOG")" = "bridge-staging" ] || return 1
+}
+
+# --- 2. absent -> skip, exit 0 ---------------------------------------------
+
+@test "a host with no bridge container logs a skip and succeeds" {
+    printf 'kagura-api-blue\nkagura-web\nkagura-postgres\n' > "$PS_FILE"
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"not running on this host"* ]] || return 1
+    # And it must not have tried anyway.
+    [ ! -s "$RESTART_LOG" ] || return 1
+}
+
+@test "an empty docker ps is a skip, not a crash" {
+    : > "$PS_FILE"
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"not running on this host"* ]] || return 1
+    [ ! -s "$RESTART_LOG" ] || return 1
+}
+
+@test "a container whose name merely CONTAINS the target does not satisfy the check" {
+    # `kagura-bridge-worker-10` and a differently-prefixed worker both share a
+    # substring with `kagura-bridge-worker-1`. A `grep` without whole-line
+    # anchoring would restart the wrong container — or claim the right one is
+    # present when it is not.
+    printf 'kagura-bridge-worker-10\nold-kagura-bridge-worker-1\n' > "$PS_FILE"
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"not running on this host"* ]] || return 1
+    [ ! -s "$RESTART_LOG" ] || return 1
+}
+
+@test "presence detection does not depend on a pipeline status (the #986 shape)" {
+    # `docker ps | grep -q` can SIGPIPE the producer once grep exits early, and
+    # under `set -o pipefail` that reports a RUNNING container as absent —
+    # intermittently. Pin the property directly: a long name list with the
+    # target on the first line still detects it.
+    {
+        echo "kagura-bridge-worker-1"
+        for i in $(seq 1 500); do echo "filler-container-$i"; done
+    } > "$PS_FILE"
+
+    run bridge_worker_is_running
+
+    [ "$status" -eq 0 ] || return 1
+}
+
+# --- 3. failing restart -> warn, do not abort -------------------------------
+
+@test "a failing restart logs a warning and still returns 0" {
+    printf 'kagura-bridge-worker-1\n' > "$PS_FILE"
+    export RESTART_RC=1
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"WARNING"* ]] || return 1
+    [[ "$output" == *"failed to restart"* ]] || return 1
+    # The operator needs the recovery command, not just the complaint.
+    [[ "$output" == *"docker restart kagura-bridge-worker-1"* ]] || return 1
+    # It must not claim success.
+    [[ "$output" != *"kagura-bridge-worker-1 restarted."* ]] || return 1
+}
+
+@test "set -e safety: a failing restart does NOT kill the caller mid-deploy" {
+    # The step sits between the Caddy switch and the drain. If a non-zero
+    # `docker restart` propagated, `set -euo pipefail` would kill the run right
+    # there and Step 7 would never drain the old color — the API cutover would
+    # be complete but the deploy would report ABORTED. bats neutralises errexit
+    # inside its own test shell, so this is only observable in a child process
+    # bats does not manage.
+    printf 'kagura-bridge-worker-1\n' > "$PS_FILE"
+    export RESTART_RC=1
+
+    run bash -c '
+        set -euo pipefail
+        source "'"$DEPLOY_SH"'"
+        trap - EXIT
+        restart_bridge_worker >/dev/null 2>&1
+        echo "STEP7_REACHED"
+    '
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"STEP7_REACHED"* ]] || return 1
+}
+
+@test "set -e safety: a docker ps that fails outright is a skip, not a death" {
+    # `docker ps` returning non-zero (daemon unreachable, permission denied)
+    # must not take the deploy with it.
+    run bash -c '
+        set -euo pipefail
+        broken_docker() { return 1; }
+        export -f broken_docker
+        DOCKER=broken_docker
+        source "'"$DEPLOY_SH"'"
+        trap - EXIT
+        restart_bridge_worker >/dev/null 2>&1
+        echo "SURVIVED"
+    '
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"SURVIVED"* ]] || return 1
+}
+
+# --- Call sites -------------------------------------------------------------
+# Static checks: calling cmd_deploy/cmd_rollback for real would build images and
+# start containers. What matters is that the call exists and sits AFTER the
+# Caddy switch — restarting before it would re-pin the worker to the old color,
+# which is worse than not restarting at all, and no runtime assertion here could
+# tell the two orders apart.
+
+@test "cmd_deploy restarts the bridge worker" {
+    run bash -o pipefail -c 'sed -n "/^cmd_deploy()/,/^}/p" "$1" | grep -c "restart_bridge_worker"' _ "$DEPLOY_SH"
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "cmd_deploy restarts it AFTER the Caddy switch, not before" {
+    run bash -o pipefail -c '
+        body=$(sed -n "/^cmd_deploy()/,/^}/p" "$1")
+        switch=$(printf "%s\n" "$body" | grep -n "^ *reload_caddy" | head -1 | cut -d: -f1)
+        restart=$(printf "%s\n" "$body" | grep -n "^ *restart_bridge_worker" | head -1 | cut -d: -f1)
+        [ -n "$switch" ] && [ -n "$restart" ] && [ "$restart" -gt "$switch" ]
+    ' _ "$DEPLOY_SH"
+    [ "$status" -eq 0 ] || return 1
+}
+
+@test "rollback flips the color too, so it restarts the bridge worker as well" {
+    run bash -o pipefail -c 'sed -n "/^cmd_rollback()/,/^}/p" "$1" | grep -c "restart_bridge_worker"' _ "$DEPLOY_SH"
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "cmd_rollback restarts it AFTER the Caddy switch, not before" {
+    run bash -o pipefail -c '
+        body=$(sed -n "/^cmd_rollback()/,/^}/p" "$1")
+        switch=$(printf "%s\n" "$body" | grep -n "^ *reload_caddy" | head -1 | cut -d: -f1)
+        restart=$(printf "%s\n" "$body" | grep -n "^ *restart_bridge_worker" | head -1 | cut -d: -f1)
+        [ -n "$switch" ] && [ -n "$restart" ] && [ "$restart" -gt "$switch" ]
+    ' _ "$DEPLOY_SH"
+    [ "$status" -eq 0 ] || return 1
+}
+
+@test "--web does not touch the bridge worker (it never changes the API color)" {
+    run bash -o pipefail -c 'sed -n "/^cmd_deploy_web()/,/^}/p" "$1" | grep -c "restart_bridge_worker"' _ "$DEPLOY_SH"
+    # grep -c prints 0 and exits 1 when there are no matches.
+    [ "$output" = "0" ] || return 1
+}

--- a/terraform/single-server/scripts/tests/deploy_bridge_restart.bats
+++ b/terraform/single-server/scripts/tests/deploy_bridge_restart.bats
@@ -215,47 +215,98 @@ teardown() {
     [[ "$output" == *"SURVIVED"* ]] || return 1
 }
 
+@test "a docker query that FAILS is not reported as 'no bridge on this host'" {
+    # The whole point of this step is to stop a color flip from being silently
+    # absorbed. If an unreachable or permission-denied docker daemon rendered as
+    # the benign "not running on this host" skip, the deploy would report
+    # success having never attempted the restart — the same class of silent
+    # absorption, just relocated. "Cannot tell" must be loud and must still try.
+    broken_docker() { return 1; }
+    DOCKER=broken_docker
+
+    run restart_bridge_worker
+
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"could not query docker"* ]] || return 1
+    [[ "$output" != *"not running on this host"* ]] || return 1
+    # ...and it must have attempted the restart rather than given up.
+    [[ "$output" == *"Restarting kagura-bridge-worker-1"* ]] || return 1
+}
+
+@test "bridge_worker_is_running separates 'absent' (1) from 'cannot tell' (2)" {
+    printf 'kagura-api-blue\n' > "$PS_FILE"
+    run bridge_worker_is_running
+    [ "$status" -eq 1 ] || return 1
+
+    broken_docker() { return 1; }
+    DOCKER=broken_docker
+    run bridge_worker_is_running
+    [ "$status" -eq 2 ] || return 1
+}
+
 # --- Call sites -------------------------------------------------------------
 # Static checks: calling cmd_deploy/cmd_rollback for real would build images and
 # start containers. What matters is that the call exists and sits AFTER the
 # Caddy switch — restarting before it would re-pin the worker to the old color,
 # which is worse than not restarting at all, and no runtime assertion here could
 # tell the two orders apart.
+#
+# `^ *restart_bridge_worker *$` matches only a BARE CALL on its own line, so
+# commenting the call out (`# restart_bridge_worker`) or merely naming it in
+# prose fails these — a plain substring count would not.
 
-@test "cmd_deploy restarts the bridge worker" {
-    run bash -o pipefail -c 'sed -n "/^cmd_deploy()/,/^}/p" "$1" | grep -c "restart_bridge_worker"' _ "$DEPLOY_SH"
-    [ "$status" -eq 0 ] || return 1
-    [ "$output" -ge 1 ] || return 1
+# Count bare calls to $2 inside function $1 of deploy.sh. Prints the count.
+count_calls_in() {
+    local fn="$1" callee="$2"
+    sed -n "/^${fn}()/,/^}/p" "$DEPLOY_SH" | grep -cE "^ *${callee} *$" || true
+}
+
+# Print the 1-based line number of the first bare call to $2 within function $1,
+# or nothing when there is none.
+first_call_line_in() {
+    local fn="$1" callee="$2"
+    sed -n "/^${fn}()/,/^}/p" "$DEPLOY_SH" \
+        | grep -nE "^ *${callee} *$" | head -1 | cut -d: -f1
+}
+
+@test "the call-site helpers actually see the function bodies (guard not vacuous)" {
+    # If a rename broke the sed range, every count below would read 0 and the
+    # negative assertions would pass for the wrong reason.
+    [ "$(count_calls_in cmd_deploy verify_internal_blocked)" -eq 1 ] || return 1
+    [ "$(count_calls_in cmd_rollback verify_internal_blocked)" -eq 1 ] || return 1
+    [ -n "$(sed -n '/^cmd_deploy_web()/,/^}/p' "$DEPLOY_SH")" ] || return 1
+}
+
+@test "cmd_deploy restarts the bridge worker exactly once" {
+    [ "$(count_calls_in cmd_deploy restart_bridge_worker)" -eq 1 ] || return 1
 }
 
 @test "cmd_deploy restarts it AFTER the Caddy switch, not before" {
-    run bash -o pipefail -c '
-        body=$(sed -n "/^cmd_deploy()/,/^}/p" "$1")
-        switch=$(printf "%s\n" "$body" | grep -n "^ *reload_caddy" | head -1 | cut -d: -f1)
-        restart=$(printf "%s\n" "$body" | grep -n "^ *restart_bridge_worker" | head -1 | cut -d: -f1)
-        [ -n "$switch" ] && [ -n "$restart" ] && [ "$restart" -gt "$switch" ]
-    ' _ "$DEPLOY_SH"
-    [ "$status" -eq 0 ] || return 1
+    local switch restart
+    switch="$(first_call_line_in cmd_deploy reload_caddy)"
+    restart="$(first_call_line_in cmd_deploy restart_bridge_worker)"
+    [ -n "$switch" ] || return 1
+    [ -n "$restart" ] || return 1
+    # Exactly one switch, so "after the first reload_caddy" IS "after the
+    # switch" — asserted rather than assumed.
+    [ "$(count_calls_in cmd_deploy reload_caddy)" -eq 1 ] || return 1
+    [ "$restart" -gt "$switch" ] || return 1
 }
 
 @test "rollback flips the color too, so it restarts the bridge worker as well" {
-    run bash -o pipefail -c 'sed -n "/^cmd_rollback()/,/^}/p" "$1" | grep -c "restart_bridge_worker"' _ "$DEPLOY_SH"
-    [ "$status" -eq 0 ] || return 1
-    [ "$output" -ge 1 ] || return 1
+    [ "$(count_calls_in cmd_rollback restart_bridge_worker)" -eq 1 ] || return 1
 }
 
 @test "cmd_rollback restarts it AFTER the Caddy switch, not before" {
-    run bash -o pipefail -c '
-        body=$(sed -n "/^cmd_rollback()/,/^}/p" "$1")
-        switch=$(printf "%s\n" "$body" | grep -n "^ *reload_caddy" | head -1 | cut -d: -f1)
-        restart=$(printf "%s\n" "$body" | grep -n "^ *restart_bridge_worker" | head -1 | cut -d: -f1)
-        [ -n "$switch" ] && [ -n "$restart" ] && [ "$restart" -gt "$switch" ]
-    ' _ "$DEPLOY_SH"
-    [ "$status" -eq 0 ] || return 1
+    local switch restart
+    switch="$(first_call_line_in cmd_rollback reload_caddy)"
+    restart="$(first_call_line_in cmd_rollback restart_bridge_worker)"
+    [ -n "$switch" ] || return 1
+    [ -n "$restart" ] || return 1
+    [ "$(count_calls_in cmd_rollback reload_caddy)" -eq 1 ] || return 1
+    [ "$restart" -gt "$switch" ] || return 1
 }
 
 @test "--web does not touch the bridge worker (it never changes the API color)" {
-    run bash -o pipefail -c 'sed -n "/^cmd_deploy_web()/,/^}/p" "$1" | grep -c "restart_bridge_worker"' _ "$DEPLOY_SH"
-    # grep -c prints 0 and exits 1 when there are no matches.
-    [ "$output" = "0" ] || return 1
+    [ "$(count_calls_in cmd_deploy_web restart_bridge_worker)" -eq 0 ] || return 1
 }


### PR DESCRIPTION
Closes #1476

## 何が壊れていたか

`deploy.sh` は API の色を切り替えるのに、同居している `kagura-bridge-worker-1` を再起動していませんでした。worker は接続時に API コンテナを色で解決してその接続を保持するため、flip 後は **drain される側の色に話しかけ続け**、kagura-bridge の connect-level cross-color fallback だけで生き延びていました。

その fallback のコストは `deploy.sh` 自身がコメントに書いています — 2026-07-21..24 のインシデントで **65時間かけて 4162 コール**を吸収し、安全網が常用経路に変わって他の警告を全部埋めました。2026-07-29 には Slack ingest が **約30時間**気づかれずに停止しています。

この1行が **v0.61.0 / v0.62.0 / v0.63.0 の3リリース連続**で欠けていて、毎回オペレーターが手で `docker restart` を覚えている必要がありました。

## 変更

Caddy 切り替え直後に **Step 6b** を追加。`/8` に振り直さず `6b` にしたのは、この処理が Step 6 のスイッチに乗っているから（Caddy が新しい色を向いた後でしか正しくない）です。

**`cmd_rollback` にも入れました。** issue は `cmd_deploy` しか挙げていませんが、rollback も色の flip です — 同じ理由で bridge は切り替え前の色を向いたまま残ります。

無条件に走らせて安全な理由が3つあり、それぞれ bats で固定しています:

| 性質 | 理由 |
|---|---|
| **presence-gated** | `deploy.sh` は OSS の single-server スクリプトでもあります。bridge スタックの無いホストは skip をログして exit 0 |
| **non-fatal** | ここに来た時点で API の cutover は完了して新しい色が配信中です。戻ってこない bridge は bridge 側の問題で、ここで abort すると健全な deploy が失敗扱いになり不要な rollback を誘発します。代わりに手動コマンド付きで大きく警告 |
| **switch の後** | 古い色がまだ配信しているうちに再起動しても、drain される色に再 pin されるだけです |

### 「居ない」と「docker に聞けない」を分ける

presence 判定は **0=居る / 1=確かに居ない / 2=判定不能** の3値です。ここを潰すと、daemon 不達や permission denied が「このホストには bridge が無い」という無害な skip として出てしまい、**再起動を一度も試さないまま deploy が成功を報告します** — このステップが消そうとしている silent absorption そのものが一段下に移動するだけです。

判定不能のときは警告を出したうえで**再起動を試します**。docker が本当に落ちていれば restart が失敗して既存の「手動で戻して」警告に落ちますし、クエリだけ壊れていたなら再起動は正しく効きます。どちらも黙らないし、どちらも abort しません。

### presence 判定を `grep -q` にしていない理由

```sh
docker ps --format '{{.Names}}' | grep -qx "$BRIDGE_WORKER_CONTAINER"   # ← 使っていない
```

`grep -q` は最初のマッチで抜けるので producer に SIGPIPE を投げることがあり、`set -o pipefail` 下ではそれが**パイプライン失敗**として出ます。つまり **動いているコンテナが不定期に「居ない」と報告される**。#986 の silent death と同じ形です。先に出力を捕まえてから行単位で比較しています。行完全一致なので `kagura-bridge-worker-10` が `kagura-bridge-worker-1` として拾われることもありません。

### `dc()` ではなく `docker` な理由

bridge worker はこのリポジトリの `docker-compose.prod.yml` の service では**なく**、同じ VM / docker network に同居する別スタックです。compose はこのコンテナを知らないので、コンテナ名で直接叩きます（`BRIDGE_WORKER_CONTAINER` で上書き可能）。

## 検証

CI の shell-quality ジョブと同じもの（`shellcheck` + `bats`）をローカルで実行。Windows チェックアウトが CRLF（`core.autocrlf=true`）なのに対しコミット済み blob は LF なので、LF 正規化したミラーに対して回しています。

| | |
|---|---|
| `shellcheck deploy.sh` | CLEAN |
| 新規 17 tests | 全部 pass |
| 既存スイート | pass |

### ガードが空振りでないことの確認

スクリプトを1箇所ずつ壊して、**意図したテストだけが赤くなる**ことを確認しました:

| 壊した内容 | 赤くなったテスト |
|---|---|
| `cmd_deploy` から呼び出しを削除 | 13, 14 |
| 呼び出しを Caddy switch の**前**へ移動 | 14 |
| 呼び出しを**コメントアウト** | 13, 14 |
| 行完全一致 → 部分一致 (`grep -q`) | 5, 10, 11 |
| 「判定不能」を「居ない」に戻す (`\|\| true`) | 10, 11 |
| restart 失敗を fatal に | 7, 8, 9, 10 |
| presence gate を削除 | 3, 4, 5 |
| `cmd_rollback` から呼び出しを削除 | 15, 16 |

復元後は再び全部 green です。

## レビューで直したもの / 見送ったもの

差分を独立にレビューさせた結果から:

**直した**
- `docker ps` の失敗が「居ない」として黙って吸収されていた（上記）
- 空行ガード。空の `names` でも here-string は空行を1行流すので、`BRIDGE_WORKER_CONTAINER` が空だと一致してしまう（env 経由では `:-` があるので到達しませんが、ループがそれに依存すべきではない）
- call-site テストが部分文字列を数えていたので、**コメントアウトされた呼び出しでも通っていました**。行頭の裸の呼び出しだけに一致させ、出現回数がちょうど1であること、`reload_caddy` もちょうど1つであること（＝「最初の reload_caddy の後」が本当に「switch の後」であること）を主張します
- `--web` のテストが 0 件を主張していましたが、sed の範囲が壊れても 0 になります。範囲が実際に解決していることを別テストで固定

**見送った**
- docker クエリへの `timeout` 付与 — このスクリプトは coreutils `timeout` を **`--web` 専用の依存**として意図的に隔離しており（`cmd_deploy_web` 内でのみ検査）、deploy 経路の他の docker/compose 呼び出しも同様に無制限です。ここだけ縛るのは一貫性を欠きます
- rollback が旧色を drain しない — 既存かつ意図的な挙動（rollback 後にまた前進する可能性がある）で、この差分の責任範囲外
- コンテナ名の `\r` — docker が生成できません

## 補足: 既存2ファイルはローカルの古い bats で落ちます

`deploy_verify_workers_blocked.bats` と `deploy_verify_internal_blocked.bats` は `$BATS_TEST_TMPDIR` を使っていますが、これは bats-core 1.4 以降の変数です。Ubuntu 22.04 の bats 1.2.1 では未定義になり、パスが `/Caddyfile.tpl` に潰れて setup で全滅します。**CI（新しい bats）では green** なので今回は触っていません。新規ファイルは `deploy_marker_integrity.bats` と同じ `mktemp -d` + `teardown` を使っているので、どちらの bats でも動きます。

## Out of scope

cross-color fallback を「黙って吸収」から「アラートする」に変えること（kagura-ai/kagura-bridge#211 / #224）— bridge 側で追跡。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
