### PR TITLE
feat(mcp): surface persistence expectations for scope=working writes (#1505)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -97,8 +97,21 @@ async def remember(
         {
             "status": "success",
             "memory_id": "uuid",
-            "scope": "working"
+            "scope": "working",
+            "persistence": {
+                "scope": "working",
+                "committed": true,
+                "promotes_via": "sleep_consolidation",
+                "consolidation_archive_min_age_days": 30,
+                "detail": "..."
+            }
         }
+
+    The memory is committed before this returns; ``scope`` selects the
+    consolidation lifecycle, not whether it was stored. ``persistence``
+    describes that lifecycle for this deployment and is null when the scope
+    cannot be classified. Its age floor is scoped to consolidation and is not a
+    retention guarantee — see ``services.persistence``.
 
     Example:
         POST /api/v1/memory/remember

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -141,9 +141,26 @@ Multi-context management (personal/work/contexts in one collection):
 
 The more semantic metadata you provide, the better the search relevance.
 
+DURABILITY — what scope="working" means:
+A new memory is committed to the database BEFORE this call returns. It is saved;
+you do not need to re-write it or wait for anything. `scope` selects which
+consolidation lifecycle the memory is on, NOT whether it was stored:
+• "working" (the default for a normal write) — a nightly consolidation pass can
+  promote it to "persistent"; `persistence.promotes_via` names the pass this
+  server actually runs (null if none is enabled). That pass will not archive a
+  working memory before `persistence.consolidation_archive_min_age_days` old,
+  and only if it has never been adopted.
+• "persistent" — outside consolidation's reach. delivery_mode="always" pins
+  straight here on write; that is a delivery guarantee, not a stronger
+  durability guarantee than a working-scope write already has.
+That age floor is scoped to consolidation and is NOT a retention SLA: separate
+near-duplicate merge maintenance can retire a memory at any age (its tags and
+edges move to the memory it merged into), and forget() removes one on demand.
+The response carries a `persistence` block for the scope you actually got back.
+
 IMPORTANT: Always specify context_id to ensure you're using the intended context. Use list_contexts() to discover available context IDs.
 
-Returns: {status, memory_id, scope, context_id, context_name, context_display_name, context_is_private, context_is_locked}. NOTE: the embedding is generated asynchronously AFTER this returns, so the new memory is not findable via recall() for a brief moment.""",
+Returns: {status, memory_id, scope, persistence?: {scope, committed, promotes_via, consolidation_archive_min_age_days, detail}, context_id, context_name, context_display_name, context_is_private, context_is_locked}. persistence is omitted (absent, never null) if the server cannot classify the scope. NOTE: the embedding is generated asynchronously AFTER this returns, so the new memory is not findable via recall() for a brief moment.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["summary", "content", "type", "context_id"],
@@ -241,7 +258,7 @@ IMPORTANT: Always specify context_id.
 
 Modes (supply exactly ONE): in-place edit by memory_id, OR upsert by external_id (found → update in place, not-found → create). Upsert additionally requires summary, content, and type.
 
-Returns: {status, memory_id, operation: "updated"|"created"|"replaced", re_embedded, scope, context_id, context_name, context_display_name, context_is_private, context_is_locked}. operation tells you which path ran; re_embedded is true only when summary/context_summary/content changed.""",
+Returns: {status, memory_id, operation: "updated"|"created"|"replaced", re_embedded, scope, persistence?: {scope, committed, promotes_via, consolidation_archive_min_age_days, detail}, context_id, context_name, context_display_name, context_is_private, context_is_locked}. operation tells you which path ran; re_embedded is true only when summary/context_summary/content changed. persistence states what scope means for durability (omitted, never null, if the scope cannot be classified) — the write is committed before this returns either way; see the remember() description for the full lifecycle.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["context_id"],

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -173,6 +173,22 @@ def _context_response_fields(context: Any) -> dict[str, Any]:
     }
 
 
+def _persistence_response_field(persistence: Any) -> dict[str, Any]:
+    """Render the Issue #1505 durability block for a write-tool response.
+
+    Args:
+        persistence: ``PersistenceInfo`` from the service response, or None.
+
+    Returns:
+        ``{"persistence": {...}}``, or an empty dict when the service could not
+        classify the scope — the block is advisory, so it is omitted rather than
+        emitted as a null the caller would have to special-case.
+    """
+    if persistence is None:
+        return {}
+    return {"persistence": persistence.model_dump()}
+
+
 # ============================================================================
 # Context resolution
 # ============================================================================

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -18,6 +18,7 @@ from mcp_server.tools._helpers import (
     _error_response,
     _format_validation_error,
     _log_tool_usage,
+    _persistence_response_field,
     _resolve_context,
     _resolve_context_for_read,
     _resolve_context_id,
@@ -109,6 +110,9 @@ async def handle_remember(
                             "status": "success",
                             "memory_id": str(result.memory_id),
                             "scope": result.scope,
+                            # #1505: scope alone reads as "not saved yet" — say
+                            # what it actually implies for durability.
+                            **_persistence_response_field(result.persistence),
                             **_context_response_fields(current_context),
                         }
                     ),
@@ -221,6 +225,7 @@ async def handle_update_memory(
                             "operation": result.operation,
                             "re_embedded": result.re_embedded,
                             "scope": result.scope,
+                            **_persistence_response_field(result.persistence),  # #1505
                             **_context_response_fields(current_context),
                         }
                     ),

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -153,12 +153,59 @@ class RememberRequest(BaseModel):
         return v
 
 
