### PR TITLE
fix(api): review findings on the v0.65.0 write/recall additions

### DIFF
--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -209,6 +209,22 @@ def location_payload_from_details(details: dict | None) -> dict | None:
     return {"lat": float(lat), "lon": float(lon)}
 
 
+# The request fields ``_update_apply_fields`` writes onto the row. Named here so
+# a dismissal-only update (#1504) can tell "no content changed" from "content
+# changed", and so adding a field to that method forces a change here too.
+_UPDATE_CONTENT_FIELDS = (
+    "summary",
+    "context_summary",
+    "content",
+    "details",
+    "type",
+    "importance",
+    "tags",
+    "context",
+    "delivery_mode",
+)
+
+
 class MemoryService:
     """Memory service for core memory operations.
 
@@ -627,6 +643,7 @@ class MemoryService:
                 lint=await self._lint_write(
                     workspace_id=UUID(workspace_id_str),
                     context_id=UUID(context_id_str),
+                    user_id=user_id,
                     summary=request.summary,
                     tags=request.tags,
                 ),
@@ -706,13 +723,31 @@ class MemoryService:
         if request.content is not None and request.content != memory.content:
             needs_reembed = True
 
+        # #1504/#1505: a dismissal-only call edits no content. Capture the
+        # timestamp before _update_apply_fields stamps it unconditionally.
+        updated_at_before = memory.updated_at
+        edits_requested = any(
+            getattr(request, field) is not None for field in _UPDATE_CONTENT_FIELDS
+        )
+
         self._update_guard_size(memory, request, normalized_summary, normalized_ctx_summary)
         effective_details = self._update_apply_fields(
             memory, request, normalized_summary, normalized_ctx_summary
         )
         # #1504: rejection path. Applied before the commit below so the tombstone
         # lands in the same transaction as any other field change in this call.
-        dismissed_target = self._apply_supersede_dismissal(memory, request)
+        # A dismissal is not a content edit, so when it is the ONLY thing this
+        # call did, restore the timestamp _update_apply_fields unconditionally
+        # stamped: updated_at is the documented staleness cue ("an old value
+        # means the fact may be stale"), and rejecting a suggestion must not make
+        # a stale memory read as freshly maintained (#1317's rule for the
+        # detection half of this lifecycle).
+        dismissed_target = self._apply_supersede_dismissal(
+            memory, request, drop_baseline=needs_reembed
+        )
+
+        if request.dismiss_supersede_candidate and not edits_requested:
+            memory.updated_at = updated_at_before
 
         if needs_reembed:
             # Async embedding via create_task (same pattern as remember)
@@ -762,18 +797,29 @@ class MemoryService:
             lint=await self._lint_write(
                 workspace_id=memory.workspace_id,
                 context_id=memory.context_id,
+                user_id=user_id,
                 summary=memory.summary,
                 tags=memory.tags,
             ),
         )
 
     @staticmethod
-    def _apply_supersede_dismissal(memory: Any, request: UpdateMemoryRequest) -> UUID | None:
+    def _apply_supersede_dismissal(
+        memory: Any, request: UpdateMemoryRequest, *, drop_baseline: bool = False
+    ) -> UUID | None:
         """#1504: tombstone the current supersede suggestion, if one is pending.
 
         Args:
             memory: The loaded update target.
             request: The update request.
+            drop_baseline: Set when this same call also re-embeds the memory.
+                The tombstone normally records the similarity at dismissal so a
+                later MATERIAL change can re-surface the pair; but a re-embed in
+                this very call is guaranteed to move that score, which would let
+                the detector overwrite the tombstone moments after the response
+                reported the dismissal as applied. Storing no baseline suppresses
+                the pair unconditionally instead — the caller rejected these two
+                memories knowing they were editing one of them.
 
         Returns:
             The dismissed candidate's memory id, or None when the flag was not
@@ -795,16 +841,29 @@ class MemoryService:
             return None
 
         target_id = str(stored["memory_id"])
+        try:
+            dismissed_id = UUID(target_id)
+        except (ValueError, TypeError):
+            # The column is server-written, but the sibling read path
+            # (_resolve_supersede_candidates) already treats a malformed stored
+            # value as reachable. A corrupt ADVISORY column must not fail the
+            # caller's real edit, so drop the dismissal and leave the row alone.
+            logger.warning(
+                "supersede_dismiss_malformed_candidate",
+                memory_id=str(memory.id),
+                stored_target=target_id[:100],
+            )
+            return None
         # Reassign (JSON column, not a MutableDict — reassignment is what marks
         # it dirty), mirroring how detection and acceptance write this column.
-        memory.supersede_candidate = build_tombstone(stored)
+        memory.supersede_candidate = build_tombstone(stored, drop_baseline=drop_baseline)
         logger.info(
             "supersede_suggestion_dismissed",
             memory_id=str(memory.id),
             candidate_memory_id=target_id,
             similarity=stored.get("similarity"),
         )
-        return UUID(target_id)
+        return dismissed_id
 
     async def _update_load_authorized(self, memory_id: UUID, user_id: str) -> Any:
         """Load the update target, or 404 (MCP-reachable in-place update path).
@@ -3582,6 +3641,7 @@ class MemoryService:
         neural_enabled: bool,
         binding_row_filtered: int,
         selection_evidence: dict[str, Any] | None,
+        cross_context: bool = False,
     ) -> RecallResponse:
         """Assemble the final response: hints, tags, confidence, audit row.
 
@@ -3597,6 +3657,8 @@ class MemoryService:
             neural_enabled: Whether the neural graph is available to hint from.
             binding_row_filtered: #1299 subtracted-row count, for the audit row.
             selection_evidence: #1306 evidence dict, or None.
+            cross_context: True when the recall spanned several contexts, which
+                disables the single-context tag hints (#1503).
 
         Returns:
             The completed RecallResponse.
@@ -3675,8 +3737,10 @@ class MemoryService:
             tag_suggestions=await self._tag_suggestions_for_empty_result(
                 request,
                 responses,
+                user_id=user_id,
                 workspace_id=effective_workspace_id,
                 context_id=current_context_id,
+                cross_context=cross_context,
             ),
         )
 
@@ -3685,6 +3749,7 @@ class MemoryService:
         *,
         workspace_id: UUID | None,
         context_id: UUID | None,
+        user_id: str,
         summary: str | None,
         tags: list[str] | None,
     ) -> list[WriteLintHint]:
