### PR TITLE
docs(infra): describe the co-resident worker by role in the deploy path

### DIFF
--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -122,7 +122,7 @@ memory.kagura-ai.com {
 # =============================================================================
 # Extension point for sibling services (one-time, do not remove)
 # =============================================================================
-# Sibling services co-resident on this VM (e.g. kagura-chat-bridge's
+# Sibling services co-resident on this VM (e.g. a consumer worker's
 # webhook receiver at aw.kagura-ai.com) plug their own top-level vhost blocks
 # in here by dropping a `*.caddy` file into /opt/kagura-caddy-extra/ on the
 # host. That directory is bind-mounted read-only into the caddy container

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -377,14 +377,15 @@ the bridge-worker restart, and draining automatically. Use
 `./scripts/deploy.sh --status` to see which color is active, or
 `./scripts/deploy.sh --rollback` to switch back.
 
-> **No manual bridge restart.** Both the deploy and the rollback path restart
-> the co-resident `kagura-bridge-worker-1` right after the Caddy switch (Step
-> 6b), because the worker pins its API connections to a color and a flip would
-> otherwise leave it talking to the color being drained — surviving only on
-> kagura-bridge's cross-color fallback, which masks the mismatch instead of
-> reporting it ([#1476](https://github.com/kagura-ai/memory-cloud/issues/1476)).
-> A host without that container logs a skip; a restart that fails logs a
-> warning and does **not** abort the deploy.
+> **No manual restart of the co-resident worker.** Both the deploy and the
+> rollback path restart it right after the Caddy switch (Step 6b), because such
+> a worker pins its API connections to a color and a flip would otherwise leave
+> it talking to the color being drained — surviving only on a connect-level
+> failover, which masks the mismatch instead of reporting it
+> ([#1476](https://github.com/kagura-ai/memory-cloud/issues/1476)). The restart
+> is also what lets a marker-based resolver read the current inode. A host
+> without that container logs a skip; a restart that fails logs a warning and
+> does **not** abort the deploy.
 
 Tunable environment variables:
 
@@ -394,7 +395,7 @@ Tunable environment variables:
 | `DRAIN_TIMEOUT` | 30 | Seconds to drain old container |
 | `WORKERS_GATE_TIMEOUT` | 30 | Seconds to wait for the post-switch security gate (`/api/v1/workers/*` blocked at Caddy) before aborting and leaving the old color running |
 | `WORKERS_GATE_INTERVAL` | 2 | Seconds between security-gate retries |
-| `BRIDGE_WORKER_CONTAINER` | `kagura-bridge-worker-1` | Co-resident chat-bridge worker to restart after a color flip. Not a compose service of this stack, so it is addressed by container name; skipped when not running |
+| `BRIDGE_WORKER_CONTAINER` | (host-specific) | Co-resident consumer worker to restart after a color flip. Not a compose service of this stack, so it is addressed by container name; skipped when not running |
 
 ### Update the frontend (in-place rebuild)
 

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -53,11 +53,12 @@ CURL="${CURL:-curl}"
 # either runs through dc() or belongs to a flow the suite never exercises.
 DOCKER="${DOCKER:-docker}"
 
-# The chat-bridge worker is NOT a service in this repo's docker-compose.prod.yml
-# — it is a separate co-resident stack sharing this VM and docker network. That
-# is why the restart below uses plain `docker` and not dc(): compose would not
-# know the container. Overridable so a host that names it differently (or a test)
-# can point at the right one (#1476).
+# The co-resident consumer worker is NOT a service in this repo's
+# docker-compose.prod.yml — it is a separate stack sharing this VM and docker
+# network. That is why the restart below uses plain `docker` and not dc():
+# compose would not know the container. The default is the container name as
+# deployed on this host; override it for a host that names it differently, or
+# for a test (#1476).
 BRIDGE_WORKER_CONTAINER="${BRIDGE_WORKER_CONTAINER:-kagura-bridge-worker-1}"
 
 # ---------------------------------------------------------------------------
@@ -181,8 +182,8 @@ is_container_running() {
 # failed pipeline — i.e. a *running* container intermittently reported as
 # absent. That is the exact shape of the #986 silent-death bug. Capture first,
 # then compare whole lines, so no pipeline status is involved. Whole-line
-# equality also means a container named `kagura-bridge-worker-10` never
-# satisfies the check for `kagura-bridge-worker-1`.
+# equality also means a container whose name merely starts with the configured
+# one (a `…-10` where `…-1` is configured) never satisfies the check.
 bridge_worker_is_running() {
     local names name
     # `|| return 2` also exempts the assignment from `set -e`.
@@ -197,15 +198,18 @@ bridge_worker_is_running() {
     return 1
 }
 
-# Restart the chat-bridge worker after the active API color changes (#1476).
+# Restart the co-resident consumer worker after the active API color changes
+# (#1476).
 #
-# The worker resolves the API container by color when it connects and then holds
-# those connections. A flip leaves it talking to the color this script is about
-# to drain, and it stays up only through kagura-bridge's connect-level
-# cross-color fallback (kagura-ai/kagura-bridge#211) — which absorbed 4162 calls
-# over 65 hours in the 2026-07-21..24 incident, turning a safety net into the
-# normal path and burying every other warning in its noise. The same gap left
-# Slack ingest down for ~30 hours on 2026-07-29 before anyone noticed.
+# Such a worker resolves the API container by color when it connects and then
+# holds those connections. A flip leaves it talking to the color this script is
+# about to drain. If it implements a connect-level failover to the other color it
+# stays up — but on the safety net rather than the normal path, which has twice
+# masked a prolonged outage here instead of surfacing it.
+#
+# A restart is also what makes a marker-based resolver correct: a fresh container
+# re-opens the marker and therefore reads the current inode, which a long-lived
+# process holding a single-file bind mount never does.
 #
 # Nothing else in the system knows a flip happened, so this is the only place
 # the restart can be triggered from.
@@ -243,7 +247,7 @@ restart_bridge_worker() {
     # new color is serving; a bridge that will not come back is a bridge
     # problem. Aborting here would report a healthy deploy as failed and invite
     # an unnecessary rollback. Say it loudly instead.
-    log "WARNING: ${BRIDGE_WORKER_CONTAINER} failed to restart. Chat ingest may still be"
+    log "WARNING: ${BRIDGE_WORKER_CONTAINER} failed to restart. It may still be"
     log "         pinned to the drained API color. Restart it manually:"
     log "             docker restart ${BRIDGE_WORKER_CONTAINER}"
     return 0
@@ -687,7 +691,7 @@ main() {
             echo "  WEB_READINESS_INTERVAL   Seconds between web health checks (default: 2)"
             echo "  WORKERS_GATE_TIMEOUT     Seconds to wait for an edge-blocked path (/api/v1/workers/*, /internal/*) to 404 at Caddy (default: 30)"
             echo "  WORKERS_GATE_INTERVAL    Seconds between security-gate checks; shared by the workers + internal gates (default: 2)"
-            echo "  BRIDGE_WORKER_CONTAINER  Co-resident chat-bridge worker restarted after a color flip; skipped when absent (default: kagura-bridge-worker-1)"
+            echo "  BRIDGE_WORKER_CONTAINER  Co-resident consumer worker restarted after a color flip; skipped when absent"
             ;;
         "")
             cmd_deploy


### PR DESCRIPTION
#1476's restart step named a specific private repository, linked its issue
number, and quoted production incident specifics (call counts, durations, dates)
in this **public** repository:

> …stays up only through `<repo>`'s connect-level cross-color fallback
> (`<org>/<repo>#211`) — which absorbed 4162 calls over 65 hours in the
> 2026-07-21..24 incident… left Slack ingest down for ~30 hours on 2026-07-29

That is the same class of content #1469 removed. It came back with the new code,
which is worth noting: there is no CI gate for this, so it recurs whenever
someone writes a comment explaining *why* a guard exists — the reason usually
lives on the other side.

## Change

Each reference is rewritten to describe the consumer by **role**. The
engineering rationale is preserved in full: why the restart exists, why it must
run **after** the Caddy switch, and why a failure warns rather than aborts.

One point is **added**: a restart is also what makes a marker-based resolver
correct, because a fresh container re-opens the marker and therefore reads the
current inode — a long-lived process holding a single-file bind mount never
does. That is the strongest argument for this step and it was not stated before.

## What is deliberately NOT removed

`BRIDGE_WORKER_CONTAINER` keeps its name and its default. The container has to
be addressable for the restart to work at all, and dropping the default would
break the flip on any host whose `.env.prod` has not been updated first — an
ordering hazard right after #1476 shipped.

The name is no longer published in the `--help` output or the README table;
operators set it per host. **If you want it out of the source default too, that
is a small follow-up, but it needs the host's `.env.prod` updated in the same
change** — say the word and I will sequence it.

## Scope

Comments, help text and Markdown only. No executable line changed.
`bash -n` clean; `deploy_bridge_restart.bats` 17/17.

## Separate, larger finding

`kagura-chat-bridge` — a different spelling from the one #1469 scrubbed — is
still present across ~15 tracked files, including backend docstrings, two public
contract documents, and an RFC, some with full GitHub URLs. My #1469 grep
matched only the other spelling and missed these.

Not folded in here: the two contract documents exist *to describe* the consumer
integration, so genericizing them changes what they are for. That needs a
decision rather than a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZpvFKGhBZrEQ4jyFRpTwJ