+class PersistenceInfo(BaseModel):
+    """What a write's ``scope`` means for durability.
+
+    ``scope="working"`` reads as "not saved yet", which is wrong: the row is
+    committed before the write returns. This block says what the scope actually
+    implies, so a caller does not have to guess whether a memory survives until
+    consolidation promotes it.
+
+    This is NOT a retention SLA. It describes the consolidation lifecycle only;
+    other maintenance (notably near-duplicate merge) has its own rules, and an
+    explicit forget() removes a memory at any time.
+    """
+
+    scope: Literal["working", "persistent"]
+    committed: bool = Field(
+        default=True,
+        description=(
+            "The memory row is committed to PostgreSQL before this response is "
+            "returned. Always true — scope does not gate durability."
+        ),
+    )
+    promotes_via: str | None = Field(
+        default=None,
+        description=(
+            "The maintenance pass that can promote this memory to "
+            "scope='persistent' on this deployment: 'sleep_consolidation', "
+            "'legacy_consolidation', or null when the memory is already "
+            "persistent or no consolidation pass is enabled here."
+        ),
+    )
+    consolidation_archive_min_age_days: int | None = Field(
+        default=None,
+        description=(
+            "Age floor CONSOLIDATION applies before it may archive this memory; "
+            "it also requires zero adoption. Scoped to consolidation only — it "
+            "is not a retention guarantee, and does not bind near-duplicate "
+            "merge or an explicit forget(). Null when no consolidation pass is "
+            "enabled, or when the memory is persistent (consolidation acts only "
+            "on scope='working')."
+        ),
+    )
+    detail: str = Field(description="One-line summary of the above for the calling agent.")
+
+
 class RememberResponse(BaseModel):
     """Response schema for remember() API."""
 
     status: str = "success"
     memory_id: UUID
     scope: str
+    # Issue #1505: durability transparency. Derived from ``scope`` at
+    # construction time by ``services.persistence.persistence_info``.
+    persistence: PersistenceInfo | None = None
 
 
 class RecallRequest(BaseModel):
@@ -682,6 +729,9 @@ class UpdateMemoryResponse(BaseModel):
     operation: str  # "updated" | "created" | "replaced"
     re_embedded: bool
     scope: str
+    # Issue #1505: same durability transparency as RememberResponse — an upsert
+    # that lands as "created" starts a fresh working-scope lifecycle.
+    persistence: PersistenceInfo | None = None
 
 
 class PatchMemoryRequest(BaseModel):

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -740,6 +740,7 @@ class MemoryService:
             operation="updated",
             re_embedded=needs_reembed,
             scope=memory.scope,
+            persistence=persistence_info(memory.scope),  # #1505
         )
 
     async def _update_load_authorized(self, memory_id: UUID, user_id: str) -> Any:
@@ -1433,6 +1434,7 @@ class MemoryService:
             operation=operation,
             re_embedded=True,
             scope=result.scope,
+            persistence=persistence_info(result.scope),  # #1505
         )
 
     async def reference(self, memory_id: UUID, user_id: str) -> ReferenceResponse:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -66,6 +66,7 @@ from repositories.memory import MemoryRepository
 from services.context_routing import resolve_collection_name
 from services.context_service import ContextService
 from services.embedding_service import EmbeddingService
+from services.persistence import persistence_info
 from services.query_router import classify_query
 from services.recall_selection import (
     RecallSelectionConfig,
@@ -612,7 +613,13 @@ class MemoryService:
                 memory_id=memory_id,
             )
 
-            return RememberResponse(memory_id=memory_id, scope=memory.scope)
+            return RememberResponse(
+                memory_id=memory_id,
+                scope=memory.scope,
+                # #1505: say what 'working' means for durability instead of
+                # leaving the caller to guess.
+                persistence=persistence_info(memory.scope),
+            )
 
         except Exception as e:
             await self.db.rollback()

