### PR TITLE
fix(worker-apps): validate the signing secret's shape before storing it (#1478)

### DIFF
--- a/backend/src/services/worker_app_identity.py
+++ b/backend/src/services/worker_app_identity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import timedelta
 from hashlib import sha256
 
@@ -16,6 +17,47 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 MAX_RETIRING_WINDOW_SECONDS = 86_400
+
+# Per-platform signing-secret shape (#1478).
+#
+# A placeholder string was once submitted to the rotate endpoint, accepted with
+# 200, encrypted and stored as the ACTIVE secret. Every webhook then failed
+# verification, and when the retiring window elapsed there was no value left
+# that could verify anything. The field's only constraint was `min_length=1`.
+#
+# Validation lives here rather than on the request models because `platform` is
+# a path parameter on rotate and a body field on create — only the service sees
+# it uniformly. Both routes funnel through this module, so a caller cannot
+# bypass the check by picking a different entry point, and neither can a future
+# UI: a form validator is advisory, this is the boundary.
+#
+# An unknown platform keeps the caller's length bounds and no shape, so adding
+# Discord/Teams is additive and never rejects a valid credential for a format
+# that has not been described yet.
+_SIGNING_SECRET_SHAPES: dict[str, re.Pattern[str]] = {
+    # Slack signing secrets are 32 lowercase hex characters.
+    "slack": re.compile(r"^[0-9a-f]{32}$"),
+}
+
+
+def validate_signing_secret(platform: str, signing_secret: str) -> None:
+    """Reject a secret that cannot be a credential for ``platform``.
+
+    Raises :class:`ValidationError`. The message carries the expected shape and
+    the OBSERVED LENGTH only — never the submitted value. An admin who pastes
+    the wrong thing must not get it reflected back into a response body or a
+    log line, because the wrong thing is very often the right secret for
+    somewhere else.
+    """
+    shape = _SIGNING_SECRET_SHAPES.get(platform)
+    if shape is None:
+        return
+    if shape.fullmatch(signing_secret) is None:
+        raise ValidationError(
+            f"signing_secret for platform {platform!r} must match "
+            f"{shape.pattern} (received {len(signing_secret)} characters)",
+            field="signing_secret",
+        )
 
 
 def opaque_revision(*parts: object) -> str:
@@ -87,6 +129,7 @@ class WorkerAppIdentityService:
         signing_secret: str,
         actor_id: str,
     ) -> WorkerAppIdentity:
+        validate_signing_secret(platform, signing_secret)
         if await self.get_identity(platform, app_key) is not None:
             raise ConflictError("Worker app identity already exists")
         identity = WorkerAppIdentity(
@@ -191,6 +234,10 @@ class WorkerAppIdentityService:
         retiring_for_seconds: int,
         actor_id: str,
     ) -> WorkerAppIdentity:
+        # Validate BEFORE any mutation: a rejected rotation must leave the
+        # existing active/retiring pair exactly as it was. #1478's outage was
+        # made worse by the bad value displacing the working one.
+        validate_signing_secret(platform, signing_secret)
         if not 0 <= retiring_for_seconds <= MAX_RETIRING_WINDOW_SECONDS:
             raise ValidationError(
                 f"retiring_for_seconds must be between 0 and {MAX_RETIRING_WINDOW_SECONDS}",

--- a/backend/tests/services/test_worker_app_identity.py
+++ b/backend/tests/services/test_worker_app_identity.py
@@ -34,7 +34,7 @@ async def test_rotate_keeps_previous_secret_for_bounded_window(_fernet_env):
         active_secret_revision=4,
         config_version=8,
     )
-    identity.set_active_signing_secret("old-secret")
+    identity.set_active_signing_secret("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
     service = WorkerAppIdentityService(db)
     service._require_identity = AsyncMock(return_value=identity)
 
@@ -42,14 +42,14 @@ async def test_rotate_keeps_previous_secret_for_bounded_window(_fernet_env):
     result = await service.rotate_secret(
         platform="slack",
         app_key="sales",
-        signing_secret="new-secret",
+        signing_secret="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
         retiring_for_seconds=3600,
         actor_id="admin-1",
     )
 
-    assert result.get_active_signing_secret() == "new-secret"
+    assert result.get_active_signing_secret() == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     assert result.active_secret_revision == 5
-    assert result.get_retiring_signing_secret() == "old-secret"
+    assert result.get_retiring_signing_secret() == "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     assert result.retiring_secret_revision == 4
     assert before + timedelta(seconds=3599) <= result.retiring_valid_until
     assert result.config_version == 9
@@ -68,7 +68,7 @@ async def test_disable_preserves_ciphertext_but_bumps_revision(_fernet_env):
         active_secret_revision=1,
         config_version=1,
     )
