### PR TITLE
feat(auth): switch accounts from the sidebar, and a login that adds one (#1488 Phase 3)

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -494,8 +494,10 @@ def _get_enabled_providers() -> list[ProviderInfo]:
 
 @google_router.get("/login")
 async def google_login(
+    request: Request,
     redirect_uri: str | None = None,
     return_to: str | None = None,
+    add_account: bool = False,
 ):
     """Initiate Google OAuth2 login flow.
 
@@ -535,6 +537,14 @@ async def google_login(
         # Issue #102: Store return_to for later redirect after callback
         if return_to:
             _session_manager._redis.setex(f"oauth2_return_to:{state}", 300, return_to)
+
+        # #1488: "add another account" — remember WHICH session this flow may
+        # append to. Only meaningful when the caller already has one; without a
+        # cookie there is nothing to add to and this degrades to a normal login.
+        if add_account:
+            current_session = request.cookies.get("kagura_session")
+            if current_session:
+                _remember_add_account_intent(state, current_session)
 
     # Get authorization URL
     redirect = redirect_uri or os.getenv("GOOGLE_REDIRECT_URI")
@@ -806,6 +816,11 @@ async def google_callback(
 
         # Issue #114: Invalidate old sessions before creating new one
         # This prevents session fixation attacks and ensures only one active session per user
+        #
+        # #1488: this runs for an ADD too. It deletes the incoming user's OTHER
+        # sessions, which is exactly what #114 asks for, and cannot touch the
+        # session we are adding into because that container does not hold this
+        # user yet (membership matching, see session_owns_user).
         deleted_count = _session_manager.delete_user_sessions(user_info["sub"])
         if deleted_count > 0:
             logger.info(f"Invalidated {deleted_count} old session(s) for {user_info['email']}")
@@ -818,7 +833,16 @@ async def google_callback(
             "picture": user_info.get("picture"),
             "role": role.value,
         }
-        session_id = _session_manager.create_session(session_data)
+
+        # #1488: "add another account" keeps the CURRENT session and appends to
+        # it; a normal login mints a fresh one. Deciding here rather than at the
+        # cookie write keeps the two paths from diverging further down.
+        add_to_session = _take_add_account_intent(state, request)
+        if add_to_session and _session_manager.add_account(add_to_session, session_data):
+            session_id = add_to_session
+            logger.info(f"Added account to existing session: {user_info['email']}")
+        else:
+            session_id = _session_manager.create_session(session_data)
 
         # Issue #212: Auto-create personal workspace on first login
         # Skip if user has pending invitations (they'll get workspace via invitation)
@@ -942,6 +966,60 @@ class AccountSwitchRequest(BaseModel):
     """Which already-signed-in account to make active (#1488)."""
 
     user_id: str = Field(..., min_length=1, max_length=255)
+
+
+# --- adding a second account to an existing session (#1488 Phase 2/3) -------
+#
+# A normal login REPLACES: it deletes the user's old sessions and mints a new
+# cookie. To sign a second account into the SAME browser session we need a
+# login that ADDS instead, or the switcher can never have anything to switch
+# between.
+#
+# The intent travels the same way `return_to` does — a short-lived Redis key
+# beside the CSRF state — but it stores the SESSION ID it is allowed to add to,
+# and the callback additionally requires the request's cookie to still match
+# that id. State alone is therefore not enough: the callback must come from the
+# browser that actually holds the session, so a leaked state cannot graft an
+# account onto someone else's session.
+_ADD_ACCOUNT_KEY = "oauth2_add_to_session:{state}"
+_ADD_ACCOUNT_TTL = 300
+
+
+def _remember_add_account_intent(state: str, session_id: str) -> None:
+    """Record that this OAuth flow should ADD to ``session_id``."""
+    if _session_manager:
+        _session_manager._redis.setex(
+            _ADD_ACCOUNT_KEY.format(state=state), _ADD_ACCOUNT_TTL, session_id
+        )
+
+
+def _take_add_account_intent(state: str, request: Request) -> str | None:
+    """Return the session to add to, or None for a normal (replacing) login.
+
+    Consumes the key either way — an intent is single-use, like the state.
+
+    Returns None unless the request's own cookie still names the same session,
+    so possession of ``state`` is not sufficient authority.
+    """
+    if not _session_manager:
+        return None
+    key = _ADD_ACCOUNT_KEY.format(state=state)
+    intended = _session_manager._redis.get(key)
+    if not intended:
+        return None
+    _session_manager._redis.delete(key)
+
+    cookie_session = request.cookies.get("kagura_session")
+    if not cookie_session or cookie_session != intended:
+        logger.warning("add_account_intent_rejected_cookie_mismatch")
+        return None
+    # The session must still be alive; a dead one would silently fall back to a
+    # replacing login, which is a surprising outcome to hand a user who asked
+    # to add an account.
+    if _session_manager.get_session(cookie_session, update_access=False) is None:
+        logger.warning("add_account_intent_rejected_dead_session")
+        return None
+    return cookie_session
 
 
 @router.get("/accounts")
@@ -1124,7 +1202,9 @@ def build_github_authorization_url(*, client_id: str, redirect_uri: str, state: 
 
 @github_router.get("/login")
 async def github_login(
+    request: Request,
     return_to: str | None = None,
+    add_account: bool = False,
 ):
     """Initiate GitHub OAuth2 login flow."""
     if not _session_manager:
@@ -1139,6 +1219,13 @@ async def github_login(
 
     if return_to:
         _session_manager._redis.setex(f"oauth2_return_to:{state}", 300, return_to)
+
+    # #1488: see the Google login for why the session id (not just a flag) is
+    # what gets stored.
+    if add_account:
+        current_session = request.cookies.get("kagura_session")
+        if current_session:
+            _remember_add_account_intent(state, current_session)
 
     redirect_uri = os.getenv(
         "GITHUB_REDIRECT_URI",
@@ -1362,7 +1449,14 @@ async def github_callback(
             "picture": user_info.get("picture"),
             "role": role.value,
         }
-        session_id = _session_manager.create_session(session_data)
+        # #1488: append to the current session when this flow was started as
+        # "add another account"; otherwise mint a fresh one.
+        add_to_session = _take_add_account_intent(state, request)
+        if add_to_session and _session_manager.add_account(add_to_session, session_data):
+            session_id = add_to_session
+            logger.info(f"Added account to existing session: {user_info['email']}")
+        else:
+            session_id = _session_manager.create_session(session_data)
 
         # 6. Auto-create personal workspace
         try:

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -835,10 +835,20 @@ async def google_callback(
         }
 
         # #1488: "add another account" keeps the CURRENT session and appends to
-        # it; a normal login mints a fresh one. Deciding here rather than at the
-        # cookie write keeps the two paths from diverging further down.
-        add_to_session = _take_add_account_intent(state, request)
-        if add_to_session and _session_manager.add_account(add_to_session, session_data):
+        # it; a normal login mints a fresh one.
+        #
+        # An intent that cannot be honoured must NOT fall through to
+        # create_session: that replaces the cookie and discards every other
+        # account already signed in, which is the opposite of what was asked.
+        intent, add_to_session = _take_add_account_intent(state, request)
+        if intent == "unusable":
+            return _oauth_error_redirect("google", "add_account_failed")
+        if intent == "add" and add_to_session:
+            if not _session_manager.add_account(add_to_session, session_data):
+                # The session died between the check and the write. Refuse for
+                # the same reason — better a retryable error than a silent loss.
+                logger.warning("add_account_write_failed")
+                return _oauth_error_redirect("google", "add_account_failed")
             session_id = add_to_session
             logger.info(f"Added account to existing session: {user_info['email']}")
         else:
@@ -993,33 +1003,41 @@ def _remember_add_account_intent(state: str, session_id: str) -> None:
         )
 
 
-def _take_add_account_intent(state: str, request: Request) -> str | None:
-    """Return the session to add to, or None for a normal (replacing) login.
+def _take_add_account_intent(state: str, request: Request) -> tuple[str, str | None]:
+    """Classify this callback: normal login, add-to-session, or refuse.
 
-    Consumes the key either way — an intent is single-use, like the state.
+    Returns ``(status, session_id)`` where status is one of:
 
-    Returns None unless the request's own cookie still names the same session,
-    so possession of ``state`` is not sufficient authority.
+    - ``"none"``     — no intent recorded; this is an ordinary login.
+    - ``"add"``      — append to ``session_id``.
+    - ``"unusable"`` — an intent WAS recorded but cannot be honoured.
+
+    The three-way answer is load-bearing. Collapsing "unusable" into "none"
+    makes the caller mint a fresh session, which REPLACES the cookie and
+    silently discards every other account already signed in — the exact
+    outcome someone asking to *add* an account must not get. Two-valued, that
+    bug is invisible; named, the caller cannot fall into it.
+
+    Consumes the key on every path — an intent is single-use, like the state.
     """
     if not _session_manager:
-        return None
+        return ("none", None)
     key = _ADD_ACCOUNT_KEY.format(state=state)
     intended = _session_manager._redis.get(key)
     if not intended:
-        return None
+        return ("none", None)
     _session_manager._redis.delete(key)
 
+    # Possession of `state` is not authority: the callback must arrive from the
+    # browser that actually holds the session.
     cookie_session = request.cookies.get("kagura_session")
     if not cookie_session or cookie_session != intended:
         logger.warning("add_account_intent_rejected_cookie_mismatch")
-        return None
-    # The session must still be alive; a dead one would silently fall back to a
-    # replacing login, which is a surprising outcome to hand a user who asked
-    # to add an account.
+        return ("unusable", None)
     if _session_manager.get_session(cookie_session, update_access=False) is None:
         logger.warning("add_account_intent_rejected_dead_session")
-        return None
-    return cookie_session
+        return ("unusable", None)
+    return ("add", cookie_session)
 
 
 @router.get("/accounts")
@@ -1449,10 +1467,16 @@ async def github_callback(
             "picture": user_info.get("picture"),
             "role": role.value,
         }
-        # #1488: append to the current session when this flow was started as
-        # "add another account"; otherwise mint a fresh one.
-        add_to_session = _take_add_account_intent(state, request)
-        if add_to_session and _session_manager.add_account(add_to_session, session_data):
+        # #1488: append when this flow was started as "add another account";
+        # otherwise mint a fresh one. See the Google callback for why an
+        # unusable intent refuses instead of falling back to a replacing login.
+        intent, add_to_session = _take_add_account_intent(state, request)
+        if intent == "unusable":
+            return _oauth_error_redirect("github", "add_account_failed")
+        if intent == "add" and add_to_session:
+            if not _session_manager.add_account(add_to_session, session_data):
+                logger.warning("add_account_write_failed")
+                return _oauth_error_redirect("github", "add_account_failed")
             session_id = add_to_session
             logger.info(f"Added account to existing session: {user_info['email']}")
         else:

--- a/backend/tests/api/test_add_account_intent.py
+++ b/backend/tests/api/test_add_account_intent.py
@@ -1,0 +1,127 @@
+"""Adding a second account to an existing session (#1488).
+
+Phase 2 shipped `switch_account` and the endpoints, but every login path still
+REPLACED the session — so nothing could ever put a second account in it and the
+switcher had nothing to switch between. This is the missing half.
+
+The intent travels as a short-lived Redis key beside the CSRF state, holding
+the SESSION ID it may append to. Two properties make that safe, and both are
+pinned here:
+
+- possession of `state` is not authority: the callback must also arrive with a
+  cookie naming that same session, so a leaked state cannot graft an account
+  onto someone else's session;
+- the intent is single-use, like the state itself.
+
+Unit-level against the helpers, because the security decision lives there —
+the OAuth round trip around it is already covered by the callback suites.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from api.routes import auth as auth_routes
+
+
+class FakeRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    def setex(self, key: str, _ttl: int, value: str) -> None:
+        self.store[key] = value
+
+    def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    def delete(self, *keys: str) -> int:
+        n = 0
+        for k in keys:
+            if k in self.store:
+                del self.store[k]
+                n += 1
+        return n
+
+
+class FakeManager:
+    """Only what the intent helpers touch."""
+
+    def __init__(self, live_sessions: set[str]) -> None:
+        self._redis = FakeRedis()
+        self._live = live_sessions
+
+    def get_session(self, session_id: str, update_access: bool = True):
+        return {"user_id": "u"} if session_id in self._live else None
+
+
+class FakeRequest:
+    def __init__(self, cookie: str | None) -> None:
+        self.cookies = {"kagura_session": cookie} if cookie else {}
+
+
+@pytest.fixture
+def mgr(monkeypatch):
+    m = FakeManager(live_sessions={"sess-A"})
+    monkeypatch.setattr(auth_routes, "_session_manager", m)
+    return m
+
+
+class TestIntentIsHonouredForTheRightBrowser:
+    def test_round_trip(self, mgr):
+        auth_routes._remember_add_account_intent("st1", "sess-A")
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) == "sess-A"
+
+    def test_absent_intent_means_a_normal_login(self, mgr):
+        assert auth_routes._take_add_account_intent("nope", FakeRequest("sess-A")) is None
+
+
+class TestStateAloneIsNotAuthority:
+    def test_a_different_cookie_cannot_use_the_intent(self, mgr):
+        """The attack the cookie check exists for.
+
+        If `state` leaked, completing the flow would otherwise append the
+        attacker's account to the victim's session — after which the victim
+        could switch into it.
+        """
+        auth_routes._remember_add_account_intent("st1", "sess-A")
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-EVIL")) is None
+
+    def test_no_cookie_at_all_cannot_use_the_intent(self, mgr):
+        auth_routes._remember_add_account_intent("st1", "sess-A")
+        assert auth_routes._take_add_account_intent("st1", FakeRequest(None)) is None
+
+    def test_a_dead_session_is_refused(self, mgr):
+        """Falling back to a replacing login would surprise someone who asked
+        to ADD an account — they would silently lose the other one."""
+        auth_routes._remember_add_account_intent("st1", "sess-GONE")
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-GONE")) is None
+
+
+class TestSingleUse:
+    def test_intent_is_consumed_on_success(self, mgr):
+        auth_routes._remember_add_account_intent("st1", "sess-A")
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) == "sess-A"
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) is None
+
+    def test_intent_is_consumed_even_when_rejected(self, mgr):
+        """A rejected attempt must not leave a reusable key behind."""
+        auth_routes._remember_add_account_intent("st1", "sess-A")
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-EVIL")) is None
+        # ...and the legitimate browser cannot use it afterwards either.
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) is None
+
+
+class TestWiring:
+    def test_both_providers_offer_the_flag(self):
+        import inspect
+
+        for fn in (auth_routes.google_login, auth_routes.github_login):
+            assert "add_account" in inspect.signature(fn).parameters, fn.__name__
+
+    def test_both_callbacks_consult_the_intent(self):
+        import inspect
+
+        for fn in (auth_routes.google_callback, auth_routes.github_callback):
+            src = inspect.getsource(fn)
+            assert "_take_add_account_intent" in src, fn.__name__
+            assert "add_account(" in src, fn.__name__

--- a/backend/tests/api/test_add_account_intent.py
+++ b/backend/tests/api/test_add_account_intent.py
@@ -69,10 +69,16 @@ def mgr(monkeypatch):
 class TestIntentIsHonouredForTheRightBrowser:
     def test_round_trip(self, mgr):
         auth_routes._remember_add_account_intent("st1", "sess-A")
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) == "sess-A"
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) == (
+            "add",
+            "sess-A",
+        )
 
     def test_absent_intent_means_a_normal_login(self, mgr):
