### PR TITLE
feat(mcp): dismiss action for supersede_candidate (#1504)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -258,7 +258,7 @@ IMPORTANT: Always specify context_id.
 
 Modes (supply exactly ONE): in-place edit by memory_id, OR upsert by external_id (found → update in place, not-found → create). Upsert additionally requires summary, content, and type.
 
-Returns: {status, memory_id, operation: "updated"|"created"|"replaced", re_embedded, scope, persistence?: {scope, committed, promotes_via, consolidation_archive_min_age_days, detail}, context_id, context_name, context_display_name, context_is_private, context_is_locked}. operation tells you which path ran; re_embedded is true only when summary/context_summary/content changed. persistence states what scope means for durability (omitted, never null, if the scope cannot be classified) — the write is committed before this returns either way; see the remember() description for the full lifecycle.""",
+Returns: {status, memory_id, operation: "updated"|"created"|"replaced", re_embedded, scope, persistence?: {scope, committed, promotes_via, consolidation_archive_min_age_days, detail}, supersede_candidate_dismissed? (the rejected candidate's memory_id; absent when nothing was dismissed, including a dismissal that found no live suggestion), context_id, context_name, context_display_name, context_is_private, context_is_locked}. operation tells you which path ran; re_embedded is true only when summary/context_summary/content changed. persistence states what scope means for durability (omitted, never null, if the scope cannot be classified) — the write is committed before this returns either way; see the remember() description for the full lifecycle.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["context_id"],
@@ -271,6 +271,10 @@ Returns: {status, memory_id, operation: "updated"|"created"|"replaced", re_embed
                     "external_id": {
                         "type": "string",
                         "description": "External resource ID for upsert lookup (stored in details.resource_id).",
+                    },
+                    "dismiss_supersede_candidate": {
+                        "type": "boolean",
+                        "description": "Reject this memory's current supersede_candidate (requires memory_id). Use when the two memories are DELIBERATELY separate — e.g. the same conclusion recorded at two altitudes — so the suggestion stops resurfacing on every recall/reference. Neither memory is deleted or shadowed; only the suggestion is tombstoned. Detection resumes for this pair if the similarity later changes materially, and a suggestion for a DIFFERENT memory still surfaces normally. The accept path remains create_edge(edge_type='supersedes').",
                     },
                     "summary": {
                         "type": "string",

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -173,6 +173,8 @@ async def handle_update_memory(
             tags=args.get("tags"),
             context=args.get("context"),
             delivery_mode=args.get("delivery_mode"),  # Issue #886 (pin/unpin)
+            # #1504: rejection path for a supersede suggestion.
+            dismiss_supersede_candidate=bool(args.get("dismiss_supersede_candidate", False)),
         )
     except ValidationError as e:
         # #1323: plain field/constraint summary — no pydantic internals.
@@ -226,6 +228,17 @@ async def handle_update_memory(
                             "re_embedded": result.re_embedded,
                             "scope": result.scope,
                             **_persistence_response_field(result.persistence),  # #1505
+                            # #1504: echo WHICH pairing was tombstoned, so the
+                            # caller can confirm it rejected what it meant to.
+                            **(
+                                {
+                                    "supersede_candidate_dismissed": str(
+                                        result.supersede_candidate_dismissed
+                                    )
+                                }
+                                if result.supersede_candidate_dismissed
+                                else {}
+                            ),
                             **_context_response_fields(current_context),
                         }
                     ),

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -690,6 +690,19 @@ class UpdateMemoryRequest(BaseModel):
     delivery_mode: Literal["always", "on_recall", "on_trigger"] | None = Field(
         None, description="Updated delivery mode (always pins to persistent; on_recall unpins)"
     )
+    # Issue #1504: the rejection half of the supersede-suggestion lifecycle.
+    # Acceptance clears the stored suggestion at edge-creation time; without
+    # this, judging a suggestion WRONG left it resurfacing on every recall and
+    # reference forever, with a wrong accept or a deletion as the only escapes.
+    dismiss_supersede_candidate: bool = Field(
+        default=False,
+        description=(
+            "Reject the currently-suggested supersede candidate for this memory. "
+            "The pair is tombstoned so it stops surfacing; neither memory is "
+            "deleted, and detection resumes if the similarity later changes "
+            "materially. In-place mode only."
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_identifier_and_required_fields(self) -> "UpdateMemoryRequest":
@@ -700,6 +713,16 @@ class UpdateMemoryRequest(BaseModel):
             raise ValueError("Either memory_id or external_id must be provided")
         if has_memory_id and has_external_id:
             raise ValueError("Provide either memory_id or external_id, not both")
+
+        # #1504: the upsert path replaces the memory (new id, fresh detection),
+        # so there is no stored suggestion for it to dismiss. Reject rather than
+        # silently ignore — a caller passing this on the wrong mode has a
+        # mistaken model of what the flag does.
+        if has_external_id and self.dismiss_supersede_candidate:
+            raise ValueError(
+                "dismiss_supersede_candidate requires memory_id (in-place mode); "
+                "an external_id upsert replaces the memory and its suggestion."
+            )
 
         # For upsert-by-external_id mode, enforce required fields
         if has_external_id:
@@ -732,6 +755,10 @@ class UpdateMemoryResponse(BaseModel):
     # Issue #1505: same durability transparency as RememberResponse — an upsert
     # that lands as "created" starts a fresh working-scope lifecycle.
     persistence: PersistenceInfo | None = None
+    # Issue #1504: the candidate this call rejected, echoed back so the caller
+    # can confirm WHICH pairing was tombstoned. None when nothing was dismissed
+    # (including a dismissal that found no live suggestion — see the service).
+    supersede_candidate_dismissed: UUID | None = None
 
 
 class PatchMemoryRequest(BaseModel):

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -699,6 +699,9 @@ class MemoryService:
         effective_details = self._update_apply_fields(
             memory, request, normalized_summary, normalized_ctx_summary
         )
+        # #1504: rejection path. Applied before the commit below so the tombstone
+        # lands in the same transaction as any other field change in this call.
+        dismissed_target = self._apply_supersede_dismissal(memory, request)
 
         if needs_reembed:
             # Async embedding via create_task (same pattern as remember)
@@ -741,7 +744,47 @@ class MemoryService:
             re_embedded=needs_reembed,
             scope=memory.scope,
             persistence=persistence_info(memory.scope),  # #1505
+            supersede_candidate_dismissed=dismissed_target,  # #1504
         )
+
+    @staticmethod
+    def _apply_supersede_dismissal(memory: Any, request: UpdateMemoryRequest) -> UUID | None:
+        """#1504: tombstone the current supersede suggestion, if one is pending.
+
+        Args:
+            memory: The loaded update target.
+            request: The update request.
+
+        Returns:
+            The dismissed candidate's memory id, or None when the flag was not
+            set or there was no live suggestion to reject. A no-op dismissal is
+            NOT an error: the suggestion may have self-healed (target deleted)
+            or been accepted between the read that showed it and this call, and
+            failing the whole update over that would be hostile.
+        """
+        if not request.dismiss_supersede_candidate:
+            return None
+
+        from services.supersede_dismissal import build_tombstone, dismissed_entry
+
+        stored = memory.supersede_candidate
+        if not isinstance(stored, dict) or not stored.get("memory_id"):
+            # Already a tombstone, or nothing pending.
+            if dismissed_entry(stored) is None:
+                logger.info("supersede_dismiss_noop", memory_id=str(memory.id))
+            return None
+
+        target_id = str(stored["memory_id"])
+        # Reassign (JSON column, not a MutableDict — reassignment is what marks
+        # it dirty), mirroring how detection and acceptance write this column.
+        memory.supersede_candidate = build_tombstone(stored)
+        logger.info(
+            "supersede_suggestion_dismissed",
+            memory_id=str(memory.id),
+            candidate_memory_id=target_id,
+            similarity=stored.get("similarity"),
+        )
+        return UUID(target_id)
 
     async def _update_load_authorized(self, memory_id: UUID, user_id: str) -> Any:
         """Load the update target, or 404 (MCP-reachable in-place update path).
@@ -4999,7 +5042,26 @@ async def _create_knn_seed_edges(
                 already_superseded = (
                     existing_super is not None and existing_super.edge_type == EDGE_TYPE_SUPERSEDES
                 )
-                if not already_superseded:
+                # #1504: don't resurrect a REJECTED suggestion either. The
+                # accept-side guard above keys on the edge; rejection leaves no
+                # edge by design (the memories stay independent), so it keys on
+                # the tombstone instead. Keeping both guards here means a
+                # re-embed cannot undo either decision.
+                from services.supersede_dismissal import is_dismissed
+
+                already_dismissed = is_dismissed(
+                    memory.supersede_candidate,
+                    target_id=str(raw_top["id"]),
+                    similarity=raw_top_score,
+                )
+                if already_dismissed:
+                    logger.info(
+                        "supersede_candidate_suppressed_by_dismissal",
+                        memory_id=memory_id_str,
+                        candidate_memory_id=str(raw_top["id"]),
+                        similarity=round(raw_top_score, 4),
+                    )
+                if not already_superseded and not already_dismissed:
                     candidate = {
                         "memory_id": str(raw_top["id"]),
                         "similarity": round(raw_top_score, 4),

--- a/backend/src/services/supersede_dismissal.py
+++ b/backend/src/services/supersede_dismissal.py
@@ -1,0 +1,101 @@
+"""Rejection half of the supersede-suggestion lifecycle (Issue #1504).
+
+Accepting a ``supersede_candidate`` is one ``create_edge(..., "supersedes")``
+call, and the edge itself both records the decision and stops the suggestion
+resurfacing (the detector skips a pair that already has the edge, and acceptance
+clears the stored value). There was no equivalent for the opposite judgement.
+
+When an agent decides two memories are deliberately SEPARATE — the same
+conclusion held at two altitudes, say, rather than one superseding the other —
+the suggestion returned on every ``recall()`` and ``reference()`` touching that
+memory, indefinitely, across sessions. The only ways to silence it were a wrong
+accept (which shadows a memory that should stay live) or deleting one of them.
+
+This adds a tombstone, stored in the same server-only ``supersede_candidate``
+column so no migration is needed and no client-writable surface is involved:
+
+    {"dismissed": {"memory_id": ..., "similarity": ..., "dismissed_at": ...}}
+
+Two properties follow from that shape:
+
+* It carries no top-level ``memory_id``/``similarity``, so
+  ``_resolve_supersede_candidates`` — which requires both — skips it without
+  needing to know tombstones exist. Dismissed suggestions simply stop surfacing.
+* It records the similarity AT dismissal, which is what makes re-detection
+  conditional rather than permanent. See :func:`is_dismissed`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from utils.datetime import to_utc_iso, utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# How far the recomputed similarity must move before a dismissed pair is
+# reconsidered. The issue asks for re-detection when "either memory's embedding
+# changes materially" — clearing the tombstone on ANY re-embed would not do
+# that, because process_pending_embedding also runs for sleep reindexes and
+# backfills, which recompute the SAME vector and would resurrect every dismissal
+# the first night. Keying on the similarity delta separates the two: a
+# mechanical reindex reproduces the score and stays suppressed, while a real
+# content edit moves it and gets a fresh judgement.
+RESURFACE_SIMILARITY_DELTA = 0.02
+
+
+def build_tombstone(candidate: dict[str, Any]) -> dict[str, Any]:
+    """Tombstone value for a rejected suggestion.
+
+    Args:
+        candidate: The stored suggestion being rejected — must carry
+            ``memory_id``; ``similarity`` is recorded when present so
+            re-detection can compare against it.
+
+    Returns:
+        The value to store in ``Memory.supersede_candidate``.
+    """
+    dismissed: dict[str, Any] = {
+        "memory_id": str(candidate["memory_id"]),
+        "dismissed_at": to_utc_iso(utcnow()),
+    }
+    similarity = candidate.get("similarity")
+    if isinstance(similarity, (int, float)):
+        dismissed["similarity"] = float(similarity)
+    return {"dismissed": dismissed}
+
+
+def dismissed_entry(stored: Any) -> dict[str, Any] | None:
+    """The tombstone inside a stored column value, or None."""
+    if not isinstance(stored, dict):
+        return None
+    entry = stored.get("dismissed")
+    return entry if isinstance(entry, dict) else None
+
+
+def is_dismissed(stored: Any, *, target_id: str, similarity: float) -> bool:
+    """Whether a freshly-detected pair was already rejected and still is.
+
+    Args:
+        stored: Current ``Memory.supersede_candidate`` value.
+        target_id: The newly-detected candidate's memory id.
+        similarity: The newly-computed similarity.
+
+    Returns:
+        True when this exact pair was dismissed and the similarity has not moved
+        by at least ``RESURFACE_SIMILARITY_DELTA`` since. A dismissal of a
+        DIFFERENT target never suppresses a new one — rejecting one pairing says
+        nothing about another.
+    """
+    entry = dismissed_entry(stored)
+    if entry is None or entry.get("memory_id") != target_id:
+        return False
+
+    prior = entry.get("similarity")
+    if not isinstance(prior, (int, float)):
+        # Pre-delta tombstone (or a malformed one): keep it suppressed. A
+        # dismissal is a deliberate judgement, so the safe reading of a missing
+        # baseline is "still rejected", not "resurface".
+        return True
+    return abs(similarity - float(prior)) < RESURFACE_SIMILARITY_DELTA

--- a/backend/tests/mcp_server/test_context_last_used_touch.py
+++ b/backend/tests/mcp_server/test_context_last_used_touch.py
@@ -324,6 +324,7 @@ async def test_update_memory_bumps_context():
             re_embedded=False,
             scope="personal",
             persistence=None,  # #1505 block, not under test here
+            supersede_candidate_dismissed=None,  # #1504, not under test here
         )
     )
 

--- a/backend/tests/services/test_persistence_info.py
+++ b/backend/tests/services/test_persistence_info.py
@@ -543,6 +543,7 @@ async def test_update_memory_tool_json_carries_the_block(sleep_pass):
             re_embedded=False,
             scope="persistent",
             persistence=persistence_info("persistent"),
+            supersede_candidate_dismissed=None,  # #1504, not under test here
         )
     )
 

--- a/backend/tests/services/test_supersede_dismissal.py
+++ b/backend/tests/services/test_supersede_dismissal.py
@@ -1,0 +1,286 @@
+"""Rejection path for supersede suggestions (#1504).
+
+The feature is only worth anything if the suppression actually STICKS. The
+detector runs on every re-embed — including sleep reindexes and backfills that
+recompute an identical vector — so the tests below are organised around the two
+ways this could fail:
+
+* it resurfaces anyway (the dismissal was pointless), or
+* it suppresses forever, including a pairing that genuinely became a supersede
+  after the memory was rewritten (the dismissal was a trap).
+"""
+
+import ast
+from pathlib import Path
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import UpdateMemoryRequest
+from services.supersede_dismissal import (
+    RESURFACE_SIMILARITY_DELTA,
+    build_tombstone,
+    dismissed_entry,
+    is_dismissed,
+)
+
+TARGET = str(uuid4())
+OTHER = str(uuid4())
+
+
+def _live_candidate(target=TARGET, similarity=0.9037):
+    return {"memory_id": target, "similarity": similarity, "detected_at": "2026-08-08T00:00:00Z"}
+
+
+class TestTombstoneShape:
+    def test_tombstone_is_invisible_to_the_read_path(self):
+        """``_resolve_supersede_candidates`` requires a top-level memory_id AND
+        similarity; a tombstone must satisfy neither, so it stops surfacing
+        without that code needing to know tombstones exist."""
+        tombstone = build_tombstone(_live_candidate())
+        assert "memory_id" not in tombstone
+        assert "similarity" not in tombstone
+
+    def test_tombstone_records_the_pair_and_the_similarity(self):
+        tombstone = build_tombstone(_live_candidate(similarity=0.91))
+        entry = dismissed_entry(tombstone)
+        assert entry is not None
+        assert entry["memory_id"] == TARGET
+        assert entry["similarity"] == pytest.approx(0.91)
+        assert entry["dismissed_at"]
+
+    def test_a_candidate_without_similarity_still_tombstones(self):
+        entry = dismissed_entry(build_tombstone({"memory_id": TARGET}))
+        assert entry is not None
+        assert "similarity" not in entry
+
+    @pytest.mark.parametrize("stored", [None, {}, {"memory_id": TARGET}, "junk", 7])
+    def test_non_tombstones_are_not_read_as_dismissals(self, stored):
+        assert dismissed_entry(stored) is None
+
+
+class TestSuppressionSticks:
+    def test_the_same_pair_at_the_same_similarity_stays_suppressed(self):
+        """A sleep reindex / backfill recomputes an identical vector. If ANY
+        re-embed cleared the tombstone, every dismissal would die the first
+        night — which is exactly what this keys on the delta to avoid."""
+        stored = build_tombstone(_live_candidate(similarity=0.9037))
+        assert is_dismissed(stored, target_id=TARGET, similarity=0.9037)
+
+    def test_a_sub_threshold_drift_stays_suppressed(self):
+        stored = build_tombstone(_live_candidate(similarity=0.90))
+        drift = RESURFACE_SIMILARITY_DELTA / 2
+        assert is_dismissed(stored, target_id=TARGET, similarity=0.90 + drift)
+        assert is_dismissed(stored, target_id=TARGET, similarity=0.90 - drift)
+
+    def test_a_tombstone_without_a_baseline_stays_suppressed(self):
+        """A deliberate judgement with no recorded baseline reads as 'still
+        rejected', not 'resurface'."""
+        stored = build_tombstone({"memory_id": TARGET})
+        assert is_dismissed(stored, target_id=TARGET, similarity=0.99)
+
+
+class TestSuppressionIsNotATrap:
+    def test_a_material_similarity_change_resurfaces(self):
+        """The memory was really rewritten — it deserves a fresh judgement."""
+        stored = build_tombstone(_live_candidate(similarity=0.90))
+        assert not is_dismissed(
+            stored, target_id=TARGET, similarity=0.90 + RESURFACE_SIMILARITY_DELTA
+        )
+
+    def test_a_dismissal_never_suppresses_a_different_pairing(self):
+        """Rejecting one pairing says nothing about another.
+
+        The new candidate is given the SAME similarity as the dismissed one on
+        purpose: with a distant score the delta check would mask a missing
+        target comparison, and the test would pass on broken code.
+        """
+        stored = build_tombstone(_live_candidate(target=TARGET, similarity=0.9037))
+        assert not is_dismissed(stored, target_id=OTHER, similarity=0.9037)
+
+    def test_a_different_pairing_is_live_even_with_no_recorded_baseline(self):
+        """The no-baseline branch must not become a blanket suppressor either."""
+        stored = build_tombstone({"memory_id": TARGET})
+        assert not is_dismissed(stored, target_id=OTHER, similarity=0.95)
+
+    def test_no_tombstone_suppresses_nothing(self):
+        assert not is_dismissed(None, target_id=TARGET, similarity=0.99)
+        assert not is_dismissed(_live_candidate(), target_id=TARGET, similarity=0.99)
+
+
+class TestRequestValidation:
+    def test_dismissal_defaults_off(self):
+        assert UpdateMemoryRequest(memory_id=uuid4()).dismiss_supersede_candidate is False
+
+    def test_dismissal_is_accepted_in_place_with_no_other_field(self):
+        """Rejecting a suggestion is a complete action on its own."""
+        request = UpdateMemoryRequest(memory_id=uuid4(), dismiss_supersede_candidate=True)
+        assert request.dismiss_supersede_candidate is True
+
+    def test_dismissal_is_rejected_on_the_upsert_path(self):
+        """An upsert replaces the memory, so there is no suggestion to dismiss —
+        reject rather than silently ignore a caller's mistaken model."""
+        with pytest.raises(ValueError, match="requires memory_id"):
+            UpdateMemoryRequest(
+                external_id="res-1",
+                summary="a summary long enough to pass validation",
+                content="content",
+                type="note",
+                dismiss_supersede_candidate=True,
+            )
+
+
+class TestServiceApplication:
+    def _memory(self, stored):
+        memory = MagicMock()
+        memory.id = uuid4()
+        memory.supersede_candidate = stored
+        return memory
+
+    def _apply(self, stored, *, dismiss=True):
+        from services.memory_service import MemoryService
+
+        memory = self._memory(stored)
+        request = UpdateMemoryRequest(memory_id=memory.id, dismiss_supersede_candidate=dismiss)
+        returned = MemoryService._apply_supersede_dismissal(memory, request)
+        return memory, returned
+
+    def test_a_live_suggestion_is_tombstoned_and_echoed(self):
+        memory, returned = self._apply(_live_candidate())
+        assert str(returned) == TARGET
+        assert dismissed_entry(memory.supersede_candidate) is not None
+
+    def test_the_flag_off_leaves_the_suggestion_untouched(self):
+        live = _live_candidate()
+        memory, returned = self._apply(live, dismiss=False)
+        assert returned is None
+        assert memory.supersede_candidate == live
+
+    @pytest.mark.parametrize("stored", [None, {}, {"similarity": 0.9}])
+    def test_dismissing_with_nothing_pending_is_a_no_op_not_an_error(self, stored):
+        """The suggestion may have self-healed or been accepted between the read
+        that showed it and this call; failing the whole update would be hostile."""
+        memory, returned = self._apply(stored)
+        assert returned is None
+        assert memory.supersede_candidate == stored
+
+    def test_dismissing_twice_is_idempotent(self):
+        memory, first = self._apply(_live_candidate())
+        tombstone = memory.supersede_candidate
+        request = UpdateMemoryRequest(memory_id=memory.id, dismiss_supersede_candidate=True)
+
+        from services.memory_service import MemoryService
+
+        second = MemoryService._apply_supersede_dismissal(memory, request)
+        assert first is not None
+        assert second is None
+        assert memory.supersede_candidate == tombstone
+
+
+class TestWiring:
+    """Both halves must be connected: the write, and the detector's guard."""
+
+    def _service_ast(self):
+        import services.memory_service as memory_service
+
+        return ast.parse(Path(memory_service.__file__).read_text(encoding="utf-8"))
+
+    def test_update_in_place_applies_the_dismissal(self):
+        tree = self._service_ast()
+        fn = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_update_in_place"
+        )
+        assert any(
+            isinstance(node, ast.Attribute) and node.attr == "_apply_supersede_dismissal"
+            for node in ast.walk(fn)
+        ), "_update_in_place no longer applies the dismissal"
+
+    def test_the_detector_consults_the_tombstone(self):
+        """Without this, the next re-embed rewrites the suggestion and the
+        dismissal silently does nothing beyond the current session.
+
+        The detector is located by what it DOES — assigning
+        ``memory.supersede_candidate`` — rather than by name, so moving or
+        renaming it keeps the guarantee under test instead of quietly passing.
+        """
+        tree = self._service_ast()
+
+        def writes_a_candidate(fn):
+            return any(
+                isinstance(node, ast.Attribute)
+                and node.attr == "supersede_candidate"
+                and isinstance(node.ctx, ast.Store)
+                for node in ast.walk(fn)
+            )
+
+        writers = [
+            fn
+            for fn in ast.walk(tree)
+            if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and writes_a_candidate(fn)
+        ]
+        # The dismissal itself writes the column too; the detector is the other one.
+        detectors = [fn for fn in writers if fn.name != "_apply_supersede_dismissal"]
+        assert detectors, "no function assigns memory.supersede_candidate any more"
+        for fn in detectors:
+            assert any(
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "is_dismissed"
+                for node in ast.walk(fn)
+            ), (
+                f"{fn.name} writes a supersede candidate without consulting the "
+                "dismissal tombstone — a re-embed would resurrect rejected suggestions"
+            )
+
+    def test_the_dismissal_check_actually_gates_the_write(self):
+        """Computing the guard is not enough — it must be in the condition.
+
+        Dropping ``already_dismissed`` from the ``if`` leaves ``is_dismissed``
+        called and its result unused, so the previous test still passes while
+        the dismissal silently becomes session-only. This asserts on the branch
+        that guards the assignment.
+        """
+        tree = self._service_ast()
+
+        def assigns_candidate(node):
+            return any(
+                isinstance(n, ast.Attribute)
+                and n.attr == "supersede_candidate"
+                and isinstance(n.ctx, ast.Store)
+                for n in ast.walk(node)
+            )
+
+        guards = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.If)
+            and any(assigns_candidate(stmt) for stmt in node.body)
+            and any(
+                isinstance(n, ast.Name) and n.id == "already_superseded"
+                for n in ast.walk(node.test)
+            )
+        ]
+        assert guards, "could not find the branch guarding the candidate write"
+        for guard in guards:
+            names = {n.id for n in ast.walk(guard.test) if isinstance(n, ast.Name)}
+            assert "already_dismissed" in names, (
+                "the candidate write is not gated on already_dismissed — the "
+                "tombstone is computed but ignored, so a re-embed resurrects "
+                "rejected suggestions"
+            )
+
+    def test_update_response_carries_the_dismissed_id(self):
+        tree = self._service_ast()
+        sites = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "UpdateMemoryResponse"
+        ]
+        assert any(
+            any(kw.arg == "supersede_candidate_dismissed" for kw in call.keywords) for call in sites
+        ), "no UpdateMemoryResponse reports the dismissal"