--- a/backend/src/services/persistence.py
+++ b/backend/src/services/persistence.py
@@ -1,0 +1,177 @@
+"""Durability contract surfaced on every memory write (Issue #1505).
+
+``remember()`` returns ``scope: "working"``, which reads as "not saved yet" to a
+writing agent — especially next to ``delivery_mode="always"``, which pins
+straight to persistent. Nothing in the response said what working actually
+implies, so a caller storing a high-importance result had no way to tell whether
+it survives until consolidation runs.
+
+What this module states, all read off the code that enforces it:
+
+* The row is committed to PostgreSQL before ``remember()`` returns. ``scope``
+  does not gate durability at all — it selects which consolidation lifecycle the
+  memory is on.
+* Which consolidation pass, if any, this deployment actually runs. The two are
+  mutually exclusive and neither is guaranteed to be on:
+
+  - ``SLEEP_ENABLED=true`` + ``ENABLE_NEURAL_MEMORY=true`` -> the sleep pass
+    (``services/sleep/consolidation.py``). Promotes on adoption (a deliberate
+    ``reference()``), importance once aged, or graph centrality.
+  - ``SLEEP_ENABLED=true`` + ``ENABLE_NEURAL_MEMORY=false`` -> **neither**:
+    ``sleep_maintenance_task`` returns at its neural-memory guard, and
+    ``schedule_neural_tasks`` skips registering the legacy cron whenever sleep
+    is on. Nothing promotes or archives.
+  - ``SLEEP_ENABLED`` unset/false -> the legacy pass
+    (``tasks/neural_tasks.py::consolidation_task``, registered unconditionally
+    by ``schedule_neural_tasks``, which ``api/main.py`` always calls). Promotes
+    on ``access_count`` (surfacing, not adoption) or importance once aged; it
+    has no centrality criterion.
+
+* The consolidation archival floor. Derived from whichever path is running so
+  the number can never describe a pass this deployment does not have.
+
+DELIBERATELY NOT CLAIMED — this is not a retention SLA:
+
+* Near-duplicate merge (``services/sleep/dedup_merge.py``) soft-deletes the
+  loser of a >= 0.98-cosine pair with **no age, scope, or adoption gate**;
+  ``_fetch_active_memories`` selects on user/workspace/context and
+  ``deleted_at IS NULL`` only. A memory written minutes ago can lose a merge the
+  same night (its tags and edges transfer to the winner, but its id stops
+  resolving). Any global "nothing you write today can be removed" wording would
+  therefore be false, which is why the age field is named for consolidation and
+  the detail text scopes itself.
+* ``forget()`` and account erasure remove memories on demand.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from models.schemas import PersistenceInfo
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+SLEEP_CONSOLIDATION = "sleep_consolidation"
+LEGACY_CONSOLIDATION = "legacy_consolidation"
+
+
+def _env_true(name: str) -> bool:
+    """Match how the task modules themselves read these flags."""
+    return os.getenv(name, "false").lower() == "true"
+
+
+def active_consolidation_pass() -> str | None:
+    """Which consolidation pass this deployment runs, or None if neither.
+
+    Mirrors the guards in ``tasks/sleep_tasks.py::sleep_maintenance_task`` and
+    ``tasks/neural_tasks.py::schedule_neural_tasks``. Not cached: the flags are
+    read per call so a process that is reconfigured and restarted never reports
+    a stale pass, and ``os.getenv`` is far cheaper than the write it rides on.
+    """
+    if _env_true("SLEEP_ENABLED"):
+        # schedule_neural_tasks skips the legacy cron whenever sleep is on, so
+        # the sleep pass's own neural-memory guard decides whether ANY pass runs.
+        return SLEEP_CONSOLIDATION if _env_true("ENABLE_NEURAL_MEMORY") else None
+    return LEGACY_CONSOLIDATION
+
+
+@lru_cache(maxsize=1)
+def _sleep_archive_min_age_days() -> int:
+    """Archival age floor enforced by the sleep consolidation pass.
+
+    Imported lazily: ``services.sleep.consolidation`` pulls in Qdrant, the graph
+    service and the LLM service, none of which a write path should drag in at
+    import time.
+    """
+    from services.sleep.consolidation import ARCHIVE_MIN_AGE_DAYS
+
+    return ARCHIVE_MIN_AGE_DAYS
+
+
+@lru_cache(maxsize=1)
+def _legacy_archive_min_age_days() -> int:
+    """Archival age floor enforced by the legacy consolidation task."""
+    from tasks.neural_tasks import LEGACY_ARCHIVE_MIN_AGE_DAYS
+
+    return LEGACY_ARCHIVE_MIN_AGE_DAYS
+
+
+def consolidation_archive_min_age_days() -> int | None:
+    """The running pass's archival floor, or None when no pass runs."""
+    pass_name = active_consolidation_pass()
+    if pass_name == SLEEP_CONSOLIDATION:
+        return _sleep_archive_min_age_days()
+    if pass_name == LEGACY_CONSOLIDATION:
+        return _legacy_archive_min_age_days()
+    return None
+
+
+_PROMOTION_CRITERIA = {
+    SLEEP_CONSOLIDATION: (
+        "adoption via reference(), high importance once aged, or graph centrality"
+    ),
+    LEGACY_CONSOLIDATION: "repeat access, or high importance once aged",
+}
+
+
+def persistence_info(scope: str) -> PersistenceInfo | None:
+    """Build the durability block for a just-written memory.
+
+    Args:
+        scope: The memory's scope as persisted ("working" or "persistent").
+
+    Returns:
+        PersistenceInfo describing what that scope implies for durability, or
+        None for an unrecognized scope. This block is advisory: an unexpected
+        scope must not fail a write that already committed, so the field is
+        omitted (and the anomaly logged) rather than raised.
+    """
+    if scope == "persistent":
+        return PersistenceInfo(
+            scope="persistent",
+            committed=True,
+            promotes_via=None,
+            consolidation_archive_min_age_days=None,
+            detail=(
+                "Committed and persistent. Consolidation acts only on "
+                "working-scope memories, so it will not archive this one. "
+                "Separate maintenance (near-duplicate merge) and an explicit "
+                "forget() are not scope-gated and still apply."
+            ),
+        )
+    if scope != "working":
+        logger.warning("persistence_info_unknown_scope", scope=scope)
+        return None
+
+    pass_name = active_consolidation_pass()
+    if pass_name is None:
+        return PersistenceInfo(
+            scope="working",
+            committed=True,
+            promotes_via=None,
+            consolidation_archive_min_age_days=None,
+            detail=(
+                "Committed and durable now — 'working' is a lifecycle label, "
+                "not a staging buffer. No consolidation pass is enabled on this "
+                "deployment, so it will stay working-scope and consolidation "
+                "will not archive it."
+            ),
+        )
+
+    days = consolidation_archive_min_age_days()
+    return PersistenceInfo(
+        scope="working",
+        committed=True,
+        promotes_via=pass_name,
+        consolidation_archive_min_age_days=days,
+        detail=(
+            "Committed and durable now — 'working' is a lifecycle label, not a "
+            f"staging buffer. Promotes to persistent via {pass_name} "
+            f"({_PROMOTION_CRITERIA[pass_name]}). That pass will not archive it "
+            f"before {days} days old, and only with zero adoption. Separate "
+            "maintenance (near-duplicate merge) and an explicit forget() are "
+            "not bound by that floor."
+        ),
+    )