-    identity.set_active_signing_secret("secret")
+    identity.set_active_signing_secret("cccccccccccccccccccccccccccccccc")
     ciphertext = identity.active_signing_secret_encrypted
     service = WorkerAppIdentityService(db)
     service._require_identity = AsyncMock(return_value=identity)
@@ -101,20 +101,20 @@ async def test_rotate_disabled_identity_stays_disabled_and_drops_revoked_secret(
         active_secret_revision=3,
         config_version=5,
     )
-    identity.set_active_signing_secret("compromised")
+    identity.set_active_signing_secret("dddddddddddddddddddddddddddddddd")
     service = WorkerAppIdentityService(db)
     service._require_identity = AsyncMock(return_value=identity)
 
     result = await service.rotate_secret(
         platform="slack",
         app_key="sales",
-        signing_secret="fresh-secret",
+        signing_secret="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         retiring_for_seconds=3600,
         actor_id="admin-1",
     )
 
     assert result.status == "disabled"
-    assert result.get_active_signing_secret() == "fresh-secret"
+    assert result.get_active_signing_secret() == "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     assert result.active_secret_revision == 4
     assert result.retiring_signing_secret_encrypted is None
     assert result.retiring_secret_revision is None
@@ -143,13 +143,13 @@ async def test_rotate_unconfigured_identity_preserves_status(_fernet_env):
     result = await service.rotate_secret(
         platform="slack",
         app_key="default",
-        signing_secret="staged-secret",
+        signing_secret="ffffffffffffffffffffffffffffffff",
         retiring_for_seconds=3600,
         actor_id="admin-1",
     )
 
     assert result.status == "unconfigured"
-    assert result.get_active_signing_secret() == "staged-secret"
+    assert result.get_active_signing_secret() == "ffffffffffffffffffffffffffffffff"
     assert result.active_secret_revision == 1
     assert result.retiring_signing_secret_encrypted is None
     assert result.retiring_valid_until is None
@@ -180,12 +180,12 @@ async def test_rotate_recovers_when_previous_ciphertext_undecryptable(_fernet_en
         result = await service.rotate_secret(
             platform="slack",
             app_key="sales",
-            signing_secret="new-secret",
+            signing_secret="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
             retiring_for_seconds=3600,
             actor_id="admin-1",
         )
 
-    assert result.get_active_signing_secret() == "new-secret"
+    assert result.get_active_signing_secret() == "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
     assert result.active_secret_revision == 5
     assert result.retiring_signing_secret_encrypted is None
     assert result.retiring_secret_revision is None
@@ -199,7 +199,7 @@ async def test_rotate_recovers_when_previous_ciphertext_undecryptable(_fernet_en
     assert kwargs["platform"] == "slack"
     assert kwargs["app_key"] == "sales"
     for value in kwargs.values():
-        assert "new-secret" not in str(value)
+        assert "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" not in str(value)
         assert "gAAAAA" not in str(value)
 
 
@@ -217,7 +217,7 @@ async def test_disable_clears_retiring_window(_fernet_env):
         active_secret_revision=5,
         config_version=9,
     )
-    identity.set_active_signing_secret("current")
+    identity.set_active_signing_secret("00000000000000000000000000000000")
     identity.set_retiring_signing_secret("previous")
     identity.retiring_secret_revision = 4
     identity.retiring_valid_until = utcnow() + timedelta(hours=1)
@@ -252,7 +252,7 @@ async def test_reenable_clears_stale_retiring_window(_fernet_env):
         active_secret_revision=5,
         config_version=9,
     )
-    identity.set_active_signing_secret("current")
+    identity.set_active_signing_secret("00000000000000000000000000000000")
     identity.set_retiring_signing_secret("revoked-old")
     identity.retiring_secret_revision = 4
     identity.retiring_valid_until = utcnow() + timedelta(hours=1)
@@ -294,13 +294,13 @@ async def test_rotate_undecryptable_on_disabled_identity_stays_disabled(_fernet_
     result = await service.rotate_secret(
         platform="slack",
         app_key="sales",
-        signing_secret="fresh-secret",
+        signing_secret="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
         retiring_for_seconds=3600,
         actor_id="admin-1",
     )
 
     assert result.status == "disabled"
-    assert result.get_active_signing_secret() == "fresh-secret"
+    assert result.get_active_signing_secret() == "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
     assert result.active_secret_revision == 4
     assert result.retiring_signing_secret_encrypted is None
     assert result.retiring_valid_until is None
@@ -349,7 +349,7 @@ async def test_disabled_noop_update_purges_stale_retiring_material(_fernet_env):
         active_secret_revision=5,
         config_version=9,
     )
-    identity.set_active_signing_secret("current")
+    identity.set_active_signing_secret("00000000000000000000000000000000")
     identity.set_retiring_signing_secret("revoked-old")
     identity.retiring_secret_revision = 4
     identity.retiring_valid_until = utcnow() + timedelta(hours=1)
