### PR TITLE
fix(auth): "add another account" must show Google's account chooser (#1488)

### DIFF
--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -551,7 +551,12 @@ async def google_login(
     if not redirect:
         raise HTTPException(status_code=500, detail="GOOGLE_REDIRECT_URI not configured")
 
-    auth_url = _oauth2_manager.get_authorization_url_web(redirect, state)
+    # #1488: "add another account" must show Google's account chooser. Without
+    # it, a user with one Google session is returned the identity they already
+    # have and the switcher never gains a second account.
+    auth_url = _oauth2_manager.get_authorization_url_web(
+        redirect, state, select_account=add_account
+    )
 
     # Issue #102: Auto-redirect for browser/iOS users
     if return_to:

--- a/backend/src/auth/oauth2.py
+++ b/backend/src/auth/oauth2.py
@@ -5,6 +5,7 @@ import logging
 import os
 from datetime import UTC
 from typing import Any, cast
+from urllib.parse import quote
 
 from cryptography.fernet import Fernet
 from google.auth.transport.requests import Request
@@ -291,12 +292,15 @@ class OAuth2Manager:
     # Web OAuth2 Flow (Issue #650)
     # ========================================================================
 
-    def get_authorization_url_web(self, redirect_uri: str, state: str) -> str:
+    def get_authorization_url_web(
+        self, redirect_uri: str, state: str, select_account: bool = False
+    ) -> str:
         """Get OAuth2 authorization URL for Web flow.
 
         Args:
             redirect_uri: Callback URL (e.g., https://your-domain.com/auth/callback)
             state: CSRF state token
+            select_account: Ask Google to show the account chooser (#1488).
 
         Returns:
             Authorization URL to redirect user to
@@ -316,6 +320,20 @@ class OAuth2Manager:
         scopes = self.WEB_SCOPES[self.provider]
         scope_str = " ".join(scopes)
 
+        # `prompt=consent` alone re-consents with whoever is ALREADY signed in at
+        # Google, with no chooser. For an ordinary login that is what we want.
+        #
+        # For "add another account" (#1488) it is exactly wrong: a user with one
+        # Google session is handed back the identity they already have, the
+        # callback re-adds it idempotently, and the switcher still shows a single
+        # account. From the UI that is indistinguishable from the feature being
+        # broken — which is how it was reported.
+        #
+        # `select_account` is added rather than substituted: dropping `consent`
+        # would stop Google issuing a refresh token, which the manual-refresh
+        # flow (#515) depends on. Google accepts a space-separated list.
+        prompt = quote("select_account consent") if select_account else "consent"
+
         auth_url = (
             f"{oauth_endpoints.google_auth_url()}?"
             f"client_id={client_id}&"
@@ -324,7 +342,7 @@ class OAuth2Manager:
             f"scope={scope_str}&"
             f"state={state}&"
             f"access_type=offline&"
-            f"prompt=consent"
+            f"prompt={prompt}"
         )
 
         return auth_url

--- a/backend/tests/api/test_add_account_intent.py
+++ b/backend/tests/api/test_add_account_intent.py
@@ -250,3 +250,49 @@ class TestTheInvalidationCannotEatTheSessionItIsAddingTo:
         assert refusals, f"{fn_name}: no add_account_failed refusal found"
         invalidate_at = min(c.lineno for c in calls["delete_user_sessions"])
         assert min(refusals) < invalidate_at, fn_name
+
+
+class TestTheAddFlowActuallyOffersAChoice:
+    """#1488: the login leg must ask Google for the account chooser.
+
+    Pinned separately from the callback ordering above because this defect had
+    the same *symptom* as a broken switcher while every mechanism worked: the
+    intent was recorded, the callback honoured it, `add_account` returned True
+    — and the container still held one account, because Google had handed back
+    the identity it already held. Reported as "adding an account does not let
+    me switch".
+    """
+
+    def test_google_login_requests_the_chooser_only_when_adding(self):
+        calls = self._authorization_url_calls()
+        assert calls, "google_login no longer builds an authorization URL"
+        for call in calls:
+            kwargs = {kw.arg for kw in call.keywords}
+            assert "select_account" in kwargs, (
+                "google_login calls get_authorization_url_web without "
+                "select_account; an add-account login will re-consent with the "
+                "identity already signed in and never add a second account."
+            )
+
+    @staticmethod
+    def _authorization_url_calls() -> list[ast.Call]:
+        import inspect
+        import textwrap
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(auth_routes.google_login)))
+        return [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "get_authorization_url_web"
+        ]
+
+    def test_the_chooser_is_tied_to_the_add_account_flag(self):
+        """Not hardcoded True — an ordinary login must keep its single click."""
+        for call in self._authorization_url_calls():
+            for kw in call.keywords:
+                if kw.arg == "select_account":
+                    assert isinstance(kw.value, ast.Name) and kw.value.id == "add_account", (
+                        "select_account must follow the add_account flag, not be a constant"
+                    )

--- a/backend/tests/auth/test_oauth2_coverage.py
+++ b/backend/tests/auth/test_oauth2_coverage.py
@@ -487,6 +487,53 @@ class TestAuthorizationUrlWeb:
         with pytest.raises(ValueError, match="GOOGLE_CLIENT_ID"):
             manager.get_authorization_url_web(redirect_uri="https://x/cb", state="s")
 
+    def test_add_account_asks_google_for_the_account_chooser(
+        self, manager: OAuth2Manager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#1488: without this, "add another account" can never add one.
+
+        `prompt=consent` re-consents with whoever is ALREADY signed in at
+        Google and shows no chooser. A user with a single Google session is
+        therefore handed back the identity they already have; the callback
+        re-adds it idempotently, the container still holds one account, and the
+        switcher has nothing to switch to. Reported as "adding an account does
+        not let me switch" — the flow ran perfectly and produced nothing.
+        """
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+        url = manager.get_authorization_url_web(
+            redirect_uri="https://x/cb", state="s", select_account=True
+        )
+        assert "select_account" in url
+
+    def test_the_chooser_does_not_cost_us_the_refresh_token(
+        self, manager: OAuth2Manager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`consent` is ADDED to, not replaced by, `select_account`.
+
+        Substituting it would stop Google issuing a refresh token, silently
+        breaking the manual-refresh flow (#515) — a regression with no symptom
+        until someone tries to refresh.
+        """
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+        url = manager.get_authorization_url_web(
+            redirect_uri="https://x/cb", state="s", select_account=True
+        )
+        assert "consent" in url
+        assert "access_type=offline" in url
+
+    def test_an_ordinary_login_still_gets_no_chooser(
+        self, manager: OAuth2Manager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only the add-account flow opts in.
+
+        Showing the chooser on every sign-in would make the common case — one
+        account, one click — worse for everyone.
+        """
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+        url = manager.get_authorization_url_web(redirect_uri="https://x/cb", state="s")
+        assert "select_account" not in url
+        assert "prompt=consent" in url
+
     def test_consumes_endpoint_override(
         self, manager: OAuth2Manager, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
Follow-up to #1493, from the user testing it on production: *"I added an
account but switching doesn't work."*

## What was wrong

Nothing failed. `GET /api/v1/auth/accounts` returned exactly one account after
the add flow completed, so the switcher — which only renders rows when the
session holds more than one — stayed hidden. The feature looked broken while
every mechanism worked correctly.

The login leg sent `prompt=consent`. That re-consents with whoever is **already
signed in at Google** and shows no account chooser, so a user with a single
Google session is handed back the identity they already have. The callback then
does exactly what it should: `add_account` re-adds it idempotently, refreshing
the existing entry. One account in, one account out.

## The fix

The add-account flow now sends `prompt=select_account consent`.

Two things it deliberately does not do:

- **It does not replace `consent`.** Dropping it stops Google issuing a refresh
  token, which the manual-refresh flow (#515) depends on — a regression with no
  symptom until someone tries to refresh. Google accepts a space-separated list.
- **It does not apply to ordinary logins.** Showing a chooser on every sign-in
  would make the common one-account case worse for everyone. `select_account`
  follows the `add_account` flag, and a test pins that it is not a constant.

## GitHub

Unchanged, and worth stating plainly: GitHub's OAuth has no chooser parameter.
Adding a second GitHub account requires switching accounts at GitHub first.
Nothing here can paper over that.

## Verification

| Gate | Result |
|---|---|
| backend pytest (auth surface) | 457 passed |
| ruff | clean |
| pyright | 0 errors |

The wiring pin is verified by mutation: removing `select_account=add_account`
from `google_login` fails `test_google_login_requests_the_chooser_only_when_adding`.

Still not verified in a real browser with two accounts — that needs a second
sign-in I cannot perform. This fix makes the chooser appear; whether the rest of
the flow then behaves is the thing to watch on the next manual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
