### PR TITLE
fix(api): merge_contexts left unembedded memories behind, then deleted them (#1497)

### DIFF
--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1046,11 +1046,17 @@ async def copy_context_points(
     memory_id_mapping: dict[str, str],
     collection_name: str = KAGURA_MEMORIES_COLLECTION,
     batch_size: int = 100,
-) -> int:
+) -> set[str]:
     """Copy Qdrant points from source context to target context (Issue #90).
 
     Retrieves points by ID, creates new points with updated context_id and new IDs.
     Processes in batches for memory efficiency.
+
+    #1497: returns the NEW ids actually upserted, not a count. Two branches here
+    skip a memory silently — a source point that does not exist, and one stored
+    without a vector — and a bare count cannot say WHICH. The caller needs that
+    to avoid marking a target row ``success`` when nothing was copied for it,
+    which would manufacture a row no automatic path can ever repair.
 
     Args:
         workspace_id: Workspace ID
@@ -1061,7 +1067,9 @@ async def copy_context_points(
         batch_size: Points per batch
 
     Returns:
-        Number of points copied
+        The set of new memory ids whose vector was upserted. A caller comparing
+        this against ``memory_id_mapping.values()`` learns exactly which rows
+        have no vector in the target.
 
     Raises:
         QdrantError: If copy fails
@@ -1072,7 +1080,7 @@ async def copy_context_points(
         )
 
     client = get_qdrant_client()
-    copied = 0
+    upserted: set[str] = set()
 
     try:
         old_ids = list(memory_id_mapping.keys())
@@ -1124,13 +1132,13 @@ async def copy_context_points(
                     collection_name=collection_name,
                     points=new_points,
                 )
-                copied += len(new_points)
+                upserted.update(str(p.id) for p in new_points)
 
             logger.debug(
                 "context_points_copy_batch",
                 batch=i // batch_size + 1,
                 copied_in_batch=len(new_points),
-                total_copied=copied,
+                total_copied=len(upserted),
             )
 
         logger.info(
@@ -1139,10 +1147,10 @@ async def copy_context_points(
             workspace_id=workspace_id,
             source_context_id=source_context_id,
             target_context_id=target_context_id,
-            count=copied,
+            count=len(upserted),
         )
 
-        return copied
+        return upserted
 
     except Exception as e:
         logger.error(

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -870,6 +870,14 @@ class ContextService:
                 "Source context is locked. Unlock it first via update_context(is_locked=false)."
             )
 
+        # #1497: delete_context refuses a default context — but it is called AFTER
+        # the rows and vectors have been copied, so the merge half-completed and
+        # then raised. Check it up front, with the other pre-flights.
+        if delete_source and source.is_default:
+            raise ValidationError(
+                "Cannot delete the default context. Merge with delete_source=false."
+            )
+
         # Validate same embedding model (single query for both configs)
         settings = get_settings()
         cfg_result = await self.db.execute(
@@ -893,32 +901,41 @@ class ContextService:
                 "Only same-model merge is supported."
             )
 
-        # Fetch source memories (non-deleted, with successful embeddings)
+        # #1497: EVERY live memory moves, not only the embedded ones.
+        #
+        # This used to filter on ``embedding_status == "success"`` and then, with
+        # delete_source=True, soft-delete the source anyway — so a pending or
+        # failed memory was neither copied nor kept. It stayed parented to a
+        # context the user had just removed, and the caller was told how many
+        # were "merged" without being told what was left behind.
+        #
+        # The filter did protect something real: the Qdrant copy needs a vector,
+        # and a non-success row has no point. But that is a reason to copy the
+        # row WITHOUT a vector, not to discard it. #1496 established that
+        # ``failed`` is a recoverable state — the sweep re-embeds those rows once
+        # a credential exists — so discarding them throws away data that would
+        # have come back on its own.
         result = await self.db.execute(
             select(Memory).where(
                 Memory.context_id == source_context_id,
                 Memory.deleted_at.is_(None),
-                Memory.embedding_status == "success",
             )
         )
         source_memories = result.scalars().all()
 
-        if not source_memories:
-            # Still honor delete_source even if no memories to copy
-            if delete_source:
-                await self.delete_context(user_id, source_context_id)
-            return {
-                "merged": 0,
-                "source_id": str(source_context_id),
-                "target_id": str(target_context_id),
-            }
-
-        # Build ID mapping and copy memories in PostgreSQL
+        # Build ID mapping and copy memories in PostgreSQL.
+        #
+        # #1497: only rows that HAVE a vector go into the mapping — that dict is
+        # what drives the Qdrant copy, and asking it to fetch a point that was
+        # never written just logs a skip.
         memory_id_mapping: dict[str, str] = {}
+        rows_by_new_id: dict[str, Memory] = {}
 
         for mem in source_memories:
             new_id = uuid4()
-            memory_id_mapping[str(mem.id)] = str(new_id)
+            embedded = mem.embedding_status == "success"
+            if embedded:
+                memory_id_mapping[str(mem.id)] = str(new_id)
 
             # Normalize nested context JSON to reference target context
             ctx_json = mem.context
@@ -945,31 +962,86 @@ class ContextService:
                 scope=mem.scope,
                 long_term=mem.long_term,
                 promoted_at=mem.promoted_at,
+                # The usage-stat cluster resets as one group: this is a NEW
+                # memory in a new context, with no history of its own. Splitting
+                # it (carrying reference_count while zeroing access_count) would
+                # break the access_count >= reference_count invariant documented
+                # on the model.
                 access_count=0,
+                reference_count=0,
                 client=mem.client,
                 client_version=mem.client_version,
                 source=mem.source,
-                embedding_status="success",
+                # #1497: provenance must survive the copy. source_type defaults
+                # to "manual", and a row that arrived from a connector is
+                # EXCLUDED from the pinned/bootstrap lane precisely because it is
+                # not manual (repositories/memory.py, OWASP LLM01/LLM03). Letting
+                # the default apply would silently promote connector content into
+                # a lane that exists to keep it out — and merging into a trusted
+                # context clears the other half of that gate at the same moment.
+                source_type=mem.source_type,
+                source_uri=mem.source_uri,
+                delivery_mode=mem.delivery_mode,
+                # #1497: a row with no vector is copied as `pending` so the #1496
+                # sweep embeds it into its NEW home — process_pending_embedding
+                # resolves the collection from context_id, so the copy lands in
+                # the target's collection.
+                #
+                # `pending` rather than the source's own status, deliberately: a
+                # failed row may have exhausted its retry budget, and copying
+                # that verbatim would produce a memory born terminal that nothing
+                # ever retries. A new row in a new context is a new episode,
+                # which is what the budget already means elsewhere.
+                embedding_status="success" if embedded else "pending",
+                embedding_retry_count=0,
+                embedding_error=None,
                 created_at=mem.created_at,
                 updated_at=utcnow(),
             )
             self.db.add(new_mem)
+            rows_by_new_id[str(new_id)] = new_mem
 
         await self.db.flush()
 
-        # Copy Qdrant points — rollback PG on failure for consistency
-        collection = get_collection_name(src_model, src_dims)
-        try:
-            copied = await copy_context_points(
-                workspace_id=str(source.workspace_id),
-                source_context_id=str(source_context_id),
-                target_context_id=str(target_context_id),
-                memory_id_mapping=memory_id_mapping,
-                collection_name=collection,
-            )
-        except Exception:
+        # Copy Qdrant points — rollback PG on failure for consistency.
+        # Guarded: with no embedded source rows there is nothing to fetch, and
+        # skipping the call also keeps this path working on backends that do not
+        # implement it.
+        upserted: set[str] = set()
+        if memory_id_mapping:
+            collection = get_collection_name(src_model, src_dims)
+            try:
+                upserted = await copy_context_points(
+                    workspace_id=str(source.workspace_id),
+                    source_context_id=str(source_context_id),
+                    target_context_id=str(target_context_id),
+                    memory_id_mapping=memory_id_mapping,
+                    collection_name=collection,
+                )
+            except Exception:
+                await self.db.rollback()
+                raise
+
+        # #1497: a row we intended to mark `success` but whose vector did not
+        # actually land must not claim to be embedded. Without this it would be
+        # a brand-new memory that is invisible to search and that no automatic
+        # path can repair, since the sweep only ever claims pending/processing/
+        # failed — exactly the #1496 shape, manufactured by the merge itself.
+        unvectored = 0
+        for new_id in memory_id_mapping.values():
+            if new_id not in upserted:
+                rows_by_new_id[new_id].embedding_status = "pending"
+                unvectored += 1
+
+        # #1497: never remove the source unless every row reached the target.
+        # True by construction above, so this is an assertion rather than a
+        # branch — which is the point: if someone narrows the selection again,
+        # the merge refuses to delete instead of quietly resurrecting this bug.
+        if delete_source and len(rows_by_new_id) != len(source_memories):
             await self.db.rollback()
-            raise
+            raise ValidationError(
+                "Merge did not transfer every memory; refusing to delete the source context."
+            )
 
         # Optional: delete source (_commit=False for atomic transaction)
         if delete_source:
@@ -977,16 +1049,29 @@ class ContextService:
 
         await self.db.commit()
 
+        # `merged` counts ROWS transferred, which is what the caller can see in
+        # the context's memory count. It used to count Qdrant points, so a
+        # source full of unembedded memories reported 0 while the UI had just
+        # shown their real number.
+        merged = len(rows_by_new_id)
+        pending = merged - len(upserted)
+
         logger.info(
             "contexts_merged",
             source_context_id=str(source_context_id),
             target_context_id=str(target_context_id),
-            merged=copied,
+            merged=merged,
+            pending_embedding=pending,
+            unvectored=unvectored,
             delete_source=delete_source,
         )
 
         return {
-            "merged": copied,
+            "merged": merged,
+            # #1497: name what is not searchable YET rather than leaving the
+            # caller to infer it. These rows transferred; only their index is
+            # deferred, and the sweep builds it in the new context.
+            "pending_embedding": pending,
             "source_id": str(source_context_id),
             "target_id": str(target_context_id),
         }

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -1033,15 +1033,30 @@ class ContextService:
                 rows_by_new_id[new_id].embedding_status = "pending"
                 unvectored += 1
 
-        # #1497: never remove the source unless every row reached the target.
-        # True by construction above, so this is an assertion rather than a
-        # branch — which is the point: if someone narrows the selection again,
-        # the merge refuses to delete instead of quietly resurrecting this bug.
-        if delete_source and len(rows_by_new_id) != len(source_memories):
-            await self.db.rollback()
-            raise ValidationError(
-                "Merge did not transfer every memory; refusing to delete the source context."
+        # #1497: never remove the source unless every LIVE row reached the target.
+        #
+        # Counted independently, straight from the table — NOT against
+        # `source_memories`. Comparing the copy to the selection that produced it
+        # is a tautology: narrow the SELECT and both sides shrink together, so
+        # the guard passes while rows are left behind. That is exactly the
+        # regression it exists to stop, and the first version of this check made
+        # exactly that mistake (caught in review on #1499).
+        if delete_source:
+            live_result = await self.db.execute(
+                select(func.count())
+                .select_from(Memory)
+                .where(
+                    Memory.context_id == source_context_id,
+                    Memory.deleted_at.is_(None),
+                )
             )
+            live_rows = live_result.scalar_one()
+            if live_rows != len(rows_by_new_id):
+                await self.db.rollback()
+                raise ValidationError(
+                    f"Merge transferred {len(rows_by_new_id)} of {live_rows} memories; "
+                    "refusing to delete the source context."
+                )
 
         # Optional: delete source (_commit=False for atomic transaction)
         if delete_source:

--- a/backend/tests/db/test_qdrant_coverage.py
+++ b/backend/tests/db/test_qdrant_coverage.py
@@ -761,7 +761,8 @@ class TestCopyContextPoints:
             )
         ]
         copied = await copy_context_points(WS, "src-ctx", "tgt-ctx", mapping)
-        assert copied == 1
+        # #1497: the ids that actually landed, not a count.
+        assert copied == {"new1"}
         new_point = mock_client.upsert.await_args.kwargs["points"][0]
         assert new_point.id == "new1"
         assert new_point.payload["context_id"] == "tgt-ctx"
@@ -771,7 +772,7 @@ class TestCopyContextPoints:
         """Retrieve returning [] yields zero copied, no upsert."""
         mock_client.retrieve.return_value = []
         copied = await copy_context_points(WS, "s", "t", {"old1": "new1"})
-        assert copied == 0
+        assert copied == set()
         mock_client.upsert.assert_not_awaited()
 
     async def test_skips_point_not_in_mapping_and_without_vector(self, mock_client):
@@ -782,7 +783,7 @@ class TestCopyContextPoints:
             SimpleNamespace(id="old1", vector=None, payload={}),
         ]
         copied = await copy_context_points(WS, "s", "t", mapping)
-        assert copied == 0
+        assert copied == set()
         mock_client.upsert.assert_not_awaited()
 
     async def test_batching_two_batches(self, mock_client):
@@ -794,7 +795,7 @@ class TestCopyContextPoints:
 
         mock_client.retrieve.side_effect = fake_retrieve
         copied = await copy_context_points(WS, "s", "t", mapping, batch_size=2)
-        assert copied == 3
+        assert len(copied) == 3
         assert mock_client.retrieve.await_count == 2
 
     async def test_copy_failure_wrapped(self, mock_client):

--- a/backend/tests/services/test_context_merge_use_count.py
+++ b/backend/tests/services/test_context_merge_use_count.py
@@ -135,7 +135,7 @@ async def test_merge_contexts_copies_memory_without_dropped_use_count():
 # ---------------------------------------------------------------------------
 
 
-def _merge_harness(memories, *, upsert=None):
+def _merge_harness(memories, *, upsert=None, live_count=None):
     """Drive the real copy loop over `memories`. Returns (result, added_rows)."""
     user_id = "user-merge"
     source_id = uuid4()
@@ -156,16 +156,22 @@ def _merge_harness(memories, *, upsert=None):
     mem_result.scalars.return_value.all.return_value = [
         m(user_id, source_id) if callable(m) else m for m in memories
     ]
-    mock_db.execute.side_effect = [cfg_result, mem_result]
+    # #1497: with delete_source the guard issues a third statement — an
+    # independent count of live rows still in the source.
+    live_result = MagicMock()
+    live_result.scalar_one.return_value = (
+        live_count if live_count is not None else len(mem_result.scalars.return_value.all())
+    )
+    mock_db.execute.side_effect = [cfg_result, mem_result, live_result]
     mock_db.add = MagicMock()
 
     service = ContextService(mock_db)
     return service, mock_db, source_ctx, target_ctx, source_id, target_id, user_id
 
 
-async def _run_merge(memories, *, upsert=None, delete_source=False):
+async def _run_merge(memories, *, upsert=None, delete_source=False, live_count=None):
     (service, mock_db, source_ctx, target_ctx, source_id, target_id, user_id) = _merge_harness(
-        memories
+        memories, live_count=live_count
     )
     delete_called = AsyncMock()
     with (
@@ -335,3 +341,48 @@ async def test_the_selection_does_not_filter_on_embedding_status():
     assert "context_id" in where and "deleted_at" in where, (
         "the selection lost its context/liveness scoping"
     )
+
+
+@pytest.mark.asyncio
+async def test_the_delete_guard_counts_live_rows_independently():
+    """The guard must not measure the copy against its own selection.
+
+    Reviewed finding on #1499: the first version compared
+    `len(rows_by_new_id) != len(source_memories)`. Narrow the SELECT and both
+    sides shrink together, so it passes while rows are left behind — a
+    tautology dressed as a safety check, guarding against precisely the
+    regression it could not see.
+
+    Here the source holds 16 live rows but only 1 was selected. The merge must
+    refuse to delete.
+    """
+    from utils.exceptions import ValidationError
+
+    with pytest.raises(ValidationError, match="refusing to delete"):
+        await _run_merge([_source_memory], delete_source=True, live_count=16)
+
+
+@pytest.mark.asyncio
+async def test_a_complete_transfer_still_deletes_the_source():
+    """The guard must not become a blanket refusal — delete_source has to keep
+    working for the case it was designed for."""
+    _, rows, delete_called, _ = await _run_merge(
+        [_source_memory, _source_memory], delete_source=True, live_count=2
+    )
+    assert len(rows) == 2
+    delete_called.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_an_unembedded_row_counts_as_transferred():
+    """A row copied as `pending` HAS moved; only its index is deferred.
+
+    Gating on vectors instead of rows would refuse deletes for merges that lost
+    nothing at all.
+    """
+    _, _, delete_called, _ = await _run_merge(
+        [lambda u, c: _source_memory(u, c, embedding_status="failed")],
+        delete_source=True,
+        live_count=1,
+    )
+    delete_called.assert_awaited_once()

--- a/backend/tests/services/test_context_merge_use_count.py
+++ b/backend/tests/services/test_context_merge_use_count.py
@@ -25,7 +25,15 @@ from services.context_service import ContextService
 from utils.datetime import utcnow
 
 
-def _source_memory(user_id: str, source_context_id) -> Memory:
+def _source_memory(
+    user_id: str,
+    source_context_id,
+    *,
+    embedding_status: str = "success",
+    embedding_retry_count: int = 0,
+    source_type: str = "manual",
+    delivery_mode: str = "on_recall",
+) -> Memory:
     """A real (transient) Memory the copy loop will read its fields from."""
     return Memory(
         id=uuid4(),
@@ -47,9 +55,23 @@ def _source_memory(user_id: str, source_context_id) -> Memory:
         client="test",
         client_version="1",
         source="manual",
+        source_type=source_type,
+        source_uri="connector://slack/C123",
+        delivery_mode=delivery_mode,
         created_at=utcnow(),
-        embedding_status="success",
+        embedding_status=embedding_status,
+        embedding_retry_count=embedding_retry_count,
     )
+
+
+async def _upsert_all(**kwargs) -> set[str]:
+    """Stand-in for Qdrant: every requested point lands."""
+    return set(kwargs["memory_id_mapping"].values())
+
+
+async def _upsert_none(**kwargs) -> set[str]:
+    """Stand-in for Qdrant losing the write — nothing lands."""
+    return set()
 
 
 @pytest.mark.asyncio
@@ -79,7 +101,7 @@ async def test_merge_contexts_copies_memory_without_dropped_use_count():
             service, "get_context", new_callable=AsyncMock, side_effect=[source_ctx, target_ctx]
         ),
         patch("services.permission_service.PermissionService") as PermSvc,
-        patch("db.qdrant.copy_context_points", new_callable=AsyncMock, return_value=1),
+        patch("db.qdrant.copy_context_points", new_callable=AsyncMock, side_effect=_upsert_all),
         patch("db.qdrant.get_collection_name", return_value="collection"),
     ):
         PermSvc.return_value.check_context_owner = AsyncMock()
@@ -94,3 +116,222 @@ async def test_merge_contexts_copies_memory_without_dropped_use_count():
     assert new_mem.context_id == target_id
     assert new_mem.access_count == 0
     assert not hasattr(new_mem, "use_count")
+
+
+# ---------------------------------------------------------------------------
+# #1497: a merge must not lose the memories it declines to index.
+#
+# merge_contexts selected only `embedding_status == "success"` rows, copied
+# those, and then — with delete_source=True — soft-deleted the source anyway.
+# Anything pending or failed was neither copied nor kept: it stayed parented to
+# a context the user had just removed, and the caller was told a "merged" count
+# that silently omitted it.
+#
+# Live, not theoretical. The deployment in #1496 had a context with 0 successful
+# and 16 failed memories; merging it would have copied nothing, reported 0, and
+# deleted the context holding all 16. #1496 established that `failed` is
+# RECOVERABLE — the sweep re-embeds those rows once a credential exists — so
+# discarding them threw away data that was coming back on its own.
+# ---------------------------------------------------------------------------
+
+
+def _merge_harness(memories, *, upsert=None):
+    """Drive the real copy loop over `memories`. Returns (result, added_rows)."""
+    user_id = "user-merge"
+    source_id = uuid4()
+    target_id = uuid4()
+    workspace_id = uuid4()
+
+    source_ctx = MagicMock(
+        id=source_id, workspace_id=workspace_id, is_locked=False, is_default=False
+    )
+    target_ctx = MagicMock(
+        id=target_id, workspace_id=workspace_id, is_locked=False, is_default=False
+    )
+
+    mock_db = AsyncMock()
+    cfg_result = MagicMock()
+    cfg_result.scalars.return_value.all.return_value = []
+    mem_result = MagicMock()
+    mem_result.scalars.return_value.all.return_value = [
+        m(user_id, source_id) if callable(m) else m for m in memories
+    ]
+    mock_db.execute.side_effect = [cfg_result, mem_result]
+    mock_db.add = MagicMock()
+
+    service = ContextService(mock_db)
+    return service, mock_db, source_ctx, target_ctx, source_id, target_id, user_id
+
+
+async def _run_merge(memories, *, upsert=None, delete_source=False):
+    (service, mock_db, source_ctx, target_ctx, source_id, target_id, user_id) = _merge_harness(
+        memories
+    )
+    delete_called = AsyncMock()
+    with (
+        patch.object(
+            service, "get_context", new_callable=AsyncMock, side_effect=[source_ctx, target_ctx]
+        ),
+        patch("services.permission_service.PermissionService") as PermSvc,
+        patch(
+            "db.qdrant.copy_context_points",
+            new_callable=AsyncMock,
+            side_effect=upsert or _upsert_all,
+        ),
+        patch("db.qdrant.get_collection_name", return_value="collection"),
+        patch.object(service, "delete_context", delete_called),
+    ):
+        PermSvc.return_value.check_context_owner = AsyncMock()
+        result = await service.merge_contexts(
+            user_id, source_id, target_id, delete_source=delete_source
+        )
+    rows = [c.args[0] for c in mock_db.add.call_args_list]
+    return result, rows, delete_called, target_id
+
+
+@pytest.mark.asyncio
+async def test_a_failed_memory_is_carried_over_not_dropped():
+    """The bug, at its smallest."""
+    result, rows, _, target_id = await _run_merge(
+        [lambda u, c: _source_memory(u, c, embedding_status="failed")]
+    )
+    assert len(rows) == 1, "the failed memory was not copied — it would be lost"
+    assert rows[0].context_id == target_id
+    assert result["merged"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_source_of_only_failed_memories_still_transfers():
+    """The worst case, and the one production was actually in.
+
+    This used to hit an early return that copied nothing and honoured
+    delete_source anyway.
+    """
+    result, rows, delete_called, _ = await _run_merge(
+        [(lambda u, c: _source_memory(u, c, embedding_status="failed")) for _ in range(16)],
+        delete_source=True,
+    )
+    assert len(rows) == 16
+    assert result["merged"] == 16
+    delete_called.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_an_unembedded_copy_lands_as_pending_so_the_sweep_finds_it():
+    """Carrying the source status verbatim would be worse than useless.
+
+    A failed row that exhausted its retry budget, copied as-is, would be born
+    terminal — the #1496 sweep only claims rows below MAX_EMBEDDING_RETRIES.
+    A new row in a new context is a new failure episode.
+    """
+    _, rows, _, _ = await _run_merge(
+        [lambda u, c: _source_memory(u, c, embedding_status="failed", embedding_retry_count=3)]
+    )
+    assert rows[0].embedding_status == "pending"
+    assert rows[0].embedding_retry_count == 0
+    assert rows[0].embedding_error is None
+
+
+@pytest.mark.asyncio
+async def test_provenance_survives_the_copy():
+    """source_type defaults to "manual", and "manual" is TRUSTED.
+
+    A connector-origin row is excluded from the pinned/bootstrap lane precisely
+    because it is not manual (OWASP LLM01/LLM03). Letting the column default
+    apply would promote connector content into a lane built to keep it out —
+    and merging into a trusted context clears the other half of that gate at the
+    same moment.
+    """
+    _, rows, _, _ = await _run_merge([lambda u, c: _source_memory(u, c, source_type="connector")])
+    assert rows[0].source_type == "connector", (
+        "connector provenance was lost; the copy is now trusted content"
+    )
+    assert rows[0].source_uri == "connector://slack/C123"
+
+
+@pytest.mark.asyncio
+async def test_delivery_mode_survives_the_copy():
+    """An always-delivered memory must not quietly become on-recall."""
+    _, rows, _, _ = await _run_merge([lambda u, c: _source_memory(u, c, delivery_mode="always")])
+    assert rows[0].delivery_mode == "always"
+
+
+@pytest.mark.asyncio
+async def test_a_row_whose_vector_did_not_land_is_not_marked_success():
+    """Otherwise the merge manufactures a fresh #1496.
+
+    A row claiming `success` with no vector is invisible to search AND invisible
+    to the sweep, which only ever claims pending/processing/failed. Nothing
+    would ever repair it.
+    """
+    _, rows, _, _ = await _run_merge(
+        [lambda u, c: _source_memory(u, c, embedding_status="success")],
+        upsert=_upsert_none,
+    )
+    assert rows[0].embedding_status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_the_count_names_what_is_not_searchable_yet():
+    """`merged` used to count Qdrant points, so a source full of unembedded
+    memories reported 0 while the UI had just shown their real number."""
+    result, _, _, _ = await _run_merge(
+        [
+            lambda u, c: _source_memory(u, c, embedding_status="success"),
+            lambda u, c: _source_memory(u, c, embedding_status="failed"),
+        ]
+    )
+    assert result["merged"] == 2
+    assert result["pending_embedding"] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_usage_stats_reset_as_one_group():
+    """access_count >= reference_count is a documented invariant; resetting one
+    while carrying the other would violate it."""
+    _, rows, _, _ = await _run_merge([_source_memory])
+    assert rows[0].access_count == 0
+    assert rows[0].reference_count == 0
+
+
+@pytest.mark.asyncio
+async def test_the_selection_does_not_filter_on_embedding_status():
+    """The bug itself, which every test above is blind to.
+
+    Those tests hand the copy loop a list of memories through a mocked
+    `db.execute`, so the WHERE clause never runs — restoring the original
+    `embedding_status == "success"` predicate leaves all of them green while
+    the data loss is fully back. Verified by mutation, which is how this gap
+    was found.
+
+    So assert on the SQL actually emitted: the source-memory query must scope by
+    context and liveness, and must NOT mention embedding_status.
+    """
+    (service, mock_db, source_ctx, target_ctx, source_id, target_id, user_id) = _merge_harness(
+        [_source_memory]
+    )
+    with (
+        patch.object(
+            service, "get_context", new_callable=AsyncMock, side_effect=[source_ctx, target_ctx]
+        ),
+        patch("services.permission_service.PermissionService") as PermSvc,
+        patch("db.qdrant.copy_context_points", new_callable=AsyncMock, side_effect=_upsert_all),
+        patch("db.qdrant.get_collection_name", return_value="collection"),
+    ):
+        PermSvc.return_value.check_context_owner = AsyncMock()
+        await service.merge_contexts(user_id, source_id, target_id)
+
+    # execute() call 2 is the source-memory query (1 is the embedding config).
+    # Only the WHERE clause matters — embedding_status appears in the SELECT
+    # column list either way, since the copy loop reads it.
+    sql = str(mock_db.execute.await_args_list[1].args[0])
+    where = sql.split("WHERE", 1)[1] if "WHERE" in sql else ""
+    assert where, "the source-memory query has no WHERE clause at all"
+    assert "embedding_status" not in where, (
+        "merge_contexts is selecting source memories by embedding_status again; "
+        "unembedded memories will be left behind when the source is deleted "
+        "(#1497)"
+    )
+    assert "context_id" in where and "deleted_at" in where, (
+        "the selection lost its context/liveness scoping"
+    )


### PR DESCRIPTION
Closes #1497. Found while designing #1496 — filed separately because that issue
was about memories being *invisible*, and this one is about *losing* them.

## The bug

`merge_contexts` selected only `embedding_status == "success"` rows, copied
those into the target, and then — with `delete_source=True` — soft-deleted the
source anyway. Anything `pending` or `failed` was neither copied nor kept. A
separate early-return path honoured `delete_source` having copied nothing at
all.

**Live, not theoretical.** The production deployment in #1496 has:

| context | success | failed |
|---|---|---|
| `kagura-desk` | 269 | 383 |
| `wemof-trading` | **0** | **16** |

Merging `wemof-trading` would have copied nothing, reported `merged: 0`, and
deleted the context holding all 16 — against a UI that had just displayed 16.
And #1496 established that `failed` is **recoverable**: the sweep re-embeds
those rows as soon as a credential exists. This was discarding data that was
coming back on its own.

## Why widening the filter would have been worse than the bug

`copy_context_points` needs a vector, and an unembedded row has no Qdrant point,
so the filter was protecting something real. But it protected the *vector* copy;
it never justified excluding the *row*.

The trap: the copy loop hardcoded `embedding_status="success"` on every new row.
Widening the `WHERE` alone would have minted rows claiming to be embedded with
no vector — invisible to search **and** to the sweep, which only claims
pending/processing/failed. Nothing would ever have repaired them. That is a
fresh #1496, manufactured by the merge. The two changes only make sense
together.

## Changes

- Every live row is selected. Unembedded ones copy as `pending` with a fresh
  retry budget, so the #1496 sweep embeds them into their **new** home
  (`process_pending_embedding` resolves the collection from `context_id`).
  `pending` rather than the source's status verbatim — a row that had exhausted
  its budget would otherwise be born terminal and never retried.
- `copy_context_points` returns the ids it upserted instead of a count, and any
  row whose vector did not land is downgraded to `pending` rather than left
  claiming success.
- `merged` counts **rows transferred**. It used to count Qdrant points.
  `pending_embedding` names what is not searchable yet.
- `delete_source` is gated on every row having transferred.
- `is_default` is pre-checked beside `is_locked` — `delete_context` refuses a
  default context, but only *after* rows and vectors were copied, so the merge
  half-completed and then raised.

### Provenance columns the copy was dropping

`source_type` is the serious one. It defaults to `"manual"`, and connector-origin
rows are excluded from the pinned/bootstrap lane precisely because they are not
manual (OWASP LLM01/LLM03, `repositories/memory.py`). A merge promoted connector
content into a lane built to keep it out — and merging into a `trusted` context
cleared the other half of that gate at the same moment. `source_uri` and
`delivery_mode` were dropped alongside it.

`reference_count` is now reset explicitly next to `access_count`; carrying one
while zeroing the other breaks the documented `access_count >= reference_count`
invariant.

## On the tests

**The first version of this regression suite did not catch the bug.** The
harness mocks `db.execute`, so the WHERE clause never runs — restoring the
original `success`-only filter left all nine tests green while the data loss was
fully back. Found by mutation testing, fixed by asserting on the emitted SQL.

Mutation-verified: the selection filter, `source_type` preservation, the
unvectored downgrade, and the copy-loop field set each fail a specific test when
reverted.

**Correction (91b121b4).** An earlier revision of this PR claimed the
`delete_source` gate protected against a future re-narrowing of the selection,
and that it could not be tested. Both were wrong: it compared the copy against
that same selection, so narrowing shrank both sides and the guard passed while
rows were left behind. It now counts live rows independently from the table, and
that version *is* testable — three tests cover it, one mutation-verified against
the old comparison. Caught in review.

## Not addressed here

The frontend merge dialog and its copy. This PR makes the API safe; whether the
UI should warn about deferred indexing is a separate question, and I did not
want to hold the data-loss fix behind it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)