### PR TITLE
feat(auth): add and switch accounts within one session (#1488 Phase 2)

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -955,9 +955,14 @@ async def list_signed_in_accounts(request: Request, user: SessionUser):
     if not _session_manager:
         raise HTTPException(status_code=500, detail="Session manager not initialized")
 
+    # `SessionUser` (require_session_auth -> get_current_user -> the cookie the
+    # middleware resolved) has already established that a session exists, so an
+    # absent cookie here is a contradiction rather than an anonymous caller.
+    # Answer 401 as the dependency itself would, instead of an empty list that
+    # would read as "signed in with no accounts".
     session_id = request.cookies.get("kagura_session")
     if not session_id:
-        return {"accounts": []}
+        raise HTTPException(status_code=401, detail="Not authenticated")
 
     accounts = _session_manager.list_accounts(session_id)
     # Never ship anything but display fields — this is read by a menu.

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -25,7 +25,7 @@ from typing import Any
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -936,6 +936,73 @@ async def logout(request: Request, response: Response):
         response.delete_cookie(key="kagura_session", path="/")
 
     return {"success": True, "message": "Logged out successfully"}
+
+
+class AccountSwitchRequest(BaseModel):
+    """Which already-signed-in account to make active (#1488)."""
+
+    user_id: str = Field(..., min_length=1, max_length=255)
+
+
+@router.get("/accounts")
+async def list_signed_in_accounts(request: Request, user: SessionUser):
+    """List the accounts signed in on THIS browser session (#1488 Phase 2).
+
+    Reads only from the caller's own session container, so it can never
+    enumerate anyone else's identities. Returns the active one flagged, which
+    is what the sidebar switcher renders.
+    """
+    if not _session_manager:
+        raise HTTPException(status_code=500, detail="Session manager not initialized")
+
+    session_id = request.cookies.get("kagura_session")
+    if not session_id:
+        return {"accounts": []}
+
+    accounts = _session_manager.list_accounts(session_id)
+    # Never ship anything but display fields — this is read by a menu.
+    return {
+        "accounts": [
+            {
+                "user_id": a.get("user_id") or a.get("sub"),
+                "email": a.get("email"),
+                "name": a.get("name"),
+                "picture": a.get("picture"),
+                "is_active": a.get("is_active", False),
+            }
+            for a in accounts
+        ]
+    }
+
+
+@router.post("/accounts/switch")
+async def switch_active_account(
+    body: AccountSwitchRequest,
+    request: Request,
+    user: SessionUser,
+):
+    """Make another already-signed-in account active (#1488 Phase 2).
+
+    The security boundary is `switch_account`'s membership check: the target
+    must already be in THIS session's container. A caller naming an arbitrary
+    user id gets 404, not that user's session — there is no lookup anywhere in
+    this path, so no id a caller invents can widen their access.
+
+    404 rather than 403 on a non-member: whether some other account exists is
+    not this caller's business to learn.
+    """
+    if not _session_manager:
+        raise HTTPException(status_code=500, detail="Session manager not initialized")
+
+    session_id = request.cookies.get("kagura_session")
+    if not session_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    if not _session_manager.switch_account(session_id, body.user_id):
+        raise HTTPException(status_code=404, detail="Account not found in this session")
+
+    logger.info(f"Switched active account on session {session_id[:8]}...")
+    return {"success": True, "active_user_id": body.user_id}
 
 
 @router.get("/me")

--- a/backend/src/auth/session.py
+++ b/backend/src/auth/session.py
@@ -318,7 +318,8 @@ class SessionManager:
             # Read BOTH shapes (#1488). Sessions minted before this change are
             # flat and still live in Redis; refusing them would log every
             # signed-in user out the moment this deploys.
-            container = stored if is_container(stored) else to_container(stored)
+            was_legacy = not is_container(stored)
+            container = stored if not was_legacy else to_container(stored)
 
             # A record whose active account is missing or id-less is corrupt;
             # treat it as no session at all rather than authenticating a shell.
@@ -329,25 +330,40 @@ class SessionManager:
                 logger.warning(f"Discarding unusable session record: {session_id[:10]}...")
                 return None
 
-            # Update last accessed time and refresh TTL. This is also where a
-            # legacy record gets rewritten in the new shape — migration happens
-            # by being used, with no backfill job.
+            # Refresh the rolling TTL.
             #
-            # PHASE 2 PREREQUISITE: this is a read-modify-write of the WHOLE
-            # record with no lock, purely to refresh `last_accessed`. With one
-            # account there is nothing to lose. Once a container can hold
-            # several, a concurrent "add account" could be clobbered by any
-            # ordinary request that happens to read first and write second.
-            # Phase 2 must make this a targeted update (Lua/WATCH, or write the
-            # timestamp outside the record) before adding a second account.
+            # This used to SETEX the whole record just to bump `last_accessed`.
+            # That is an unlocked read-modify-write, and it was safe only while
+            # a container held ONE account. With two, any ordinary request could
+            # read first, write second, and silently discard a concurrent
+            # "add account" — and since a request arrives on every page load,
+            # that race would be routine rather than theoretical. Phase 1 flagged
+            # this as the prerequisite for Phase 2; this is it.
+            #
+            # EXPIRE renews the TTL without touching the value, so the hot path
+            # no longer writes the record and there is nothing to clobber.
+            #
+            # The trade, stated plainly: STORED `last_accessed` now advances on
+            # writes rather than on every request. Nothing reads it — no route,
+            # no service, no UI; only a docstring mentions it — so this costs
+            # nothing today, and the returned projection still reports the
+            # current time so callers see an accurate value. If true
+            # per-request last-access is ever needed it must be added
+            # deliberately with an atomic mechanism, not by restoring the
+            # whole-record rewrite.
             if update_access:
-                container["last_accessed"] = utcnow().isoformat()
-                self._redis.setex(
-                    f"session:{session_id}",
-                    self.session_ttl,
-                    json.dumps(container),
-                )
-                projected["last_accessed"] = container["last_accessed"]
+                if was_legacy:
+                    # One-time: a flat record must be written once to become a
+                    # container. The only write left on the read path, and it
+                    # happens at most once per record.
+                    self._redis.setex(
+                        f"session:{session_id}",
+                        self.session_ttl,
+                        json.dumps(container),
+                    )
+                else:
+                    self._redis.expire(f"session:{session_id}", self.session_ttl)
+                projected["last_accessed"] = utcnow().isoformat()
 
             # Callers see the flat shape they always have.
             return projected
@@ -377,6 +393,144 @@ class SessionManager:
         except Exception as e:
             logger.error(f"Failed to delete session: {e}")
             return False
+
+    # ------------------------------------------------------------------
+    # Multi-account operations (#1488 Phase 2)
+    # ------------------------------------------------------------------
+    #
+    # These are the only writers that change `accounts` or `active`. They all
+    # go through _mutate_container so the read-modify-write lives in ONE place;
+    # the hot read path no longer writes at all (see get_session), so these are
+    # the only writers that can race each other. They are rare — a login or an
+    # explicit switch — and each is a single user action, so last-writer-wins
+    # between two of them is acceptable in a way it was not for every page load.
+
+    def _mutate_container(self, session_id: str, mutate) -> bool:
+        """Read a session, apply ``mutate`` to the container, write it back.
+
+        Returns False when the session is missing or unusable. ``mutate`` may
+        return False to abort the write.
+        """
+        try:
+            raw = self._redis.get(f"session:{session_id}")
+            if not raw:
+                return False
+            stored = json.loads(raw)  # type: ignore[arg-type]
+            container = stored if is_container(stored) else to_container(stored)
+
+            # Same rule as get_session/update_session: a record whose active
+            # account cannot be resolved is unusable, and writing to it would
+            # only corrupt it further.
+            if project_active(container) is None:
+                logger.warning(f"Refusing to mutate unusable session: {session_id[:10]}...")
+                return False
+
+            if mutate(container) is False:
+                return False
+
+            container["last_accessed"] = utcnow().isoformat()
+            self._redis.setex(
+                f"session:{session_id}",
+                self.session_ttl,
+                json.dumps(container),
+            )
+            return True
+        except Exception as e:
+            logger.error(f"Failed to mutate session: {e}")
+            return False
+
+    def list_accounts(self, session_id: str) -> list[dict[str, Any]]:
+        """Identities signed in on this session, active one flagged.
+
+        Returns [] for a missing or unusable session — the UI shows no switcher
+        rather than an error, which is the right failure for a menu.
+        """
+        try:
+            raw = self._redis.get(f"session:{session_id}")
+            if not raw:
+                return []
+            stored = json.loads(raw)  # type: ignore[arg-type]
+            container = stored if is_container(stored) else to_container(stored)
+            if project_active(container) is None:
+                return []
+            active = container.get("active")
+            return [
+                {**identity, "is_active": account_id == active}
+                for account_id, identity in container.get("accounts", {}).items()
+            ]
+        except Exception as e:
+            logger.error(f"Failed to list accounts: {e}")
+            return []
+
+    def add_account(self, session_id: str, user_info: dict[str, Any]) -> bool:
+        """Add an identity to an existing session and make it active.
+
+        This is what a login performs INSTEAD of minting a fresh session when
+        the browser already has one. Re-adding an account that is already
+        present refreshes its identity and activates it, so "sign in again" is
+        idempotent rather than creating a duplicate entry.
+        """
+        account_id = _account_id(user_info)
+        if not account_id:
+            logger.warning("Refusing to add an account with no id")
+            return False
+
+        def _add(container: dict[str, Any]) -> None:
+            container.setdefault("accounts", {})[account_id] = dict(user_info)
+            container["active"] = account_id
+
+        return self._mutate_container(session_id, _add)
+
+    def switch_account(self, session_id: str, account_id: str) -> bool:
+        """Make an already-signed-in account the active one.
+
+        Refuses an account that is not in the container. That refusal is the
+        security boundary of this whole feature: without it, a caller could
+        name ANY user id and the session would start acting as them. The check
+        is membership in this session's own container — never a lookup.
+        """
+
+        def _switch(container: dict[str, Any]) -> bool:
+            if account_id not in container.get("accounts", {}):
+                logger.warning(
+                    f"Refusing to switch session {session_id[:10]}... to a non-member account"
+                )
+                return False
+            container["active"] = account_id
+            return True
+
+        return self._mutate_container(session_id, _switch)
+
+    def remove_account(self, session_id: str, account_id: str) -> bool:
+        """Sign one account out, leaving the others signed in.
+
+        Removing the LAST account leaves nothing to be active, so the whole
+        session is deleted — that is a full sign-out, and it must not leave an
+        empty container behind for `project_active` to reject on every request.
+        Removing the ACTIVE account promotes an arbitrary remaining one.
+        """
+        try:
+            raw = self._redis.get(f"session:{session_id}")
+            if not raw:
+                return False
+            stored = json.loads(raw)  # type: ignore[arg-type]
+            container = stored if is_container(stored) else to_container(stored)
+            accounts = container.get("accounts", {})
+            if account_id not in accounts:
+                return False
+            if len(accounts) <= 1:
+                return self.delete_session(session_id)
+        except Exception as e:
+            logger.error(f"Failed to read session for account removal: {e}")
+            return False
+
+        def _remove(container: dict[str, Any]) -> None:
+            accounts = container.get("accounts", {})
+            accounts.pop(account_id, None)
+            if container.get("active") == account_id:
+                container["active"] = next(iter(accounts))
+
+        return self._mutate_container(session_id, _remove)
 
     def update_session(self, session_id: str, updates: dict[str, Any]) -> bool:
         """Update session data.

--- a/backend/tests/api/test_account_switch_routes.py
+++ b/backend/tests/api/test_account_switch_routes.py
@@ -1,0 +1,145 @@
+"""Account list/switch endpoints (#1488 Phase 2).
+
+The whole feature rests on one rule: a switch may only target an account that
+is ALREADY in the caller's own session container. There is no lookup anywhere
+in the path, so no id a caller invents can widen their access. These tests
+exist mainly to pin that, because the failure would be catastrophic and quiet —
+a working switch to an arbitrary user id looks exactly like a working switch.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.routes import auth as auth_routes
+from auth.dependencies import require_session_auth
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def setex(self, key: str, _ttl: int, value: str) -> None:
+        self.store[key] = value
+
+    def expire(self, key: str, _ttl: int) -> bool:
+        return key in self.store
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def delete(self, *keys: str) -> int:
+        return sum(1 for k in keys if self.store.pop(k, None) is not None)
+
+    def scan(self, cursor: int, match: str = "*", count: int = 100):
+        return 0, [k for k in list(self.store) if k.startswith(match.rstrip("*"))]
+
+    def pipeline(self):
+        return _Pipe(self)
+
+
+class _Pipe:
+    def __init__(self, r: FakeRedis) -> None:
+        self.r, self.ops = r, []
+
+    def delete(self, key: str) -> None:
+        self.ops.append(key)
+
+    def execute(self):
+        return [self.r.delete(k) for k in self.ops]
+
+
+ALICE = {"sub": "alice", "user_id": "alice", "email": "alice@example.com", "name": "Alice"}
+BOB = {"sub": "bob", "user_id": "bob", "email": "bob@example.com", "name": "Bob"}
+
+
+@pytest.fixture
+def client(monkeypatch):
+    from auth.session import SessionManager
+
+    fake = FakeRedis()
+    monkeypatch.setattr(
+        SessionManager, "_get_or_create_redis_client", staticmethod(lambda _url: fake)
+    )
+    manager = SessionManager(redis_url="redis://fake:6379")
+    monkeypatch.setattr(auth_routes, "_session_manager", manager)
+
+    app = FastAPI()
+    app.include_router(auth_routes.router)
+    # SessionUser -> require_session_auth (dependencies.py:927). The routes take
+    # it only to require authentication; the identity they act on comes from the
+    # cookie's own container, never from this dependency.
+    app.dependency_overrides[require_session_auth] = lambda: dict(ALICE)
+
+    c = TestClient(app)
+    c.manager = manager  # type: ignore[attr-defined]
+    c.fake = fake  # type: ignore[attr-defined]
+    return c
+
+
+def signed_in(client, *identities) -> str:
+    sid = client.manager.create_session(identities[0])
+    for extra in identities[1:]:
+        client.manager.add_account(sid, extra)
+    client.cookies.set("kagura_session", sid)
+    return sid
+
+
+class TestListAccounts:
+    def test_lists_both_and_flags_active(self, client):
+        signed_in(client, ALICE, BOB)
+        body = client.get("/auth/accounts").json()
+        assert {a["user_id"] for a in body["accounts"]} == {"alice", "bob"}
+        assert [a["user_id"] for a in body["accounts"] if a["is_active"]] == ["bob"]
+
+    def test_returns_display_fields_only(self, client):
+        """A menu must not become a data-leak surface."""
+        client.manager.create_session({**ALICE, "role": "admin", "secret": "x"})
+        sid = client.manager.create_session({**ALICE, "role": "admin", "secret": "x"})
+        client.cookies.set("kagura_session", sid)
+        account = client.get("/auth/accounts").json()["accounts"][0]
+        assert set(account) == {"user_id", "email", "name", "picture", "is_active"}
+
+    def test_no_cookie_yields_no_accounts(self, client):
+        client.cookies.clear()
+        assert client.get("/auth/accounts").json() == {"accounts": []}
+
+
+class TestSwitch:
+    def test_switches_to_a_member(self, client):
+        sid = signed_in(client, ALICE, BOB)
+        assert client.post("/auth/accounts/switch", json={"user_id": "alice"}).status_code == 200
+        assert client.manager.get_session(sid)["user_id"] == "alice"
+
+    def test_REFUSES_a_non_member(self, client):
+        """The security boundary. A 200 here would be a full account takeover."""
+        sid = signed_in(client, ALICE)
+        r = client.post("/auth/accounts/switch", json={"user_id": "bob"})
+        assert r.status_code == 404
+        # ...and the session is untouched.
+        assert client.manager.get_session(sid)["user_id"] == "alice"
+
+    def test_a_refused_switch_does_not_add_the_account(self, client):
+        sid = signed_in(client, ALICE)
+        client.post("/auth/accounts/switch", json={"user_id": "intruder"})
+        stored = json.loads(client.fake.store[f"session:{sid}"])
+        assert "intruder" not in stored["accounts"]
+
+    def test_404_not_403_so_existence_is_not_disclosed(self, client):
+        """Whether another account exists is not the caller's business."""
+        signed_in(client, ALICE)
+        # 'bob' exists elsewhere in the system but not in this session.
+        client.manager.create_session(BOB)
+        assert client.post("/auth/accounts/switch", json={"user_id": "bob"}).status_code == 404
+
+    def test_requires_a_session_cookie(self, client):
+        client.cookies.clear()
+        assert client.post("/auth/accounts/switch", json={"user_id": "alice"}).status_code == 401
+
+    def test_rejects_an_empty_user_id(self, client):
+        signed_in(client, ALICE)
+        assert client.post("/auth/accounts/switch", json={"user_id": ""}).status_code == 422

--- a/backend/tests/api/test_account_switch_routes.py
+++ b/backend/tests/api/test_account_switch_routes.py
@@ -76,6 +76,7 @@ def client(monkeypatch):
     app.dependency_overrides[require_session_auth] = lambda: dict(ALICE)
 
     c = TestClient(app)
+    c.app = app  # type: ignore[attr-defined]
     c.manager = manager  # type: ignore[attr-defined]
     c.fake = fake  # type: ignore[attr-defined]
     return c
@@ -98,15 +99,24 @@ class TestListAccounts:
 
     def test_returns_display_fields_only(self, client):
         """A menu must not become a data-leak surface."""
-        client.manager.create_session({**ALICE, "role": "admin", "secret": "x"})
         sid = client.manager.create_session({**ALICE, "role": "admin", "secret": "x"})
         client.cookies.set("kagura_session", sid)
         account = client.get("/auth/accounts").json()["accounts"][0]
         assert set(account) == {"user_id", "email", "name", "picture", "is_active"}
 
-    def test_no_cookie_yields_no_accounts(self, client):
+    def test_unauthenticated_is_401_not_an_empty_list(self, client):
+        """Exercises the REAL dependency, not the override.
+
+        `SessionUser` -> require_session_auth -> get_current_user reads the
+        session the middleware resolved from the cookie, so an anonymous caller
+        never reaches the handler. A test that overrides that dependency and
+        then asserts `{"accounts": []}` is asserting something production cannot
+        produce — the override is the only reason it passes. Clear it so the
+        assertion means what it says.
+        """
+        client.app.dependency_overrides.clear()
         client.cookies.clear()
-        assert client.get("/auth/accounts").json() == {"accounts": []}
+        assert client.get("/auth/accounts").status_code == 401
 
 
 class TestSwitch:
@@ -137,6 +147,8 @@ class TestSwitch:
         assert client.post("/auth/accounts/switch", json={"user_id": "bob"}).status_code == 404
 
     def test_requires_a_session_cookie(self, client):
+        """Also through the real dependency — see the note on the GET case."""
+        client.app.dependency_overrides.clear()
         client.cookies.clear()
         assert client.post("/auth/accounts/switch", json={"user_id": "alice"}).status_code == 401
 

--- a/backend/tests/auth/test_session_container.py
+++ b/backend/tests/auth/test_session_container.py
@@ -41,9 +41,25 @@ class FakeRedis:
 
     def __init__(self) -> None:
         self.store: dict[str, str] = {}
+        # Counted so tests can assert the hot path does not rewrite records.
+        self.writes: dict[str, int] = {}
+        self.expires: dict[str, int] = {}
 
     def setex(self, key: str, _ttl: int, value: str) -> None:
         self.store[key] = value
+        self.writes[key] = self.writes.get(key, 0) + 1
+
+    def expire(self, key: str, _ttl: int) -> bool:
+        """Renew the TTL WITHOUT touching the value — like the real thing.
+
+        Modelling this faithfully is the point: the hot read path switched from
+        SETEX to EXPIRE precisely so it stops rewriting the record (#1488). A
+        fake that quietly rewrote here would hide the very property under test.
+        """
+        if key not in self.store:
+            return False
+        self.expires[key] = self.expires.get(key, 0) + 1
+        return True
 
     def get(self, key: str) -> str | None:
         return self.store.get(key)
@@ -344,3 +360,151 @@ class TestUpdateRefusesCorruptRecords:
         """Guard must not have become 'refuse everything'."""
         sid = manager.create_session(USER)
         assert manager.update_session(sid, {"role": "admin"}) is True
+
+
+OTHER = {"sub": "google_2", "user_id": "google_2", "email": "b@example.com", "role": "member"}
+
+
+class TestHotPathDoesNotRewrite:
+    """The Phase 2 prerequisite, as a property.
+
+    Refreshing the rolling TTL used to SETEX the whole record. With two
+    accounts that is an unlocked read-modify-write on every page load, able to
+    discard a concurrent add_account. EXPIRE renews the TTL without touching
+    the value, so there is nothing to clobber.
+    """
+
+    def test_reading_a_container_uses_expire_not_setex(self, manager):
+        sid = manager.create_session(USER)
+        writes_after_create = manager._redis.writes[f"session:{sid}"]
+        manager.get_session(sid)
+        manager.get_session(sid)
+        assert manager._redis.writes[f"session:{sid}"] == writes_after_create
+        assert manager._redis.expires[f"session:{sid}"] == 2
+
+    def test_a_concurrent_read_cannot_discard_an_added_account(self, manager):
+        """The race, played out in order."""
+        sid = manager.create_session(USER)
+        # A request reads the session (as middleware does on every call)...
+        manager.get_session(sid)
+        # ...meanwhile another account is added...
+        assert manager.add_account(sid, OTHER) is True
+        # ...and a further read must not roll it back.
+        manager.get_session(sid)
+        assert set(raw(manager, sid)["accounts"]) == {"google_1", "google_2"}
+
+    def test_migrating_a_legacy_record_still_writes_once(self, manager):
+        """The one write left on the read path."""
+        manager._redis.store["session:legacy"] = json.dumps({**USER})
+        manager.get_session("legacy")
+        assert manager._redis.writes["session:legacy"] == 1
+        manager.get_session("legacy")  # already a container now
+        assert manager._redis.writes["session:legacy"] == 1
+
+
+class TestAddAccount:
+    def test_adds_and_activates(self, manager):
+        sid = manager.create_session(USER)
+        assert manager.add_account(sid, OTHER) is True
+        stored = raw(manager, sid)
+        assert set(stored["accounts"]) == {"google_1", "google_2"}
+        assert stored["active"] == "google_2"
+        # Callers see the newly active identity.
+        assert manager.get_session(sid)["user_id"] == "google_2"
+
+    def test_re_adding_is_idempotent(self, manager):
+        """Signing in again must not create a duplicate entry."""
+        sid = manager.create_session(USER)
+        manager.add_account(sid, OTHER)
+        manager.add_account(sid, {**OTHER, "email": "changed@example.com"})
+        stored = raw(manager, sid)
+        assert set(stored["accounts"]) == {"google_1", "google_2"}
+        assert stored["accounts"]["google_2"]["email"] == "changed@example.com"
+
+    def test_refuses_an_identity_with_no_id(self, manager):
+        sid = manager.create_session(USER)
+        assert manager.add_account(sid, {"email": "x@y"}) is False
+        assert set(raw(manager, sid)["accounts"]) == {"google_1"}
+
+    def test_refuses_a_missing_session(self, manager):
+        assert manager.add_account("nope", OTHER) is False
+
+
+class TestSwitchAccount:
+    def test_switches_between_members(self, manager):
+        sid = manager.create_session(USER)
+        manager.add_account(sid, OTHER)
+        assert manager.switch_account(sid, "google_1") is True
+        assert manager.get_session(sid)["user_id"] == "google_1"
+
+    def test_REFUSES_an_account_not_in_this_session(self, manager):
+        """The security boundary of the entire feature.
+
+        Without this a caller could name any user id and the session would
+        start acting as them. Membership in this session's own container is the
+        only thing that may authorise a switch — never a lookup.
+        """
+        sid = manager.create_session(USER)
+        assert manager.switch_account(sid, "someone-elses-id") is False
+        assert manager.get_session(sid)["user_id"] == "google_1"
+        assert "someone-elses-id" not in raw(manager, sid)["accounts"]
+
+    def test_a_refused_switch_does_not_touch_the_record(self, manager):
+        sid = manager.create_session(USER)
+        before = manager._redis.store[f"session:{sid}"]
+        manager.switch_account(sid, "intruder")
+        assert manager._redis.store[f"session:{sid}"] == before
+
+
+class TestRemoveAccount:
+    def test_removing_one_leaves_the_other_signed_in(self, manager):
+        sid = manager.create_session(USER)
+        manager.add_account(sid, OTHER)
+        assert manager.remove_account(sid, "google_2") is True
+        assert manager.get_session(sid)["user_id"] == "google_1"
+
+    def test_removing_the_active_account_promotes_another(self, manager):
+        sid = manager.create_session(USER)
+        manager.add_account(sid, OTHER)  # google_2 is active
+        assert manager.remove_account(sid, "google_2") is True
+        assert raw(manager, sid)["active"] == "google_1"
+
+    def test_removing_the_last_account_ends_the_session(self, manager):
+        """Must delete, not leave an empty container that fails every request."""
+        sid = manager.create_session(USER)
+        assert manager.remove_account(sid, "google_1") is True
+        assert manager.get_session(sid) is None
+        assert f"session:{sid}" not in manager._redis.store
+
+    def test_removing_a_non_member_is_a_no_op(self, manager):
+        sid = manager.create_session(USER)
+        assert manager.remove_account(sid, "stranger") is False
+        assert manager.get_session(sid) is not None
+
+
+class TestListAccounts:
+    def test_lists_members_and_flags_the_active_one(self, manager):
+        sid = manager.create_session(USER)
+        manager.add_account(sid, OTHER)
+        accounts = manager.list_accounts(sid)
+        assert {a["user_id"] for a in accounts} == {"google_1", "google_2"}
+        assert [a["user_id"] for a in accounts if a["is_active"]] == ["google_2"]
+
+    def test_empty_for_a_missing_session(self, manager):
+        assert manager.list_accounts("nope") == []
+
+    def test_empty_for_a_corrupt_session(self, manager):
+        manager._redis.store["session:bad"] = json.dumps(
+            {"v": 2, "accounts": {"a": {"user_id": "a"}}, "active": "missing"}
+        )
+        assert manager.list_accounts("bad") == []
+
+
+class TestOneSessionPerUserWithTwoAccounts:
+    def test_deleting_a_users_sessions_finds_a_shared_container(self, manager):
+        """#114 still applies to an account that shares a container."""
+        sid = manager.create_session(USER)
+        manager.add_account(sid, OTHER)
+        # Either member must locate the container.
+        assert manager.delete_user_sessions("google_1") == 1
+        assert manager.get_session(sid) is None


### PR DESCRIPTION
#1488 Phase 2 / 4。**サーバ側のみ。UI はまだありません**（Phase 3）。

## まず前提条件を潰しました

Phase 1 で「`get_session(update_access=True)` が `last_accessed` を更新するためだけにレコード全体をロック無しで read-modify-write している」と記録しました。アカウントが1つなら失うものはありませんが、**2つになると通常のリクエストが並行する `add_account` を巻き戻せます**。リクエストはページ表示のたびに飛ぶので、理論上ではなく日常的に起きます。

ホットパスを **`EXPIRE`** に変更しました。値に触れずローリング TTL だけ延ばすので、**読み取り経路はもうレコードを書きません**。残る書き込みはレガシーレコードの一度きりの移行だけです。

トレードオフを明示します: **保存されている `last_accessed` は、リクエスト毎ではなく書き込み毎に進む**ようになります。これを読んでいるコードは**どこにもありません**（ルートもサービスも UI も無く、docstring が言及するのみ）。返す射影は現在時刻を報告するので呼び出し元から見た値は正確です。本当にリクエスト毎の最終アクセスが必要になったら、全体書き換えを復活させるのではなく atomic な手段で意図的に追加すべきです。

## 操作

`add_account` / `switch_account` / `remove_account` / `list_accounts` を追加。すべて `_mutate_container` を通し、残る read-modify-write を1箇所に閉じ込めています。これらが `accounts`/`active` の唯一の書き手で、頻度は「ログイン」か「明示的な切り替え」のみ。**1回のユーザー操作**なので、ページ表示毎とは違い last-writer-wins が許容できます。

挙動として明記しておくもの:

- **既存アカウントの再追加は冪等** — identity を更新して active にするだけで、重複エントリを作りません
- **最後の1つを削除したらセッションごと削除** — 空のコンテナを残すと、以降の全リクエストで `project_active` が弾き続けます
- **active を削除したら残りの1つを昇格**

## セキュリティ境界

`switch_account` は**このセッションのコンテナに既に居ないアカウントを拒否**します。この1つのチェックに機能全体が乗っています — 無ければ、呼び出し元が任意の user id を名乗るだけでそのユーザーとして振る舞えます。**経路上にルックアップは一切ありません**ので、呼び出し元が捏造した id で権限が広がることはありません。

`POST /auth/accounts/switch` は非メンバーに対し 403 ではなく **404** を返します — 他のアカウントが存在するかどうかは、この呼び出し元が知ってよい情報ではありません。`GET /auth/accounts` は自分のコンテナだけを読み、表示用フィールドのみ返します（メニューが情報漏洩面にならないように）。

## テストについて

`FakeRedis` に **値を書き換えずに TTL だけ延ばす** `expire` を実装し、write/expire のカウンタも追加しました。ここを忠実にモデル化することが要点です — expire でこっそり書き換えるフェイクだと、**この変更が確立しようとしている性質そのものを隠します**。

テストは「ホットパスの書き込み回数が0であること」を主張し、競合を順番どおり再生します（read → add_account → read）。追加したアカウントが生き残ることを確認しています。

## 検証

| | |
|---|---|
| ruff / format / pyright | clean |
| セッションテスト | 46 |
| ルートテスト | 9 |
| auth + mcp_server + OAuth 群 | 815 passed |

## 次 (Phase 3)

左下のサイドバーにアカウント切替 UI。既存の下部ユーザーメニューを土台にします（上部の `WorkspaceSwitcher` は手書きの非標準コントロールなので参考にしません）。

なお **`current_workspace_id` が users テーブルの列**である問題は未解決です。アカウントを切り替えてもワークスペースが全デバイス共有のままなので、Phase 3 の前か最中に片付ける必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)