### PR TITLE
feat(worker-runtime): carry the three fields the consumer could not be given

### DIFF
--- a/backend/src/models/worker_runtime.py
+++ b/backend/src/models/worker_runtime.py
@@ -107,6 +107,12 @@ class WorkerRuntimeLifecycleConfig(BaseModel):
     dormant_summary: str = Field(
         default="[dormant] (channel archived)", min_length=1, max_length=_MAX_SUMMARY_CHARS
     )
+    # Sentinel written when a source message is EDITED, distinct from the
+    # deletion one so the record does not claim the message was removed while it
+    # still exists upstream.
+    edited_summary: str = Field(
+        default="[stale] (source message edited)", min_length=1, max_length=_MAX_SUMMARY_CHARS
+    )
 
 
 class WorkerRuntimeContinuityConfig(BaseModel):
@@ -130,6 +136,14 @@ class WorkerRuntimeConfig(BaseModel):
     lifecycle: WorkerRuntimeLifecycleConfig = Field(default_factory=WorkerRuntimeLifecycleConfig)
     continuity: WorkerRuntimeContinuityConfig = Field(default_factory=WorkerRuntimeContinuityConfig)
     vision_enabled: bool = True
+    # Both default OFF and are DORMANT capabilities on the consumer side: each
+    # one, once enabled, changes what the consumer returns or ingests, so the
+    # flip is an operational decision taken per connector after measuring the
+    # impact. This model must carry them or they cannot be set at all — the
+    # config is `extra="forbid"`, so an unknown key is a 422 rather than a
+    # forward-compatible pass-through.
+    team_scope_filter_enabled: bool = False
+    channel_allowlist_enabled: bool = False
     mention_answer_enabled: bool = False
     answer_relevance_threshold: float = Field(default=0.35, ge=0.0, le=1.0, allow_inf_nan=False)
     answer_timeout_sec: float = Field(

--- a/backend/tests/models/test_worker_runtime.py
+++ b/backend/tests/models/test_worker_runtime.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from models.worker_runtime import WorkerRuntimeConfig
+from models.worker_runtime import WorkerRuntimeConfig, WorkerRuntimeLifecycleConfig
 
 
 def test_worker_runtime_config_materializes_worker_compatible_defaults() -> None:
@@ -155,3 +155,75 @@ class TestNormalizeWorkerLocale:
 
         with pytest.raises(ValueError):
             normalize_worker_locale(raw)
+
+
+# ── field parity with the consumer's contract ────────────────────────
+
+
+def test_runtime_config_carries_every_field_the_consumer_can_read():
+    """`WorkerRuntimeConfig` is `extra="forbid"`, so a field the consumer supports
+    but this model lacks cannot be set AT ALL — the PATCH 422s rather than passing
+    it through.
+
+    That is not hypothetical: `edited_summary`, `team_scope_filter_enabled` and
+    `channel_allowlist_enabled` shipped on the consumer side and were silently
+    unsettable here until this test existed. Each is a dormant capability whose
+    whole point is that an operator can flip it per connector.
+
+    Pinned as an explicit list rather than by importing the consumer's model —
+    that lives in a different repository, so the contract is asserted here and
+    reviewed when it changes.
+    """
+    expected = {
+        "buffer",
+        "flush",
+        "supervisor",
+        "lifecycle",
+        "continuity",
+        "vision_enabled",
+        "team_scope_filter_enabled",
+        "channel_allowlist_enabled",
+        "mention_answer_enabled",
+        "answer_relevance_threshold",
+        "answer_timeout_sec",
+        "memory_link_template",
+        "entity_extraction_enabled",
+        "entity_max",
+    }
+    actual = set(WorkerRuntimeConfig.model_fields)
+
+    assert actual == expected, (
+        "runtime contract drifted. Adding a field here is additive and safe; "
+        f"only in model={actual - expected}, only in contract={expected - actual}"
+    )
+
+
+def test_lifecycle_block_carries_every_sentinel():
+    """Same reasoning, for the nested lifecycle block."""
+    expected = {"deletion_mode", "redacted_summary", "dormant_summary", "edited_summary"}
+
+    assert set(WorkerRuntimeLifecycleConfig.model_fields) == expected
+
+
+def test_the_dormant_flags_default_off():
+    """Their defaults are load-bearing: enabling either changes what the consumer
+    returns or ingests, so a wrong default here would flip behaviour for every
+    connector that has never been configured."""
+    cfg = WorkerRuntimeConfig()
+
+    assert cfg.team_scope_filter_enabled is False
+    assert cfg.channel_allowlist_enabled is False
+
+
+def test_the_new_fields_round_trip_through_validation():
+    cfg = WorkerRuntimeConfig.model_validate(
+        {
+            "team_scope_filter_enabled": True,
+            "channel_allowlist_enabled": True,
+            "lifecycle": {"edited_summary": "[stale]"},
+        }
+    )
+
+    assert cfg.team_scope_filter_enabled is True
+    assert cfg.channel_allowlist_enabled is True
+    assert cfg.lifecycle.edited_summary == "[stale]"


### PR DESCRIPTION
## The gap

`WorkerRuntimeConfig` is `extra="forbid"`, so a field the consumer supports but
this model lacks **cannot be set at all** — the PATCH 422s rather than passing it
through as forward-compatible.

Three had shipped on the consumer side and were silently unsettable here:

| field | what it controls |
|---|---|
| `lifecycle.edited_summary` | sentinel written when a source message is edited |
| `team_scope_filter_enabled` | team-scoped workspace-wide recall |
| `channel_allowlist_enabled` | makes the channel list a real ingest gate |

Found by probing the live vend for a production tenant — all three came back
`null`.

## Why it matters more than a missing field usually does

Each is a **dormant capability**: it ships OFF specifically so an operator can
measure the impact and then flip it per connector. Being unsettable makes the
dormancy permanent instead of deliberate — the migration path the consumer built
could never be taken.

## Defaults

Both flags default **OFF**, matching the consumer. That default is load-bearing:
enabling either changes what the consumer returns or ingests, so a wrong default
here would flip behaviour for every connector that has never been configured.

## Parity test

Pins the full field set, written as an **explicit list** rather than by importing
the consumer's model — that lives in a different repository, so the contract is
asserted here and reviewed when it changes.

This same class of gap has now appeared **twice**, both silent, both only visible
by probing production:

- the lifecycle block is enumerated field-by-field on the consumer side, so a
  field added on one side only is un-overridable
- this model forbids extras, so a field missing here is un-settable

Different mechanisms, same symptom. The test closes the second.

`tests/models` + `tests/api -k worker`: 86 passed. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZpvFKGhBZrEQ4jyFRpTwJ