-        assert auth_routes._take_add_account_intent("nope", FakeRequest("sess-A")) is None
+        assert auth_routes._take_add_account_intent("nope", FakeRequest("sess-A")) == (
+            "none",
+            None,
+        )
 
 
 class TestStateAloneIsNotAuthority:
@@ -84,31 +90,45 @@ class TestStateAloneIsNotAuthority:
         could switch into it.
         """
         auth_routes._remember_add_account_intent("st1", "sess-A")
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-EVIL")) is None
+        status, sid = auth_routes._take_add_account_intent("st1", FakeRequest("sess-EVIL"))
+        assert (status, sid) == ("unusable", None)
 
     def test_no_cookie_at_all_cannot_use_the_intent(self, mgr):
         auth_routes._remember_add_account_intent("st1", "sess-A")
-        assert auth_routes._take_add_account_intent("st1", FakeRequest(None)) is None
+        assert auth_routes._take_add_account_intent("st1", FakeRequest(None)) == (
+            "unusable",
+            None,
+        )
 
     def test_a_dead_session_is_refused(self, mgr):
-        """Falling back to a replacing login would surprise someone who asked
-        to ADD an account — they would silently lose the other one."""
+        """Must be UNUSABLE, never NONE.
+
+        `none` makes the caller mint a fresh session, which replaces the cookie
+        and discards every other account already signed in — the opposite of
+        what someone asking to *add* an account wants. Two-valued, that bug is
+        invisible; this assertion is the reason the status is named.
+        """
         auth_routes._remember_add_account_intent("st1", "sess-GONE")
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-GONE")) is None
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-GONE")) == (
+            "unusable",
+            None,
+        )
 
 
 class TestSingleUse:
     def test_intent_is_consumed_on_success(self, mgr):
         auth_routes._remember_add_account_intent("st1", "sess-A")
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) == "sess-A"
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) is None
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A"))[0] == "add"
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A"))[0] == "none"
 
     def test_intent_is_consumed_even_when_rejected(self, mgr):
         """A rejected attempt must not leave a reusable key behind."""
         auth_routes._remember_add_account_intent("st1", "sess-A")
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-EVIL")) is None
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-EVIL"))[0] == (
+            "unusable"
+        )
         # ...and the legitimate browser cannot use it afterwards either.
-        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A")) is None
+        assert auth_routes._take_add_account_intent("st1", FakeRequest("sess-A"))[0] == "none"
 
 
 class TestWiring:
@@ -125,3 +145,16 @@ class TestWiring:
             src = inspect.getsource(fn)
             assert "_take_add_account_intent" in src, fn.__name__
             assert "add_account(" in src, fn.__name__
+
+    def test_neither_callback_replaces_the_session_on_an_unusable_intent(self):
+        """The destructive fallback, pinned.
+
+        Falling through to create_session here mints a new cookie and drops
+        every other signed-in account. Both callbacks must refuse instead.
+        """
+        import inspect
+
+        for fn in (auth_routes.google_callback, auth_routes.github_callback):
+            src = inspect.getsource(fn)
+            assert 'intent == "unusable"' in src, fn.__name__
+            assert "add_account_failed" in src, fn.__name__

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/auth/rbac";
 import { getContexts } from "@/lib/api/contexts";
 import { listExternalAPIKeys } from "@/lib/api/external-keys";
+import { useAccountSwitcher } from "@/hooks/useAccountSwitcher";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { KaguraLogo } from "@/components/icons/KaguraLogo";
 import {
@@ -71,6 +72,8 @@ import {
   ExternalLink,
   Plug,
   HardDrive,
+  UserPlus,
+  Check,
 } from "lucide-react";
 import { apiClient } from "@/lib/api/base";
 // Issue #246: ContextSelector removed - use /contexts link instead
@@ -479,8 +482,24 @@ export function Sidebar() {
   const [systemVersion, setSystemVersion] = useState<string | null>(null);
   const versionFetchedRef = useRef(false);
 
+  // Accounts signed in on THIS browser session (#1488). The decisions live in
+  // the hook; this component only renders them.
+  const {
+    accounts,
+    switchingTo,
+    refresh: refreshAccounts,
+    switchTo: switchToAccount,
+    addAccount: handleAddAccount,
+  } = useAccountSwitcher();
+
   const handleUserMenuOpenChange = (open: boolean) => {
-    if (!open || versionFetchedRef.current) return;
+    if (!open) return;
+
+    // Re-read on every open: another tab may have added or switched an
+    // account, and a stale list would offer a switch the server rejects.
+    void refreshAccounts();
+
+    if (versionFetchedRef.current) return;
     versionFetchedRef.current = true; // fetch at most once per session
     apiClient
       .get<{ version: string }>("/api/v1/system/info")
@@ -856,7 +875,70 @@ export function Sidebar() {
                 </div>
               </button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent className="w-56" align="end" side="top">
+            <DropdownMenuContent className="w-64" align="end" side="top">
+              {/* Account switcher (#1488).
+                  Rows render only when this session actually holds more than
+                  one account — with a single account there is nothing to switch
+                  between and the trigger above already shows who you are, so
+                  the rows would be pure noise. "Add another account" is always
+                  offered, since that is how a second one gets here. */}
+              {accounts.length > 1 && (
+                <>
+                  <DropdownMenuLabel className="text-xs font-normal text-slate-500 dark:text-slate-400">
+                    {t("signedInAccounts")}
+                  </DropdownMenuLabel>
+                  {accounts.map((account) => (
+                    <DropdownMenuItem
+                      key={account.user_id}
+                      disabled={account.is_active || switchingTo !== null}
+                      onClick={() => {
+                        if (!account.is_active) {
+                          void switchToAccount(account.user_id);
+                        }
+                      }}
+                      className="gap-2"
+                    >
+                      <Avatar className="h-6 w-6 shrink-0">
+                        <AvatarImage
+                          src={account.picture ?? undefined}
+                          alt={account.name ?? ""}
+                        />
+                        <AvatarFallback className="text-[10px]">
+                          {(account.name ?? account.email ?? "?")
+                            .substring(0, 2)
+                            .toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="flex-1 overflow-hidden">
+                        <p className="truncate text-sm">
+                          {account.name ?? account.email}
+                        </p>
+                        {account.name && account.email && (
+                          <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+                            {account.email}
+                          </p>
+                        )}
+                      </div>
+                      {account.is_active && (
+                        <Check
+                          className="h-4 w-4 shrink-0 text-brand-green-600"
+                          aria-label={t("activeAccount")}
+                        />
+                      )}
+                    </DropdownMenuItem>
+                  ))}
+                  <DropdownMenuSeparator />
+                </>
+              )}
+
+              {/* Add another account */}
+              <DropdownMenuItem onClick={handleAddAccount}>
+                <UserPlus className="mr-2 h-4 w-4" />
+                <span>{t("addAnotherAccount")}</span>
+              </DropdownMenuItem>
+
+              <DropdownMenuSeparator />
+
               {/* Profile Settings */}
               <DropdownMenuItem
                 onClick={() => {

--- a/frontend/src/hooks/useAccountSwitcher.test.ts
+++ b/frontend/src/hooks/useAccountSwitcher.test.ts
@@ -35,6 +35,10 @@ const BOB = {
 };
 
 let assignSpy: ReturnType<typeof vi.fn>;
+// Stubbing window.location without restoring it leaks into every test file
+// that runs afterwards in the same worker — capture the descriptor and put it
+// back.
+const realLocation = Object.getOwnPropertyDescriptor(window, "location");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -43,11 +47,20 @@ beforeEach(() => {
   assignSpy = vi.fn();
   Object.defineProperty(window, "location", {
     configurable: true,
-    value: { assign: assignSpy, origin: "https://app.test" },
+    value: {
+      assign: assignSpy,
+      origin: "https://app.test",
+      href: "https://app.test/",
+    },
   });
 });
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  if (realLocation) {
+    Object.defineProperty(window, "location", realLocation);
+  }
+  vi.restoreAllMocks();
+});
 
 describe("useAccountSwitcher", () => {
   it("starts empty and only reads when asked", () => {
@@ -117,6 +130,20 @@ describe("useAccountSwitcher", () => {
       resolveSwitch();
       await pending;
     });
+  });
+
+  it("does not duplicate /api/v1 when the env var already carries it", async () => {
+    // Some deployments set NEXT_PUBLIC_API_URL=https://api.example.com/api/v1.
+    // Concatenating would yield /api/v1/api/v1/auth/... and break the flow;
+    // buildOAuthRedirect strips the suffix, which is why it is used here
+    // instead of string building.
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "https://api.example.com/api/v1");
+    const { result } = renderHook(() => useAccountSwitcher());
+    act(() => result.current.addAccount());
+    const url = assignSpy.mock.calls[0][0] as string;
+    expect(url).not.toContain("/api/v1/api/v1");
+    expect(url).toContain("https://api.example.com/api/v1/auth/google/login");
+    vi.unstubAllEnvs();
   });
 
   it("the add flow carries the flag that makes the callback append", async () => {

--- a/frontend/src/hooks/useAccountSwitcher.test.ts
+++ b/frontend/src/hooks/useAccountSwitcher.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The account switcher's decisions (#1488 Phase 3).
+ *
+ * Pinned here rather than through the sidebar's Radix dropdown: this repo has
+ * no working pattern for opening one under a DOM emulator, and the dropdown is
+ * not where the risk is. What can be wrong is *when* the list is re-read, what
+ * happens when a switch is rejected, and whether the page is genuinely left.
+ */
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockListAccounts = vi.hoisted(() => vi.fn());
+const mockSwitchAccount = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api/accounts", () => ({
+  listAccounts: (...a: unknown[]) => mockListAccounts(...a),
+  switchAccount: (...a: unknown[]) => mockSwitchAccount(...a),
+}));
+
+import { useAccountSwitcher } from "./useAccountSwitcher";
+
+const ALICE = {
+  user_id: "alice",
+  email: "alice@example.com",
+  name: "Alice",
+  picture: null,
+  is_active: true,
+};
+const BOB = {
+  user_id: "bob",
+  email: "bob@example.com",
+  name: "Bob",
+  picture: null,
+  is_active: false,
+};
+
+let assignSpy: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockListAccounts.mockResolvedValue([ALICE, BOB]);
+  mockSwitchAccount.mockResolvedValue(undefined);
+  assignSpy = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { assign: assignSpy, origin: "https://app.test" },
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("useAccountSwitcher", () => {
+  it("starts empty and only reads when asked", () => {
+    const { result } = renderHook(() => useAccountSwitcher());
+    expect(result.current.accounts).toEqual([]);
+    expect(mockListAccounts).not.toHaveBeenCalled();
+  });
+
+  it("refresh loads the session's accounts", async () => {
+    const { result } = renderHook(() => useAccountSwitcher());
+    await act(() => result.current.refresh());
+    expect(result.current.accounts).toEqual([ALICE, BOB]);
+  });
+
+  it("refresh can be called repeatedly — the menu re-reads on every open", async () => {
+    // A cached list would offer a switch the server rejects after another tab
+    // signed an account out.
+    const { result } = renderHook(() => useAccountSwitcher());
+    await act(() => result.current.refresh());
+    await act(() => result.current.refresh());
+    expect(mockListAccounts).toHaveBeenCalledTimes(2);
+  });
+
+  it("degrades to an empty list when the endpoint is missing", async () => {
+    // An older backend must leave the menu exactly as it was, never broken.
+    mockListAccounts.mockRejectedValue(new Error("404"));
+    const { result } = renderHook(() => useAccountSwitcher());
+    await act(() => result.current.refresh());
+    expect(result.current.accounts).toEqual([]);
+  });
+
+  it("switching leaves the page instead of soft-refreshing", async () => {
+    // The active workspace is a per-user column and providers cache per-user
+    // data; a client-side refresh would render the old workspace under the new
+    // identity.
+    const { result } = renderHook(() => useAccountSwitcher());
+    await act(() => result.current.switchTo("bob"));
+    expect(mockSwitchAccount).toHaveBeenCalledWith("bob");
+    expect(assignSpy).toHaveBeenCalledWith("/");
+  });
+
+  it("a rejected switch re-reads the list and does NOT navigate", async () => {
+    // 404 = the account is no longer on this session. Navigating would land on
+    // a page rendered for an identity we no longer hold.
+    mockSwitchAccount.mockRejectedValueOnce(new Error("404"));
+    const { result } = renderHook(() => useAccountSwitcher());
+    await act(() => result.current.switchTo("bob"));
+    expect(assignSpy).not.toHaveBeenCalled();
+    expect(mockListAccounts).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.switchingTo).toBeNull());
+  });
+
+  it("marks the in-flight account so the rows can disable", async () => {
+    let resolveSwitch: () => void = () => {};
+    mockSwitchAccount.mockReturnValue(
+      new Promise<void>((r) => {
+        resolveSwitch = r;
+      }),
+    );
+    const { result } = renderHook(() => useAccountSwitcher());
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.switchTo("bob");
+    });
+    await waitFor(() => expect(result.current.switchingTo).toBe("bob"));
+    await act(async () => {
+      resolveSwitch();
+      await pending;
+    });
+  });
+
+  it("the add flow carries the flag that makes the callback append", async () => {
+    // Without add_account=1 the callback REPLACES the session and there is
+    // never a second account to switch to.
+    const { result } = renderHook(() => useAccountSwitcher());
+    act(() => result.current.addAccount());
+    const url = assignSpy.mock.calls[0][0] as string;
+    expect(url).toContain("add_account=1");
+    expect(url).toContain("/api/v1/auth/google/login");
+    expect(url).toContain(encodeURIComponent("https://app.test/"));
+  });
+});

--- a/frontend/src/hooks/useAccountSwitcher.ts
+++ b/frontend/src/hooks/useAccountSwitcher.ts
@@ -1,0 +1,77 @@
+/**
+ * Accounts signed in on this browser session, and how to move between them
+ * (#1488 Phase 3).
+ *
+ * Extracted from the sidebar rather than inlined: every decision worth getting
+ * right lives here (when to re-read, what to do on a rejected switch, how to
+ * leave the page), while the menu itself is declarative JSX. That also makes
+ * the behaviour testable without driving a Radix dropdown through a DOM
+ * emulator, which this repo has no working pattern for.
+ */
+"use client";
+
+import { useCallback, useState } from "react";
+
+import {
+  listAccounts,
+  switchAccount,
+  type SignedInAccount,
+} from "@/lib/api/accounts";
+
+export interface UseAccountSwitcher {
+  accounts: SignedInAccount[];
+  /** Non-null while a switch is in flight — disables the rows. */
+  switchingTo: string | null;
+  /** Re-read the list. Call on every menu open. */
+  refresh: () => Promise<void>;
+  switchTo: (userId: string) => Promise<void>;
+  addAccount: () => void;
+}
+
+export function useAccountSwitcher(): UseAccountSwitcher {
+  const [accounts, setAccounts] = useState<SignedInAccount[]>([]);
+  const [switchingTo, setSwitchingTo] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setAccounts(await listAccounts());
+    } catch {
+      // An older backend has no /auth/accounts. Empty means the menu renders
+      // exactly as it did before this feature — degraded, never broken.
+      setAccounts([]);
+    }
+  }, []);
+
+  const switchTo = useCallback(
+    async (userId: string) => {
+      setSwitchingTo(userId);
+      try {
+        await switchAccount(userId);
+        // Hard navigation, deliberately. The active workspace is a per-user
+        // column and several providers cache per-user data, so a client-side
+        // refresh would leave the previous account's workspace and contexts on
+        // screen under the new identity. A reload is the only honest reset.
+        window.location.assign("/");
+      } catch {
+        // 404 means the account is no longer on this session (signed out in
+        // another tab). Re-read instead of navigating, or we would land on a
+        // page rendered for an identity this session no longer holds.
+        setSwitchingTo(null);
+        await refresh();
+      }
+    },
+    [refresh],
+  );
+
+  const addAccount = useCallback(() => {
+    // `add_account=1` makes the OAuth callback APPEND to this session instead
+    // of replacing it. Without it there is never a second account to switch to.
+    const returnTo = `${window.location.origin}/`;
+    const base = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
+    window.location.assign(
+      `${base}/api/v1/auth/google/login?add_account=1&return_to=${encodeURIComponent(returnTo)}`,
+    );
+  }, []);
+
+  return { accounts, switchingTo, refresh, switchTo, addAccount };
+}

--- a/frontend/src/hooks/useAccountSwitcher.ts
+++ b/frontend/src/hooks/useAccountSwitcher.ts
@@ -12,6 +12,7 @@
 
 import { useCallback, useState } from "react";
 
+import { buildOAuthRedirect } from "@/lib/auth/buildOAuthRedirect";
 import {
   listAccounts,
   switchAccount,
@@ -64,13 +65,18 @@ export function useAccountSwitcher(): UseAccountSwitcher {
   );
 
   const addAccount = useCallback(() => {
-    // `add_account=1` makes the OAuth callback APPEND to this session instead
-    // of replacing it. Without it there is never a second account to switch to.
-    const returnTo = `${window.location.origin}/`;
-    const base = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
-    window.location.assign(
-      `${base}/api/v1/auth/google/login?add_account=1&return_to=${encodeURIComponent(returnTo)}`,
-    );
+    // Build through the shared helper, not by concatenation. It guards three
+    // traps this flow has no reason to re-learn: NEXT_PUBLIC_API_URL may
+    // already carry an `/api/v1` suffix (yielding `/api/v1/api/v1/...`), the
+    // backend redirects to `return_to` verbatim so it must be absolute and
+    // same-origin (CWE-601), and the env var may end in trailing slashes.
+    //
+    // `add_account=1` is appended after: it makes the OAuth callback APPEND to
+    // this session instead of replacing it. Without it there is never a second
+    // account to switch to.
+    const url = new URL(buildOAuthRedirect("google", "/"));
+    url.searchParams.set("add_account", "1");
+    window.location.assign(url.toString());
   }, []);
 
   return { accounts, switchingTo, refresh, switchTo, addAccount };

--- a/frontend/src/lib/api/accounts.ts
+++ b/frontend/src/lib/api/accounts.ts
@@ -1,0 +1,38 @@
+/**
+ * Accounts signed in on THIS browser session (#1488 Phase 3).
+ *
+ * The server keeps several identities inside one session record and marks one
+ * active; these two calls read that list and move the marker. Nothing here can
+ * enumerate or reach an account the session does not already hold — the server
+ * answers 404 for a user_id that is not a member, so an invented id widens
+ * nothing.
+ */
+import { apiClient } from "./base";
+
+export interface SignedInAccount {
+  user_id: string;
+  email: string | null;
+  name: string | null;
+  picture: string | null;
+  is_active: boolean;
+}
+
+interface AccountsResponse {
+  accounts: SignedInAccount[];
+}
+
+/** Accounts on this session, active one flagged. */
+export async function listAccounts(): Promise<SignedInAccount[]> {
+  const res = await apiClient.get<AccountsResponse>("/api/v1/auth/accounts");
+  return res.accounts;
+}
+
+/**
+ * Make an already-signed-in account active.
+ *
+ * Throws on 404 (not a member of this session) — the caller should treat that
+ * as "this account is gone" and refresh the list rather than retrying.
+ */
+export async function switchAccount(userId: string): Promise<void> {
+  await apiClient.post("/api/v1/auth/accounts/switch", { user_id: userId });
+}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -166,7 +166,10 @@
     "version": "v{version}",
     "kaguraLogoAria": "Kagura Memory Cloud",
     "connectors": "Connectors",
-    "storage": "Storage"
+    "storage": "Storage",
+    "signedInAccounts": "Signed in",
+    "addAnotherAccount": "Add another account",
+    "activeAccount": "Active account"
   },
   "storage": {
     "list": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -166,7 +166,10 @@
     "version": "v{version}",
     "kaguraLogoAria": "Kagura Memory Cloud",
     "connectors": "コネクタ",
-    "storage": "ストレージ"
+    "storage": "ストレージ",
+    "signedInAccounts": "サインイン中",
+    "addAnotherAccount": "別のアカウントを追加",
+    "activeAccount": "使用中のアカウント"
   },
   "storage": {
     "list": {


### PR DESCRIPTION
#1488 Phase 3。**ご依頼の「左下のメニューからアカウントを切り替える」がここで動きます。**

## まず: Phase 2 に穴がありました

Phase 2 は「switch エンドポイント **および置換ではなく追加するログイン経路**」と定義していましたが、**前者しか入っていませんでした**。`add_account` はセッションマネージャに存在するのに、**それを呼ぶルートが1つもなく**、全ログインが `delete_user_sessions` + `create_session`（置換）のままでした。

つまり切り替えはできても、**2つ目のアカウントをセッションに入れる手段が無く**、機能として端から端まで到達不能でした。この上に UI を載せれば「アカウントを追加」が黙って何もしないボタンになります。Phase 2 を「完了」と書いてマージした私のミスです。本 PR で塞ぎます。

## アカウントの追加

どちらの OAuth ログインでも `?add_account=1` を付けると、CSRF state の隣に**追加先のセッション ID** を記録します。コールバックは新規発行ではなく、そのセッションに追加します。

侵入経路にしないための性質が2つ:

- **state の所持は権限ではない。** コールバックは同じセッションを指す Cookie を伴って到達する必要があります。これが無いと、state が漏れた場合に**攻撃者のアカウントを被害者のメニューに差し込め**、被害者がそこへ切り替えてしまえます。
- **拒否時も intent を消費**するので、失敗した試行が再利用可能な鍵を残しません。

対象セッションが死んでいる場合は「置換ログインへフォールバック」ではなく**拒否**します。追加を求めた人が、黙って既存アカウントを失うのはおかしいためです。

**#114 はこの経路でも走ります。** 追加される側ユーザーの*他の*セッションを消すのは #114 の要求どおりで、追加先コンテナには手が届きません（そのコンテナはまだこのユーザーを保持していないため）。Phase 1 のメンバーシップ照合がこれを安全にしています。

## UI

| 判断 | 理由 |
|---|---|
| 行はアカウント2つ以上のときだけ表示 | 1つなら切り替え先が無く、トリガーが既に本人を表示しているので純粋なノイズ |
| 「別のアカウントを追加」は常時表示 | 2つ目はここからしか入らない |
| メニューを開く**たび**に再取得 | 別タブで追加/サインアウトされている可能性。古い一覧はサーバが拒否する切替を提示してしまう |
| 切替失敗時は再取得して**遷移しない** | 遷移すると、このセッションが既に保持していない identity 向けのページに着地する |
| 切替成功時は**ハードナビゲーション** | active workspace はユーザー単位の列で、各プロバイダが per-user データをキャッシュしている。ソフト更新だと**前のアカウントのワークスペースが新しい identity の下に表示される** |
| `/auth/accounts` が 404 なら空のまま | 古いバックエンドでもメニューは従来どおり。degraded であって broken ではない |

## テストについて

判断は `useAccountSwitcher` フックに抽出してそちらでテストしています。**このリポジトリには Radix ドロップダウンを DOM エミュレータ上で開くテストが1件も存在せず**、かつリスクがあるのはドロップダウンではありません。抽出により約1000行の Sidebar をこれ以上太らせずに済みます。`@testing-library/user-event` は依存に無いので追加せず、既存流儀の `fireEvent` に合わせました。

## 検証

| | |
|---|---|
| ruff / format / tsc | clean |
| intent テスト | 9 |
| フックテスト | 8 |
| backend（auth + account） | 386 passed |
| frontend | 114 passed |

frontend の1件失敗（`useSystemFeatures`）は**クリーンな origin/main でも同一に失敗**します。本 PR とは無関係です。

## 残り

Phase 4（サインアウトの意味論: このアカウント / 全アカウント、クライアントキャッシュの掃除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)