### PR DESCRIPTION
Closes #1504

## Problem

Accepting a `supersede_candidate` is one `create_edge(..., "supersedes")` call, and the edge itself both records the decision *and* stops the suggestion resurfacing. There was no equivalent for the opposite judgement.

When an agent decides two memories are deliberately **separate** — the same conclusion recorded at two altitudes, say — the suggestion came back on every `recall()` and `reference()` touching that memory, indefinitely, across sessions. The only ways to silence it were a wrong accept (which shadows a memory that should stay live) or deleting one of them.

## What this adds

`update_memory(memory_id=..., dismiss_supersede_candidate=true)`, tombstoning the pair in the same server-only column:

```json
{"dismissed": {"memory_id": "...", "similarity": 0.9037, "dismissed_at": "..."}}
```

No migration, no client-writable surface, and **the shape does the work**: the tombstone carries no top-level `memory_id`/`similarity`, and `_resolve_supersede_candidates` requires both — so dismissed suggestions stop surfacing without that code needing to know tombstones exist.

## Re-detection is conditional, not permanent

The issue asks for re-detection when "either memory's embedding changes materially", and notes "re-embed clears the tombstone". Taken literally, that would not deliver it: `process_pending_embedding` also runs for **sleep reindexes and backfills**, which recompute the *same* vector — every dismissal would be resurrected the first night.

