### PR TITLE
ci: exempt deployment facts from the private-repo gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,14 +37,22 @@ jobs:
       # comment explaining WHY a guard exists naturally names the system the
       # guard protects against, and reviewers read that as good context.
       #
-      # Container names are exempt: `BRIDGE_WORKER_CONTAINER` must address a
-      # real container for the color flip to restart it. A deployment fact is
-      # not a repository reference.
+      # DEPLOYMENT FACTS ARE EXEMPT. A container name and an on-host path have
+      # to be literal for the operation to work at all — `BRIDGE_WORKER_CONTAINER`
+      # must address a real container, and a recovery procedure printed to an
+      # operator mid-incident must name the real file. Neither is a repository
+      # reference, and gating them would push people to write unusable runbooks.
+      #
+      # What this catches is the trail INTO the private repository: its name in
+      # prose, links to its issues, and production incident specifics.
       - name: No private-repo references
         run: |
+          # `:!.github/workflows/ci.yml` excludes THIS file: the patterns below
+          # necessarily contain the string they search for.
           if git grep -nIE 'kagura-(chat-)?bridge' -- \
-               ':!*BRIDGE_WORKER_CONTAINER*' \
-             | grep -vE 'kagura-bridge-worker[-0-9]*' ; then
+               ':!*BRIDGE_WORKER_CONTAINER*' ':!.github/workflows/ci.yml' \
+             | grep -vE 'kagura-bridge-worker[-0-9]*' \
+             | grep -vE '/opt/kagura-bridge[/[:space:]"]' ; then
             echo
             echo "ERROR: this public repository must not name the private consumer."
             echo "Describe it by role ('the connector worker', 'a co-resident"


### PR DESCRIPTION
Follow-up to #1484, prompted by #1481 — which the gate as written would fail for
the wrong reason.

## Two problems with the gate as merged

**1. It punishes recovery procedures.** #1481 prints the real on-host path an
operator has to edit mid-incident. Gating that pushes people to write runbooks
that cannot be followed. Same class as `BRIDGE_WORKER_CONTAINER`: a deployment
fact has to be literal for the operation to work at all.

**2. It failed on its own definition.** The workflow file necessarily contains
the string its patterns search for.

## What the gate still catches

The trail **into** the private repository — its name in prose, links to its
issues, and production incident specifics. That is the part that matters, and
the part that has twice come back.

## Note for #1481

After rebasing onto current `main`, six lines of that PR's **own new content**
still trip the gate. The rest of its hits are pre-existing lines already scrubbed
in #1483/#1484, which the rebase resolves.

Details posted on that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZpvFKGhBZrEQ4jyFRpTwJ