--- a/backend/src/tasks/neural_tasks.py
+++ b/backend/src/tasks/neural_tasks.py
@@ -22,6 +22,16 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Issue #1505: the legacy consolidation path's archival floor, named so the
+# durability contract returned on every write (services/persistence.py) can be
+# derived from it instead of restating a literal that would silently rot if this
+# task were re-tuned. The sleep path's counterpart is
+# ``services.sleep.consolidation.ARCHIVE_MIN_AGE_DAYS``. At most one of the two
+# runs: this one only when SLEEP_ENABLED is off (see schedule_neural_tasks), the
+# sleep one only when SLEEP_ENABLED and ENABLE_NEURAL_MEMORY are both on — so
+# SLEEP_ENABLED=true with neural memory off leaves NEITHER running.
+LEGACY_ARCHIVE_MIN_AGE_DAYS = 30
+
 
 async def weight_decay_task():
     """Apply weight decay to all users' graphs.
@@ -178,7 +188,7 @@ async def consolidation_task():
                         )
 
                     # Deletion criteria
-                    elif age_days >= 30 and memory.access_count == 0:
+                    elif age_days >= LEGACY_ARCHIVE_MIN_AGE_DAYS and memory.access_count == 0:
                         # ================================================================
                         # BUG FIX #83-10: Delete from Qdrant to prevent orphan vectors
                         # ================================================================

--- a/backend/tests/mcp_server/test_context_last_used_touch.py
+++ b/backend/tests/mcp_server/test_context_last_used_touch.py
@@ -289,7 +289,11 @@ def _patched_write_handler(context, service):
 async def test_remember_bumps_context():
     ctx = _make_context(last_used_at=None)
     service = MagicMock()
-    service.remember = AsyncMock(return_value=SimpleNamespace(memory_id=uuid4(), scope="personal"))
+    # persistence: the #1505 durability block the handler forwards (None here —
+    # this test is about the context touch, not the block's contents).
+    service.remember = AsyncMock(
+        return_value=SimpleNamespace(memory_id=uuid4(), scope="personal", persistence=None)
+    )
 
     with _patched_write_handler(ctx, service) as db:
         result = await handle_remember(
@@ -315,7 +319,11 @@ async def test_update_memory_bumps_context():
     service = MagicMock()
     service.update_memory = AsyncMock(
         return_value=SimpleNamespace(
-            memory_id=uuid4(), operation="update", re_embedded=False, scope="personal"
+            memory_id=uuid4(),
+            operation="update",
+            re_embedded=False,
+            scope="personal",
+            persistence=None,  # #1505 block, not under test here
         )
     )
 

--- a/backend/tests/services/test_persistence_info.py
+++ b/backend/tests/services/test_persistence_info.py
@@ -339,6 +339,115 @@ async def test_pinned_write_reports_persistent_persistence(service, sleep_pass):
     assert result.persistence.consolidation_archive_min_age_days is None
 
 
+# The update paths need their OWN service-level coverage. An earlier revision
+# tested them only by handing a PersistenceInfo to a mocked service and
+# asserting the handler splatted it back — which passes even when the service
+# never populates the field. Both construction sites shipped it missing, and the
+# whole suite stayed green. These drive the real methods.
+
+
+@pytest.mark.asyncio
+async def test_in_place_update_populates_persistence(service, sleep_pass):
+    """update_memory(memory_id=...) — the in-place path."""
+    from models.schemas import UpdateMemoryRequest
+
+    memory = MagicMock()
+    memory.id = uuid4()
+    memory.user_id = "test_user"
+    memory.workspace_id = uuid4()
+    memory.context_id = uuid4()
+    memory.summary = "Original summary for testing"
+    memory.context_summary = None
+    memory.content = "Original content"
+    memory.details = None
+    memory.type = "note"
+    memory.importance = 0.5
+    memory.tags = ["original"]
+    memory.context = None
+    memory.scope = "working"
+    memory.client = "mcp"
+    memory.created_at = None
+    memory.updated_at = None
+    memory.deleted_at = None
+    memory.embedding_status = "success"
+    service.memory_repo.get = AsyncMock(return_value=memory)
+
+    with (
+        patch("services.permission_service.PermissionService") as perm_cls,
+        patch("services.memory_service.update_memory_payload_in_qdrant", new=AsyncMock()),
+        patch(
+            "services.memory_service.resolve_collection_name",
+            new=AsyncMock(return_value="kagura_memories"),
+        ),
+    ):
+        perm_cls.return_value.can_access_memory = AsyncMock(return_value=True)
+        result = await service._update_in_place(
+            UpdateMemoryRequest(memory_id=memory.id, importance=0.9),
+            user_id="test_user",
+        )
+
+    assert result.persistence is not None, "_update_in_place dropped the #1505 block"
+    assert result.persistence.scope == "working"
+    assert (
+        result.persistence.consolidation_archive_min_age_days
+        == consolidation_archive_min_age_days()
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_populates_persistence(service, sleep_pass):
+    """update_memory(external_id=...) — the create/replace path."""
+    from models.schemas import UpdateMemoryRequest
+
+    service.memory_repo.get_by_resource_id = AsyncMock(return_value=None)
+    remembered = MagicMock()
+    remembered.memory_id = uuid4()
+    remembered.scope = "working"
+    service.remember = AsyncMock(return_value=remembered)
+
+    result = await service._upsert_by_external_id(
+        UpdateMemoryRequest(
+            external_id="new-resource",
+            summary="Brand new memory for the upsert path",
+            content="content",
+            type="note",
+        ),
+        user_id="test_user",
+        client="mcp",
+        current_context_id=uuid4(),
+        current_workspace_id=uuid4(),
+    )
+
+    assert result.operation == "created"
+    assert result.persistence is not None, "_upsert_by_external_id dropped the #1505 block"
+    assert result.persistence.scope == "working"
+
+
+def test_every_write_response_construction_populates_persistence():
+    """No construction site may omit the field.
+
+    The two service-level tests above cover today's paths; this catches a NEW
+    construction site added later without it — the shape of the regression that
+    already happened once.
+    """
+    import services.memory_service as memory_service
+
+    tree = ast.parse(Path(memory_service.__file__).read_text(encoding="utf-8"))
+    sites = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id in {"RememberResponse", "UpdateMemoryResponse"}
+    ]
+    assert len(sites) >= 3, f"expected the known write-response sites, found {len(sites)}"
+    for call in sites:
+        assert any(kw.arg == "persistence" for kw in call.keywords), (
+            f"{call.func.id} at line {call.lineno} is built without persistence — "
+            "the block would be silently absent from that response"
+        )
+
+
 # ---------------------------------------------------------------------------
 # MCP surface
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_persistence_info.py
+++ b/backend/tests/services/test_persistence_info.py
@@ -1,0 +1,471 @@
+"""Durability transparency on write responses (#1505).
+
+Three things are tested, and the split matters:
+
+1. The *contract* — what persistence_info() says for each scope, and for each
+   of the three consolidation configurations (sleep / legacy / neither).
+2. The *truth of the numbers* — the advertised archival floor is checked against
+   the code that actually enforces it (``_archival_eligible`` for the sleep
+   path, the ``age_days`` comparison for the legacy path), so the response
+   cannot drift into promising a floor nobody enforces.
+3. The *limits of the claim* — a first review of this change caught the response
+   asserting "nothing you write today can be dropped", which is false: the
+   near-duplicate merge pass soft-deletes at any age. The scoping is now part of
+   the contract, so there is a test pinning why.
+
+The wiring tests use the mocked-DB pattern from test_remember_delivery_mode.py:
+a real MemoryService.remember() call, so a construction site that forgets the
+field fails here rather than shipping an invisible feature.
+"""
+
+import ast
+import contextlib
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import RememberRequest
+from services.memory_service import MemoryService
+from services.persistence import (
+    LEGACY_CONSOLIDATION,
+    SLEEP_CONSOLIDATION,
+    active_consolidation_pass,
+    consolidation_archive_min_age_days,
+    persistence_info,
+)
+
+
+@pytest.fixture
+def sleep_pass(monkeypatch):
+    monkeypatch.setenv("SLEEP_ENABLED", "true")
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+
+
+@pytest.fixture
+def legacy_pass(monkeypatch):
+    monkeypatch.setenv("SLEEP_ENABLED", "false")
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "false")
+
+
+@pytest.fixture
+def no_pass(monkeypatch):
+    """SLEEP_ENABLED on but neural memory off: the sleep task returns at its
+    guard and schedule_neural_tasks skips the legacy cron — nothing runs."""
+    monkeypatch.setenv("SLEEP_ENABLED", "true")
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "false")
+
+
+# ---------------------------------------------------------------------------
+# Which pass is running
+# ---------------------------------------------------------------------------
+
+
+def test_sleep_config_reports_the_sleep_pass(sleep_pass):
+    assert active_consolidation_pass() == SLEEP_CONSOLIDATION
+
+
+def test_default_config_reports_the_legacy_pass(legacy_pass):
+    assert active_consolidation_pass() == LEGACY_CONSOLIDATION
+
+
+def test_sleep_without_neural_memory_reports_no_pass(no_pass):
+    """The configuration where NEITHER pass runs must not advertise one."""
+    assert active_consolidation_pass() is None
+    assert consolidation_archive_min_age_days() is None
+
+
+def test_env_is_read_per_call_not_frozen_at_import(monkeypatch):
+    """A cached pass name would misreport a reconfigured process."""
+    monkeypatch.setenv("SLEEP_ENABLED", "false")
+    assert active_consolidation_pass() == LEGACY_CONSOLIDATION
+    monkeypatch.setenv("SLEEP_ENABLED", "true")
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+    assert active_consolidation_pass() == SLEEP_CONSOLIDATION
+
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+
+def test_working_scope_is_reported_as_already_committed(sleep_pass):
+    """The whole point of #1505: 'working' must not read as 'not saved yet'."""
+    info = persistence_info("working")
+    assert info is not None
+    assert info.scope == "working"
+    assert info.committed is True
+    assert info.promotes_via == SLEEP_CONSOLIDATION
+    assert info.consolidation_archive_min_age_days == consolidation_archive_min_age_days()
+
+
+def test_legacy_config_advertises_the_legacy_pass_and_its_criteria(legacy_pass):
+    """Promotion criteria differ per pass; the legacy one has no centrality rule."""
+    info = persistence_info("working")
+    assert info is not None
+    assert info.promotes_via == LEGACY_CONSOLIDATION
+    assert "centrality" not in info.detail
+    assert "reference()" not in info.detail
+
+
+def test_sleep_config_advertises_adoption_and_centrality(sleep_pass):
+    info = persistence_info("working")
+    assert info is not None
+    assert "reference()" in info.detail
+    assert "centrality" in info.detail
+
+
+def test_no_pass_advertises_neither_promotion_nor_a_floor(no_pass):
+    info = persistence_info("working")
+    assert info is not None
+    assert info.promotes_via is None
+    assert info.consolidation_archive_min_age_days is None
+
+
+def test_persistent_scope_reports_no_removal_floor(sleep_pass):
+    """Consolidation selects on scope == 'working', so persistent has no floor."""
+    info = persistence_info("persistent")
+    assert info is not None
+    assert info.scope == "persistent"
+    assert info.committed is True
+    assert info.promotes_via is None
+    assert info.consolidation_archive_min_age_days is None
+
+
+def test_unknown_scope_is_omitted_rather_than_raised():
+    """Advisory field: an unexpected scope must not fail an already-committed write."""
+    assert persistence_info("archived") is None
+    assert persistence_info("") is None
+
+
+# ---------------------------------------------------------------------------
+# The advertised number is the enforced number
+# ---------------------------------------------------------------------------
+
+
+def test_advertised_floor_matches_the_sleep_path_archival_gate(sleep_pass):
+    """One day under the advertised floor must be archival-INELIGIBLE.
+
+    This is the anti-drift test: it exercises the predicate consolidation
+    actually calls, so retuning ARCHIVE_MIN_AGE_DAYS without updating the
+    response (or vice versa) fails here.
+    """
+    from services.sleep.consolidation import _archival_eligible
+
+    days = consolidation_archive_min_age_days()
+    assert days is not None
+    memory = MagicMock(reference_count=0, created_at=datetime(2020, 1, 1))  # noqa: DTZ001
+    cutoff = datetime(2019, 1, 1)  # noqa: DTZ001 — operator opt-in, already elapsed
+
+    assert _archival_eligible(memory, days - 1, cutoff) is False, (
+        "response promises nothing is archived before this age, but the sleep path would archive it"
+    )
+    assert _archival_eligible(memory, days, cutoff) is True, (
+        "advertised floor is more conservative than the enforced one — it is stale"
+    )
+
+
+def test_legacy_floor_matches_the_legacy_constant(legacy_pass):
+    from tasks.neural_tasks import LEGACY_ARCHIVE_MIN_AGE_DAYS
+
+    assert consolidation_archive_min_age_days() == LEGACY_ARCHIVE_MIN_AGE_DAYS
+
+
+def test_legacy_consolidation_compares_against_the_named_constant():
+    """The legacy constant must be load-bearing, not decorative.
+
+    consolidation_archive_min_age_days() derives from LEGACY_ARCHIVE_MIN_AGE_DAYS.
+    If consolidation_task went back to comparing a bare literal, that derivation
+    would report a number nothing reads — so assert the comparison itself.
+    """
+    import tasks.neural_tasks as neural_tasks
+
+    tree = ast.parse(Path(neural_tasks.__file__).read_text(encoding="utf-8"))
+    task = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "consolidation_task"
+    )
+    guarded = [
+        cmp
+        for cmp in ast.walk(task)
+        if isinstance(cmp, ast.Compare)
+        and isinstance(cmp.left, ast.Name)
+        and cmp.left.id == "age_days"
+        and any(
+            isinstance(c, ast.Name) and c.id == "LEGACY_ARCHIVE_MIN_AGE_DAYS"
+            for c in cmp.comparators
+        )
+    ]
+    assert guarded, "consolidation_task no longer gates archival on LEGACY_ARCHIVE_MIN_AGE_DAYS"
+
+
+# ---------------------------------------------------------------------------
+# The limits of the claim (review finding: dedup ignores the floor)
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_merge_still_has_no_age_or_adoption_gate():
+    """Pin WHY the age field is named for consolidation only.
+
+    ``DedupMergePhase._fetch_active_memories`` selects on identity columns and
+    ``deleted_at`` alone — no age, scope, or reference_count gate — so a memory
+    written minutes ago can lose a near-duplicate merge the same night. Any
+    global "not removed before N days" wording would therefore be false.
+
+    If a gate is ever added here, this test fails: revisit the response wording,
+    because the promise could then legitimately be widened.
+    """
+    import services.sleep.dedup_merge as dedup_merge
+
+    tree = ast.parse(Path(dedup_merge.__file__).read_text(encoding="utf-8"))
+    fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_fetch_active_memories"
+    )
+    referenced = {
+        node.attr
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "Memory"
+    }
+    assert referenced == {"user_id", "deleted_at", "updated_at", "workspace_id", "context_id"}, (
+        f"dedup selection columns changed to {sorted(referenced)} — if an age or "
+        "adoption gate was added, the persistence wording can be widened"
+    )
+
+
+@pytest.mark.parametrize("scope", ["working", "persistent"])
+def test_response_makes_no_unscoped_retention_promise(sleep_pass, scope):
+    """The detail text must not read as a retention SLA for the whole system.
+
+    Both scopes need the caveat: ``_fetch_active_memories`` has no scope filter
+    either, so "consolidation will not archive this one" is equally misleading
+    on a persistent memory if left unqualified.
+    """
+    detail = persistence_info(scope).detail
+    assert "merge" in detail and "forget()" in detail, (
+        f"{scope} detail must name the lifecycles the consolidation floor does NOT bind"
+    )
+
+
+def test_dedup_merge_is_not_scope_gated():
+    """Pin the reason the persistent branch needs the caveat too."""
+    import services.sleep.dedup_merge as dedup_merge
+
+    tree = ast.parse(Path(dedup_merge.__file__).read_text(encoding="utf-8"))
+    fn = next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "_fetch_active_memories"
+    )
+    assert not any(
+        isinstance(node, ast.Attribute) and node.attr == "scope" for node in ast.walk(fn)
+    ), "dedup selection is now scope-gated — the persistent-scope wording can be widened"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: the block reaches an actual write response
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def service():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+    db.execute = AsyncMock()
+
+    svc = MemoryService(db)
+    context = MagicMock()
+    context.id = uuid4()
+    context.workspace_id = uuid4()
+    svc._get_context_isolation_params = AsyncMock(
+        return_value=(context, str(context.workspace_id), str(context.id))
+    )
+    svc.memory_repo = MagicMock()
+    svc.memory_repo.create = AsyncMock()
+    svc._create_declared_links = AsyncMock()
+    svc._mock_context = context
+    return svc
+
+
+async def _remember(service, **kwargs):
+    request = RememberRequest(
+        summary="durability contract surfaced on write",
+        content="see #1505",
+        type="note",
+        **kwargs,
+    )
+    with (
+        patch("services.memory_service.process_pending_embedding", new=AsyncMock()),
+        patch("services.quota_service.QuotaService"),
+    ):
+        return await service.remember(
+            request,
+            user_id="test_user",
+            client="test",
+            current_context_id=service._mock_context.id,
+            current_workspace_id=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_remember_response_carries_the_persistence_block(service, sleep_pass):
+    result = await _remember(service)
+    assert result.scope == "working"
+    assert result.persistence is not None, "remember() dropped the #1505 block"
+    assert result.persistence.scope == "working"
+    assert result.persistence.committed is True
+    assert (
+        result.persistence.consolidation_archive_min_age_days
+        == consolidation_archive_min_age_days()
+    )
+
+
+@pytest.mark.asyncio
+async def test_pinned_write_reports_persistent_persistence(service, sleep_pass):
+    """delivery_mode='always' pins to persistent — the block must follow the real scope."""
+    result = await _remember(service, delivery_mode="always")
+    assert result.scope == "persistent"
+    assert result.persistence is not None
+    assert result.persistence.scope == "persistent"
+    assert result.persistence.consolidation_archive_min_age_days is None
+
+
+# ---------------------------------------------------------------------------
+# MCP surface
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_helper_emits_the_block_when_present(sleep_pass):
+    from mcp_server.tools._helpers import _persistence_response_field
+
+    field = _persistence_response_field(persistence_info("working"))
+    assert set(field) == {"persistence"}
+    payload = field["persistence"]
+    assert payload["scope"] == "working"
+    assert payload["committed"] is True
+    assert payload["promotes_via"] == SLEEP_CONSOLIDATION
+    assert payload["consolidation_archive_min_age_days"] == consolidation_archive_min_age_days()
+    assert payload["detail"]
+
+
+def test_mcp_helper_omits_the_key_when_scope_is_unclassifiable():
+    """Absent beats null — the caller should not have to special-case a null block."""
+    from mcp_server.tools._helpers import _persistence_response_field
+
+    assert _persistence_response_field(None) == {}
+
+
+@contextlib.contextmanager
+def _patched_write_handler(service):
+    """Mocked seams for a write handler call (mirrors test_context_last_used_touch)."""
+    db = AsyncMock()
+
+    async def mock_get_db():
+        yield db
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.memory._check_viewer_permission", new=AsyncMock(return_value=None)),
+        patch("mcp_server.tools.memory._resolve_context", new=AsyncMock(return_value=MagicMock())),
+        patch("mcp_server.tools.memory._touch_context_last_used", new=AsyncMock()),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+        patch("services.memory_service.MemoryService", new=MagicMock(return_value=service)),
+    ):
+        yield
+
+
+@pytest.mark.asyncio
+async def test_remember_tool_json_carries_the_block(sleep_pass):
+    """End of the wire: what the agent actually reads back from the MCP tool."""
+    import json
+
+    from mcp_server.tools.memory import handle_remember
+
+    service = MagicMock()
+    service.remember = AsyncMock(
+        return_value=SimpleNamespace(
+            memory_id=uuid4(), scope="working", persistence=persistence_info("working")
+        )
+    )
+
+    with _patched_write_handler(service):
+        result = await handle_remember(
+            {
+                "summary": "durability contract surfaced on write",
+                "content": "see #1505",
+                "type": "note",
+                "context_id": str(uuid4()),
+            },
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    assert payload["persistence"]["scope"] == "working"
+    assert payload["persistence"]["committed"] is True
+    assert (
+        payload["persistence"]["consolidation_archive_min_age_days"]
+        == consolidation_archive_min_age_days()
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_memory_tool_json_carries_the_block(sleep_pass):
+    import json
+
+    from mcp_server.tools.memory import handle_update_memory
+
+    service = MagicMock()
+    service.update_memory = AsyncMock(
+        return_value=SimpleNamespace(
+            memory_id=uuid4(),
+            operation="updated",
+            re_embedded=False,
+            scope="persistent",
+            persistence=persistence_info("persistent"),
+        )
+    )
+
+    with _patched_write_handler(service):
+        result = await handle_update_memory(
+            {"memory_id": str(uuid4()), "summary": "x" * 20, "context_id": str(uuid4())},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    assert payload["persistence"]["scope"] == "persistent"
+    assert payload["persistence"]["consolidation_archive_min_age_days"] is None
+
+
+# ---------------------------------------------------------------------------
+# Agent-facing text hygiene (#1417 convention)
+# ---------------------------------------------------------------------------
+
+
+def test_persistence_schema_text_carries_no_bare_issue_ids():
+    """PersistenceInfo's docstring and Field descriptions ship to OpenAPI.
+
+    Bare issue IDs are noise to an agent and leak internal provenance into a
+    public API surface.
+    """
+    import re
+
+    from models.schemas import PersistenceInfo
+
+    texts = [PersistenceInfo.__doc__ or ""]
+    texts += [f.description or "" for f in PersistenceInfo.model_fields.values()]
+    for text in texts:
+        assert not re.search(r"#\d{2,}", text), f"bare issue id in agent-facing text: {text!r}"


### PR DESCRIPTION
Closes #1505

## Problem

`remember()` returned `scope: "working"` and nothing else about what that means. Next to `delivery_mode="always"` — which pins straight to persistent — a high-importance write reads as provisional, and the caller had no way to answer "does this survive until consolidation promotes it?"

## What this adds

A `persistence` block on the `remember()` / `update_memory()` responses, plus the lifecycle in the tool descriptions. Every statement is read off the code that enforces it:

- **`committed`** — the row is committed to PostgreSQL before the call returns. `scope` does not gate durability; it selects a consolidation lifecycle.
- **`promotes_via`** — which consolidation pass *this deployment* runs, resolved from the same flags the task modules read. The three configurations are genuinely different, and one runs nothing:

  | `SLEEP_ENABLED` | `ENABLE_NEURAL_MEMORY` | pass |
  |---|---|---|
  | true | true | `sleep_consolidation` |
  | true | false | **neither** — `sleep_maintenance_task` returns at its neural guard, and `schedule_neural_tasks` skips the legacy cron whenever sleep is on |
  | false | — | `legacy_consolidation` |

  `promotes_via` is `null` in the middle case rather than naming a pass that never fires. Promotion criteria differ too: the legacy pass gates on `access_count` (surfacing) and has no centrality rule, so the advertised criteria follow the running pass.
- **`consolidation_archive_min_age_days`** — the running pass's own archival floor.

## What it deliberately does not claim

Not a retention SLA. An earlier revision of this PR said "nothing you write today can be dropped out from under you" — **that was false.** `DedupMergePhase._fetch_active_memories` selects on user/workspace/context and `deleted_at IS NULL` only: no age gate, no scope gate, no adoption gate. A memory written minutes ago can lose a ≥0.98-cosine merge the same night (tags and edges transfer to the winner; its id stops resolving), and that applies to persistent-scope memories too.

So the age field is **named** for its scope rather than relying on prose, and both `detail` strings name the lifecycles the floor does not bind (near-duplicate merge, `forget()`).

## Anti-drift

- The advertised floor is bound to the sleep path's own `_archival_eligible` predicate, asserted at `days-1` (ineligible) and `days` (eligible) — retuning either side without the other fails.
- The legacy path's literal `30` is now the named `LEGACY_ARCHIVE_MIN_AGE_DAYS`, with an AST test that `consolidation_task` still compares against it (so the constant can't become decorative).
- Two AST tests pin the dedup selection columns. If an age or scope gate is ever added there, they fail — prompting the wording to be *widened*, rather than staying silently over-conservative.

## Testing

24 tests. All three configurations, both scopes, the service wiring (real `MemoryService.remember()` with a mocked DB), and the MCP JSON both handlers actually emit. Mutation-checked: dropping the field at a construction site, freezing the env read behind a cache, hardcoding the floor, dropping the scoping clause, and reintroducing a bare issue ID are each caught.

One test asserts the agent-facing schema text carries no bare issue IDs — a Pydantic model docstring and `Field(description=)` ship to OpenAPI, so the `#NNNN` convention applies there too.

## Not implemented

Proposal (3) from the issue, auto-persist above an importance threshold. The issue notes (1)+(2) resolve the gap; (3) changes consolidation behaviour and deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)