### PR TITLE
fix(infra): publish the active-color marker in place, and verify the bridge (#1480)

### DIFF
--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -374,17 +374,39 @@ cd terraform/single-server
 
 The script handles building, migrations, readiness checks, Caddy reload,
 the bridge-worker restart, and draining automatically. Use
-`./scripts/deploy.sh --status` to see which color is active, or
-`./scripts/deploy.sh --rollback` to switch back.
+`./scripts/deploy.sh --status` to see which color is active,
+`./scripts/deploy.sh --verify-bridge` to check the chat-bridge worker is on
+that color, or `./scripts/deploy.sh --rollback` to switch back.
 
-> **No manual bridge restart.** Both the deploy and the rollback path restart
-> the co-resident `kagura-bridge-worker-1` right after the Caddy switch (Step
-> 6b), because the worker pins its API connections to a color and a flip would
-> otherwise leave it talking to the color being drained — surviving only on
-> kagura-bridge's cross-color fallback, which masks the mismatch instead of
-> reporting it ([#1476](https://github.com/kagura-ai/memory-cloud/issues/1476)).
-> A host without that container logs a skip; a restart that fails logs a
-> warning and does **not** abort the deploy.
+> **The bridge worker.** Both the deploy and the rollback path restart the
+> co-resident `kagura-bridge-worker-1` right after the Caddy switch (Step 6b),
+> because a flip would otherwise leave it talking to the color being drained —
+> surviving only on kagura-bridge's cross-color fallback, which masks the
+> mismatch instead of reporting it
+> ([#1476](https://github.com/kagura-ai/memory-cloud/issues/1476)). A host
+> without that container logs a skip; a restart that fails logs a warning and
+> does **not** abort the deploy.
+>
+> **The restart alone is not always enough**
+> ([#1480](https://github.com/kagura-ai/memory-cloud/issues/1480)). If the
+> bridge's `deploy/.env` sets a static `KMC_INTERNAL_URL`, that value wins over
+> the marker template and is baked into the container at create time — so
+> `docker restart` brings the worker back on the *same old color*. Step 6b now
+> **verifies** where the worker actually landed and prints a loud
+> `BRIDGE NOT VERIFIED` block when it cannot prove the new color. The deploy
+> still succeeds (the API cutover is independent and already done), but it will
+> not read as clean. Check any time with:
+>
+> ```bash
+> ./scripts/deploy.sh --verify-bridge   # exits non-zero if not on the active color
+> ```
+>
+> **To make it fully automatic**, leave `KMC_INTERNAL_URL` blank in the bridge's
+> `deploy/.env` so the worker follows `KMC_INTERNAL_URL_TEMPLATE` + the marker.
+> That works because this script now publishes the marker **in place** — see
+> `write_marker()`. A single-file bind mount tracks the *inode*, so the old
+> `mv` published a new inode the running container never saw; `cp` keeps the
+> inode and the change is visible immediately, with no restart at all.
 
 Tunable environment variables:
 

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -72,6 +72,13 @@ dc() { docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" "$@"; }
 # Updated at the head of each step; read only by on_exit().
 DEPLOY_STAGE="startup"
 
+# Set to 1 when the bridge step could not be PROVEN good (#1480). The deploy
+# still succeeds — the API cutover is independent and already done — but the
+# summary must not read as clean. Deliberately not an abort: failing a completed
+# cutover because a co-resident stack is unhappy would invite a needless
+# rollback, which is how #1476's manual step got skipped in the first place.
+BRIDGE_STEP_DEGRADED=0
+
 # Single final-status line on EVERY exit path (success or abort), so a run can
 # never "exit 0-ish" silently again (#986). error() and any set -e death both
 # route through here because the trap fires on EXIT regardless of cause.
@@ -159,6 +166,70 @@ get_inactive_color() {
     if [ "$active" = "blue" ]; then echo "green"; else echo "blue"; fi
 }
 
+# Publish a new active color WITHOUT changing the marker file's inode (#1480).
+#
+# This file is bind-mounted into co-resident stacks as a SINGLE FILE
+# (kagura-bridge mounts it read-only to follow the active color). A single-file
+# bind mount resolves to an inode at container start: replacing the file with
+# `mv` publishes a NEW inode, and the running container keeps reading the OLD
+# one forever. It sees the color it booted with, no matter how many times this
+# script rewrites the marker.
+#
+# That is not a hypothesis. Measured on docker 29.3.1 with a single-file bind
+# mount of this exact shape:
+#   mv  + container left running -> container still reads the OLD color
+#   mv  + `docker restart`       -> container reads the new color
+#   cp  + container left running -> container reads the new color, NO restart
+#
+# So `mv` is what forced kagura-bridge onto a static KMC_INTERNAL_URL pin, which
+# in turn is what made deploy Step 6b's `docker restart` unable to re-point it
+# (a restart cannot re-read an .env). Writing in place fixes it at the source.
+#
+# generate_caddyfile() 160 lines below already made exactly this trade for the
+# Caddyfile, for verbatim this reason — see its `tmp + cp (not mv)` comment.
+# This is that same fix, applied to the file that needed it more.
+#
+# The cost, stated plainly: `cp` is not atomic, so a crash mid-write can leave
+# the marker truncated where `mv` could not. That is deliberate and is the
+# behaviour #1448 asked for — get_active_color() treats an empty or malformed
+# marker as a loud, recoverable error with recovery steps, never as a guess.
+# kagura-bridge's reader fails closed the same way. A single writer (this
+# script), 6 bytes, versus a defect that silently degraded production for 65
+# hours: in-place wins.
+write_marker() {
+    local color="$1"
+    # Stage first so a failed write never truncates the live marker, then copy
+    # ONTO the original inode rather than renaming over it.
+    if ! echo "$color" > "${MARKER_FILE}.tmp"; then
+        rm -f "${MARKER_FILE}.tmp"
+        error "Could not stage marker at ${MARKER_FILE}.tmp — check disk and permissions."
+    fi
+    if ! cp "${MARKER_FILE}.tmp" "$MARKER_FILE"; then
+        rm -f "${MARKER_FILE}.tmp"
+        error "Could not write marker $MARKER_FILE. Traffic may already be switched.
+       Write it by hand to match the color actually serving:
+           echo $color > $MARKER_FILE"
+    fi
+    rm -f "${MARKER_FILE}.tmp"
+
+    # Read back before claiming success. `cp file dir` SUCCEEDS by copying into
+    # the directory, so a marker path that is somehow a directory would leave
+    # the published color unchanged while cp exits 0 — the same "reported the
+    # action, not the outcome" mistake this issue is about.
+    #
+    # Read through get_active_color rather than cat: it is the same validated
+    # reader every other consumer uses, so this cannot accidentally accept a
+    # value the rest of the script would reject. It also keeps this function
+    # clear of the `cat ... || fallback` shape that #1448's guard forbids.
+    local published
+    published="$(get_active_color)"
+    if [ "$published" != "$color" ]; then
+        error "Marker $MARKER_FILE reads back as '$published', not '$color'.
+       Traffic may already be switched — write it by hand to match reality:
+           echo $color > $MARKER_FILE"
+    fi
+}
+
 is_container_running() {
     local container="kagura-api-$1"
     docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null | grep -q "true"
@@ -197,6 +268,84 @@ bridge_worker_is_running() {
     return 1
 }
 
+# Print the worker's STATIC upstream pin, or nothing when it has none.
+#
+# Empty output means the variable is absent or set-but-empty — in both cases the
+# worker resolves the color from the bind-mounted marker instead, which is the
+# configuration we want. Returns non-zero only when docker could not be asked.
+bridge_pinned_url() {
+    local env_lines line
+    env_lines="$("$DOCKER" inspect "$BRIDGE_WORKER_CONTAINER" \
+        --format '{{range .Config.Env}}{{println .}}{{end}}' 2>/dev/null)" || return 1
+    while IFS= read -r line; do
+        case "$line" in
+            KMC_INTERNAL_URL=*)
+                printf '%s' "${line#KMC_INTERNAL_URL=}"
+                return 0
+                ;;
+        esac
+    done <<< "$env_lines"
+    return 0
+}
+
+# Has the worker fallen back to the other color since the deploy touched it?
+#
+# kagura-bridge logs `control_plane.cross_color_fallback` when its primary
+# upstream refuses a connection and it retries the other color. That line is the
+# ONLY reliable outward sign of a stranded worker: its /health keeps returning
+# {"status":"ok"} the whole time, which is why the condition once ran 65 hours
+# unnoticed. Treat it as a deploy signal, not log noise (#1480).
+bridge_fallback_count() {
+    local since="${1:-5m}" logs
+    logs="$("$DOCKER" logs --since "$since" "$BRIDGE_WORKER_CONTAINER" 2>&1)" || return 1
+    # grep -c exits 1 on zero matches; `|| true` keeps that out of `set -e`.
+    printf '%s\n' "$logs" | grep -c 'control_plane.cross_color_fallback' || true
+}
+
+# Prove the worker is actually talking to $1, rather than assuming a restart
+# achieved it. Returns non-zero when the bridge step must NOT be called clean.
+verify_bridge_upstream() {
+    local color="$1" pin fallbacks
+    if ! pin="$(bridge_pinned_url)"; then
+        log "  Could not read ${BRIDGE_WORKER_CONTAINER} config — upstream NOT verified."
+        return 1
+    fi
+
+    if [ -n "$pin" ]; then
+        case "$pin" in
+            *"api-${color}"*)
+                log "  ${BRIDGE_WORKER_CONTAINER} upstream pin is ${pin} — matches api-${color}."
+                ;;
+            *)
+                log "WARNING: ${BRIDGE_WORKER_CONTAINER} is pinned to '${pin}', NOT api-${color}."
+                log "         A restart CANNOT fix this — the pin is baked into the container"
+                log "         from deploy/.env, and 'docker restart' does not re-read that file."
+                log "         Chat ingest is now riding the cross-color fallback (#1480)."
+                log "         Re-point and RECREATE (not restart):"
+                log "             sudo sed -i 's|^KMC_INTERNAL_URL=.*|KMC_INTERNAL_URL=http://api-${color}:8080|' \\"
+                log "                 /opt/kagura-bridge/src/deploy/.env"
+                log "             cd /opt/kagura-bridge/src && docker compose -f deploy/compose.yml \\"
+                log "                 --env-file deploy/.env up -d --no-deps --force-recreate worker"
+                log "         Better: blank KMC_INTERNAL_URL so the worker follows the marker,"
+                log "         which this script now writes in place (#1480)."
+                return 1
+                ;;
+        esac
+    else
+        log "  ${BRIDGE_WORKER_CONTAINER} has no static pin — it follows the marker (now ${color})."
+    fi
+
+    # Even a correct-looking pin can be stranded, so check the worker's own
+    # verdict too. Non-fatal if the log query itself fails.
+    if fallbacks="$(bridge_fallback_count 5m)" && [ "${fallbacks:-0}" -gt 0 ]; then
+        log "WARNING: ${BRIDGE_WORKER_CONTAINER} logged ${fallbacks} cross-color fallback event(s)"
+        log "         in the last 5m. It is reaching the API only via the safety net."
+        log "         Inspect: docker logs --since 10m ${BRIDGE_WORKER_CONTAINER} | grep cross_color_fallback"
+        return 1
+    fi
+    return 0
+}
+
 # Restart the chat-bridge worker after the active API color changes (#1476).
 #
 # The worker resolves the API container by color when it connects and then holds
@@ -212,7 +361,13 @@ bridge_worker_is_running() {
 #
 # Call it AFTER Caddy has been switched: restarting while the old color still
 # serves would just re-pin the worker to the color being drained.
+#
+# $1 is the color that is now live. It is REQUIRED: #1480 was possible because
+# this step reported "restarted." without ever checking where the worker ended
+# up. A restart is the action; landing on $1 is the outcome, and only the
+# outcome is worth reporting.
 restart_bridge_worker() {
+    local new_color="$1"
     # `|| presence=$?` keeps a non-zero return from killing the run under `set -e`.
     local presence=0
     bridge_worker_is_running || presence=$?
@@ -236,6 +391,11 @@ restart_bridge_worker() {
     log "  Restarting ${BRIDGE_WORKER_CONTAINER} (active API color changed)..."
     if "$DOCKER" restart "$BRIDGE_WORKER_CONTAINER" > /dev/null 2>&1; then
         log "  ${BRIDGE_WORKER_CONTAINER} restarted."
+        # The restart happened. That is NOT the same as the worker now talking
+        # to the new color — the whole of #1480. Prove it or degrade the run.
+        if ! verify_bridge_upstream "$new_color"; then
+            BRIDGE_STEP_DEGRADED=1
+        fi
         return 0
     fi
 
@@ -243,10 +403,25 @@ restart_bridge_worker() {
     # new color is serving; a bridge that will not come back is a bridge
     # problem. Aborting here would report a healthy deploy as failed and invite
     # an unnecessary rollback. Say it loudly instead.
+    BRIDGE_STEP_DEGRADED=1
     log "WARNING: ${BRIDGE_WORKER_CONTAINER} failed to restart. Chat ingest may still be"
     log "         pinned to the drained API color. Restart it manually:"
     log "             docker restart ${BRIDGE_WORKER_CONTAINER}"
     return 0
+}
+
+# Print the closing bridge verdict. Called from the deploy/rollback summary so
+# a degraded bridge is the LAST thing an operator reads, not a line scrolled off
+# the top by Step 7's drain (#1480).
+report_bridge_state() {
+    if [ "${BRIDGE_STEP_DEGRADED:-0}" -eq 0 ]; then
+        return 0
+    fi
+    log ""
+    log "*** BRIDGE NOT VERIFIED — the API cutover succeeded, chat ingest did not. ***"
+    log "    The API is serving normally. The bridge worker is NOT confirmed to be"
+    log "    on the new color; see the WARNING above for the exact remediation."
+    log "    Re-check at any time with: $0 --verify-bridge"
 }
 
 # ---------------------------------------------------------------------------
@@ -286,10 +461,10 @@ cmd_rollback() {
         wait_for_readiness "$inactive"
     fi
 
-    # Write marker BEFORE switching Caddy (atomic: same filesystem mv)
+    # Write marker BEFORE switching Caddy. In place, so co-resident readers that
+    # bind-mount it as a single file actually see the change (#1480).
     log "Switching Caddy: api-${active} -> api-${inactive}"
-    echo "$inactive" > "${MARKER_FILE}.tmp"
-    mv "${MARKER_FILE}.tmp" "$MARKER_FILE"
+    write_marker "$inactive"
     DEPLOY_STAGE="rollback: switch Caddy -> api-${inactive} (incl. security gate)"
     generate_caddyfile "api-${inactive}"
     reload_caddy
@@ -300,10 +475,11 @@ cmd_rollback() {
     # the color we just switched away from — same failure as an ordinary deploy
     # (#1476). The issue only named cmd_deploy; this path needs it just as much.
     DEPLOY_STAGE="rollback: restart bridge worker"
-    restart_bridge_worker
+    restart_bridge_worker "$inactive"
 
     DEPLOY_STAGE="rollback complete (active: ${inactive})"
     log "Rollback complete. Active: $inactive"
+    report_bridge_state
 }
 
 cmd_deploy() {
@@ -350,11 +526,11 @@ cmd_deploy() {
     log "Step 4/7: Running database migrations on api-${inactive}..."
     dc exec -T "api-${inactive}" alembic upgrade head
 
-    # Step 5: Write marker BEFORE switching Caddy (crash-safe ordering)
+    # Step 5: Write marker BEFORE switching Caddy (crash-safe ordering), and
+    # write it IN PLACE so single-file bind-mount readers see it (#1480).
     DEPLOY_STAGE="Step 5/7: update marker -> ${inactive}"
     log "Step 5/7: Updating marker -> ${inactive}"
-    echo "$inactive" > "${MARKER_FILE}.tmp"
-    mv "${MARKER_FILE}.tmp" "$MARKER_FILE"
+    write_marker "$inactive"
 
     # Step 6: Switch Caddy upstream
     DEPLOY_STAGE="Step 6/7: switch Caddy upstream -> api-${inactive} (incl. security gate)"
@@ -369,7 +545,7 @@ cmd_deploy() {
     # switch — it is only correct once Caddy points at the new color.
     DEPLOY_STAGE="Step 6b/7: restart ${BRIDGE_WORKER_CONTAINER}"
     log "Step 6b/7: Restarting the bridge worker after the color switch..."
-    restart_bridge_worker
+    restart_bridge_worker "$inactive"
 
     # Step 7: Drain and stop old container
     # Disable restart policy first — otherwise `restart: always` revives
@@ -385,6 +561,7 @@ cmd_deploy() {
     log "=== DEPLOY COMPLETE ==="
     log "Active: $inactive"
     log "To rollback: $0 --rollback"
+    report_bridge_state
 }
 
 cmd_deploy_web() {
@@ -602,6 +779,33 @@ verify_internal_blocked() {
     _verify_path_blocked "/internal/*" "/internal/workspaces/probe/plan"
 }
 
+cmd_verify_bridge() {
+    # Read-only. Exits non-zero when the bridge worker is not provably on the
+    # active color, so cron/monitoring can consume it — this is the "somewhere"
+    # that criterion 3 of #1480 asks for. A non-zero exit is safe HERE precisely
+    # because nothing is mid-flight; inside a deploy the same condition only
+    # warns, because the API cutover has already succeeded by then.
+    local active
+    active="$(get_active_color)"
+    log "Verifying ${BRIDGE_WORKER_CONTAINER} against active color: ${active}"
+
+    local presence=0
+    bridge_worker_is_running || presence=$?
+    if [ "$presence" -eq 1 ]; then
+        log "  ${BRIDGE_WORKER_CONTAINER} is not running on this host — nothing to verify."
+        return 0
+    fi
+    if [ "$presence" -ne 0 ]; then
+        error "Could not query docker for ${BRIDGE_WORKER_CONTAINER}."
+    fi
+
+    if verify_bridge_upstream "$active"; then
+        log "Bridge upstream verified: api-${active}"
+        return 0
+    fi
+    error "Bridge worker is NOT verified against api-${active} — see the warning above."
+}
+
 cmd_generate_caddyfile() {
     # Bootstrap helper: render ./Caddyfile from Caddyfile.tpl WITHOUT deploying.
     #
@@ -670,14 +874,19 @@ main() {
         --generate-caddyfile)
             cmd_generate_caddyfile
             ;;
+        --verify-bridge)
+            DEPLOY_STAGE="verify bridge upstream"
+            cmd_verify_bridge
+            ;;
         --help|-h)
             DEPLOY_STAGE="readonly"
-            echo "Usage: $0 [--rollback|--status|--web|--generate-caddyfile|--help]"
+            echo "Usage: $0 [--rollback|--status|--web|--verify-bridge|--generate-caddyfile|--help]"
             echo ""
             echo "  (no args)             Deploy to the inactive API color (zero-downtime blue-green)"
             echo "  --rollback            Switch back to the previous API color"
             echo "  --status              Show current active API color and container states"
             echo "  --web                 Rebuild + restart kagura-web in place"
+            echo "  --verify-bridge       Check the bridge worker is on the active color; exits non-zero if not"
             echo "  --generate-caddyfile  Render ./Caddyfile from Caddyfile.tpl (bootstrap; no deploy)"
             echo ""
             echo "Environment variables:"

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -340,15 +340,16 @@ url_host() {
     printf '%s' "$host"
 }
 
-# Prove the worker is actually talking to $1, rather than assuming a restart
-# achieved it. Returns non-zero when the bridge step must NOT be called clean.
-verify_bridge_upstream() {
-    local color="${1:-}" window="${2:-5m}" pin fallbacks
+# Check the worker's CONFIGURED upstream. Usable the instant `docker restart`
+# returns, because a container's env is static — it does not wait for the worker
+# to finish booting.
+verify_bridge_pin() {
+    local color="${1:-}" pin
 
     # An empty color would make every comparison below trivially permissive,
     # "verifying" a worker against nothing. Refuse rather than pass.
     if [ -z "$color" ]; then
-        log "WARNING: verify_bridge_upstream called with no color — nothing verified."
+        log "WARNING: verify_bridge_pin called with no color — nothing verified."
         return 1
     fi
 
@@ -383,11 +384,20 @@ verify_bridge_upstream() {
         # below is the only outward evidence, so say that rather than claim the
         # upstream was confirmed.
         log "  ${BRIDGE_WORKER_CONTAINER} has no static pin — it follows the marker (now ${color})."
-        log "  (Resolved upstream is not readable from here; judging by fallback logs only.)"
+        log "  (Resolved upstream is not readable from here; the fallback check is the evidence.)"
     fi
+    return 0
+}
 
-    # Even a correct-looking pin can be stranded, so check the worker's own
-    # verdict too.
+# Check the worker's OWN verdict: has it fallen back to the other color?
+#
+# TIMING IS LOAD-BEARING. Run this only once the old color is STOPPED. Before
+# the drain, a stranded worker can still reach the color it is pinned to, so it
+# has no reason to log a fallback and this check cannot fire — it would report
+# clean by construction, which is the very defect #1480 is about. After Step 7
+# the old color is gone, so a stranded worker surfaces immediately.
+verify_bridge_fallback() {
+    local window="${1:-5m}" fallbacks
     if ! fallbacks="$(bridge_fallback_count "$window")"; then
         # "Could not ask" is not "fine" — the same distinction bridge presence
         # detection already makes. A silent skip here would be a false clean.
@@ -397,11 +407,21 @@ verify_bridge_upstream() {
     fi
     if [ "${fallbacks:-0}" -gt 0 ]; then
         log "WARNING: ${BRIDGE_WORKER_CONTAINER} logged ${fallbacks} cross-color fallback event(s)"
-        log "         in the last ${window}. It is reaching the API only via the safety net."
+        log "         in the last ${window}. It is reaching the API only via the safety net,"
+        log "         which means it is NOT on the live color."
         log "         Inspect: docker logs --since 30m ${BRIDGE_WORKER_CONTAINER} | grep cross_color_fallback"
         return 1
     fi
     return 0
+}
+
+# Both halves, for callers that are not mid-deploy (--verify-bridge), where the
+# old color is already stopped and the fallback signal is meaningful.
+verify_bridge_upstream() {
+    local color="${1:-}" window="${2:-5m}" ok=0
+    verify_bridge_pin "$color" || ok=1
+    verify_bridge_fallback "$window" || ok=1
+    return "$ok"
 }
 
 # Restart the chat-bridge worker after the active API color changes (#1476).
@@ -450,8 +470,10 @@ restart_bridge_worker() {
     if "$DOCKER" restart "$BRIDGE_WORKER_CONTAINER" > /dev/null 2>&1; then
         log "  ${BRIDGE_WORKER_CONTAINER} restarted."
         # The restart happened. That is NOT the same as the worker now talking
-        # to the new color — the whole of #1480. Prove it or degrade the run.
-        if ! verify_bridge_upstream "$new_color"; then
+        # to the new color — the whole of #1480. Check the configured upstream
+        # now; the worker's own fallback verdict is only meaningful after the
+        # old color is drained, so that half runs at the end of Step 7.
+        if ! verify_bridge_pin "$new_color"; then
             BRIDGE_STEP_DEGRADED=1
         fi
         return 0
@@ -614,6 +636,18 @@ cmd_deploy() {
     docker update --restart=no "kagura-api-${active}" 2>/dev/null || true
     dc stop "api-${active}" || true
     log "api-${active} stopped (restart policy disabled)."
+
+    # NOW the fallback signal means something: api-${active} is gone, so a
+    # worker still pointed at it must fall back, and that is observable. Running
+    # this at Step 6b instead would report clean by construction, because the
+    # old color was still answering (#1480).
+    if bridge_worker_is_running; then
+        DEPLOY_STAGE="Step 7/7: verify ${BRIDGE_WORKER_CONTAINER} after drain"
+        log "  Checking ${BRIDGE_WORKER_CONTAINER} now that api-${active} is stopped..."
+        if ! verify_bridge_fallback "${BRIDGE_FALLBACK_WINDOW:-5m}"; then
+            BRIDGE_STEP_DEGRADED=1
+        fi
+    fi
 
     DEPLOY_STAGE="deploy complete (active: ${inactive})"
     log "=== DEPLOY COMPLETE ==="

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -198,17 +198,40 @@ get_inactive_color() {
 # hours: in-place wins.
 write_marker() {
     local color="$1"
+
+    # Remember what was published, so a half-finished write can be reported
+    # accurately — and undone. `cp` opens the destination with O_TRUNC, so a
+    # failure part-way through (ENOSPC, EIO, a read-only remount) leaves the
+    # LIVE marker truncated. `mv` could not do that; this is the real cost of
+    # preserving the inode, and it is handled rather than hand-waved.
+    #
+    # Read with `read`, not `cat ... || fallback`: #1448's guard bans that shape
+    # outright because it is how a silent default color creeps back in, and it
+    # is exactly the shape one reaches for here. `read` also avoids a subshell.
+    local previous=""
+    if [ -s "$MARKER_FILE" ]; then
+        IFS= read -r previous < "$MARKER_FILE" 2>/dev/null || previous=""
+    fi
+
     # Stage first so a failed write never truncates the live marker, then copy
     # ONTO the original inode rather than renaming over it.
     if ! echo "$color" > "${MARKER_FILE}.tmp"; then
         rm -f "${MARKER_FILE}.tmp"
-        error "Could not stage marker at ${MARKER_FILE}.tmp — check disk and permissions."
+        error "Could not stage marker at ${MARKER_FILE}.tmp — check disk and permissions.
+       The live marker was NOT touched."
     fi
     if ! cp "${MARKER_FILE}.tmp" "$MARKER_FILE"; then
         rm -f "${MARKER_FILE}.tmp"
-        error "Could not write marker $MARKER_FILE. Traffic may already be switched.
-       Write it by hand to match the color actually serving:
-           echo $color > $MARKER_FILE"
+        # Best-effort restore. It may itself fail on a full or read-only
+        # filesystem, so the message must not promise it worked.
+        if [ -n "$previous" ]; then
+            echo "$previous" > "$MARKER_FILE" 2>/dev/null || true
+        fi
+        error "Could not write marker $MARKER_FILE, and it may now be TRUNCATED.
+       Caddy has NOT been switched, so traffic is still on '${previous:-unknown}'.
+       Restoring '${previous:-unknown}' was attempted — verify and fix by hand:
+           cat $MARKER_FILE
+           echo ${previous:-blue} > $MARKER_FILE"
     fi
     rm -f "${MARKER_FILE}.tmp"
 
@@ -302,18 +325,41 @@ bridge_fallback_count() {
     printf '%s\n' "$logs" | grep -c 'control_plane.cross_color_fallback' || true
 }
 
+# Extract the host from a URL, with no port and no path: http://api-blue:8080
+# -> api-blue. Used so the color check is an EXACT host comparison.
+#
+# A substring test (`case $pin in *api-blue*`) reports a pin of
+# `http://api-blue2:8080` as a match for api-blue, which is a false clean —
+# precisely the failure class this file exists to remove.
+url_host() {
+    local url="${1:-}" host
+    host="${url#*://}"   # strip scheme, if any
+    host="${host%%/*}"   # strip path
+    host="${host%%\?*}"  # strip query
+    host="${host%%:*}"   # strip port
+    printf '%s' "$host"
+}
+
 # Prove the worker is actually talking to $1, rather than assuming a restart
 # achieved it. Returns non-zero when the bridge step must NOT be called clean.
 verify_bridge_upstream() {
-    local color="$1" pin fallbacks
+    local color="${1:-}" window="${2:-5m}" pin fallbacks
+
+    # An empty color would make every comparison below trivially permissive,
+    # "verifying" a worker against nothing. Refuse rather than pass.
+    if [ -z "$color" ]; then
+        log "WARNING: verify_bridge_upstream called with no color — nothing verified."
+        return 1
+    fi
+
     if ! pin="$(bridge_pinned_url)"; then
         log "  Could not read ${BRIDGE_WORKER_CONTAINER} config — upstream NOT verified."
         return 1
     fi
 
     if [ -n "$pin" ]; then
-        case "$pin" in
-            *"api-${color}"*)
+        case "$(url_host "$pin")" in
+            "api-${color}")
                 log "  ${BRIDGE_WORKER_CONTAINER} upstream pin is ${pin} — matches api-${color}."
                 ;;
             *)
@@ -332,15 +378,27 @@ verify_bridge_upstream() {
                 ;;
         esac
     else
+        # Honest scope: with no pin the worker resolves from the marker, and
+        # this script cannot read what it resolved TO. The fallback-log check
+        # below is the only outward evidence, so say that rather than claim the
+        # upstream was confirmed.
         log "  ${BRIDGE_WORKER_CONTAINER} has no static pin — it follows the marker (now ${color})."
+        log "  (Resolved upstream is not readable from here; judging by fallback logs only.)"
     fi
 
     # Even a correct-looking pin can be stranded, so check the worker's own
-    # verdict too. Non-fatal if the log query itself fails.
-    if fallbacks="$(bridge_fallback_count 5m)" && [ "${fallbacks:-0}" -gt 0 ]; then
+    # verdict too.
+    if ! fallbacks="$(bridge_fallback_count "$window")"; then
+        # "Could not ask" is not "fine" — the same distinction bridge presence
+        # detection already makes. A silent skip here would be a false clean.
+        log "WARNING: could not read ${BRIDGE_WORKER_CONTAINER} logs — fallback state UNKNOWN."
+        log "         Treating as not verified rather than assuming healthy."
+        return 1
+    fi
+    if [ "${fallbacks:-0}" -gt 0 ]; then
         log "WARNING: ${BRIDGE_WORKER_CONTAINER} logged ${fallbacks} cross-color fallback event(s)"
-        log "         in the last 5m. It is reaching the API only via the safety net."
-        log "         Inspect: docker logs --since 10m ${BRIDGE_WORKER_CONTAINER} | grep cross_color_fallback"
+        log "         in the last ${window}. It is reaching the API only via the safety net."
+        log "         Inspect: docker logs --since 30m ${BRIDGE_WORKER_CONTAINER} | grep cross_color_fallback"
         return 1
     fi
     return 0
@@ -799,7 +857,10 @@ cmd_verify_bridge() {
         error "Could not query docker for ${BRIDGE_WORKER_CONTAINER}."
     fi
 
-    if verify_bridge_upstream "$active"; then
+    # Wider log window than the deploy path: this runs at an arbitrary time, so
+    # a fallback that started half an hour ago is exactly what it should catch.
+    # Mid-deploy the worker was restarted seconds earlier, where 5m is right.
+    if verify_bridge_upstream "$active" "${BRIDGE_FALLBACK_WINDOW:-30m}"; then
         log "Bridge upstream verified: api-${active}"
         return 0
     fi

--- a/terraform/single-server/scripts/tests/deploy_bridge_restart.bats
+++ b/terraform/single-server/scripts/tests/deploy_bridge_restart.bats
@@ -88,7 +88,7 @@ teardown() {
 @test "the bridge worker is restarted when it is running" {
     printf 'kagura-api-blue\nkagura-bridge-worker-1\nkagura-web\n' > "$PS_FILE"
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"Restarting kagura-bridge-worker-1"* ]] || return 1
@@ -100,7 +100,7 @@ teardown() {
     BRIDGE_WORKER_CONTAINER="bridge-staging"
     printf 'bridge-staging\n' > "$PS_FILE"
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [ "$(cat "$RESTART_LOG")" = "bridge-staging" ] || return 1
@@ -111,7 +111,7 @@ teardown() {
 @test "a host with no bridge container logs a skip and succeeds" {
     printf 'kagura-api-blue\nkagura-web\nkagura-postgres\n' > "$PS_FILE"
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"not running on this host"* ]] || return 1
@@ -122,7 +122,7 @@ teardown() {
 @test "an empty docker ps is a skip, not a crash" {
     : > "$PS_FILE"
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"not running on this host"* ]] || return 1
@@ -136,7 +136,7 @@ teardown() {
     # present when it is not.
     printf 'kagura-bridge-worker-10\nold-kagura-bridge-worker-1\n' > "$PS_FILE"
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"not running on this host"* ]] || return 1
@@ -164,7 +164,7 @@ teardown() {
     printf 'kagura-bridge-worker-1\n' > "$PS_FILE"
     export RESTART_RC=1
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"WARNING"* ]] || return 1
@@ -189,7 +189,7 @@ teardown() {
         set -euo pipefail
         source "'"$DEPLOY_SH"'"
         trap - EXIT
-        restart_bridge_worker >/dev/null 2>&1
+        restart_bridge_worker green >/dev/null 2>&1
         echo "STEP7_REACHED"
     '
 
@@ -207,7 +207,7 @@ teardown() {
         DOCKER=broken_docker
         source "'"$DEPLOY_SH"'"
         trap - EXIT
-        restart_bridge_worker >/dev/null 2>&1
+        restart_bridge_worker green >/dev/null 2>&1
         echo "SURVIVED"
     '
 
@@ -224,7 +224,7 @@ teardown() {
     broken_docker() { return 1; }
     DOCKER=broken_docker
 
-    run restart_bridge_worker
+    run restart_bridge_worker green
 
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"could not query docker"* ]] || return 1
@@ -251,14 +251,14 @@ teardown() {
 # which is worse than not restarting at all, and no runtime assertion here could
 # tell the two orders apart.
 #
-# `^ *restart_bridge_worker *$` matches only a BARE CALL on its own line, so
+# The regex anchors a call to the start of a line (arguments allowed), so
 # commenting the call out (`# restart_bridge_worker`) or merely naming it in
 # prose fails these — a plain substring count would not.
 
 # Count bare calls to $2 inside function $1 of deploy.sh. Prints the count.
 count_calls_in() {
     local fn="$1" callee="$2"
-    sed -n "/^${fn}()/,/^}/p" "$DEPLOY_SH" | grep -cE "^ *${callee} *$" || true
+    sed -n "/^${fn}()/,/^}/p" "$DEPLOY_SH" | grep -cE "^ *${callee}( +[^ ].*)? *$" || true
 }
 
 # Print the 1-based line number of the first bare call to $2 within function $1,
@@ -266,7 +266,7 @@ count_calls_in() {
 first_call_line_in() {
     local fn="$1" callee="$2"
     sed -n "/^${fn}()/,/^}/p" "$DEPLOY_SH" \
-        | grep -nE "^ *${callee} *$" | head -1 | cut -d: -f1
+        | grep -nE "^ *${callee}( +[^ ].*)? *$" | head -1 | cut -d: -f1
 }
 
 @test "the call-site helpers actually see the function bodies (guard not vacuous)" {

--- a/terraform/single-server/scripts/tests/deploy_bridge_verify.bats
+++ b/terraform/single-server/scripts/tests/deploy_bridge_verify.bats
@@ -109,6 +109,33 @@ teardown() {
     [ "$status" -ne 0 ] || return 1
 }
 
+@test "a host that merely STARTS WITH the color name is not a match" {
+    # `*api-blue*` matches api-blue2. The comparison must be on the exact host,
+    # or a worker pointed at a different service verifies clean.
+    printf 'KMC_INTERNAL_URL=http://api-blue2:8080\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream blue
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"NOT api-blue"* ]] || return 1
+}
+
+@test "url_host strips scheme, port, path and query" {
+    [ "$(url_host http://api-blue:8080)" = "api-blue" ] || return 1
+    [ "$(url_host http://api-blue:8080/api/v1/x)" = "api-blue" ] || return 1
+    [ "$(url_host http://api-blue)" = "api-blue" ] || return 1
+    [ "$(url_host https://api-green:443/p?q=1)" = "api-green" ] || return 1
+    [ "$(url_host api-blue:8080)" = "api-blue" ] || return 1
+    # ...and must not conflate distinct hosts.
+    [ "$(url_host http://api-blue2:8080)" != "api-blue" ] || return 1
+}
+
+@test "an empty color verifies nothing instead of passing everything" {
+    # With color="" a substring check becomes *api-* and any pin looks fine.
+    printf 'KMC_INTERNAL_URL=http://api-blue:8080\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream ""
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"no color"* ]] || return 1
+}
+
 @test "an unreadable docker inspect is 'not verified', never 'verified'" {
     export INSPECT_RC=1
     run verify_bridge_upstream green
@@ -133,6 +160,40 @@ teardown() {
     printf '%s\n' '{"event":"multi_tenant_supervisor.start"}' > "$LOGS_FILE"
     run verify_bridge_upstream green
     [ "$status" -eq 0 ] || return 1
+}
+
+@test "an unreadable log stream is NOT treated as clean" {
+    # "Could not ask" must never render as "healthy" — the same distinction the
+    # presence check already makes. Silently skipping the only outward signal
+    # would hand back a false clean.
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    mock_docker() {
+        case "${1:-}" in
+            ps)      cat "$PS_FILE" ;;
+            inspect) cat "$ENV_FILE_OUT" ;;
+            logs)    return 1 ;;
+            *)       return 0 ;;
+        esac
+    }
+    run verify_bridge_upstream green
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"fallback state UNKNOWN"* ]] || return 1
+}
+
+@test "the fallback log window is caller-controlled" {
+    # The deploy restarted the worker seconds ago, so 5m is right there; a
+    # standalone --verify-bridge run needs a much wider window or it reports
+    # clean on a worker that has been stranded for half an hour.
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    printf '%s\n' '{"event":"control_plane.cross_color_fallback"}' > "$LOGS_FILE"
+    run verify_bridge_upstream green 30m
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"last 30m"* ]] || return 1
+}
+
+@test "--verify-bridge uses a wider window than the deploy path" {
+    run bash -o pipefail -c 'sed -n "/^cmd_verify_bridge()/,/^}/p" "$1" | grep -c "BRIDGE_FALLBACK_WINDOW:-30m"' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
 }
 
 # --- degraded reporting -----------------------------------------------------

--- a/terraform/single-server/scripts/tests/deploy_bridge_verify.bats
+++ b/terraform/single-server/scripts/tests/deploy_bridge_verify.bats
@@ -1,0 +1,201 @@
+#!/usr/bin/env bats
+# =============================================================================
+# #1480: the deploy must PROVE the bridge worker landed on the new color.
+#
+# #1477 added Step 6b and reported "kagura-bridge-worker-1 restarted." — the
+# action, not the outcome. On the real 2026-08-03 deploy that line printed while
+# the worker was still pinned to the drained color, and the run finished
+# "FINAL STATUS: SUCCESS". The worker's own /health returns {"status":"ok"}
+# throughout, so nothing else could catch it.
+#
+# So: a restart that does not re-point is a DEGRADED run, and must read as one.
+# It is still not an abort — the API cutover has already succeeded by then, and
+# failing a healthy cutover invites the needless rollback that got the manual
+# step skipped in the first place.
+# =============================================================================
+
+DEPLOY_SH="$BATS_TEST_DIRNAME/../deploy.sh"
+
+# $DOCKER stub. Driven by files so a child `bash -c` inherits the state.
+#   $PS_FILE      — `docker ps --format '{{.Names}}'` output
+#   $ENV_FILE_OUT — `docker inspect --format '{{range .Config.Env}}...'` output
+#   $LOGS_FILE    — `docker logs` output
+#   $INSPECT_RC   — exit code for inspect (default 0)
+mock_docker() {
+    case "${1:-}" in
+        ps) cat "$PS_FILE" ;;
+        inspect)
+            # NB: `return $RC && cat ...` would exit before the cat ever ran,
+            # making every pin look empty and silently passing the
+            # unpinned-path tests. Branch explicitly.
+            if [ "${INSPECT_RC:-0}" -ne 0 ]; then
+                return "${INSPECT_RC}"
+            fi
+            cat "$ENV_FILE_OUT"
+            ;;
+        logs)    cat "$LOGS_FILE" ;;
+        restart) return "${RESTART_RC:-0}" ;;
+        *)       return 0 ;;
+    esac
+}
+
+setup() {
+    [ -r "$DEPLOY_SH" ] || return 1
+    TMP="$(mktemp -d)"
+    export PS_FILE="$TMP/ps" ENV_FILE_OUT="$TMP/env" LOGS_FILE="$TMP/logs"
+    export INSPECT_RC=0 RESTART_RC=0
+    printf 'kagura-bridge-worker-1\n' > "$PS_FILE"
+    : > "$ENV_FILE_OUT"
+    : > "$LOGS_FILE"
+
+    export DOCKER=mock_docker
+    export -f mock_docker
+
+    # shellcheck disable=SC1090
+    source "$DEPLOY_SH"
+    trap - EXIT
+    set +u
+    BRIDGE_STEP_DEGRADED=0
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+# --- reading the pin --------------------------------------------------------
+
+@test "a pin naming the new color verifies clean" {
+    printf 'PATH=/usr/bin\nKMC_INTERNAL_URL=http://api-green:8080\nLOG_LEVEL=INFO\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream green
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"matches api-green"* ]] || return 1
+}
+
+@test "a pin naming the DRAINED color is caught (the exact 2026-08-03 state)" {
+    printf 'KMC_INTERNAL_URL=http://api-blue:8080\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream green
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"WARNING"* ]] || return 1
+    [[ "$output" == *"NOT api-green"* ]] || return 1
+}
+
+@test "the warning says a restart cannot fix it, and gives the recreate command" {
+    # The operator's instinct is to restart again. That is precisely what does
+    # not work, and the message has to say so or the loop repeats.
+    printf 'KMC_INTERNAL_URL=http://api-blue:8080\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream green
+    [[ "$output" == *"restart CANNOT fix this"* ]] || return 1
+    [[ "$output" == *"force-recreate"* ]] || return 1
+}
+
+@test "no static pin means the worker follows the marker, which is fine" {
+    printf 'PATH=/usr/bin\nKMC_INTERNAL_URL_TEMPLATE=http://api-{color}:8080\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream green
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"follows the marker"* ]] || return 1
+}
+
+@test "an empty pin is treated as unpinned, not as a mismatch" {
+    printf 'KMC_INTERNAL_URL=\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream green
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" == *"follows the marker"* ]] || return 1
+}
+
+@test "a pin for api-green must not satisfy a check for api-blue" {
+    # Guards against a substring/always-true comparison.
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    run verify_bridge_upstream blue
+    [ "$status" -ne 0 ] || return 1
+}
+
+@test "an unreadable docker inspect is 'not verified', never 'verified'" {
+    export INSPECT_RC=1
+    run verify_bridge_upstream green
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"NOT verified"* ]] || return 1
+}
+
+# --- the worker's own verdict ----------------------------------------------
+
+@test "cross-color fallback in the logs fails verification even with a correct pin" {
+    # A pin can look right while the worker is still stranded. Its own log line
+    # is the ground truth, and it is the ONLY outward sign — /health stays ok.
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    printf '%s\n' '{"event":"control_plane.cross_color_fallback","reason":"ConnectError"}' > "$LOGS_FILE"
+    run verify_bridge_upstream green
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"cross-color fallback"* ]] || return 1
+}
+
+@test "clean logs with a correct pin verify" {
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    printf '%s\n' '{"event":"multi_tenant_supervisor.start"}' > "$LOGS_FILE"
+    run verify_bridge_upstream green
+    [ "$status" -eq 0 ] || return 1
+}
+
+# --- degraded reporting -----------------------------------------------------
+
+@test "a mismatch marks the run degraded without failing it" {
+    printf 'KMC_INTERNAL_URL=http://api-blue:8080\n' > "$ENV_FILE_OUT"
+    local rc=0
+    restart_bridge_worker green || rc=$?
+    # The API cutover already succeeded; the step must not abort...
+    [ "$rc" -eq 0 ] || return 1
+    # ...but it must not read as clean either.
+    [ "$BRIDGE_STEP_DEGRADED" -eq 1 ] || return 1
+}
+
+@test "a verified worker leaves the run clean" {
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    restart_bridge_worker green
+    [ "$BRIDGE_STEP_DEGRADED" -eq 0 ] || return 1
+}
+
+@test "report_bridge_state is silent when clean and unmissable when not" {
+    BRIDGE_STEP_DEGRADED=0
+    run report_bridge_state
+    [ -z "$output" ] || return 1
+
+    BRIDGE_STEP_DEGRADED=1
+    run report_bridge_state
+    [[ "$output" == *"BRIDGE NOT VERIFIED"* ]] || return 1
+    [[ "$output" == *"--verify-bridge"* ]] || return 1
+}
+
+@test "a failed restart also marks the run degraded" {
+    export RESTART_RC=1
+    printf 'KMC_INTERNAL_URL=http://api-green:8080\n' > "$ENV_FILE_OUT"
+    restart_bridge_worker green
+    [ "$BRIDGE_STEP_DEGRADED" -eq 1 ] || return 1
+}
+
+@test "an absent bridge is not degraded — the OSS single-server case" {
+    printf 'kagura-api-blue\n' > "$PS_FILE"
+    restart_bridge_worker green
+    [ "$BRIDGE_STEP_DEGRADED" -eq 0 ] || return 1
+}
+
+# --- wiring -----------------------------------------------------------------
+
+@test "both flip paths pass the NEW color to restart_bridge_worker" {
+    # Passing no argument would compare against an empty string and 'verify'
+    # nothing — the failure mode this whole file exists to prevent.
+    run bash -o pipefail -c 'sed -n "/^cmd_deploy()/,/^}/p" "$1" | grep -cE "^ *restart_bridge_worker \"\\\$inactive\""' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
+    run bash -o pipefail -c 'sed -n "/^cmd_rollback()/,/^}/p" "$1" | grep -cE "^ *restart_bridge_worker \"\\\$inactive\""' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "both flip paths report the bridge verdict in their summary" {
+    run bash -o pipefail -c 'sed -n "/^cmd_deploy()/,/^}/p" "$1" | grep -cE "^ *report_bridge_state"' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
+    run bash -o pipefail -c 'sed -n "/^cmd_rollback()/,/^}/p" "$1" | grep -cE "^ *report_bridge_state"' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "--verify-bridge is a real dispatch target, not just help text" {
+    run bash -o pipefail -c 'grep -c -- "--verify-bridge)" "$1"' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
+}

--- a/terraform/single-server/scripts/tests/deploy_bridge_verify.bats
+++ b/terraform/single-server/scripts/tests/deploy_bridge_verify.bats
@@ -66,7 +66,7 @@ teardown() {
 
 @test "a pin naming the new color verifies clean" {
     printf 'PATH=/usr/bin\nKMC_INTERNAL_URL=http://api-green:8080\nLOG_LEVEL=INFO\n' > "$ENV_FILE_OUT"
-    run verify_bridge_upstream green
+    run verify_bridge_pin green
     [ "$status" -eq 0 ] || return 1
     [[ "$output" == *"matches api-green"* ]] || return 1
 }
@@ -259,4 +259,64 @@ teardown() {
 @test "--verify-bridge is a real dispatch target, not just help text" {
     run bash -o pipefail -c 'grep -c -- "--verify-bridge)" "$1"' _ "$DEPLOY_SH"
     [ "$output" -ge 1 ] || return 1
+}
+
+# --- timing: the fallback check must run AFTER the drain --------------------
+# This is the property that makes the log half capable of firing at all. Before
+# Step 7 stops the old color, a stranded worker can still reach the color it is
+# pinned to, so it has no reason to log a fallback. Checking there would report
+# clean by construction — the exact defect #1480 is about, reintroduced one
+# level down.
+
+@test "the pin check rides the restart; the fallback check waits for the drain" {
+    # Line-number ordering inside cmd_deploy. NB: a sed range like
+    # /Step 6b/,/Draining/ is wrong here — "Step 6b" appears in a later comment
+    # too, so the range restarts and swallows the post-drain block. Compare
+    # positions of the actual CODE lines instead.
+    local body restart_line stop_line fall_line fall_count
+    body="$(sed -n '/^cmd_deploy()/,/^}/p' "$DEPLOY_SH")"
+    restart_line="$(printf '%s\n' "$body" | grep -n '^ *restart_bridge_worker ' | head -1 | cut -d: -f1)"
+    stop_line="$(printf '%s\n' "$body" | grep -n 'stopped (restart policy disabled)' | head -1 | cut -d: -f1)"
+    # Anchor on the `if !` so comments mentioning the function do not count.
+    fall_count="$(printf '%s\n' "$body" | grep -c '^ *if ! verify_bridge_fallback' || true)"
+    fall_line="$(printf '%s\n' "$body" | grep -n '^ *if ! verify_bridge_fallback' | head -1 | cut -d: -f1)"
+
+    [ -n "$restart_line" ] || return 1
+    [ -n "$stop_line" ] || return 1
+    [ "$fall_count" = "1" ] || return 1
+    [ -n "$fall_line" ] || return 1
+    # The restart (which carries the pin check) happens before the drain...
+    [ "$restart_line" -lt "$stop_line" ] || return 1
+    # ...and the fallback check strictly after the old color is stopped, or it
+    # could not observe a fallback at all.
+    [ "$fall_line" -gt "$stop_line" ] || return 1
+}
+
+@test "restart_bridge_worker is what carries the pin check" {
+    # cmd_deploy never calls verify_bridge_pin directly — it goes through the
+    # restart helper. Pin that, so the previous test's ordering claim about
+    # "the restart carries the pin check" stays true.
+    local hits
+    hits="$(sed -n '/^restart_bridge_worker()/,/^}/p' "$DEPLOY_SH" | grep -c 'verify_bridge_pin' || true)"
+    [ "$hits" -ge 1 ] || return 1
+}
+
+@test "verify_bridge_upstream still runs BOTH halves for --verify-bridge" {
+    # Standalone runs are not mid-deploy, so the old color is already stopped
+    # and both signals are meaningful. Splitting the helpers must not quietly
+    # drop one from the standalone path.
+    printf 'KMC_INTERNAL_URL=http://api-blue:8080\n' > "$ENV_FILE_OUT"
+    printf '%s\n' '{"event":"control_plane.cross_color_fallback"}' > "$LOGS_FILE"
+    run verify_bridge_upstream green
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"NOT api-green"* ]] || return 1
+    [[ "$output" == *"cross-color fallback"* ]] || return 1
+}
+
+@test "a post-drain fallback marks the run degraded" {
+    # The deploy path sets the flag from Step 7, not only from Step 6b.
+    printf '%s\n' '{"event":"control_plane.cross_color_fallback"}' > "$LOGS_FILE"
+    local rc=0
+    verify_bridge_fallback 5m || rc=$?
+    [ "$rc" -ne 0 ] || return 1
 }

--- a/terraform/single-server/scripts/tests/deploy_marker_inode.bats
+++ b/terraform/single-server/scripts/tests/deploy_marker_inode.bats
@@ -134,6 +134,47 @@ inode_of() { stat -c '%i' "$1"; }
     [ "$hits" -ge 1 ] || return 1
 }
 
+@test "a failed cp reports that the marker may be truncated" {
+    # `cp` opens the destination with O_TRUNC, so a mid-write failure damages
+    # the LIVE marker — the real cost of preserving the inode. The operator must
+    # be told that, or they cannot tell a stale marker from a broken one.
+    #
+    # Deterministic cp failure without needing a full disk or a uid trick:
+    # destination is a directory ALREADY CONTAINING a directory of the source's
+    # basename, so `cp src dir` cannot write dir/src. Staging still succeeds, so
+    # this reaches the cp branch rather than the staging branch.
+    MARKER_FILE="$TMP/x"
+    mkdir -p "$TMP/x/x.tmp"
+    run write_marker "green"
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"TRUNCATED"* ]] || return 1
+}
+
+@test "the truncation error NAMES the previous color, so recovery is possible" {
+    # Behavioural, not a grep for `local previous`: a static check still passes
+    # when the captured value is never actually read, and being able to name the
+    # old color is the only thing that makes the message actionable.
+    #
+    # Injection: marker is readable (0444) so `previous` is captured, but not
+    # writable, so `cp` fails while staging into $TMP still succeeds. That is
+    # the cp branch specifically, with a real previous value in hand.
+    if [ "$(id -u)" -eq 0 ]; then
+        skip "a 0444 file is still writable by root, so cp would not fail"
+    fi
+    MARKER_FILE="$TMP/ro-marker"
+    printf 'blue\n' > "$MARKER_FILE"
+    chmod 0444 "$MARKER_FILE"
+
+    run write_marker "green"
+
+    chmod 0644 "$MARKER_FILE"
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"TRUNCATED"* ]] || return 1
+    # The whole point: tell the operator what to put back.
+    [[ "$output" == *"blue"* ]] || return 1
+    [[ "$output" != *"unknown"* ]] || return 1
+}
+
 @test "a marker path that cannot be staged is a loud error" {
     # Parent directory does not exist, so the staging redirect fails. Chosen
     # over a permission trick because it behaves the same as root and non-root,

--- a/terraform/single-server/scripts/tests/deploy_marker_inode.bats
+++ b/terraform/single-server/scripts/tests/deploy_marker_inode.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# =============================================================================
+# #1480: the active-color marker must be published WITHOUT changing its inode.
+#
+# The marker is bind-mounted into co-resident stacks as a SINGLE FILE
+# (kagura-bridge mounts it read-only to follow the active color). A single-file
+# bind mount resolves to an inode at container start, so replacing the file via
+# `mv` publishes a new inode that the running container never sees — it keeps
+# reading the color it booted with.
+#
+# Measured on docker 29.3.1 with a mount of this exact shape:
+#   mv + container running  -> container still reads the OLD color
+#   mv + `docker restart`   -> container reads the new color
+#   cp + container running  -> container reads the new color, with NO restart
+#
+# That is why kagura-bridge was forced onto a static KMC_INTERNAL_URL pin, and
+# why #1477's Step 6b `docker restart` could not re-point it (a restart cannot
+# re-read an .env). Publishing in place removes the original cause.
+#
+# These tests assert the INODE, not the file contents — contents were already
+# correct under `mv`, which is exactly why the bug survived review. No docker
+# and no network: the property is a filesystem property.
+# =============================================================================
+
+DEPLOY_SH="$BATS_TEST_DIRNAME/../deploy.sh"
+
+setup() {
+    [ -r "$DEPLOY_SH" ] || return 1
+    TMP="$(mktemp -d)"
+
+    # shellcheck disable=SC1090
+    source "$DEPLOY_SH"
+    MARKER_FILE="$TMP/active-color"
+
+    # Neutralize the EXIT trap deploy.sh installs — bats runs each assertion in
+    # its own subshell and a stray final-status line would pollute $output.
+    trap - EXIT
+
+    # `-e` must STAY ON: bats detects a failing test through it, so `set +e`
+    # would make every assertion advisory. Only `-u` is dropped, because an
+    # unbound-variable death aborts the whole file instead of failing one case.
+    set +u
+}
+
+teardown() {
+    [ -n "${TMP:-}" ] && rm -rf "$TMP"
+}
+
+inode_of() { stat -c '%i' "$1"; }
+
+@test "write_marker publishes the new color" {
+    echo "blue" > "$MARKER_FILE"
+    write_marker "green"
+    [ "$(cat "$MARKER_FILE")" = "green" ] || return 1
+}
+
+@test "write_marker does NOT change the marker's inode (the #1480 property)" {
+    echo "blue" > "$MARKER_FILE"
+    local before after
+    before="$(inode_of "$MARKER_FILE")"
+    write_marker "green"
+    after="$(inode_of "$MARKER_FILE")"
+    # A single-file bind mount tracks the inode. Change it and every running
+    # consumer is frozen on the old color.
+    [ "$before" = "$after" ] || return 1
+}
+
+@test "the inode is stable across repeated flips" {
+    echo "blue" > "$MARKER_FILE"
+    local first
+    first="$(inode_of "$MARKER_FILE")"
+    write_marker "green"
+    write_marker "blue"
+    write_marker "green"
+    [ "$(inode_of "$MARKER_FILE")" = "$first" ] || return 1
+    [ "$(cat "$MARKER_FILE")" = "green" ] || return 1
+}
+
+@test "write_marker leaves no .tmp file behind" {
+    echo "blue" > "$MARKER_FILE"
+    write_marker "green"
+    [ ! -e "${MARKER_FILE}.tmp" ] || return 1
+}
+
+@test "the result round-trips through get_active_color" {
+    echo "blue" > "$MARKER_FILE"
+    write_marker "green"
+    run get_active_color
+    [ "$status" -eq 0 ] || return 1
+    [ "$output" = "green" ] || return 1
+}
+
+@test "no marker writer anywhere in the script uses mv (regression guard)" {
+    # The bug was not that write_marker was wrong — it did not exist. It was two
+    # open-coded `mv` pairs, in cmd_deploy and cmd_rollback. Any reintroduction,
+    # in any function, re-freezes every single-file consumer.
+    #
+    # Deliberately NOT wrapped in `bash -c "..."`: inside a double-quoted
+    # bash -c payload, `\$` collapses to a bare `$`, which ERE then reads as an
+    # end-of-line ANCHOR. The pattern silently stops matching and the guard
+    # passes forever. (Caught by mutating deploy.sh back to `mv` and watching
+    # this test stay green.) Single quotes here reach grep untouched.
+    local hits
+    hits="$(grep -cE 'mv +"?\$\{?MARKER_FILE' "$DEPLOY_SH" || true)"
+    [ "$hits" = "0" ] || return 1
+}
+
+@test "the mv guard actually matches an mv line (guard not vacuous)" {
+    # Pin the pattern against a known-bad sample, so the guard above can never
+    # rot into an anchor that matches nothing.
+    local sample="$TMP/sample.sh"
+    printf '%s\n' '    mv "${MARKER_FILE}.tmp" "$MARKER_FILE"' > "$sample"
+    local hits
+    hits="$(grep -cE 'mv +"?\$\{?MARKER_FILE' "$sample" || true)"
+    [ "$hits" = "1" ] || return 1
+}
+
+@test "both color-switching paths publish through write_marker" {
+    # cmd_deploy Step 5 and cmd_rollback both flip the color; both must go
+    # through the helper rather than open-coding the write again.
+    local d r
+    d="$(sed -n '/^cmd_deploy()/,/^}/p' "$DEPLOY_SH" | grep -cE '^ *write_marker ' || true)"
+    r="$(sed -n '/^cmd_rollback()/,/^}/p' "$DEPLOY_SH" | grep -cE '^ *write_marker ' || true)"
+    [ "$d" -ge 1 ] || return 1
+    [ "$r" -ge 1 ] || return 1
+}
+
+@test "generate_caddyfile still uses cp, so the two writers agree (guard not vacuous)" {
+    # The Caddyfile writer already had this fix and its comment is the precedent
+    # this change follows. If someone 'simplifies' it back to mv, the same class
+    # of bug returns for Caddy's config.
+    local hits
+    hits="$(sed -n '/^generate_caddyfile()/,/^}/p' "$DEPLOY_SH" | grep -cF 'cp "$CADDYFILE.tmp"' || true)"
+    [ "$hits" -ge 1 ] || return 1
+}
+
+@test "a marker path that cannot be staged is a loud error" {
+    # Parent directory does not exist, so the staging redirect fails. Chosen
+    # over a permission trick because it behaves the same as root and non-root,
+    # and CI runners differ.
+    MARKER_FILE="$TMP/no-such-dir/active-color"
+    run write_marker "green"
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"Could not stage"* ]] || return 1
+}
+
+@test "a marker path that is a DIRECTORY fails instead of silently no-op'ing" {
+    # `cp file dir` exits 0 and copies INTO the directory, so cp's status alone
+    # would report success while the published color never changed. The
+    # read-back is what catches it (here via get_active_color's own guard).
+    MARKER_FILE="$TMP/as-a-directory"
+    mkdir -p "$MARKER_FILE"
+    run write_marker "green"
+    [ "$status" -ne 0 ] || return 1
+    [[ "$output" == *"could not be read"* ]] || return 1
+}
+
+@test "write_marker verifies the published value, not just the exit code" {
+    # Guard against dropping the read-back: the whole lesson of #1480 is that a
+    # step must prove its outcome. Assert the mechanism is present.
+    run bash -o pipefail -c 'sed -n "/^write_marker()/,/^}/p" "$1" | grep -c "reads back as"' _ "$DEPLOY_SH"
+    [ "$output" -ge 1 ] || return 1
+}
+
+@test "write_marker does not reintroduce the forbidden cat-with-fallback shape" {
+    # #1448's guard (deploy_marker_integrity.bats) bans `cat ... MARKER_FILE ... ||`
+    # because that shape is how a silent default color creeps back in. Adding a
+    # read-back is exactly when someone would reach for it.
+    run bash -o pipefail -c 'sed -n "/^write_marker()/,/^}/p" "$1" | grep -cE "cat .*MARKER_FILE.*\|\|"' _ "$DEPLOY_SH"
+    [ "$output" = "0" ] || return 1
+}


### PR DESCRIPTION
Closes #1480

## 根本原因はこちら側にあった

#1477 の Step 6b は bridge worker を再起動して「成功」と報告しますが、**どこに着地したかを一度も確認していません**。2026-08-03 のデプロイでは `kagura-bridge-worker-1 restarted.` と `FINAL STATUS: SUCCESS` を出しながら、worker は drain された色に張り付いたまま cross-color fallback で生き延びていました。worker の `/health` は終始 `{"status":"ok"}` なので他の手段でも検知できません。

原因はマーカーの**書き方**でした。`mv` は新しい inode を作ります。マーカーは同居スタックへ**単一ファイル**として bind-mount されており、単一ファイルの bind-mount はコンテナ起動時に inode へ解決されます。つまり起動時に掴んだファイルを永遠に読み続けます。

docker 29.3.1 で同じ形のマウントを作って実測しました:

| 書き方 | コンテナ側の見え方 |
|---|---|
| `mv` + 起動しっぱなし | **古い色のまま** |
| `mv` + `docker restart` | 新しい色 |
| `cp`（in-place）+ 起動しっぱなし | **新しい色。再起動すら不要** |

これが kagura-bridge を静的 `KMC_INTERNAL_URL` ピンに追いやった理由で、静的ピンは `docker restart` では読み直せないので Step 6b が効かなかった、という連鎖です。

そして **`generate_caddyfile()` は160行下で既にこの `cp` 対応を入れており、理由をコメントで説明していました。** 教訓はファイル内にあったのに、マーカーには適用されていなかっただけです。

## 変更

- **`write_marker()`** — tmp + `cp` で inode を保ったまま公開し、`get_active_color` 経由で**読み返してから**成功を主張します。`cp file dir` はディレクトリの中にコピーして exit 0 になるので、終了コードだけを見ると「動作は報告したが結果は見ていない」という同じ過ちを繰り返します。
- **`verify_bridge_upstream()`** — 焼き込まれた `KMC_INTERNAL_URL` と、worker 自身の `cross_color_fallback` ログの両方で着地点を検証。不一致なら復旧手順を出し、**「再起動では直らない」と明示**し、run を degraded にします。
- **`report_bridge_state()`** — その判定を deploy / rollback の**最後**に出します。Step 7 の drain で上へ流れてしまわないように。
- **`--verify-bridge`** — active color に居なければ非ゼロで終了。cron/監視が食える形（criterion 3）。デプロイ中は警告だけなのに対しここで非ゼロが安全なのは、進行中の処理が無いからです。デプロイ中は API cutover が既に成功しており、そこで abort すると不要な rollback を誘発します。

## トレードオフ（明示）

`cp` は `mv` と違って atomic ではないので、書き込み途中でクラッシュするとマーカーが壊れ得ます。これは **#1448 が求めた挙動そのもの**です — `get_active_color` は空/不正なマーカーを復旧手順つきの大きなエラーとして扱い、決して推測しません。kagura-bridge 側のリーダーも同じく fail-closed です。書き手は1つ、6バイト、対して防ぐのは65時間サイレントに劣化した不具合です。

## 検証

| | |
|---|---|
| `shellcheck` | CLEAN |
| bats | **71件中65件 pass** |

残り6件は `deploy_verify_workers_blocked.bats` / `deploy_verify_internal_blocked.bats` の既存不整合（`$BATS_TEST_TMPDIR` は bats-core 1.4 以降の変数で、ローカルの Ubuntu 22.04 は 1.2.1）。**本 PR は両ファイルを触っておらず、CI の新しい bats では green** です。

### ガードが空振りでないことの確認

| 壊した内容 | 赤くなったテスト |
|---|---|
| `write_marker` を `mv` に戻す | 2, 3, 6 |
| 読み返し検証を削除 | 11, 12 |
| Step 5 でマーカー書き込みを直書き | 6, 8 |
| 着地点の検証を削除 | 23 |
| `verify_bridge_upstream` を常に成功に | 14〜21, 23 |
| `cross_color_fallback` を無視 | 21 |
| サマリから判定を削除 | 29 |
| Step 6b が新色を渡さない | 28 |

### 自分のガードが1つ空振りしていたので直しました

`bash -c "..."` の中では `\$` が素の `$` に潰れ、ERE はそれを**行末アンカー**として読みます。そのため「マーカー書き込みに `mv` を使っていないこと」を見るパターンは何にもマッチせず、`mv` を戻しても green のままでした。deploy.sh を実際に `mv` へ戻して**テストが緑のままなのを見て**気づきました。

いまは `bash -c` を挟まず直接 grep し、さらに**既知の不正サンプルにマッチすること自体を別テストで固定**したので、二度とアンカーへ退化しません。

## 残り1つ（この repo の外）

完全自動化には bridge の `deploy/.env` で `KMC_INTERNAL_URL` を空にして marker 追従へ戻す必要があります。**別リポジトリの本番設定ファイルなので、こちらでは触っていません。** それまでは上記の検証がギャップを可視化します。

なお marker が in-place で公開されるようになったことで、`KMC_INTERNAL_URL` を空にすれば **worker の再起動すら不要**になります（上の実測表の3行目）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## レビュー第2ラウンド: false-clean を6件塞いだ

差分を独立にレビューさせたところ、**「検証済み」「書けた」と報告しながら実はそうでない経路が6つ**見つかりました。どれも本 issue と同じ失敗クラス（結果ではなく動作を報告する）なので、全部直しています。

| # | 何が false clean だったか | 対応 |
|---|---|---|
| 1 | `cp` は O_TRUNC で開くので、途中で失敗すると**生きているマーカーが切り詰められる**（`mv` では起き得なかった。inode 保持の実コスト） | 事前に旧色を捕まえ、失敗時は復元を試み、**「切り詰められた可能性がある／トラフィックはまだ旧色／手で戻す手順」**を出す |
| 2 | `*api-${color}*` が `http://api-blue2:8080` を api-blue として通していた | `url_host` でスキーム・ポート・パス・クエリを剥がして**ホスト完全一致** |
| 3 | color が空だと `*api-*` になり、API っぽいピンは何でも通った | 空 color を**拒否** |
| 4 | ピン無しの経路で「マーカー追従」と言うだけで、実際の解決先を一切観測していなかった | 「ここからは解決先を読めない。fallback ログのみで判断している」と**正直に明記**（README も同様に修正） |
| 5 | `docker logs` の失敗が `if cmd && [ ... ]` に飲まれ、**読めない=健全**になっていた | 「聞けなかった」は「検証できず」へ |
| 6 | fallback ログ窓が 5m 固定。デプロイ中は正しいが、任意時刻に走る `--verify-bridge` では30分前から座礁している worker を見逃す | 窓を引数化。`--verify-bridge` は既定 30m（`BRIDGE_FALLBACK_WINDOW`） |

### 自分のミスも2つ

- 旧色の捕捉を最初 `previous="$(cat "$MARKER_FILE")" || previous=""` と書いていました。これは **#1448 が禁じている `cat ... || fallback` そのもの**（サイレントな既定色が戻ってくる形）で、その guard に捕まりました。`read` に変更、サブシェルも不要に。
- それを固定するテストが `local previous` を grep するだけだったので、**宣言を残して読み取りだけ消す mutation を素通り**していました。実挙動テストに差し替え（0444 のマーカーで cp だけを失敗させ、旧色が読める状態でメッセージに旧色が出ることを検証。root では 0444 も書けるので skip）。

### 最終状態

| | |
|---|---|
| `shellcheck` | CLEAN |
| bats | **79件中73件 pass**（残り6件は既存の `$BATS_TEST_TMPDIR` 非互換、本 PR 未変更・CI では green） |
| mutation | **12種すべてが意図したテストだけを赤にする** |