@@ -3692,21 +3757,31 @@ class MemoryService:
 
         Returns no hints when the write cannot be located in a context (the
         vocabulary comparison would be meaningless) or when nothing is worth
-        saying. Never raises — ``lint_write`` swallows its own errors, and the
-        guards here cover the arguments it would otherwise be handed as None.
+        saying.
+
+        Total by construction. ``lint_write`` guards its own body, but the
+        ``import`` below is outside that guard and this runs AFTER the write has
+        committed — in ``remember()`` it sits inside the ``try`` whose handler
+        rolls back and logs ``memory_creation_failed``, so an escaping exception
+        would report a stored memory as failed and invite a duplicating retry.
         """
         if workspace_id is None or context_id is None or not summary:
             return []
 
-        from services.write_lint import lint_write
+        try:
+            from services.write_lint import lint_write
 
-        return await lint_write(
-            self.db,
-            workspace_id=workspace_id,
-            context_id=context_id,
-            summary=summary,
-            tags=tags,
-        )
+            return await lint_write(
+                self.db,
+                workspace_id=workspace_id,
+                context_id=context_id,
+                user_id=user_id,
+                summary=summary,
+                tags=tags,
+            )
+        except Exception as e:  # noqa: BLE001 — advisory; never fail a committed write
+            logger.warning("write_lint_unavailable", error=str(e))
+            return []
 
     @staticmethod
     def _requested_tag_filter(filters: dict | None) -> list[str]:
@@ -3727,19 +3802,23 @@ class MemoryService:
         request: RecallRequest,
         responses: list,
         *,
+        user_id: str,
         workspace_id: UUID,
-        context_id: UUID | None,
+        context_id: UUID,
+        cross_context: bool,
     ) -> dict[str, list[str]] | None:
         """#1503: near-miss tags for a tag-filtered recall that found nothing.
 
         Deliberately narrow. It fires only on a ZERO-result recall that actually
         filtered on tags, so the extra vocabulary query never rides a successful
         recall, and it cannot be mistaken for "these tags also matched" on a
-        partial result. Returns None (field omitted) when there is nothing to
-        say, including when the caller is doing a cross-context recall — the
-        vocabulary read is scoped to one authorized context.
+        partial result.
+
+        Skipped entirely for a cross-context recall: the vocabulary read covers
+        ONE context, so suggesting from the primary alone would describe a
+        different search than the one the caller ran.
         """
-        if responses or context_id is None:
+        if responses or cross_context:
             return None
         tags = self._requested_tag_filter(request.filters)
         if not tags:
@@ -3751,6 +3830,7 @@ class MemoryService:
             self.db,
             workspace_id=workspace_id,
             context_id=context_id,
+            user_id=user_id,
             tags=tags,
         )
         return suggestions or None
@@ -3895,13 +3975,19 @@ class MemoryService:
         # and the caller has authorized exactly this one.
         effective_filters = request.filters
         tag_filter = self._requested_tag_filter(request.filters)
-        if tag_filter and request.filters.get("tags_normalize") and current_context_id:
+        if (
+            tag_filter
+            and request.filters.get("tags_normalize")
+            and current_context_id
+            and not context_ids  # one context's vocabulary cannot widen a search over many
+        ):
             from services.tag_resolution import expand_tag_filter
 
             expanded, added = await expand_tag_filter(
                 self.db,
                 workspace_id=effective_workspace_id,
                 context_id=current_context_id,
+                user_id=user_id,
                 tags=tag_filter,
             )
             if added:
@@ -4049,6 +4135,7 @@ class MemoryService:
             neural_enabled=neural_enabled,
             binding_row_filtered=binding_row_filtered,
             selection_evidence=selection_evidence,
+            cross_context=bool(context_ids),
         )
 
     async def load_pinned(

--- a/backend/src/services/persistence.py
+++ b/backend/src/services/persistence.py
@@ -124,10 +124,27 @@ def persistence_info(scope: str) -> PersistenceInfo | None:
 
     Returns:
         PersistenceInfo describing what that scope implies for durability, or
-        None for an unrecognized scope. This block is advisory: an unexpected
-        scope must not fail a write that already committed, so the field is
-        omitted (and the anomaly logged) rather than raised.
+        None when it cannot be built. This block is advisory and is computed
+        AFTER the write has committed, so it must be total: an unrecognized
+        scope, or any failure below, omits the field rather than raising.
+
+    Note:
+        The blanket guard is not defensive padding. The archival floor is read
+        through a lazy import of ``services.sleep.consolidation``, which pulls
+        in Qdrant, the graph service and the LLM service — the first write in a
+        process pays that import, and anything wrong in that chain would
+        otherwise surface as a failed ``remember()`` for a memory that is
+        already stored, prompting the caller to retry and duplicate it.
     """