@@ -378,7 +378,7 @@ async def test_disabled_noop_update_purges_stale_retiring_material(_fernet_env):
     assert cleared[0].kwargs["retiring_secret_revision"] == 4
     for value in cleared[0].kwargs.values():
         assert "revoked-old" not in str(value)
-        assert "current" not in str(value)
+        assert "00000000000000000000000000000000" not in str(value)
 
 
 @pytest.mark.asyncio
@@ -396,7 +396,7 @@ async def test_status_noop_update_keeps_retiring_window(_fernet_env):
         active_secret_revision=5,
         config_version=9,
     )
-    identity.set_active_signing_secret("current")
+    identity.set_active_signing_secret("00000000000000000000000000000000")
     identity.set_retiring_signing_secret("previous")
     identity.retiring_secret_revision = 4
     valid_until = utcnow() + timedelta(hours=1)
@@ -437,7 +437,7 @@ async def test_rename_only_does_not_bump_config_version(_fernet_env):
         active_secret_revision=2,
         config_version=7,
     )
-    identity.set_active_signing_secret("secret")
+    identity.set_active_signing_secret("cccccccccccccccccccccccccccccccc")
     revision_before = identity_revision(identity)
     service = WorkerAppIdentityService(db)
     service._require_identity = AsyncMock(return_value=identity)
@@ -467,7 +467,7 @@ async def test_status_transition_still_bumps_config_version(_fernet_env):
         active_secret_revision=2,
         config_version=7,
     )
-    identity.set_active_signing_secret("secret")
+    identity.set_active_signing_secret("cccccccccccccccccccccccccccccccc")
     service = WorkerAppIdentityService(db)
     service._require_identity = AsyncMock(return_value=identity)
 
@@ -496,3 +496,139 @@ def test_bootstrap_revision_changes_when_retiring_window_expires():
     identity.retiring_valid_until = utcnow() - timedelta(seconds=1)
 
     assert identity_collection_revision([identity]) != before_expiry