So the tombstone records the similarity **at dismissal**, and the detector compares against it:

| event | similarity | outcome |
|---|---|---|
| sleep reindex / backfill | unchanged | stays suppressed |
| real content edit | moves ≥ 0.02 | fresh judgement |
| a *different* candidate | — | surfaces normally |

Rejecting one pairing says nothing about another.

## Error semantics

Dismissing with nothing pending is a **no-op, not an error** — the suggestion may have self-healed (target deleted) or been accepted between the read that showed it and this call, and failing the whole update over that would be hostile.

Passing the flag on the `external_id` upsert path **is** rejected: that path replaces the memory, so there is no suggestion to dismiss, and a caller sending it has a mistaken model of what the flag does.

## Testing

28 tests, organised around the two ways this could fail: it resurfaces anyway (pointless), or it suppresses forever including a pairing that genuinely became a supersede (a trap).

Mutation-checked with 5 mutations. **Two initially survived, and both were real weaknesses**, now fixed:

1. Dropping `already_dismissed` from the detector's `if` left `is_dismissed` called and its result unused — the guard computed but ignored, making the dismissal session-only. The wiring test checked only that it was *called*; it now asserts on the branch condition that gates the write.
2. `test_a_dismissal_never_suppresses_a_different_pairing` used a similarity far from the dismissed one, so the delta check masked a missing target comparison. It now uses the *same* similarity, which is the only version that actually tests the target check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)