+    try:
+        return _persistence_info(scope)
+    except Exception as e:  # noqa: BLE001 — advisory; never fail a committed write
+        logger.warning("persistence_info_failed", scope=scope, error=str(e))
+        return None
+
+
+def _persistence_info(scope: str) -> PersistenceInfo | None:
+    """Build the block, or None for an unrecognized scope. May raise."""
     if scope == "persistent":
         return PersistenceInfo(
             scope="persistent",

--- a/backend/src/services/supersede_dismissal.py
+++ b/backend/src/services/supersede_dismissal.py
@@ -45,13 +45,20 @@ logger = get_logger(__name__)
 RESURFACE_SIMILARITY_DELTA = 0.02
 
 
-def build_tombstone(candidate: dict[str, Any]) -> dict[str, Any]:
+def build_tombstone(candidate: dict[str, Any], *, drop_baseline: bool = False) -> dict[str, Any]:
     """Tombstone value for a rejected suggestion.
 
     Args:
         candidate: The stored suggestion being rejected — must carry
             ``memory_id``; ``similarity`` is recorded when present so
             re-detection can compare against it.
+        drop_baseline: Omit the similarity baseline, making the suppression
+            unconditional. Set when the same call also re-embeds the memory:
+            that re-embed is guaranteed to move the score past the resurface
+            delta, so recording the pre-edit baseline would let the detector
+            overwrite this tombstone moments after the caller was told the
+            dismissal applied. See :func:`is_dismissed` for how a missing
+            baseline is read.
 
     Returns:
         The value to store in ``Memory.supersede_candidate``.
@@ -61,7 +68,7 @@ def build_tombstone(candidate: dict[str, Any]) -> dict[str, Any]:
         "dismissed_at": to_utc_iso(utcnow()),
     }
     similarity = candidate.get("similarity")
-    if isinstance(similarity, (int, float)):
+    if not drop_baseline and isinstance(similarity, (int, float)):
         dismissed["similarity"] = float(similarity)
     return {"dismissed": dismissed}
 

--- a/backend/src/services/tag_resolution.py
+++ b/backend/src/services/tag_resolution.py
@@ -46,28 +46,48 @@ MAX_EXPANSION_PER_TAG = 20
 MAX_SUGGESTIONS_PER_TAG = 5
 
 
-async def _fetch_vocabulary(
+async def fetch_vocabulary(
     db: AsyncSession,
     *,
     workspace_id: UUID,
     context_id: UUID,
+    user_id: str,
 ) -> dict[str, int]:
-    """Distinct tag -> memory count for one context.
+    """Distinct tag -> memory count for one context, as THIS caller may read it.
 
     ``DISTINCT id, unnest(tags)`` semantics are not needed here: the outer
     aggregate counts distinct memory ids per tag directly, so a memory carrying
     the same tag twice still counts once (the #614 lesson).
+
+    The ``user_id`` filter mirrors the one ``SearchService`` applies to recall:
+    in a context that is not shared, a caller sees only their OWN memories, so
+    aggregating over every author would let tag names and counts describe rows
+    the caller cannot read. Sharing is resolved once per call, and only a shared
+    context aggregates across authors.
+
+    Args:
+        db: Session.
+        workspace_id: Authorized workspace.
+        context_id: Authorized context.
+        user_id: Caller identity, used to scope the aggregate.
+
+    Returns:
+        ``{tag: memory_count}``, capped at ``VOCABULARY_LIMIT`` by descending count.
     """
+    from services.context_service import ContextService
+
+    shared = await ContextService(db).is_context_shared(context_id)
+
+    conditions = [
+        Memory.workspace_id == workspace_id,
+        Memory.context_id == context_id,
+        Memory.deleted_at.is_(None),
+    ]
+    if not shared:
+        conditions.append(Memory.user_id == user_id)
+
     tag = func.unnest(Memory.tags).label("tag")
-    inner = (
-        select(Memory.id.label("memory_id"), tag)
-        .where(
-            Memory.workspace_id == workspace_id,
-            Memory.context_id == context_id,
-            Memory.deleted_at.is_(None),
-        )
-        .subquery()
-    )
+    inner = select(Memory.id.label("memory_id"), tag).where(*conditions).subquery()
     stmt = (
         select(inner.c.tag, func.count(func.distinct(inner.c.memory_id)))
         .group_by(inner.c.tag)
@@ -83,6 +103,7 @@ async def expand_tag_filter(
     *,
     workspace_id: UUID,
     context_id: UUID,
+    user_id: str,
     tags: list[str],
 ) -> tuple[list[str], dict[str, list[str]]]:
     """Widen tags to every stored MECHANICAL variant of each requested tag.
@@ -91,6 +112,7 @@ async def expand_tag_filter(
         db: Session (caller must already have authorized the context).
         workspace_id: Authorized workspace.
         context_id: Authorized context.
+        user_id: Caller identity (scopes the vocabulary read).
         tags: Tags the caller filtered on.
 
     Returns:
@@ -105,7 +127,9 @@ async def expand_tag_filter(
         an enhancement and must never break a recall.
     """
     try:
-        vocabulary = await _fetch_vocabulary(db, workspace_id=workspace_id, context_id=context_id)
+        vocabulary = await fetch_vocabulary(
+            db, workspace_id=workspace_id, context_id=context_id, user_id=user_id
+        )
     except Exception as e:  # noqa: BLE001 — enhancement must not break recall
         logger.warning("tag_vocabulary_read_failed", error=str(e))
         return tags, {}
@@ -147,6 +171,7 @@ async def suggest_tags(
     *,
     workspace_id: UUID,
     context_id: UUID,
+    user_id: str,
     tags: list[str],
 ) -> dict[str, list[str]]:
     """Near-duplicate tags that exist in the context, for a filter that matched nothing.
@@ -155,6 +180,7 @@ async def suggest_tags(
         db: Session (caller must already have authorized the context).
         workspace_id: Authorized workspace.
         context_id: Authorized context.
+        user_id: Caller identity (scopes the vocabulary read).
         tags: Tags the caller filtered on.
 
     Returns:
@@ -164,7 +190,9 @@ async def suggest_tags(
         misspelled.
     """
     try:
-        vocabulary = await _fetch_vocabulary(db, workspace_id=workspace_id, context_id=context_id)
+        vocabulary = await fetch_vocabulary(
+            db, workspace_id=workspace_id, context_id=context_id, user_id=user_id
+        )
     except Exception as e:  # noqa: BLE001 — a hint must not break recall
         logger.warning("tag_vocabulary_read_failed", error=str(e))
         return {}

--- a/backend/src/services/write_lint.py
+++ b/backend/src/services/write_lint.py
@@ -152,6 +152,7 @@ async def lint_write(
     *,
     workspace_id: UUID,
     context_id: UUID,
+    user_id: str,
     summary: str,
     tags: list[str] | None,
 ) -> list[WriteLintHint]:
@@ -161,6 +162,8 @@ async def lint_write(
         db: Session (caller must already have authorized the context).
         workspace_id: Authorized workspace.
         context_id: Authorized context.
+        user_id: Caller identity — scopes the vocabulary read so a hint can
+            never describe memories the caller cannot read.
         summary: The summary as written.
         tags: The tags as written.
 
@@ -177,10 +180,10 @@ async def lint_write(
         if tag_list:
             # Only pay for the vocabulary read when there is something to compare
             # against it; the no-tags hint needs no vocabulary at all.
-            from services.tag_resolution import _fetch_vocabulary
+            from services.tag_resolution import fetch_vocabulary
 
-            vocabulary = await _fetch_vocabulary(
-                db, workspace_id=workspace_id, context_id=context_id
+            vocabulary = await fetch_vocabulary(
+                db, workspace_id=workspace_id, context_id=context_id, user_id=user_id
             )
         hints.extend(_tag_hints(tag_list, vocabulary))
 

--- a/backend/src/utils/tag_normalize.py
+++ b/backend/src/utils/tag_normalize.py
@@ -64,17 +64,43 @@ def normalize_tag(tag: str) -> str:
     return _strip_plural(folded)
 
 
+# Two-letter endings that are almost never an English plural, so stripping the
+# trailing ``s`` would truncate a real word rather than singularise it:
+# redis -> redi, status -> statu, chaos -> chao, alias -> alia, class -> clas.
+# ``es`` is deliberately ABSENT — it is a genuine plural ending (issues, boxes)
+# and excluding it would stop those folding at all.
+_NON_PLURAL_ENDINGS = ("ss", "is", "us", "os", "as")
+
+# Tags whose ending is indistinguishable from a plural by any rule (``https``
+# looks exactly like ``apps``), but which are common enough that the mangled
+# stem collides with a real tag — ``https`` folding to ``http`` would merge two
+# tags an author kept distinct. Kept deliberately tiny: an over-strip only does
+# harm when the stem is itself a real tag in the same context, so this is not a
+# list of every non-plural word ending in s.
+_NEVER_PLURAL = frozenset({"https"})
+
+
 def _strip_plural(folded: str) -> str:
     """Strip a trailing English plural, conservatively.
 
-    Only ``-ies -> -y`` and a bare trailing ``-s`` are folded, and never on a
-    stem short enough that the result would collide with unrelated tags. Words
-    ending in ``-ss`` (``class``, ``progress``) are left alone. Non-Latin tags
-    are unaffected because they do not end in ``s``.
+    Only ``-ies -> -y`` and a bare trailing ``-s`` are folded, never on a stem
+    short enough that the result would collide with unrelated tags, and never
+    when the word ends in one of ``_NON_PLURAL_ENDINGS``.
+
+    This is deliberately under-inclusive. A missed plural costs one unmatched
+    spelling; an over-strip silently merges two tags an author kept distinct,
+    and ``expand_tag_filter`` groups the whole vocabulary by this fold — so a
+    wrong merge widens a real filter. Non-Latin tags are unaffected because they
+    do not end in ``s``.
     """
     if len(folded) > 4 and folded.endswith("ies"):
         return folded[:-3] + "y"
-    if len(folded) > 3 and folded.endswith("s") and not folded.endswith("ss"):
+    if (
+        len(folded) > 3
+        and folded.endswith("s")
+        and folded not in _NEVER_PLURAL
+        and not folded.endswith(_NON_PLURAL_ENDINGS)
+    ):
         return folded[:-1]
     return folded
 
@@ -125,7 +151,11 @@ def is_near_duplicate(requested: str, candidate: str) -> bool:
     if not a or not b or a == b:
         return bool(a) and a == b
     if len(a) >= _MIN_AFFIX_LEN and len(b) >= _MIN_AFFIX_LEN:
-        if a.startswith(b) or b.startswith(a) or a.endswith(b) or b.endswith(a):
+        # Prefix only. A shared SUFFIX is far weaker evidence of abbreviation and
+        # relates plainly unrelated tags (test/latest, prod/reprod, auth/oauth),
+        # and noisy suggestions are how an agent learns to ignore the field.
+        # The case this rule exists for — dev-env / dev-environment — is a prefix.
+        if a.startswith(b) or b.startswith(a):
             return True
     if len(a) >= _MIN_EDIT_LEN and len(b) >= _MIN_EDIT_LEN:
         return _edit_distance_within(a, b, _MAX_EDIT_DISTANCE)

--- a/backend/tests/services/test_persistence_info.py
+++ b/backend/tests/services/test_persistence_info.py
@@ -583,3 +583,38 @@ def test_persistence_schema_text_carries_no_bare_issue_ids():
     texts += [f.description or "" for f in PersistenceInfo.model_fields.values()]
     for text in texts:
         assert not re.search(r"#\d{2,}", text), f"bare issue id in agent-facing text: {text!r}"
+
+
+class TestPersistenceInfoCanNeverFailACommittedWrite:
+    """Review finding: this runs inside remember()'s rollback try/except.
+
+    persistence_info reads the archival floor through a lazy import of
+    services.sleep.consolidation (Qdrant + graph service + LLM service). If that
+    chain raises, an unguarded call would surface as a failed remember() for a
+    memory that is already stored — and the handler logs memory_creation_failed
+    and re-raises, inviting a retry that duplicates the memory.
+    """
+
+    def test_a_failing_floor_lookup_omits_the_block_instead_of_raising(self, sleep_pass):
+        with patch(
+            "services.persistence._sleep_archive_min_age_days",
+            side_effect=ImportError("simulated broken import chain"),
+        ):
+            assert persistence_info("working") is None
+
+    def test_a_failing_pass_lookup_omits_only_the_block_that_needs_it(self, sleep_pass):
+        """The persistent branch never consults the pass, so it still builds."""
+        with patch(
+            "services.persistence.active_consolidation_pass",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert persistence_info("working") is None
+            persistent = persistence_info("persistent")
+            assert persistent is not None
+            assert persistent.scope == "persistent"
+
+    def test_remember_still_returns_when_the_block_cannot_be_built(self):
+        """The write is committed; the response must still come back."""
+        from services.persistence import persistence_info as real
+
+        assert real("nonsense-scope") is None

--- a/backend/tests/services/test_supersede_dismissal.py
+++ b/backend/tests/services/test_supersede_dismissal.py
@@ -284,3 +284,119 @@ class TestWiring:
         assert any(
             any(kw.arg == "supersede_candidate_dismissed" for kw in call.keywords) for call in sites
         ), "no UpdateMemoryResponse reports the dismissal"
+
+
+class TestDismissalSurvivesASameCallReEmbed:
+    """#1504 review: dismissing AND editing in one call must not lose the dismissal."""
+
+    def test_a_reembedding_call_stores_no_similarity_baseline(self):
+        """The re-embed is guaranteed to move the score past the resurface delta.
+
+        Recording the pre-edit baseline would let the detector overwrite the
+        tombstone moments after the response reported the dismissal as applied.
+        """
+        tombstone = build_tombstone(_live_candidate(similarity=0.9037), drop_baseline=True)
+        entry = dismissed_entry(tombstone)
+        assert entry is not None
+        assert entry["memory_id"] == TARGET
+        assert "similarity" not in entry
+
+    def test_that_tombstone_suppresses_at_any_recomputed_similarity(self):
+        stored = build_tombstone(_live_candidate(similarity=0.9037), drop_baseline=True)
+        for recomputed in (0.10, 0.50, 0.9037, 0.99):
+            assert is_dismissed(stored, target_id=TARGET, similarity=recomputed)
+
+    def test_it_still_does_not_suppress_a_different_pairing(self):
+        stored = build_tombstone(_live_candidate(), drop_baseline=True)
+        assert not is_dismissed(stored, target_id=OTHER, similarity=0.9037)
+
+    def test_a_non_reembedding_call_keeps_the_baseline(self):
+        entry = dismissed_entry(build_tombstone(_live_candidate(similarity=0.9037)))
+        assert entry is not None and entry["similarity"] == pytest.approx(0.9037)
+
+    def test_update_in_place_passes_the_reembed_flag(self):
+        """Wiring: the flag must be derived from needs_reembed, not hardcoded."""
+        import ast
+        from pathlib import Path
+
+        import services.memory_service as memory_service
+
+        tree = ast.parse(Path(memory_service.__file__).read_text(encoding="utf-8"))
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "_update_in_place"
+        )
+        calls = [
+            c
+            for c in ast.walk(fn)
+            if isinstance(c, ast.Call)
+            and isinstance(c.func, ast.Attribute)
+            and c.func.attr == "_apply_supersede_dismissal"
+        ]
+        assert calls, "_update_in_place no longer applies the dismissal"
+        for call in calls:
+            kw = {k.arg: k.value for k in call.keywords}
+            assert isinstance(kw.get("drop_baseline"), ast.Name), (
+                "drop_baseline must come from needs_reembed"
+            )
+            assert kw["drop_baseline"].id == "needs_reembed"
+
+
+class TestMalformedStoredCandidate:
+    """#1504 review: a corrupt ADVISORY column must not fail the caller's edit."""
+
+    def _apply(self, stored):
+        from services.memory_service import MemoryService
+
+        memory = MagicMock()
+        memory.id = uuid4()
+        memory.supersede_candidate = stored
+        request = UpdateMemoryRequest(memory_id=memory.id, dismiss_supersede_candidate=True)
+        return memory, MemoryService._apply_supersede_dismissal(memory, request)
+
+    @pytest.mark.parametrize("bad", ["not-a-uuid", "", "12345", "  "])
+    def test_a_malformed_target_id_is_dropped_not_raised(self, bad):
+        memory, returned = self._apply({"memory_id": bad, "similarity": 0.9})
+        assert returned is None
+
+    def test_the_row_is_left_untouched_when_the_id_is_malformed(self):
+        stored = {"memory_id": "not-a-uuid", "similarity": 0.9}
+        memory, _ = self._apply(stored)
+        assert memory.supersede_candidate == stored, (
+            "a half-applied tombstone would be worse than none"
+        )
+
+
+class TestDismissalIsNotAContentEdit:
+    """#1504 review: updated_at is the documented staleness cue."""
+
+    def test_dismissal_only_update_restores_updated_at(self):
+        import ast
+        from pathlib import Path
+
+        import services.memory_service as memory_service
+
+        tree = ast.parse(Path(memory_service.__file__).read_text(encoding="utf-8"))
+        fn = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.AsyncFunctionDef) and n.name == "_update_in_place"
+        )
+        restores = [
+            n
+            for n in ast.walk(fn)
+            if isinstance(n, ast.If)
+            and any(
+                isinstance(t, ast.Attribute)
+                and t.attr == "updated_at"
+                and isinstance(t.ctx, ast.Store)
+                for t in ast.walk(n)
+            )
+        ]
+        assert restores, (
+            "_update_apply_fields stamps updated_at unconditionally; a "
+            "dismissal-only call must put it back"
+        )
+        names = {n.id for r in restores for n in ast.walk(r.test) if isinstance(n, ast.Name)}
+        assert "edits_requested" in names

--- a/backend/tests/services/test_tag_resolution.py
+++ b/backend/tests/services/test_tag_resolution.py
@@ -6,6 +6,7 @@ what only hints, and the fail-open behaviour that keeps a recall alive when the
 vocabulary read breaks.
 """
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -16,11 +17,32 @@ from services.tag_resolution import (
     MAX_SUGGESTIONS_PER_TAG,
     VOCABULARY_LIMIT,
     expand_tag_filter,
+    fetch_vocabulary,
     suggest_tags,
 )
 
 WS = uuid4()
 CTX = uuid4()
+USER = "caller-1"
+
+
+@pytest.fixture(autouse=True)
+def _unshared_context():
+    """Default every test to a NON-shared context (the user-scoped path).
+
+    fetch_vocabulary resolves sharing per call; tests that care about the shared
+    branch override this with _shared_context().
+    """
+    with patch("services.context_service.ContextService") as cls:
+        cls.return_value.is_context_shared = AsyncMock(return_value=False)
+        yield cls
+
+
+@contextlib.contextmanager
+def _shared_context():
+    with patch("services.context_service.ContextService") as cls:
+        cls.return_value.is_context_shared = AsyncMock(return_value=True)
+        yield
 
 
 def _db_with_vocabulary(vocabulary: dict[str, int]):
@@ -42,7 +64,7 @@ class TestExpandTagFilter:
     async def test_mechanical_variants_are_added(self):
         db = _db_with_vocabulary({"Dev_Environment": 12, "dev environment": 3, "python": 40})
         expanded, added = await expand_tag_filter(
-            db, workspace_id=WS, context_id=CTX, tags=["dev-environment"]
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["dev-environment"]
         )
         assert set(expanded) == {"dev-environment", "Dev_Environment", "dev environment"}
         assert added == {"dev-environment": ["Dev_Environment", "dev environment"]}
@@ -52,7 +74,7 @@ class TestExpandTagFilter:
         """The issue's example must NOT silently widen the filter."""
         db = _db_with_vocabulary({"dev-env": 3, "authentication": 9})
         expanded, added = await expand_tag_filter(
-            db, workspace_id=WS, context_id=CTX, tags=["dev-environment", "auth"]
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["dev-environment", "auth"]
         )
         assert expanded == ["dev-environment", "auth"]
         assert added == {}
@@ -62,7 +84,7 @@ class TestExpandTagFilter:
         """Expansion widens; it must never replace what the caller asked for."""
         db = _db_with_vocabulary({"unrelated": 5})
         expanded, _ = await expand_tag_filter(
-            db, workspace_id=WS, context_id=CTX, tags=["never-used"]
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["never-used"]
         )
         assert expanded == ["never-used"]
 
@@ -70,7 +92,11 @@ class TestExpandTagFilter:
     async def test_no_duplicates_when_two_requested_tags_share_variants(self):
         db = _db_with_vocabulary({"Dev_Environment": 2})
         expanded, _ = await expand_tag_filter(
-            db, workspace_id=WS, context_id=CTX, tags=["dev-environment", "dev_environment"]
+            db,
+            workspace_id=WS,
+            context_id=CTX,
+            user_id=USER,
+            tags=["dev-environment", "dev_environment"],
         )
         assert len(expanded) == len(set(expanded))
         assert "Dev_Environment" in expanded
@@ -83,7 +109,7 @@ class TestExpandTagFilter:
         }
         db = _db_with_vocabulary(vocabulary)
         _, added = await expand_tag_filter(
-            db, workspace_id=WS, context_id=CTX, tags=["dev-environment"]
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["dev-environment"]
         )
         assert len(added["dev-environment"]) <= MAX_EXPANSION_PER_TAG
 
@@ -91,7 +117,9 @@ class TestExpandTagFilter:
     async def test_punctuation_only_tag_matches_nothing(self):
         """An empty fold must not collide with every other empty fold."""
         db = _db_with_vocabulary({"***": 4, "python": 9})
-        expanded, added = await expand_tag_filter(db, workspace_id=WS, context_id=CTX, tags=["---"])
+        expanded, added = await expand_tag_filter(
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["---"]
+        )
         assert expanded == ["---"]
         assert added == {}
 
@@ -99,7 +127,7 @@ class TestExpandTagFilter:
     async def test_vocabulary_failure_returns_the_filter_unchanged(self):
         """Widening is an enhancement — it must never break a recall."""
         expanded, added = await expand_tag_filter(
-            _broken_db(), workspace_id=WS, context_id=CTX, tags=["python"]
+            _broken_db(), workspace_id=WS, context_id=CTX, user_id=USER, tags=["python"]
         )
         assert expanded == ["python"]
         assert added == {}
@@ -108,7 +136,7 @@ class TestExpandTagFilter:
     async def test_query_is_scoped_and_bounded(self):
         """The vocabulary read must be per authorized context and capped."""
         db = _db_with_vocabulary({"python": 1})
-        await expand_tag_filter(db, workspace_id=WS, context_id=CTX, tags=["python"])
+        await expand_tag_filter(db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["python"])
         sql = str(db.execute.await_args.args[0].compile(compile_kwargs={"literal_binds": True}))
         assert "workspace_id" in sql and "context_id" in sql
         assert "deleted_at IS NULL" in sql
@@ -120,30 +148,45 @@ class TestSuggestTags:
     async def test_abbreviation_is_suggested_with_its_count(self):
         db = _db_with_vocabulary({"dev-env": 3, "python": 40})
         assert await suggest_tags(
-            db, workspace_id=WS, context_id=CTX, tags=["dev-environment"]
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["dev-environment"]
         ) == {"dev-environment": ["dev-env (3)"]}
 
     @pytest.mark.asyncio
     async def test_nothing_close_returns_empty(self):
         """Empty is the signal that the topic genuinely is not stored."""
         db = _db_with_vocabulary({"cooking": 5, "travel": 2})
-        assert await suggest_tags(db, workspace_id=WS, context_id=CTX, tags=["kubernetes"]) == {}
+        assert (
+            await suggest_tags(
+                db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["kubernetes"]
+            )
+            == {}
+        )
 
     @pytest.mark.asyncio
     async def test_the_requested_tag_never_suggests_itself(self):
         db = _db_with_vocabulary({"python": 40})
-        assert await suggest_tags(db, workspace_id=WS, context_id=CTX, tags=["python"]) == {}
+        assert (
+            await suggest_tags(db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["python"])
+            == {}
+        )
 
     @pytest.mark.asyncio
     async def test_suggestions_are_bounded_per_tag(self):
         vocabulary = {f"troubleshooting{i}": i for i in range(MAX_SUGGESTIONS_PER_TAG + 10)}
         db = _db_with_vocabulary(vocabulary)
-        out = await suggest_tags(db, workspace_id=WS, context_id=CTX, tags=["troubleshooting"])
+        out = await suggest_tags(
+            db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["troubleshooting"]
+        )
         assert len(out["troubleshooting"]) <= MAX_SUGGESTIONS_PER_TAG
 
     @pytest.mark.asyncio
     async def test_vocabulary_failure_returns_no_suggestions(self):
-        assert await suggest_tags(_broken_db(), workspace_id=WS, context_id=CTX, tags=["x"]) == {}
+        assert (
+            await suggest_tags(
+                _broken_db(), workspace_id=WS, context_id=CTX, user_id=USER, tags=["x"]
+            )
+            == {}
+        )
 
 
 class TestRecallWiring:
@@ -175,7 +218,12 @@ class TestRecallWiring:
         request = MagicMock(filters={"tags": ["python"]})
         with patch("services.tag_resolution.suggest_tags", new=AsyncMock()) as spy:
             out = await service._tag_suggestions_for_empty_result(
-                request, [MagicMock()], workspace_id=WS, context_id=CTX
+                request,
+                [MagicMock()],
+                user_id=USER,
+                workspace_id=WS,
+                context_id=CTX,
+                cross_context=False,
             )
         assert out is None
         spy.assert_not_awaited()
@@ -186,7 +234,12 @@ class TestRecallWiring:
         request = MagicMock(filters={"type": "code"})
         with patch("services.tag_resolution.suggest_tags", new=AsyncMock()) as spy:
             out = await service._tag_suggestions_for_empty_result(
-                request, [], workspace_id=WS, context_id=CTX
+                request,
+                [],
+                user_id=USER,
+                workspace_id=WS,
+                context_id=CTX,
+                cross_context=False,
             )
         assert out is None
         spy.assert_not_awaited()
@@ -197,7 +250,12 @@ class TestRecallWiring:
         service.db = _db_with_vocabulary({"dev-env": 3})
         request = MagicMock(filters={"tags": ["dev-environment"]})
         out = await service._tag_suggestions_for_empty_result(
-            request, [], workspace_id=WS, context_id=CTX
+            request,
+            [],
+            user_id=USER,
+            workspace_id=WS,
+            context_id=CTX,
+            cross_context=False,
         )
         assert out == {"dev-environment": ["dev-env (3)"]}
 
@@ -207,7 +265,12 @@ class TestRecallWiring:
         service.db = _db_with_vocabulary({"cooking": 2})
         request = MagicMock(filters={"tags": ["kubernetes"]})
         out = await service._tag_suggestions_for_empty_result(
-            request, [], workspace_id=WS, context_id=CTX
+            request,
+            [],
+            user_id=USER,
+            workspace_id=WS,
+            context_id=CTX,
+            cross_context=False,
         )
         assert out is None
 
@@ -284,3 +347,92 @@ class TestExpansionIsActuallyWired:
         assert all(
             any(kw.arg == "tag_suggestions" for kw in call.keywords) for call in responses
         ), "RecallResponse built without tag_suggestions — the hint would never reach a caller"
+
+
+class TestVocabularyIsScopedToTheCaller:
+    """#1503 review: tag names and counts must never describe unreadable rows."""
+
+    @pytest.mark.asyncio
+    async def test_unshared_context_filters_by_user(self):
+        db = _db_with_vocabulary({"python": 3})
+        await fetch_vocabulary(db, workspace_id=WS, context_id=CTX, user_id=USER)
+        sql = str(db.execute.await_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+        assert "user_id" in sql, (
+            "a non-shared context returns only the caller's own memories to recall, "
+            "so the vocabulary must be scoped the same way"
+        )
+
+    @pytest.mark.asyncio
+    async def test_shared_context_aggregates_across_authors(self):
+        db = _db_with_vocabulary({"python": 3})
+        with _shared_context():
+            await fetch_vocabulary(db, workspace_id=WS, context_id=CTX, user_id=USER)
+        sql = str(db.execute.await_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+        assert "user_id" not in sql, "a shared context is readable by every member"
+
+    @pytest.mark.asyncio
+    async def test_suggestions_do_not_leak_another_users_tags(self):
+        """End to end: the leak this fix closes."""
+        db = _db_with_vocabulary({})  # caller owns nothing in this context
+        assert (
+            await suggest_tags(
+                db, workspace_id=WS, context_id=CTX, user_id=USER, tags=["acme-migrations"]
+            )
+            == {}
+        )
+
+
+class TestCrossContextRecallSkipsSingleContextHints:
+    """#1503 review: one context's vocabulary cannot describe a multi-context search."""
+
+    def _service(self):
+        from services.memory_service import MemoryService
+
+        return MemoryService(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_suggestions_are_skipped_for_a_cross_context_recall(self):
+        service = self._service()
+        service.db = _db_with_vocabulary({"dev-env": 3})
+        request = MagicMock(filters={"tags": ["dev-environment"]})
+        with patch("services.tag_resolution.suggest_tags", new=AsyncMock()) as spy:
+            out = await service._tag_suggestions_for_empty_result(
+                request,
+                [],
+                user_id=USER,
+                workspace_id=WS,
+                context_id=CTX,
+                cross_context=True,
+            )
+        assert out is None
+        spy.assert_not_awaited()
+
+    def test_expansion_is_gated_on_a_single_context(self):
+        """The guard must be on the search shape, not merely on a non-None id."""
+        import ast
+        from pathlib import Path
+
+        import services.memory_service as memory_service
+
+        tree = ast.parse(Path(memory_service.__file__).read_text(encoding="utf-8"))
+        recall = next(
+            n for n in ast.walk(tree) if isinstance(n, ast.AsyncFunctionDef) and n.name == "recall"
+        )
+        guards = [
+            n
+            for n in ast.walk(recall)
+            if isinstance(n, ast.If)
+            and any(
+                isinstance(c, ast.Call)
+                and isinstance(c.func, ast.Name)
+                and c.func.id == "expand_tag_filter"
+                for c in ast.walk(n)
+            )
+        ]
+        assert guards, "recall no longer expands tag filters"
+        for guard in guards:
+            names = {n.id for n in ast.walk(guard.test) if isinstance(n, ast.Name)}
+            assert "context_ids" in names, (
+                "tag expansion must be skipped for a cross-context recall — the "
+                "vocabulary read covers only the primary context"
+            )

--- a/backend/tests/services/test_write_lint.py
+++ b/backend/tests/services/test_write_lint.py
@@ -21,6 +21,16 @@ from services.write_lint import MAX_HINTS, lint_write
 
 WS = uuid4()
 CTX = uuid4()
+USER = "caller-1"
+
+
+@pytest.fixture(autouse=True)
+def _unshared_context():
+    """Vocabulary reads resolve context sharing; default to the scoped path."""
+    with patch("services.context_service.ContextService") as cls:
+        cls.return_value.is_context_shared = AsyncMock(return_value=False)
+        yield cls
+
 
 GOOD_SUMMARY = (
     "JWT expiry caused intermittent 401s on the dashboard. Fixed with refresh "
@@ -42,6 +52,7 @@ async def _lint(summary=GOOD_SUMMARY, tags=None, vocabulary=None):
         db,
         workspace_id=WS,
         context_id=CTX,
+        user_id=USER,
         summary=summary,
         tags=tags if tags is not None else ["auth"],
     )
@@ -136,7 +147,9 @@ class TestTagRules:
     async def test_no_tags_skips_the_vocabulary_read_entirely(self):
         """Nothing to compare — do not pay for the query."""
         db = _db_with_vocabulary({"auth": 3})
-        await lint_write(db, workspace_id=WS, context_id=CTX, summary=GOOD_SUMMARY, tags=[])
+        await lint_write(
+            db, workspace_id=WS, context_id=CTX, user_id=USER, summary=GOOD_SUMMARY, tags=[]
+        )
         db.execute.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -168,7 +181,14 @@ class TestItCanNeverBreakAWrite:
         db = MagicMock()
         db.execute = AsyncMock(side_effect=RuntimeError("boom"))
         assert (
-            await lint_write(db, workspace_id=WS, context_id=CTX, summary=GOOD_SUMMARY, tags=["x"])
+            await lint_write(
+                db,
+                workspace_id=WS,
+                context_id=CTX,
+                user_id=USER,
+                summary=GOOD_SUMMARY,
+                tags=["x"],
+            )
             == []
         )
 
@@ -217,6 +237,7 @@ class TestServiceGuards:
             out = await self._service()._lint_write(
                 workspace_id=workspace_id,
                 context_id=context_id,
+                user_id=USER,
                 summary=summary,
                 tags=["auth"],
             )
@@ -293,3 +314,50 @@ class TestWiring:
         )
         assert out["lint"][0] == {"code": "no_tags", "hint": "add tags"}
         assert out["lint"][1]["subject"] == "authh"
+
+
+class TestLintCanNeverFailACommittedWrite:
+    """#1502 review: the import sits outside lint_write's own guard."""
+
+    def _service(self):
+        from services.memory_service import MemoryService
+
+        return MemoryService(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_an_unimportable_lint_module_yields_no_hints(self):
+        """remember() runs this INSIDE the try that rolls back and re-raises."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def boom(name, *args, **kwargs):
+            if name == "services.write_lint":
+                raise ImportError("simulated broken import chain")
+            return real_import(name, *args, **kwargs)
+
+        with patch.object(builtins, "__import__", side_effect=boom):
+            out = await self._service()._lint_write(
+                workspace_id=WS,
+                context_id=CTX,
+                user_id=USER,
+                summary=GOOD_SUMMARY,
+                tags=["auth"],
+            )
+        assert out == []
+
+
+class TestVocabularyIsScopedToTheCaller:
+    @pytest.mark.asyncio
+    async def test_hint_cannot_describe_another_users_tags(self):
+        """The lint reads the same vocabulary recall does, scoped the same way."""
+        db = _db_with_vocabulary({})
+        hints = await lint_write(
+            db,
+            workspace_id=WS,
+            context_id=CTX,
+            user_id=USER,
+            summary=GOOD_SUMMARY,
+            tags=["dev-env"],
+        )
+        assert [h.code for h in hints] == []

--- a/backend/tests/utils/test_tag_normalize.py
+++ b/backend/tests/utils/test_tag_normalize.py
@@ -79,6 +79,24 @@ class TestIsNearDuplicate:
     def test_mechanical_variants_are_also_suggested(self):
         assert is_near_duplicate("dev-environment", "Dev_Environment")
 
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        [
+            ("redis", "redi"),
+            ("https", "http"),
+            ("status", "statu"),
+            ("chaos", "chao"),
+            ("alias", "alia"),
+        ],
+    )
+    def test_non_plural_endings_are_not_stripped(self, a, b):
+        """Over-stripping merges tags an author kept distinct (review finding)."""
+        assert normalize_tag(a) != normalize_tag(b)
+
+    def test_real_plurals_still_fold(self):
+        for plural, singular in [("tags", "tag"), ("issues", "issue"), ("memories", "memory")]:
+            assert normalize_tag(plural) == normalize_tag(singular)
+
     def test_typos_within_two_edits_are_suggested(self):
         assert is_near_duplicate("troubleshooting", "troubleshootng")
         assert is_near_duplicate("authentication", "authentcation")
@@ -93,6 +111,17 @@ class TestIsNearDuplicate:
         """One edit between 3-char tags relates too many unrelated tags."""
         assert not is_near_duplicate("cat", "car")
         assert not is_near_duplicate("api", "apt")
+
+    @pytest.mark.parametrize(
+        ("a", "b"),
+        [("test", "latest"), ("prod", "reprod"), ("auth", "oauth")],
+    )
+    def test_shared_suffix_alone_does_not_suggest(self, a, b):
+        """A suffix match is weak evidence of abbreviation and adds noise.
+
+        The case this rule exists for — dev-env / dev-environment — is a prefix.
+        """
+        assert not is_near_duplicate(a, b)
 
     def test_unrelated_tags_are_not_suggested(self):
         assert not is_near_duplicate("python", "javascript")


### PR DESCRIPTION
A `/code-review` pass over the merged v0.65.0 range (#1502–#1505) surfaced 12 findings. **Nine are fixed here**, two are deferred with reasons, and one had the wrong mechanism.

## The two that mattered most

**Advisory paths could fail a committed write.** All three features were designed so an advisory extra can never break a real write — and a comment asserted exactly that. It wasn't true: only exceptions raised *inside* `lint_write`'s own `try` were caught. `persistence_info()` was unguarded and lazily imports `services.sleep.consolidation` (Qdrant + graph service + LLM service) on the first write in a process; `_lint_write`'s `import` statement sat outside the guard too. In `remember()` both run **inside the `try` whose handler rolls back and logs `memory_creation_failed`** — so a failure there reported a *stored* memory as failed and invited a retry that duplicates it. Both are now total.

**The tag vocabulary wasn't scoped to the caller.** `SearchService` applies `user_id == caller` whenever a context is not shared, but the vocabulary aggregate filtered only workspace/context/deleted_at. So `tag_suggestions` and the `tag_near_duplicate` lint could report tag names **and counts** drawn from memories the caller cannot read:

```json
"tag_suggestions": {"acme-migrations": ["acme-migration (14)"]}
```

`fetch_vocabulary` now resolves sharing and scopes to the caller unless the context is shared. Structurally the same bug as the #1496 embedding-status leak.

## Also fixed

| | |
|---|---|
| **Cross-context recall** | Expansion used only the primary context's vocabulary, silently missing spellings that exist in the others; suggestions described a narrower search than the one run. The docstring claimed a guard that didn't exist — the only check was `context_id is None`, never true there. Both paths now take a real `cross_context` flag. |
| **Dismiss + edit in one call** | A same-call re-embed necessarily moves the similarity past the resurface delta, so the detector overwrote the tombstone moments after the response reported success. Such a tombstone now stores no baseline, which `is_dismissed` already reads as unconditional suppression. |
| **`UUID()` on a stored id** | Now guarded, matching the sibling read path, so a corrupt *advisory* column no longer fails the caller's real edit. |
| **`updated_at`** | A dismissal-only update restores it — it's the documented staleness cue ("an old value means the fact may be stale"). |
| **`_strip_plural`** | No longer truncates `redis`→`redi`, `status`→`statu`, `chaos`→`chao`, `alias`→`alia`, `https`→`http`. `es` is deliberately *not* excluded — it's a real plural ending (`issues`, `boxes`). |
| **Affix rule** | Prefix-only. A shared suffix related `test`/`latest`, `prod`/`reprod`, `auth`/`oauth`. |
| **`_fetch_vocabulary`** | Public as `fetch_vocabulary`; `write_lint` no longer reaches across a module boundary for a private symbol. |

## Not changed, with reasons

**The per-write vocabulary aggregate** (`unnest` + `group_by` over every memory in the context, on each tagged write) is real added latency, and the finding stands. But choosing between a TTL cache, sampling, and moving it off the response path needs production numbers rather than a guess — it deserves its own issue.

**The "dead None-check"** is resolved as part of the cross-context fix rather than as a separate change.

**One finding named the wrong mechanism.** I claimed `updated_at` advanced via the column's `onupdate`; `#1317` removed that. The bump is real, but it comes from `_update_apply_fields` stamping it unconditionally — which is what the fix targets.

## Testing

**3000 passed.** Mutation-checked: reverting the user scope, the persistence guard, the cross-context guard, the baseline drop, the suffix rule, the plural exclusions, and the `UUID` guard each fail tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)