+
+
+# ── #1478: signing-secret shape validation ───────────────────────────
+
+
+@pytest.mark.parametrize(
+    "bad_secret",
+    [
+        pytest.param("ここに新しい署名シークレット", id="the-placeholder-that-caused-the-outage"),
+        pytest.param("PASTE_YOUR_SIGNING_SECRET_HERE", id="ascii-placeholder"),
+        pytest.param("A" * 32, id="uppercase-hex"),
+        pytest.param("a" * 31, id="one-char-short"),
+        pytest.param("a" * 33, id="one-char-long"),
+        pytest.param("g" * 32, id="right-length-not-hex"),
+        pytest.param("a" * 16 + " " + "a" * 15, id="embedded-space"),
+        pytest.param("a" * 32 + "\n", id="trailing-newline"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rotate_rejects_a_secret_that_is_not_slack_shaped(_fernet_env, bad_secret):
+    """#1478: `min_length=1` let a placeholder through, it was stored as ACTIVE,
+    and every webhook then failed verification.
+
+    The first case is the exact string that caused the production outage.
+    """
+    from utils.exceptions import ValidationError
+
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="default",
+        display_name="Slack App",
+        status="active",
+        active_secret_revision=1,
+        config_version=1,
+    )
+    identity.set_active_signing_secret("a" * 32)
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    with pytest.raises(ValidationError):
+        await service.rotate_secret(
+            platform="slack",
+            app_key="default",
+            signing_secret=bad_secret,
+            retiring_for_seconds=900,
+            actor_id="admin-1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_rejected_rotation_leaves_the_working_secret_untouched(_fernet_env):
+    """The outage was made worse because the bad value DISPLACED the working
+    one: active became the placeholder and the real secret went to retiring,
+    which then expired. A rejected rotation must be a no-op on stored state."""
+    from utils.exceptions import ValidationError
+
+    db = MagicMock()
+    db.flush = AsyncMock()
+    identity = WorkerAppIdentity(
+        platform="slack",
+        app_key="default",
+        display_name="Slack App",
+        status="active",
+        active_secret_revision=7,
+        config_version=3,
+    )
+    identity.set_active_signing_secret("a" * 32)
+    before_active = identity.active_signing_secret_encrypted
+    before_revision = identity.active_secret_revision
+    before_version = identity.config_version
+
+    service = WorkerAppIdentityService(db)
+    service._require_identity = AsyncMock(return_value=identity)
+
+    with pytest.raises(ValidationError):
+        await service.rotate_secret(
+            platform="slack",
+            app_key="default",
+            signing_secret="not-a-secret",
+            retiring_for_seconds=900,
+            actor_id="admin-1",
+        )
+
+    assert identity.active_signing_secret_encrypted == before_active
+    assert identity.active_secret_revision == before_revision
+    assert identity.config_version == before_version
+    assert identity.retiring_signing_secret_encrypted is None
+    db.flush.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_validation_error_never_echoes_the_submitted_secret(_fernet_env):
+    """An admin who pastes the wrong thing must not get it reflected into a
+    response body or a log line — the wrong thing is very often the right
+    secret for somewhere else."""
+    from services.worker_app_identity import validate_signing_secret
+    from utils.exceptions import ValidationError
+
+    leaked = "hunter2-this-is-some-other-systems-credential"
+    with pytest.raises(ValidationError) as exc:
+        validate_signing_secret("slack", leaked)
+
+    assert leaked not in str(exc.value)
+    assert str(len(leaked)) in str(exc.value)  # length IS reported
+
+
+@pytest.mark.asyncio
+async def test_unknown_platform_keeps_todays_permissive_bounds(_fernet_env):
+    """Adding Discord/Teams must be additive. A platform whose format has not
+    been described yet must not have a Slack shape guessed for it — that would
+    reject a valid credential."""
+    from services.worker_app_identity import validate_signing_secret
+
+    validate_signing_secret("discord", "a-format-nobody-has-described-yet")
+
+
+@pytest.mark.asyncio
+async def test_create_identity_also_validates(_fernet_env):
+    """Both write paths funnel through the service; rotate is not the only door."""
+    from utils.exceptions import ValidationError
+
+    db = MagicMock()
+    db.flush = AsyncMock()
+    service = WorkerAppIdentityService(db)
+    service.get_identity = AsyncMock(return_value=None)
+
+    with pytest.raises(ValidationError):
+        await service.create_identity(
+            platform="slack",
+            app_key="default",
+            display_name="Slack App",
+            signing_secret="ここに新しい署名シークレット",
+            actor_id="admin-1",
+        )


### PR DESCRIPTION
Closes #1478.

## What happened

A rotation was performed against
`POST /api/v1/admin/worker-apps/slack/default/rotate-secret` with a
**placeholder string** in the body instead of the real secret. The API returned
**200**. The placeholder was encrypted and stored as the `active` signing
secret.

Every subsequent webhook failed signature verification. When the `retiring`
window elapsed, the previous secret was cleared as well — leaving no stored
value that could verify anything.

The field's only constraint was `min_length=1`:

```python
signing_secret: str = Field(..., min_length=1, max_length=512)
```

A Slack signing secret is, by definition, 32 lowercase hex characters.

## Where the check goes, and why not the request model

The **service layer**. `platform` is a path parameter on rotate and a body
field on create, so only the service sees it uniformly. Both write paths funnel
through `WorkerAppIdentityService`, so a caller cannot bypass the check by
picking a different entry point — and neither can a future admin UI. A form
validator is advisory; this is the boundary.

`rotate_secret` already validates `retiring_for_seconds` here, so this follows
existing structure rather than inventing a layer.

## Two properties beyond "reject bad input"

**Rejection is a no-op on stored state.** The outage was made worse because the
bad value *displaced* the working one: `active` became the placeholder and the
real secret moved to `retiring`, where it then expired. Validation now runs
before any mutation, and a test asserts `active` / `retiring` / both revisions /
`config_version` are untouched and that `flush` is never awaited.

**The error never echoes the value.** It reports the expected shape and the
observed **length** only. An admin who pastes the wrong thing must not get it
reflected into a response body or a log line — the wrong thing is very often the
right secret for somewhere else. A test asserts the submitted string does not
appear in the message while its length does.

## Forward compatibility

An unknown platform keeps today's length-only bounds rather than having a shape
guessed for it, so adding Discord/Teams stays additive and cannot reject a valid
credential for a format nobody has described yet.

## Test churn worth noting

Existing fixtures passed values like `"old-secret"` with `platform="slack"` —
the same shape as the input that caused the outage. They now carry conforming
32-hex stand-ins. Five pre-existing tests failed the moment the validation
landed, which is the validation proving itself rather than incidental breakage.

New tests cover the exact placeholder that caused the outage, an ASCII
placeholder, uppercase hex, off-by-one lengths, non-hex at the right length, an
embedded space, and a trailing newline.

## Verification

`tests/services/test_worker_app_identity.py`: 26 passed.
`tests/api -k worker_app`: 18 passed. `ruff check` / `ruff format --check` clean.

Unrelated pre-existing failures in `tests/api/test_context_sleep_mode.py` (7)
reproduce identically on `main` — confirmed by stashing this branch.

## Follow-up

A consuming worker keeps a local copy of this secret as a bootstrap fallback and
can diverge from the authoritative value stored here, then silently serve a dead
secret. Tracked separately on the consumer side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZpvFKGhBZrEQ4jyFRpTwJ